### PR TITLE
ci: add a no-default-features clippy job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,6 +390,25 @@ jobs:
           args: >
             -D warnings
 
+  clippy-nodefault:
+    name: Clippy (no default features)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        id: toolchain
+        with:
+          toolchain: stable
+          components: clippy
+      - run: rustup override set "${TOOLCHAIN}"
+        shell: sh
+        env:
+          TOOLCHAIN: ${{steps.toolchain.outputs.name}}
+      - name: Run clippy (no default features)
+        run: cargo clippy --no-default-features -- -D warnings
+
   clippy-beta:
     name: Clippy (beta)
     runs-on: ubuntu-latest
@@ -539,6 +558,7 @@ jobs:
       - build-nostd
       - bitrot
       - clippy
+      - clippy-nodefault
       - doc-links
       - fmt
       - protobuf

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -2751,6 +2751,7 @@ type TransferFunding = Vec<(MigrationTransferId, orchard::note::Note)>;
 struct CommitOutput {
     state: MigrationState,
     unsigned: Vec<UnsignedMigrationTx>,
+    #[cfg_attr(not(any(test, feature = "test-dependencies")), allow(dead_code))]
     transfer_funding: TransferFunding,
 }
 


### PR DESCRIPTION
The existing `clippy` / `clippy-beta` jobs run with `--all-features`, so any
lint that only fires under a narrower feature set is masked. The most common
case is an import used only behind a feature gate: with `--all-features` it
looks used, but a `--no-default-features` build reports it as unused.

This adds a `clippy-nodefault` job that runs
`cargo clippy --no-default-features -- -D warnings` (checking the default
lib/bin targets, matching the reproduction below), and wires it into
`required-checks`.

Motivated by a review on #2742: `cargo clippy -p zcash_client_sqlite
--no-default-features --lib -- -D warnings` reported an unused `TxId` import
that the all-features clippy did not catch. Verified locally that this job is
clean on `main` and that it flags that class of issue.