### PR TITLE
zcash_pool_migration: advisory note locks at prove; wallet record at broadcast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7342,6 +7342,7 @@ dependencies = [
 name = "zcash_pool_migration"
 version = "0.1.0-rc.6"
 dependencies = [
+ "blake2b_simd",
  "corez",
  "getset",
  "incrementalmerkletree",

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -11,6 +11,17 @@ workspace.
 ## [Unreleased]
 
 ### Added
+- `pool_migration::orchard_ironwood::PoolMigrations::take_transaction_for_broadcast`:
+  finalizes a proved migration transaction, records it in the wallet's own
+  transaction tables, and returns the broadcastable `Transaction`, in one
+  database transaction. This — not proving — is now where a migration
+  transaction enters the wallet's view (see the Changed entries).
+- A schema migration removing the wallet-side transaction records of
+  never-broadcast transactions belonging to TERMINAL pool migrations, which
+  earlier releases wrote at prove time: their spend marks froze the input
+  notes out of the user's balance until each transaction's expiry, with
+  nothing left to broadcast them.
+
 - `pool_migration::MigrationUuid`: the stable external identity of one
   pool-migration record, safe to hand across an FFI (row ids are not stable
   across a restore).
@@ -29,6 +40,18 @@ workspace.
   one in progress.
 
 ### Changed
+- Proving a migration transaction no longer writes it into the wallet's own
+  transaction tables: `store_proved_transaction` records the proof in the
+  migration store alone, and the wallet-side record (raw transaction, sent
+  outputs, input spend marks, status-retrieval queue entry) is written by
+  `take_transaction_for_broadcast`, atomically with handing out the
+  broadcastable bytes. Consequences a consumer can observe: the user's full
+  balance remains spendable through the prove-to-broadcast window (the
+  reservation is the advisory note lock taken at proving, overridable via a
+  `LockedInputPolicy` naming the migration's lock owners); a never-broadcast
+  txid is no longer queued for status retrieval (previously disclosed to the
+  light wallet server before broadcast); and a pending migration transaction
+  no longer appears in `v_transactions` before broadcast.
 - `pool_migration::PoolMigrations::get_migration` now reports only the
   migration IN PROGRESS: a migration persisted with a terminal status is
   retained as history rather than returned here, and committing a replacement

--- a/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
+++ b/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
@@ -339,26 +339,25 @@ where
         self.store.update_transaction(id, state)
     }
 
-    /// The wallet-database form of the contract: apply the proof to `state`, then — in ONE
-    /// database transaction — persist the migration state and, with it, the finalized
-    /// transaction's wallet record (its raw bytes, fee, sent outputs, and input-spend marks, as
-    /// `store_transactions_to_be_sent` writes for the standard spend flows), so a transaction is
-    /// never durably recorded proved without the wallet knowing about it, nor the reverse. The
-    /// outputs are recovered by trial decryption under the account's unified full viewing key
-    /// (every real migration output is internal to the account; dummies decrypt under no key),
-    /// and the sent record's target height is the successor of the row's scheduled broadcast
-    /// height.
+    /// The wallet-database form of the contract: apply the proof to `state` and persist the
+    /// migration state, and nothing else.
+    ///
+    /// Deliberately NO wallet-side transaction record. The reservation that keeps another flow
+    /// off this transaction's inputs through the prove-to-broadcast window is the ADVISORY note
+    /// lock the proof arrived with ([`ProvedTransaction::lock_owner`]), which leaves the notes in
+    /// the user's spendable balance; the wallet's own record — raw bytes, sent outputs, hard
+    /// input-spend marks, and the status-retrieval queue entry — is written at the broadcast seam
+    /// by [`take_transaction_for_broadcast`](Self::take_transaction_for_broadcast), atomically
+    /// with handing the broadcastable bytes out.
+    ///
+    /// [`ProvedTransaction::lock_owner`]:
+    ///     zcash_pool_migration::engine::ProvedTransaction::lock_owner
     #[cfg(feature = "orchard")]
     fn store_proved_transaction(
         &mut self,
         state: &mut MigrationState,
         proven: zcash_pool_migration::engine::ProvedTransaction,
     ) -> Result<(), Self::Error> {
-        // Migration-store only, per the trait contract: the prove-to-broadcast reservation is
-        // the advisory lock the proof arrived with, and the wallet's own transaction record —
-        // with its hard spend marks and its status-retrieval queue entry — is written by
-        // [`take_transaction_for_broadcast`](Self::take_transaction_for_broadcast), atomically
-        // with handing the broadcastable bytes out.
         proven.apply(state);
         self.replace_migration(state)
     }
@@ -2125,8 +2124,9 @@ mod tests {
     use zcash_pool_migration::{
         denomination::DenominationPlan,
         engine::{
-            MigrationState, MigrationStatus, MigrationTransaction, MigrationTransferId,
-            MigrationTxKind, MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
+            MigrationLockOwner, MigrationState, MigrationStatus, MigrationTransaction,
+            MigrationTransferId, MigrationTxKind, MigrationTxState, PoolMigrationRead,
+            PoolMigrationWrite,
         },
         preparation::PreparationPlan,
         satisfiability::{
@@ -2557,8 +2557,6 @@ mod tests {
     /// covers the type more broadly.
     #[test]
     fn lock_owner_round_trips() {
-        use zcash_pool_migration::engine::MigrationLockOwner;
-
         let denominations = DenominationPlan::from_stored_parts(
             Vec::new(),
             Zatoshis::ZERO,
@@ -2646,8 +2644,6 @@ mod tests {
     /// a `None` lock_owner contributes nothing, and repeated owners collapse to one entry.
     #[test]
     fn migration_lock_owners_collects_distinct_non_none_owners() {
-        use zcash_pool_migration::engine::MigrationLockOwner;
-
         let mut store = fresh_store();
         assert_eq!(
             store.migration_lock_owners().expect("read succeeds"),

--- a/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
+++ b/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
@@ -354,9 +354,13 @@ where
         state: &mut MigrationState,
         proven: zcash_pool_migration::engine::ProvedTransaction,
     ) -> Result<(), Self::Error> {
-        let id = proven.id();
+        // Migration-store only, per the trait contract: the prove-to-broadcast reservation is
+        // the advisory lock the proof arrived with, and the wallet's own transaction record —
+        // with its hard spend marks and its status-retrieval queue entry — is written by
+        // [`take_transaction_for_broadcast`](Self::take_transaction_for_broadcast), atomically
+        // with handing the broadcastable bytes out.
         proven.apply(state);
-        self.finalize_and_store_proved(state, id)
+        self.replace_migration(state)
     }
 
     /// Without the `orchard` feature this wallet tracks no Orchard (or Ironwood) notes at all:
@@ -383,45 +387,45 @@ where
     P: zcash_protocol::consensus::Parameters,
     CL: crate::util::Clock,
 {
-    /// The body of [`PoolMigrationWrite::store_proved_transaction`], once the proof has been
-    /// applied to `state`: persist `state` and, atomically with it, finalize the
-    /// fully-constructed (proved and signed) migration transaction `proved` into the wallet's
-    /// own transaction tables.
+    /// The BROADCAST seam: finalize the proved migration transaction `proved` into its
+    /// broadcastable [`Transaction`](zcash_primitives::transaction::Transaction), record it in
+    /// the wallet's own transaction tables, and hand
+    /// it back for submission — one call, one database transaction, so the wallet record binds
+    /// at the ATTEMPT. A consumer that obtains bytes here and dies mid-submit has already left
+    /// the wallet record that the drive loop's `Proved`-row promotion sweep and the
+    /// status-retrieval queue rely on; there is no way to hold broadcastable bytes the wallet
+    /// does not know about.
     ///
-    /// The transaction named by `proved` must be in the [`Proved`](MigrationTxState::Proved)
-    /// lifecycle state in `state`: its stored bytes are then a PCZT carrying both signatures
-    /// (installed at commit) and proofs (installed by the prove step), from which the final
-    /// `Transaction` is extracted mechanically — the PCZT Spend Finalizer and Transaction
-    /// Extractor roles, the latter of which also verifies the proofs and signatures it
-    /// assembles. The wallet-side record is what
-    /// [`WalletWrite::store_transactions_to_be_sent`] writes for the standard spend flows, made
-    /// at the analogous moment: the transaction's raw bytes, fee, creation time, and target
-    /// height in the `transactions` table; its outputs as sent notes; and its input notes marked
-    /// spent — which is what prevents the wallet's OWN later spends from double-spending a
-    /// migration input during the (deliberately long, for a scheduled transfer) window between
-    /// proving and mining.
+    /// This — not proving — is where the transaction enters the wallet's view. From here its
+    /// input notes are HARD-spent (a mempool may mine it whatever the wallet does next), its
+    /// outputs are recorded as sent, and its txid may be asked after: the status-retrieval queue
+    /// entry is made here, so a never-broadcast txid is never disclosed to a light wallet
+    /// server. Before this call the only reservation on its inputs is the advisory lock taken at
+    /// proving, which is what keeps the user's full balance spendable through the deliberately
+    /// long prove-to-broadcast window.
     ///
-    /// The transaction's outputs are recovered by trial decryption under the account's unified
-    /// full viewing key rather than from PCZT metadata: every real output of a migration
-    /// transaction is internal to the migrating account, and the padded dummy outputs fail
-    /// decryption, so decryption separates them exactly. The sent-transaction target height is
-    /// the block the transaction aims to mine in: the successor of its scheduled broadcast
-    /// height.
+    /// The transaction named by `proved` must be [`Proved`](MigrationTxState::Proved) in
+    /// `state`: its stored bytes are then a PCZT carrying both signatures (installed at commit)
+    /// and proofs, from which the final `Transaction` is extracted mechanically — the PCZT Spend
+    /// Finalizer and Transaction Extractor roles, the latter of which re-verifies the proofs and
+    /// signatures it assembles, so a PCZT that would not survive broadcast is rejected here
+    /// rather than recorded. The outputs are recovered by trial decryption under the account's
+    /// unified full viewing key (every real output of a migration transaction is internal to the
+    /// migrating account; the padded dummies decrypt under no key). Idempotent at the wallet
+    /// layer: re-fetching after a crashed submission upserts the same record.
     ///
-    /// Both writes — the migration state (as [`replace_migration`]) and the wallet transaction
-    /// record — happen in ONE database transaction, so a transaction is never durably recorded
-    /// proved without the wallet record, nor the reverse.
+    /// After submitting, the consumer records the outcome exactly as before:
+    /// [`MigrationState::mark_broadcast`] on success, or
+    /// [`MigrationState::report_broadcast_failure`] on a rejection, then persists.
     ///
-    /// [`WalletWrite::store_transactions_to_be_sent`]:
-    ///     zcash_client_backend::data_api::WalletWrite::store_transactions_to_be_sent
-    /// [`replace_migration`]: PoolMigrationWrite::replace_migration
-    /// [`PoolMigrationWrite::store_proved_transaction`]:
-    ///     zcash_pool_migration::engine::PoolMigrationWrite::store_proved_transaction
-    fn finalize_and_store_proved(
+    /// [`MigrationState::mark_broadcast`]: zcash_pool_migration::engine::MigrationState::mark_broadcast
+    /// [`MigrationState::report_broadcast_failure`]:
+    ///     zcash_pool_migration::engine::MigrationState::report_broadcast_failure
+    pub fn take_transaction_for_broadcast(
         &mut self,
         state: &MigrationState,
         proved: MigrationTransferId,
-    ) -> Result<(), Error> {
+    ) -> Result<zcash_primitives::transaction::Transaction, Error> {
         let row = state
             .transactions()
             .iter()
@@ -545,7 +549,8 @@ where
             );
             crate::wallet::put_zip318_classification(dbtx, tx_ref, classification)
                 .map_err(|e| Error::Wallet(Box::new(e)))
-        })
+        })?;
+        Ok(tx)
     }
 }
 

--- a/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
+++ b/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
@@ -2552,6 +2552,8 @@ mod tests {
     /// covers the type more broadly.
     #[test]
     fn lock_owner_round_trips() {
+        use zcash_pool_migration::engine::MigrationLockOwner;
+
         let denominations = DenominationPlan::from_stored_parts(
             Vec::new(),
             Zatoshis::ZERO,
@@ -2571,7 +2573,7 @@ mod tests {
         let spend_nullifiers: Vec<[u8; 32]> = Vec::new();
         let broadcast_failure_at: Option<BlockHeight> = None;
 
-        let owner_bytes = [7u8; 32];
+        let owner = MigrationLockOwner::from_bytes([7u8; 32]);
         let locked = MigrationTransaction::from_parts(
             MigrationTransferId::new(0),
             MigrationTxKind::Preparation { layer: 0, index: 0 },
@@ -2582,7 +2584,7 @@ mod tests {
             anchor_boundary,
             TxId::from_bytes([0; 32]),
             MigrationTxState::Signed,
-            Some(owner_bytes),
+            Some(owner),
             unsatisfiable,
             spend_nullifiers.clone(),
             broadcast_failure_at,
@@ -2624,7 +2626,7 @@ mod tests {
         );
         assert_eq!(
             loaded.transactions()[0].lock_owner(),
-            Some(owner_bytes),
+            Some(owner),
             "a `Some` lock_owner must survive exactly"
         );
         assert_eq!(
@@ -2639,6 +2641,8 @@ mod tests {
     /// a `None` lock_owner contributes nothing, and repeated owners collapse to one entry.
     #[test]
     fn migration_lock_owners_collects_distinct_non_none_owners() {
+        use zcash_pool_migration::engine::MigrationLockOwner;
+
         let mut store = fresh_store();
         assert_eq!(
             store.migration_lock_owners().expect("read succeeds"),
@@ -2646,8 +2650,8 @@ mod tests {
             "an account with no migration must report no lock owners"
         );
 
-        let owner_a_bytes = [0xA1u8; 32];
-        let owner_b_bytes = [0xB2u8; 32];
+        let owner_a = MigrationLockOwner::from_bytes([0xA1u8; 32]);
+        let owner_b = MigrationLockOwner::from_bytes([0xB2u8; 32]);
 
         let denominations = DenominationPlan::from_stored_parts(
             Vec::new(),
@@ -2659,7 +2663,7 @@ mod tests {
         )
         .expect("an empty stored plan reconstructs");
 
-        let tx = |id: u32, crossing: usize, lock_owner: Option<[u8; 32]>| {
+        let tx = |id: u32, crossing: usize, lock_owner: Option<MigrationLockOwner>| {
             MigrationTransaction::from_parts(
                 MigrationTransferId::new(id),
                 MigrationTxKind::Transfer { crossing },
@@ -2682,11 +2686,11 @@ mod tests {
             denominations,
             PreparationPlan::from_parts(Vec::new(), Vec::new()),
             vec![
-                tx(0, 0, Some(owner_a_bytes)),
-                tx(1, 1, Some(owner_b_bytes)),
+                tx(0, 0, Some(owner_a)),
+                tx(1, 1, Some(owner_b)),
                 tx(2, 2, None),
                 // A second transaction locked by A, to prove duplicates collapse.
-                tx(3, 3, Some(owner_a_bytes)),
+                tx(3, 3, Some(owner_a)),
             ],
             AnchorBucketInterval::ZIP_318,
             ReplanThreshold::DEFAULT,
@@ -2697,7 +2701,10 @@ mod tests {
         let owners = store.migration_lock_owners().expect("read succeeds");
         assert_eq!(
             owners,
-            BTreeSet::from([LockOwner::new(owner_a_bytes), LockOwner::new(owner_b_bytes)]),
+            BTreeSet::from([
+                LockOwner::new(*owner_a.as_bytes()),
+                LockOwner::new(*owner_b.as_bytes()),
+            ]),
             "must contain exactly the distinct non-None lock owners, deduped"
         );
     }

--- a/zcash_client_sqlite/src/pool_migration/store.rs
+++ b/zcash_client_sqlite/src/pool_migration/store.rs
@@ -39,8 +39,8 @@ use rusqlite::{Connection, OptionalExtension, named_params, params};
 use zcash_client_backend::wallet::LockOwner;
 use zcash_pool_migration::denomination::DenominationPlan;
 use zcash_pool_migration::engine::{
-    MigrationState, MigrationStatus, MigrationTransaction, MigrationTransferId, MigrationTxKind,
-    MigrationTxState,
+    MigrationLockOwner, MigrationState, MigrationStatus, MigrationTransaction, MigrationTransferId,
+    MigrationTxKind, MigrationTxState,
 };
 use zcash_pool_migration::preparation::{PrepInput, PrepOutput, PrepTransaction, PreparationPlan};
 use zcash_pool_migration::satisfiability::{
@@ -1117,7 +1117,7 @@ fn read_transactions(
             r.anchor_boundary.map(BlockHeight::from_u32),
             txid,
             state,
-            r.lock_owner,
+            r.lock_owner.map(MigrationLockOwner::from_bytes),
             unsatisfiable,
             spend_nullifiers,
             r.broadcast_failure_at.map(BlockHeight::from_u32),
@@ -1809,7 +1809,7 @@ fn replace_migration_row(
                 ":state": tx_state.as_ref(),
                 ":txid": hex::encode(mtx.txid().as_ref()),
                 ":mined_height": tx_state.mined_height().map(u32::from),
-                ":lock_owner": mtx.lock_owner(),
+                ":lock_owner": mtx.lock_owner().map(|o| *o.as_bytes()),
                 ":unsatisfiable_at": unsatisfiable_at.map(u32::from),
                 ":unsatisfiable_kind": unsatisfiable_kind.as_ref().map(|k| k.as_ref()),
                 ":broadcast_failure_at": mtx.broadcast_failure_at().map(u32::from),

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -138,6 +138,7 @@ migration_modules!(
     ivk_item_cache,
     note_locking,
     nullifier_map,
+    orchard_ironwood_broadcast_binding,
     orchard_ironwood_migration_anchor_interval,
     orchard_ironwood_migration_history,
     orchard_ironwood_migration_tables,
@@ -393,6 +394,7 @@ pub(super) fn all_migrations<
         Box::new(v_tx_outputs_transparent_addresses::Migration),
         Box::new(orchard_ironwood_migration_unsatisfiability::Migration),
         Box::new(orchard_ironwood_migration_history::Migration),
+        Box::new(orchard_ironwood_broadcast_binding::Migration),
     ]
 }
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/orchard_ironwood_broadcast_binding.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/orchard_ironwood_broadcast_binding.rs
@@ -1,0 +1,224 @@
+//! Removes the wallet-side transaction records that the former store-at-prove behavior created
+//! for migration transactions that were NEVER BROADCAST and whose migration has reached a
+//! terminal status.
+//!
+//! The wallet-side record now binds at broadcast: a proved-but-unbroadcast migration transaction
+//! lives only in the migration store, its input notes reserved by an advisory lock rather than by
+//! hard spend marks. Records written at prove by earlier releases outlive that change, and for a
+//! TERMINAL migration nothing will ever broadcast the transaction, so its marks freeze the input
+//! notes out of the user's balance until the transaction's expiry with no possible benefit — the
+//! stuck-balance state this whole branch of work exists to remove, including the rows the mobile
+//! SDK's hand-rolled cancel (persisting `failed`) left in the field. Records belonging to a
+//! PENDING migration are deliberately kept: its transactions are still on their way to broadcast,
+//! where the new seam would recreate the record anyway.
+
+use std::collections::HashSet;
+
+use rusqlite::named_params;
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+use zcash_pool_migration::engine::MigrationStatus;
+
+use super::orchard_ironwood_migration_history;
+use crate::wallet::init::WalletMigrationError;
+
+/// Identifies this migration in the wallet's schema-migration DAG.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x20091091_c736_4d1a_bd99_7adb16842951);
+
+pub(super) const DEPENDENCIES: &[Uuid] = &[orchard_ironwood_migration_history::MIGRATION_ID];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Removes wallet-side transaction records for never-broadcast transactions of terminal \
+         pool migrations."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        // The target set: wallet `transactions` rows whose txid names a NEVER-BROADCAST
+        // transaction of a TERMINAL Orchard -> Ironwood migration. Derived from the migration
+        // store's own rows — never from a predicate over the wallet's tables that could match
+        // anything else — and joined by txid (the store keeps lowercase hex text; `hex()` yields
+        // uppercase, hence the case fold).
+        //
+        // The lifecycle states named here are the engine's stable wire names. Everything at or
+        // past broadcast is EXCLUDED by construction: a broadcast transaction may sit in a
+        // mempool, and its record — marks included — describes reality.
+        let terminal = MigrationStatus::terminal()
+            .map(|s| format!("'{}'", s.wire_name()))
+            .collect::<Vec<_>>()
+            .join(", ");
+        transaction.execute_batch(&format!(
+            "CREATE TEMPORARY TABLE tmp_dead_migration_wallet_txs AS
+             SELECT t.id_tx AS id_tx, t.txid AS txid
+               FROM transactions t
+               JOIN orchard_ironwood_migration_transactions mt
+                 ON lower(mt.txid) = lower(hex(t.txid))
+               JOIN orchard_ironwood_migrations m
+                 ON m.id = mt.migration_id
+              WHERE mt.state IN ('awaiting_signature', 'signed', 'proved')
+                AND m.status IN ({terminal});"
+        ))?;
+
+        // Foreign keys are OFF while schema migrations run, so the `ON DELETE CASCADE` these
+        // children declare does not fire: everything a deleted transaction created or spent is
+        // removed explicitly. Leaving a created output behind would be worse than the freeze
+        // being fixed — the wallet would believe it holds notes that exist nowhere on chain —
+        // and leaving a spend mark behind is the freeze itself.
+        for (table, column) in [
+            ("sapling_received_note_spends", "transaction_id"),
+            ("orchard_received_note_spends", "transaction_id"),
+            ("ironwood_received_note_spends", "transaction_id"),
+            ("sapling_received_notes", "transaction_id"),
+            ("orchard_received_notes", "transaction_id"),
+            ("ironwood_received_notes", "transaction_id"),
+            ("sent_notes", "transaction_id"),
+        ] {
+            transaction.execute(
+                &format!(
+                    "DELETE FROM {table}
+                      WHERE {column} IN (SELECT id_tx FROM tmp_dead_migration_wallet_txs)"
+                ),
+                [],
+            )?;
+        }
+        // The status-retrieval queue is keyed by txid; a never-broadcast txid must not be asked
+        // after (pre-broadcast txid disclosure), and its entry is dead alongside the record.
+        transaction.execute(
+            "DELETE FROM tx_retrieval_queue
+              WHERE txid IN (SELECT txid FROM tmp_dead_migration_wallet_txs)",
+            named_params! {},
+        )?;
+        transaction.execute_batch(
+            "DELETE FROM transactions
+              WHERE id_tx IN (SELECT id_tx FROM tmp_dead_migration_wallet_txs);
+             DROP TABLE tmp_dead_migration_wallet_txs;",
+        )?;
+
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    use super::*;
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[MIGRATION_ID]);
+    }
+
+    /// The dependency-state columns this migration TOUCHES, as reduced stand-ins (the full
+    /// schema-path equality is `verify_schema`'s job): the wallet's transactions table and the
+    /// children it deletes from, plus the migration store's parent and transactions tables.
+    fn dependency_state(conn: &Connection) {
+        conn.execute_batch(
+            "CREATE TABLE transactions (id_tx INTEGER PRIMARY KEY, txid BLOB NOT NULL);
+             CREATE TABLE sapling_received_note_spends (transaction_id INTEGER NOT NULL);
+             CREATE TABLE orchard_received_note_spends (transaction_id INTEGER NOT NULL);
+             CREATE TABLE ironwood_received_note_spends (transaction_id INTEGER NOT NULL);
+             CREATE TABLE sapling_received_notes (transaction_id INTEGER NOT NULL);
+             CREATE TABLE orchard_received_notes (transaction_id INTEGER NOT NULL);
+             CREATE TABLE ironwood_received_notes (transaction_id INTEGER NOT NULL);
+             CREATE TABLE sent_notes (transaction_id INTEGER NOT NULL);
+             CREATE TABLE tx_retrieval_queue (txid BLOB NOT NULL);
+             CREATE TABLE orchard_ironwood_migrations (
+                id INTEGER PRIMARY KEY,
+                account_id INTEGER NOT NULL,
+                status TEXT NOT NULL
+             );
+             CREATE TABLE orchard_ironwood_migration_transactions (
+                migration_id INTEGER NOT NULL,
+                transfer_id INTEGER NOT NULL,
+                state TEXT NOT NULL,
+                txid TEXT
+             );",
+        )
+        .unwrap();
+    }
+
+    fn apply(conn: &mut Connection) {
+        let tx = conn.transaction().unwrap();
+        RusqliteMigration::up(&Migration, &tx).unwrap();
+        tx.commit().unwrap();
+    }
+
+    fn counts(conn: &Connection) -> (i64, i64, i64, i64) {
+        let one = |sql: &str| conn.query_row(sql, [], |r| r.get(0)).unwrap();
+        (
+            one("SELECT COUNT(*) FROM transactions"),
+            one("SELECT COUNT(*) FROM orchard_received_note_spends"),
+            one("SELECT COUNT(*) FROM orchard_received_notes"),
+            one("SELECT COUNT(*) FROM tx_retrieval_queue"),
+        )
+    }
+
+    /// Exactly the never-broadcast transactions of TERMINAL migrations lose their wallet-side
+    /// records — spends, created outputs, queue entries, and the transaction row itself — while
+    /// a pending migration's proved transaction and a terminal migration's BROADCAST transaction
+    /// keep theirs untouched.
+    #[test]
+    fn deletes_only_terminal_never_broadcast_records() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        dependency_state(&conn);
+        // Three wallet transactions: A (proved, terminal migration: the stranded record), B
+        // (proved, PENDING migration: kept), C (broadcast, terminal migration: kept — it may be
+        // in a mempool). Txids as the store encodes them: lowercase hex of the wallet's blob.
+        conn.execute_batch(
+            "INSERT INTO transactions (id_tx, txid) VALUES
+                (1, X'AA'), (2, X'BB'), (3, X'CC');
+             INSERT INTO orchard_received_note_spends (transaction_id) VALUES (1), (2), (3);
+             INSERT INTO orchard_received_notes (transaction_id) VALUES (1), (2), (3);
+             INSERT INTO sent_notes (transaction_id) VALUES (1), (2), (3);
+             INSERT INTO tx_retrieval_queue (txid) VALUES (X'AA'), (X'BB'), (X'CC');
+             INSERT INTO orchard_ironwood_migrations (id, account_id, status) VALUES
+                (10, 1, 'cancelled'), (11, 2, 'committed');
+             INSERT INTO orchard_ironwood_migration_transactions
+                (migration_id, transfer_id, state, txid) VALUES
+                (10, 0, 'proved', 'aa'),
+                (11, 0, 'proved', 'bb'),
+                (10, 1, 'broadcast', 'cc');",
+        )
+        .unwrap();
+
+        apply(&mut conn);
+
+        assert_eq!(
+            counts(&conn),
+            (2, 2, 2, 2),
+            "one stranded record removed, its two neighbors intact"
+        );
+        let survivors: Vec<i64> = conn
+            .prepare("SELECT id_tx FROM transactions ORDER BY id_tx")
+            .unwrap()
+            .query_map([], |r| r.get(0))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(
+            survivors,
+            vec![2, 3],
+            "the pending migration's and the broadcast transaction's records survive"
+        );
+    }
+}

--- a/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
+++ b/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
@@ -436,28 +436,27 @@ impl Run {
         }
     }
 
-    /// Perform an [`AdvanceStep::Broadcast`] step: extract the stored proven transaction and
-    /// submit it, which in this simulation means mining and scanning it, then record both
-    /// lifecycle transitions a consumer records (broadcast, then mined) and persist. Returns the
-    /// extracted transaction and the height it mined at.
+    /// Perform an [`AdvanceStep::Broadcast`] step: obtain the broadcastable transaction through
+    /// the store's broadcast seam — which finalizes the stored proven PCZT and records the
+    /// wallet-side transaction in the same atomic step — and submit it, which in this simulation
+    /// means mining and scanning it, then record both lifecycle transitions a consumer records
+    /// (broadcast, then mined) and persist. Returns the extracted transaction and the height it
+    /// mined at.
     fn perform_broadcast(
         &mut self,
         state: &mut MigrationState,
         id: MigrationTransferId,
     ) -> (Transaction, BlockHeight) {
-        let (tx, stored_txid) = {
-            let proven = state
-                .transactions()
-                .iter()
-                .find(|t| t.id() == id)
-                .expect("the broadcast candidate is present");
-            let extracted = TransactionExtractor::new(
-                pczt::Pczt::parse(proven.pczt()).expect("parses the proven PCZT"),
-            )
-            .extract()
-            .expect("extracts and verifies the transaction's proofs");
-            (extracted, proven.txid())
-        };
+        let stored_txid = state
+            .transactions()
+            .iter()
+            .find(|t| t.id() == id)
+            .expect("the broadcast candidate is present")
+            .txid();
+        let tx = self
+            .store()
+            .take_transaction_for_broadcast(state, id)
+            .expect("finalizes and records the broadcastable transaction");
         // The id the engine derived from the PCZT when it BUILT this transaction, against the id
         // the real extracted transaction actually has. This is the claim the stored txid rests
         // on — that deriving before signing and proving gives the same answer as extracting
@@ -1075,7 +1074,7 @@ fn migration_proves_end_to_end_against_a_funded_wallet() {
     feature = "ignore-expensive-tests",
     ignore = "covered by the expensive-test CI matrix"
 )]
-fn proving_persists_the_finalized_transaction_to_the_wallet() {
+fn broadcast_persists_the_finalized_transaction_to_the_wallet() {
     use zcash_client_backend::data_api::InputSource;
     use zcash_client_backend::data_api::wallet::TargetHeight;
     use zcash_client_backend::data_api::wallet::input_selection::LockFilter;
@@ -1139,8 +1138,6 @@ fn proving_persists_the_finalized_transaction_to_the_wallet() {
     let engine::ProveOutcome::Proved(proven) = outcome else {
         panic!("expected a proof, got {outcome:?}");
     };
-    // The proof is consumed by the failure-side attempt below; keep its parts to retry with.
-    let proven_bytes = proven.pczt().to_vec();
     let txid = committed
         .state
         .transactions()
@@ -1149,19 +1146,14 @@ fn proving_persists_the_finalized_transaction_to_the_wallet() {
         .expect("the transfer is present")
         .txid();
 
-    // FAILURE SIDE: with the wallet-side half unable to write, the migration-store half must
-    // roll back with it — the store keeps saying `Signed`, and the wallet holds no record.
-    run.st
-        .wallet_mut()
-        .conn_mut()
-        .execute_batch("ALTER TABLE sent_notes RENAME TO sent_notes_hidden")
-        .expect("hides the sent-notes table");
-    assert!(
-        run.store()
-            .store_proved_transaction(&mut committed.state, proven)
-            .is_err(),
-        "the wallet-side write cannot succeed without its table",
-    );
+    // PROVE persists the migration store's half ONLY: the transfer is durably `Proved`, and the
+    // wallet's transaction tables know nothing — the user's balance is untouched by a
+    // transaction that is in no mempool, and the never-broadcast txid enters no retrieval
+    // queue. The prove-to-broadcast reservation is the advisory lock, exercised by the locking
+    // tests above.
+    run.store()
+        .store_proved_transaction(&mut committed.state, proven)
+        .expect("records the proof in the migration store");
     assert!(
         matches!(
             run.stored_migration()
@@ -1171,9 +1163,33 @@ fn proving_persists_the_finalized_transaction_to_the_wallet() {
                 .find(|t| t.id() == transfer_id)
                 .expect("the transfer is present")
                 .state(),
-            MigrationTxState::Signed
+            MigrationTxState::Proved
         ),
-        "the migration-store half rolled back with the failed wallet-side half",
+        "the store records the transfer proved",
+    );
+    assert!(
+        run.st
+            .wallet()
+            .get_transaction(txid)
+            .expect("queries the wallet")
+            .is_none(),
+        "proving leaves no record in the wallet's transaction tables",
+    );
+
+    // FAILURE SIDE of the BROADCAST seam: with the wallet-side half unable to write, no
+    // broadcastable bytes are handed out and no partial record survives — the bytes bind to the
+    // record, so there is no crash prefix in which the consumer holds a transaction the wallet
+    // does not know about.
+    run.st
+        .wallet_mut()
+        .conn_mut()
+        .execute_batch("ALTER TABLE sent_notes RENAME TO sent_notes_hidden")
+        .expect("hides the sent-notes table");
+    assert!(
+        run.store()
+            .take_transaction_for_broadcast(&committed.state, transfer_id)
+            .is_err(),
+        "the wallet-side write cannot succeed without its table",
     );
     assert!(
         run.st
@@ -1189,28 +1205,12 @@ fn proving_persists_the_finalized_transaction_to_the_wallet() {
         .execute_batch("ALTER TABLE sent_notes_hidden RENAME TO sent_notes")
         .expect("restores the sent-notes table");
 
-    // SUCCESS SIDE: one atomic write records both halves. (The failure-side attempt consumed the
-    // engine's proof value; the retry reassembles it from the parts kept above, exactly the
-    // resume-and-reprove a real consumer performs more cheaply here.)
-    run.store()
-        .store_proved_transaction(
-            &mut committed.state,
-            engine::ProvedTransaction::from_parts(transfer_id, proven_bytes),
-        )
-        .expect("finalizes and persists the proved transaction");
-    assert!(
-        matches!(
-            run.stored_migration()
-                .expect("the store holds the migration")
-                .transactions()
-                .iter()
-                .find(|t| t.id() == transfer_id)
-                .expect("the transfer is present")
-                .state(),
-            MigrationTxState::Proved
-        ),
-        "the store records the transfer proved",
-    );
+    // SUCCESS SIDE: one atomic step records the wallet-side half and returns the transaction.
+    let extracted = run
+        .store()
+        .take_transaction_for_broadcast(&committed.state, transfer_id)
+        .expect("finalizes, records, and returns the broadcastable transaction");
+    assert_eq!(extracted.txid(), txid);
 
     // The wallet holds the raw finalized transaction under the txid the engine derived at build
     // time, with its Ironwood crossing bundle intact.

--- a/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
+++ b/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
@@ -29,6 +29,7 @@
     feature = "expensive-tests"
 ))]
 
+use std::collections::BTreeSet;
 use std::convert::Infallible;
 
 use rand_chacha::ChaCha8Rng;
@@ -36,10 +37,16 @@ use rand_core::SeedableRng;
 
 use pczt::roles::tx_extractor::TransactionExtractor;
 
+use zcash_client_backend::data_api::locking::{LockOwner, OutputLockStore};
 use zcash_client_backend::data_api::testing::{
     AddressType, TestBuilder, TestState, orchard::OrchardPoolTester, pool::ShieldedPoolTester,
 };
-use zcash_client_backend::data_api::{Account, WalletRead, WalletTest};
+use zcash_client_backend::data_api::wallet::TargetHeight;
+use zcash_client_backend::data_api::wallet::input_selection::{
+    LockFilter, LockedInputPolicy, NonEmptyBTreeSet,
+};
+use zcash_client_backend::data_api::{Account, InputSource, WalletRead, WalletTest};
+use zcash_client_backend::wallet::OutputRef;
 // The wallet, block cache, DB factory, and Orchard-checkpoint helper come from this crate's own
 // test harness, exposed under its `test-dependencies` feature.
 use zcash_client_sqlite::pool_migration::orchard_ironwood::PoolMigrations;
@@ -50,11 +57,11 @@ use zcash_keys::keys::UnifiedSpendingKey;
 
 use zcash_primitives::block::BlockHash;
 use zcash_primitives::transaction::Transaction;
-use zcash_protocol::TxId;
 use zcash_protocol::consensus::BlockHeight;
 use zcash_protocol::local_consensus::LocalNetwork;
 use zcash_protocol::value::testing::zats;
 use zcash_protocol::value::{COIN, ZatBalance, Zatoshis};
+use zcash_protocol::{PoolType, ShieldedPool, TxId};
 
 use zcash_pool_migration::engine::{
     self, MigrationState, MigrationStatus, MigrationTransferId, MigrationTxKind, MigrationTxState,
@@ -64,7 +71,7 @@ use zcash_pool_migration::satisfiability::{
     self, AdvanceConfig, DuenessTargets, ReorgSettleDepth, ReplanThreshold,
 };
 use zcash_pool_migration::state::{AdvanceStep, Blocker};
-use zcash_pool_migration::wallet::{WalletMigration, WalletMigrationProver};
+use zcash_pool_migration::wallet::{WalletMigration, WalletMigrationProver, WalletProveError};
 
 /// The drive policy every scenario here uses: a ten-block reorg settle depth, the caller policy
 /// the satisfiability oracle judges anchor displacements under.
@@ -1524,16 +1531,6 @@ fn scenario_named(label: &str) -> Scenario {
 /// owners in a [`LockedInputPolicy`] override. Locking is a DEFAULT, never a veto.
 #[test]
 fn proving_locks_the_spent_notes_without_taking_them_from_the_user() {
-    use std::collections::BTreeSet;
-
-    use zcash_client_backend::data_api::InputSource;
-    use zcash_client_backend::data_api::locking::{LockOwner, OutputLockStore};
-    use zcash_client_backend::data_api::wallet::TargetHeight;
-    use zcash_client_backend::data_api::wallet::input_selection::{
-        LockFilter, LockedInputPolicy, NonEmptyBTreeSet,
-    };
-    use zcash_protocol::ShieldedPool;
-
     // One source note keeps the migration to a single preparation layer, so the first prove is the
     // one that reserves the account's only spendable note.
     let scenario = scenario_named(SMALLEST);
@@ -1690,14 +1687,6 @@ fn proving_locks_the_spent_notes_without_taking_them_from_the_user() {
 /// around the conflict and must wait (or die at its expiry) instead.
 #[test]
 fn proving_refuses_to_take_a_note_another_flow_has_reserved() {
-    use zcash_client_backend::data_api::InputSource;
-    use zcash_client_backend::data_api::locking::{LockOwner, OutputLockStore};
-    use zcash_client_backend::data_api::wallet::TargetHeight;
-    use zcash_client_backend::data_api::wallet::input_selection::LockFilter;
-    use zcash_client_backend::wallet::OutputRef;
-    use zcash_pool_migration::wallet::WalletProveError;
-    use zcash_protocol::{PoolType, ShieldedPool};
-
     let scenario = scenario_named(SMALLEST);
     let mut run = Run::setup(&scenario);
     let mut committed = run.plan_and_commit(&scenario);

--- a/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
+++ b/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
@@ -1500,6 +1500,290 @@ fn migration_anchors_to_the_wallets_configured_retention_grid() {
     }
 }
 
+/// The cheapest scenario that still exercises the whole shape: one preparation and one transfer,
+/// so a test that only needs a proved transaction pays for exactly one Orchard proof. Drawn from
+/// the shared `MIGRATION_SCENARIOS` so its expected counts stay in sync with the planner.
+const SMALLEST: &str = "Gwen, 0.0152 ZEC (a single minimum-denomination note)";
+
+/// The named scenario from the shared list.
+fn scenario_named(label: &str) -> Scenario {
+    scenarios()
+        .into_iter()
+        .find(|scenario| scenario.label == label)
+        .expect("the named scenario exists")
+}
+
+/// Proving a migration transaction RESERVES the notes it spends, and the reservation is advisory:
+/// the account's own spending is steered away from those notes by default, but a caller that names
+/// the migration's lock owner still reaches them.
+///
+/// This is the property that lets a wallet schedule a migration without taking the user's money
+/// hostage. A migration transaction that is signed and proved is a broadcastable artifact
+/// committing to specific notes, so by default nothing else should select them; but the user must
+/// remain able to pay, swap, or send at any moment, which they do by passing the migration's own
+/// owners in a [`LockedInputPolicy`] override. Locking is a DEFAULT, never a veto.
+#[test]
+fn proving_locks_the_spent_notes_without_taking_them_from_the_user() {
+    use std::collections::BTreeSet;
+
+    use zcash_client_backend::data_api::InputSource;
+    use zcash_client_backend::data_api::locking::{LockOwner, OutputLockStore};
+    use zcash_client_backend::data_api::wallet::TargetHeight;
+    use zcash_client_backend::data_api::wallet::input_selection::{
+        LockFilter, LockedInputPolicy, NonEmptyBTreeSet,
+    };
+    use zcash_protocol::ShieldedPool;
+
+    // One source note keeps the migration to a single preparation layer, so the first prove is the
+    // one that reserves the account's only spendable note.
+    let scenario = scenario_named(SMALLEST);
+    let mut run = Run::setup(&scenario);
+    let mut committed = run.plan_and_commit(&scenario);
+
+    let prep_id = committed
+        .state
+        .transactions()
+        .iter()
+        .find(|t| matches!(t.kind(), MigrationTxKind::Preparation { .. }))
+        .expect("the migration has a preparation transaction")
+        .id();
+
+    let account_id = run.account_id;
+    let target = {
+        let tip = run
+            .st
+            .wallet()
+            .chain_height()
+            .expect("reads the chain height")
+            .expect("the wallet has a chain tip");
+        TargetHeight::from(u32::from(tip) + 1)
+    };
+
+    // Before proving, nothing is reserved and the account's notes are selectable by default.
+    assert!(
+        run.st
+            .wallet()
+            .get_locked_outputs(account_id)
+            .expect("reads the locked outputs")
+            .is_empty(),
+        "a committed but unproved migration reserves nothing"
+    );
+    let selectable_before = run
+        .st
+        .wallet()
+        .select_unspent_notes(
+            account_id,
+            &[ShieldedPool::Orchard],
+            target,
+            &[],
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
+        )
+        .expect("selects the account's unspent notes")
+        .orchard()
+        .len();
+    assert!(
+        selectable_before > 0,
+        "the funded account has selectable Orchard notes before proving"
+    );
+
+    let anchor = {
+        let tip = run
+            .st
+            .wallet()
+            .chain_height()
+            .expect("reads the chain height")
+            .expect("the wallet has a chain tip");
+        highest_rooted_orchard_checkpoint(run.st.wallet_mut(), tip)
+            .expect("a rooted Orchard checkpoint exists")
+    };
+    let outcome = {
+        let mut prover =
+            WalletMigrationProver::new(run.st.wallet_mut(), account_id, run.fvk.clone());
+        engine::prove_preparation(&mut prover, &mut committed.state, prep_id, anchor)
+            .expect("proves the preparation transaction")
+    };
+    // The proof — and the lock-owner token it was reserved under — travel as a value; the state
+    // records both through the store seam.
+    let engine::ProveOutcome::Proved(proven) = outcome else {
+        panic!("expected a proof, got {outcome:?}");
+    };
+    run.store()
+        .store_proved_transaction(&mut committed.state, proven)
+        .expect("records the proof");
+
+    let proved = committed
+        .state
+        .transactions()
+        .iter()
+        .find(|t| t.id() == prep_id)
+        .expect("the preparation transaction is present");
+    assert!(matches!(proved.state(), MigrationTxState::Proved));
+
+    // The transaction records the token its notes were reserved under, so the reservation can be
+    // named (and released) later from the persisted migration alone.
+    let owner = proved
+        .lock_owner()
+        .expect("a proved transaction records the lock owner its notes were reserved under");
+
+    // The notes the transaction spends are now reserved.
+    let locked = run
+        .st
+        .wallet()
+        .get_locked_outputs(account_id)
+        .expect("reads the locked outputs");
+    assert!(
+        !locked.is_empty(),
+        "proving reserves the notes the transaction spends"
+    );
+
+    // Reserved notes drop out of DEFAULT selection: another flow will not pick them by accident.
+    let selectable_after = run
+        .st
+        .wallet()
+        .select_unspent_notes(
+            account_id,
+            &[ShieldedPool::Orchard],
+            target,
+            &[],
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
+        )
+        .expect("selects the account's unspent notes")
+        .orchard()
+        .len();
+    assert_eq!(
+        selectable_after,
+        selectable_before - locked.len(),
+        "exactly the reserved notes leave the default candidate set"
+    );
+
+    // ...but the user is NOT locked out. Naming the migration's owner brings them back, which is
+    // how a wallet lets a payment spend through a migration in flight.
+    let owners = NonEmptyBTreeSet::from_set(BTreeSet::from([LockOwner::new(*owner.as_bytes())]))
+        .expect("the migration holds at least one lock owner");
+    let policy = LockedInputPolicy::PreferUnlocked(owners);
+    let selectable_with_override = run
+        .st
+        .wallet()
+        .select_unspent_notes(
+            account_id,
+            &[ShieldedPool::Orchard],
+            target,
+            &[],
+            LockFilter::Policy(&policy),
+        )
+        .expect("selects the account's unspent notes")
+        .orchard()
+        .len();
+    assert_eq!(
+        selectable_with_override, selectable_before,
+        "naming the migration's lock owner restores every reserved note to the candidate set, so \
+         a user payment is never blocked by a migration in flight"
+    );
+}
+
+/// A note already reserved by ANOTHER flow is not stolen by the migration: proving reports the
+/// conflict and the transaction stays `Signed` rather than becoming a `Proved` artifact whose
+/// inputs the wallet has already promised elsewhere.
+///
+/// This is the losing side of the same rule as the test above. The user's in-flight payment holds
+/// the note; the migration transaction's spends were fixed by its signature, so it cannot select
+/// around the conflict and must wait (or die at its expiry) instead.
+#[test]
+fn proving_refuses_to_take_a_note_another_flow_has_reserved() {
+    use zcash_client_backend::data_api::InputSource;
+    use zcash_client_backend::data_api::locking::{LockOwner, OutputLockStore};
+    use zcash_client_backend::data_api::wallet::TargetHeight;
+    use zcash_client_backend::data_api::wallet::input_selection::LockFilter;
+    use zcash_client_backend::wallet::OutputRef;
+    use zcash_pool_migration::wallet::WalletProveError;
+    use zcash_protocol::{PoolType, ShieldedPool};
+
+    let scenario = scenario_named(SMALLEST);
+    let mut run = Run::setup(&scenario);
+    let mut committed = run.plan_and_commit(&scenario);
+
+    let prep_id = committed
+        .state
+        .transactions()
+        .iter()
+        .find(|t| matches!(t.kind(), MigrationTxKind::Preparation { .. }))
+        .expect("the migration has a preparation transaction")
+        .id();
+
+    let account_id = run.account_id;
+    let tip = run
+        .st
+        .wallet()
+        .chain_height()
+        .expect("reads the chain height")
+        .expect("the wallet has a chain tip");
+    let anchor = highest_rooted_orchard_checkpoint(run.st.wallet_mut(), tip)
+        .expect("a rooted Orchard checkpoint exists");
+
+    // Another flow gets there first and reserves every note in the account, well past the
+    // migration transaction's own expiry.
+    let rival = LockOwner::new([0x5Au8; 32]);
+    let rival_outputs: Vec<OutputRef> = {
+        let notes = run
+            .st
+            .wallet()
+            .select_unspent_notes(
+                account_id,
+                &[ShieldedPool::Orchard],
+                TargetHeight::from(u32::from(tip) + 1),
+                &[],
+                LockFilter::Unfiltered,
+            )
+            .expect("enumerates the account's unspent Orchard notes");
+        let refs: Vec<OutputRef> = notes
+            .orchard()
+            .iter()
+            .map(|rn| {
+                OutputRef::new(
+                    *rn.txid(),
+                    PoolType::Shielded(ShieldedPool::Orchard),
+                    rn.output_index().into(),
+                )
+            })
+            .collect();
+        assert!(!refs.is_empty(), "the funded account holds Orchard notes");
+        refs
+    };
+    run.st
+        .wallet_mut()
+        .lock_outputs(&rival_outputs, rival, tip + 10_000)
+        .expect("the rival flow reserves the notes first");
+
+    let result = {
+        let mut prover =
+            WalletMigrationProver::new(run.st.wallet_mut(), account_id, run.fvk.clone());
+        engine::prove_preparation(&mut prover, &mut committed.state, prep_id, anchor)
+    };
+    assert!(
+        matches!(
+            result,
+            Err(engine::ProveError::Prover(WalletProveError::Lock(_)))
+        ),
+        "proving must report the reservation conflict, got {result:?}"
+    );
+
+    let unchanged = committed
+        .state
+        .transactions()
+        .iter()
+        .find(|t| t.id() == prep_id)
+        .expect("the preparation transaction is present");
+    assert!(
+        matches!(unchanged.state(), MigrationTxState::Signed),
+        "a transaction that could not reserve its inputs stays Signed"
+    );
+    assert_eq!(
+        unchanged.lock_owner(),
+        None,
+        "a transaction that could not reserve its inputs records no lock owner"
+    );
+}
+
 /// The scenario the unsatisfiability machinery exists for: while a committed migration waits out
 /// its privacy schedule, the user spends the whole balance — a "send max" to an external address —
 /// consuming the very funding notes the pre-signed crossings were built to spend.

--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -398,8 +398,8 @@ and this library adheres to Rust's notion of
 - `zcash_pool_migration::engine::MigrationProver::lock_spent_notes`, called by
   `prove_transfer` and `prove_preparation` once the proof succeeds, so a
   transaction reserves the notes it spends for exactly as long as it is proved
-  and awaiting broadcast. It has a default implementation that takes no locks,
-  so an existing prover is unaffected.
+  and awaiting broadcast. It is a REQUIRED method: an existing prover must
+  implement it, returning `Ok(None)` if it models no lock state.
 - `zcash_pool_migration::wallet::WalletProveError::Lock`, reporting a note that
   another flow has already reserved.
 

--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -393,6 +393,15 @@ and this library adheres to Rust's notion of
   transfer schedule's drawn anchor boundaries and broadcast heights.
 - `zcash_pool_migration::engine::MigrationState::sync_wakeup_schedule`, the above computed over a
   committed migration's transfers that still need proofs.
+- `zcash_pool_migration::engine::MigrationLockOwner`, the token identifying the
+  holder of the wallet-side locks on a migration transaction's input notes.
+- `zcash_pool_migration::engine::MigrationProver::lock_spent_notes`, called by
+  `prove_transfer` and `prove_preparation` once the proof succeeds, so a
+  transaction reserves the notes it spends for exactly as long as it is proved
+  and awaiting broadcast. It has a default implementation that takes no locks,
+  so an existing prover is unaffected.
+- `zcash_pool_migration::wallet::WalletProveError::Lock`, reporting a note that
+  another flow has already reserved.
 
 ### Changed
 - Migrated to `zcash_client_backend 0.24.0-rc.5`.
@@ -423,6 +432,16 @@ and this library adheres to Rust's notion of
 - `zcash_pool_migration::wallet::WalletMigration` implements `MigrationCrypto`
   only where the wallet's `WalletRead::AccountId` and `InputSource::AccountId`
   are the same type, which is required to read the account's derivation.
+- `zcash_pool_migration::engine::MigrationTransaction::lock_owner` and
+  `MigrationTransaction::from_parts` now use `MigrationLockOwner` in place of a
+  bare `[u8; 32]`.
+- `zcash_pool_migration::engine::MigrationState::set_transaction_proved` takes
+  the lock owner the transaction's notes were reserved under, so a store write
+  persists the proven artifact and its lock token together.
+- `zcash_pool_migration::wallet::WalletProveError` has a fourth type parameter,
+  the lock store's error type.
+- `zcash_pool_migration::wallet::WalletMigrationProver` implements
+  `MigrationProver` only for a wallet that is also an `OutputLockStore`.
 
 ## [0.1.0-rc.3] - 2026-07-26
 

--- a/zcash_pool_migration/Cargo.toml
+++ b/zcash_pool_migration/Cargo.toml
@@ -47,8 +47,6 @@ zcash_client_backend = { workspace = true, optional = true, features = ["orchard
 zcash_keys = { workspace = true, optional = true, features = ["orchard"] }
 shardtree = { workspace = true, optional = true }
 incrementalmerkletree = { workspace = true, optional = true }
-# Derives the migration lock-owner token from the notes a transaction spends, so the token is
-# recoverable from the stored PCZT rather than drawn at random and lost on a crash.
 blake2b_simd = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/zcash_pool_migration/Cargo.toml
+++ b/zcash_pool_migration/Cargo.toml
@@ -47,6 +47,9 @@ zcash_client_backend = { workspace = true, optional = true, features = ["orchard
 zcash_keys = { workspace = true, optional = true, features = ["orchard"] }
 shardtree = { workspace = true, optional = true }
 incrementalmerkletree = { workspace = true, optional = true }
+# Derives the migration lock-owner token from the notes a transaction spends, so the token is
+# recoverable from the stored PCZT rather than drawn at random and lost on a crash.
+blake2b_simd = { workspace = true, optional = true }
 
 [dev-dependencies]
 incrementalmerkletree.workspace = true
@@ -83,6 +86,7 @@ orchard = ["dep:orchard", "dep:pczt", "dep:zip32"]
 ## migration wallet with no hand-wired crypto. Implies `orchard`.
 wallet = [
     "orchard",
+    "dep:blake2b_simd",
     "dep:zcash_client_backend",
     "dep:zcash_keys",
     "dep:shardtree",

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -2636,7 +2636,7 @@ where
 }
 
 /// Shared body of [`rebuild_expired_transfer`] (with [`Signing::InProcess`]) and
-/// [`rebuild_expired_transfer_unsigned`] (with [`Signing::External`]). Returns the
+/// [`rebuild_expired_transfer_unsigned`] (which defers signing to an external signer). Returns the
 /// [`UnsignedMigrationTx`] for the external path, `None` for the in-process path.
 #[cfg(feature = "orchard")]
 fn rebuild_expired_transfer_inner<P, B, R>(

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -237,20 +237,25 @@ pub trait PoolMigrationWrite: PoolMigrationRead {
     ///
     /// From the moment the proof exists, the transaction is FULLY CONSTRUCTED: its PCZT carries
     /// both signatures (installed at commit) and proofs, and extracting the broadcastable
-    /// `Transaction` from it is purely mechanical. This method is where a backend makes the
-    /// wallet aware of that fact. An implementation over a wallet database MUST, atomically with
-    /// recording the proof in the migration store, finalize the transaction and persist it to
-    /// the wallet's own transaction store — the record `store_transactions_to_be_sent` writes
-    /// for the standard spend flows: the raw transaction, its outputs, and its input notes
-    /// marked spent, so the wallet's own later spends cannot consume a migration input during
-    /// the (deliberately long, for a scheduled transfer) window between proving and broadcast.
-    /// A store with no wallet-level transaction records (a mock, or a store deferring the wallet
-    /// side elsewhere) applies the proof and persists the migration state alone:
+    /// `Transaction` from it is purely mechanical. Every implementation applies the proof and
+    /// persists the migration state:
     ///
     /// ```ignore
     /// proven.apply(state);
     /// self.replace_migration(state)
     /// ```
+    ///
+    /// Deliberately NOT here: any record in the wallet's own transaction store. A
+    /// proved-but-unbroadcast transaction is in no mempool and is scheduled future intent, not
+    /// in-flight outgoing intent, so recording it wallet-side at prove would freeze its input
+    /// notes out of the user's balance for the whole prove-to-broadcast window — days to weeks
+    /// on the ZIP 318 schedule — in violation of the rule that the user always has full access
+    /// to their funds. The prove-to-broadcast reservation is the ADVISORY lock taken by
+    /// [`MigrationProver::lock_spent_notes`] (overridable, expiring with the transaction), and
+    /// the wallet-side record is written by the store's own broadcast seam, atomically with
+    /// handing the broadcastable bytes out (for `zcash_client_sqlite`, its
+    /// `take_transaction_for_broadcast`), which is also the moment its transaction-status
+    /// retrieval may begin without disclosing a never-broadcast txid.
     ///
     /// On an error the proof is lost with the value and `state` may or may not carry it (an
     /// implementation applies it before writing); the caller should re-read the migration from

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -237,13 +237,9 @@ pub trait PoolMigrationWrite: PoolMigrationRead {
     ///
     /// From the moment the proof exists, the transaction is FULLY CONSTRUCTED: its PCZT carries
     /// both signatures (installed at commit) and proofs, and extracting the broadcastable
-    /// `Transaction` from it is purely mechanical. Every implementation applies the proof and
-    /// persists the migration state:
-    ///
-    /// ```ignore
-    /// proven.apply(state);
-    /// self.replace_migration(state)
-    /// ```
+    /// `Transaction` from it is purely mechanical. Every implementation does the same two things
+    /// and nothing else: apply the proof to `state` with [`ProvedTransaction::apply`], then
+    /// persist it with [`replace_migration`](Self::replace_migration).
     ///
     /// Deliberately NOT here: any record in the wallet's own transaction store. A
     /// proved-but-unbroadcast transaction is in no mempool and is scheduled future intent, not
@@ -935,11 +931,10 @@ impl MigrationState {
     /// [`PoolMigrationWrite::store_proved_transaction`]: the proof travels from the prove step to
     /// the store as a value, and the state records it in the same act that persists it.
     ///
-    /// `lock_owner` is `None` when the prover took no locks
-    /// ([`MigrationProver::lock_spent_notes`]'s default). It is recorded in the same pass as the
-    /// proven bytes so a store write persists the artifact and its lock token together: a caller
-    /// that persists after proving can never end up with a proved transaction whose locks it can
-    /// no longer name.
+    /// `lock_owner` is `None` when the prover took no locks (see
+    /// [`MigrationProver::lock_spent_notes`]). It is recorded in the same pass as the proven bytes
+    /// so a store write persists the artifact and its lock token together: a caller that persists
+    /// after proving can never end up with a proved transaction whose locks it can no longer name.
     pub fn set_transaction_proved(
         &mut self,
         id: MigrationTransferId,
@@ -1737,7 +1732,7 @@ pub enum ProveOutcome {
 
 /// A successfully proved migration transaction awaiting its persistence: the proven PCZT — now
 /// carrying both signatures (installed at commit) and proofs, ready to broadcast — together with
-/// the id of the row it belongs to.
+/// the id of the row it belongs to and the token its spent notes were reserved under.
 ///
 /// Only a successful [`prove_transfer`] / [`prove_preparation`] produces one, and only
 /// [`PoolMigrationWrite::store_proved_transaction`] consumes one (through
@@ -1754,10 +1749,6 @@ pub enum ProveOutcome {
 pub struct ProvedTransaction {
     id: MigrationTransferId,
     pczt: Vec<u8>,
-    /// The token the transaction's spent notes were reserved under at proving
-    /// ([`MigrationProver::lock_spent_notes`]), or `None` when the prover models no lock state.
-    /// Carried with the proof so the artifact and its reservation are recorded — and persisted —
-    /// in the same act.
     lock_owner: Option<MigrationLockOwner>,
 }
 
@@ -1772,7 +1763,12 @@ impl ProvedTransaction {
         &self.pczt
     }
 
-    /// The token the transaction's notes were reserved under at proving, when locks were taken.
+    /// The token the transaction's spent notes were reserved under at proving
+    /// ([`MigrationProver::lock_spent_notes`]), or `None` when the prover models no lock state.
+    ///
+    /// Carried with the proof so the artifact and its reservation are recorded — and persisted —
+    /// in the same act: a caller that persists after proving can never end up with a proved
+    /// transaction whose locks it can no longer name.
     pub fn lock_owner(&self) -> Option<MigrationLockOwner> {
         self.lock_owner
     }
@@ -1905,17 +1901,15 @@ pub trait MigrationProver {
     ///
     /// Returns the opaque owner token the locks were taken under, recorded on the transaction as
     /// [`MigrationTransaction::lock_owner`] so that a later cancel, or a restart, can release
-    /// exactly these locks. The default implementation takes no locks and returns `None`, which is
-    /// the correct behavior for a prover over a wallet that models no lock state (a test mock, or
-    /// a signing-only backend).
+    /// exactly these locks. An implementation over a wallet that models no lock state (a test
+    /// mock, or a signing-only backend) returns `None`, and must do so deliberately: there is no
+    /// default, because silently taking no locks would leave a prover's migration inputs
+    /// spendable out from under it with nothing at the type level to say so.
     fn lock_spent_notes(
         &mut self,
         pczt: &pczt::Pczt,
         lock_expiry_height: BlockHeight,
-    ) -> Result<Option<MigrationLockOwner>, Self::Error> {
-        let _ = (pczt, lock_expiry_height);
-        Ok(None)
-    }
+    ) -> Result<Option<MigrationLockOwner>, Self::Error>;
 }
 
 /// Why committing a migration's preparation failed.
@@ -4590,6 +4584,17 @@ mod commit_tests {
             // tests exercise.
             Ok(install_stand_in_witnesses(pczt))
         }
+
+        /// This mock models no note-lock state, so it reserves nothing and reports no owner; a
+        /// transaction it proves therefore carries `lock_owner == None`. The prove-step tests
+        /// below exercise the engine's orchestration, not the reservation.
+        fn lock_spent_notes(
+            &mut self,
+            _pczt: &pczt::Pczt,
+            _lock_expiry_height: BlockHeight,
+        ) -> Result<Option<MigrationLockOwner>, Self::Error> {
+            Ok(None)
+        }
     }
 
     /// A planned single-note migration and the mock wallet that holds the note.
@@ -6351,6 +6356,16 @@ mod commit_tests {
 
         fn anchor_bucket_interval(&self) -> crate::scheduling::AnchorBucketInterval {
             crate::scheduling::SchedulingParams::ZIP_318.anchor_bucket_interval()
+        }
+
+        /// Never reached: every prove call above fails first, which is precisely the ordering
+        /// these tests pin — a failed proof takes no locks.
+        fn lock_spent_notes(
+            &mut self,
+            _pczt: &pczt::Pczt,
+            _lock_expiry_height: BlockHeight,
+        ) -> Result<Option<MigrationLockOwner>, Self::Error> {
+            Ok(None)
         }
     }
 

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -399,6 +399,47 @@ pub enum MigrationTxState {
     Mined { txid: TxId, height: BlockHeight },
 }
 
+/// The opaque token identifying the holder of the wallet-side locks on a migration transaction's
+/// input notes.
+///
+/// This is the engine's mirror of `zcash_client_backend::wallet::LockOwner`, carried as its own
+/// type because this pool-agnostic engine must not depend on `zcash_client_backend` (only
+/// `wallet`-feature code does). The two are byte-identical and round-trip through
+/// [`from_bytes`](Self::from_bytes) / [`as_bytes`](Self::as_bytes); a wallet adapter converts at
+/// that boundary, and a store persists the bytes.
+///
+/// The token is not a secret: anything that can read the wallet database can read it. It exists so
+/// that one flow cannot release, or accidentally reuse, another's reservation, and so that a
+/// wallet can name the migration's own locks when it deliberately spends through them.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct MigrationLockOwner([u8; 32]);
+
+impl MigrationLockOwner {
+    /// Wrap raw token bytes, for a store reading a persisted lock owner back or a wallet adapter
+    /// converting from its own lock-owner type.
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// The raw token bytes, for a store persisting the lock owner or a wallet adapter converting to
+    /// its own lock-owner type.
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl From<[u8; 32]> for MigrationLockOwner {
+    fn from(bytes: [u8; 32]) -> Self {
+        Self::from_bytes(bytes)
+    }
+}
+
+impl From<MigrationLockOwner> for [u8; 32] {
+    fn from(owner: MigrationLockOwner) -> Self {
+        owner.0
+    }
+}
+
 /// One transaction of a committed migration: its pre-signed PCZT plus the metadata the consuming
 /// application needs to prove it against a fresh anchor, wait for its dependencies, broadcast it at
 /// its scheduled height, and track its state.
@@ -508,11 +549,15 @@ pub struct MigrationTransaction {
     /// `LockOwner::new()` round-trip) — carried here as an opaque `[u8; 32]` rather than the typed
     /// `LockOwner` because this `orchard`-gated engine module must not depend on
     /// `zcash_client_backend` (only `wallet`-feature code does); the conversion to/from `LockOwner`
-    /// happens at that boundary, not here. The migration flow does not yet acquire locks, so every
-    /// transaction the engine itself builds carries `None`; a store still round-trips whatever a
-    /// caller sets.
+    /// happens at that boundary, not here.
+    ///
+    /// Set when the transaction is PROVED: [`prove_transfer`] and [`prove_preparation`] ask the
+    /// prover to lock the notes the transaction spends ([`MigrationProver::lock_spent_notes`]) and
+    /// record the token it returns here, so a transaction holds a lock exactly while it is proved
+    /// and awaiting broadcast. A transaction that is merely built and signed carries `None`, as
+    /// does one proved by a prover that models no lock state.
     #[getset(get_copy = "pub")]
-    pub(crate) lock_owner: Option<[u8; 32]>,
+    pub(crate) lock_owner: Option<MigrationLockOwner>,
 }
 
 impl MigrationTransaction {
@@ -557,7 +602,7 @@ impl MigrationTransaction {
         anchor_boundary: Option<BlockHeight>,
         txid: TxId,
         state: MigrationTxState,
-        lock_owner: Option<[u8; 32]>,
+        lock_owner: Option<MigrationLockOwner>,
         unsatisfiable: Option<(BlockHeight, UnsatisfiableKind)>,
         spend_nullifiers: Vec<[u8; 32]>,
         broadcast_failure_at: Option<BlockHeight>,
@@ -876,18 +921,31 @@ impl MigrationState {
             .and_then(|crossing| self.crossing_values().get(crossing).copied())
     }
 
-    /// Replace transaction `id`'s stored PCZT with its proven bytes and move it to
-    /// [`Proved`](MigrationTxState::Proved), so the artifact becomes the proven,
-    /// ready-to-broadcast PCZT.
+    /// Replace transaction `id`'s stored PCZT with its proven bytes, record the lock owner its
+    /// spent notes were reserved under, and move it to [`Proved`](MigrationTxState::Proved), so
+    /// the artifact becomes the proven, ready-to-broadcast PCZT together with the token that
+    /// releases its reservation.
     ///
     /// In the production flow this is reached only through [`ProvedTransaction::apply`], inside
     /// [`PoolMigrationWrite::store_proved_transaction`]: the proof travels from the prove step to
     /// the store as a value, and the state records it in the same act that persists it.
-    pub fn set_transaction_proved(&mut self, id: MigrationTransferId, proven_pczt: Vec<u8>) {
+    ///
+    /// `lock_owner` is `None` when the prover took no locks
+    /// ([`MigrationProver::lock_spent_notes`]'s default). It is recorded in the same pass as the
+    /// proven bytes so a store write persists the artifact and its lock token together: a caller
+    /// that persists after proving can never end up with a proved transaction whose locks it can
+    /// no longer name.
+    pub fn set_transaction_proved(
+        &mut self,
+        id: MigrationTransferId,
+        proven_pczt: Vec<u8>,
+        lock_owner: Option<MigrationLockOwner>,
+    ) {
         for tx in &mut self.transactions {
             if tx.id() == id {
                 tx.pczt = proven_pczt;
                 tx.state = MigrationTxState::Proved;
+                tx.lock_owner = lock_owner;
                 break;
             }
         }
@@ -1691,6 +1749,11 @@ pub enum ProveOutcome {
 pub struct ProvedTransaction {
     id: MigrationTransferId,
     pczt: Vec<u8>,
+    /// The token the transaction's spent notes were reserved under at proving
+    /// ([`MigrationProver::lock_spent_notes`]), or `None` when the prover models no lock state.
+    /// Carried with the proof so the artifact and its reservation are recorded — and persisted —
+    /// in the same act.
+    lock_owner: Option<MigrationLockOwner>,
 }
 
 impl ProvedTransaction {
@@ -1704,12 +1767,18 @@ impl ProvedTransaction {
         &self.pczt
     }
 
-    /// Record this proof on `state`: the proven PCZT replaces the stored bytes and the
-    /// transaction becomes [`Proved`](MigrationTxState::Proved). This is the sole consumer of
-    /// the value, called by [`PoolMigrationWrite::store_proved_transaction`] implementations on
-    /// the state they are about to persist.
+    /// The token the transaction's notes were reserved under at proving, when locks were taken.
+    pub fn lock_owner(&self) -> Option<MigrationLockOwner> {
+        self.lock_owner
+    }
+
+    /// Record this proof on `state`: the proven PCZT replaces the stored bytes, the lock-owner
+    /// token is recorded beside it, and the transaction becomes
+    /// [`Proved`](MigrationTxState::Proved). This is the sole consumer of the value, called by
+    /// [`PoolMigrationWrite::store_proved_transaction`] implementations on the state they are
+    /// about to persist.
     pub fn apply(self, state: &mut MigrationState) {
-        state.set_transaction_proved(self.id, self.pczt);
+        state.set_transaction_proved(self.id, self.pczt, self.lock_owner);
     }
 
     /// Reassemble a proved transaction from its parts, for exercising a store's
@@ -1718,7 +1787,11 @@ impl ProvedTransaction {
     /// from [`prove_transfer`] / [`prove_preparation`].
     #[cfg(any(test, feature = "test-dependencies"))]
     pub fn from_parts(id: MigrationTransferId, pczt: Vec<u8>) -> Self {
-        Self { id, pczt }
+        Self {
+            id,
+            pczt,
+            lock_owner: None,
+        }
     }
 }
 
@@ -1798,6 +1871,46 @@ pub trait MigrationProver {
     /// mid-migration surfaces as [`ProveError::AnchorIntervalMismatch`] rather than as a bare
     /// missing checkpoint at witness-resolution time.
     fn anchor_bucket_interval(&self) -> crate::scheduling::AnchorBucketInterval;
+
+    /// Lock, on the wallet side, the notes `pczt` spends, so that ordinary note selection does not
+    /// hand them to another transaction while this one is proved and awaiting broadcast.
+    ///
+    /// [`prove_transfer`] and [`prove_preparation`] call this once the proof succeeds and record
+    /// the returned token on the transaction, so the window in which the locks are held is exactly
+    /// the window in which a broadcastable artifact exists that nothing else has yet invalidated:
+    /// a `Signed` transaction still has no proof and may never acquire one, and a `Broadcast` one
+    /// has already claimed its notes on the network.
+    ///
+    /// `pczt` is the transaction as STORED, with its witnesses still deferred, not the proven one
+    /// returned by the prove call. The two commit to the same spends, but an implementation that
+    /// picks out the real (non-padding) spends by their absent witnesses can only do so before
+    /// proving installs them.
+    ///
+    /// `lock_expiry_height` is the transaction's own
+    /// [`expiry_height`](MigrationTransaction::expiry_height): the notes are reserved for exactly
+    /// as long as the transaction that spends them can still be mined (ZIP 203), so a migration
+    /// that dies unbroadcast releases its claim on its own rather than stranding the balance.
+    ///
+    /// The locks are ADVISORY, which is what keeps the user in control: excluding them is only the
+    /// DEFAULT of note selection, and a wallet that wants to spend the migration's notes anyway
+    /// passes an owner-scoped override naming these tokens. The user is never blocked from
+    /// spending by a migration in flight; they are only steered away from it by default. The
+    /// migration discovers such a spend at its next prove or broadcast rather than being consulted
+    /// about it.
+    ///
+    /// Returns the opaque owner token the locks were taken under, recorded on the transaction as
+    /// [`MigrationTransaction::lock_owner`] so that a later cancel, or a restart, can release
+    /// exactly these locks. The default implementation takes no locks and returns `None`, which is
+    /// the correct behavior for a prover over a wallet that models no lock state (a test mock, or
+    /// a signing-only backend).
+    fn lock_spent_notes(
+        &mut self,
+        pczt: &pczt::Pczt,
+        lock_expiry_height: BlockHeight,
+    ) -> Result<Option<MigrationLockOwner>, Self::Error> {
+        let _ = (pczt, lock_expiry_height);
+        Ok(None)
+    }
 }
 
 /// Why committing a migration's preparation failed.
@@ -2121,7 +2234,14 @@ where
         _ => None,
     };
 
+    // Read before the PCZT parse ends the borrow of `tx`: the locks on the spent notes live
+    // exactly as long as the transaction that spends them can still be mined.
+    let lock_expiry_height = tx.expiry_height();
+
     let pczt = pczt::Pczt::parse(tx.pczt()).map_err(ProveError::Parse)?;
+    // Retained for the lock step below: proving installs the spend witnesses, which is exactly the
+    // marker `lock_spent_notes` reads to tell a real spend from a padding dummy.
+    let unproven = pczt.clone();
     let anchor_boundary = if let Some(fresh) = new_anchor_boundary {
         state.set_transfer_anchor_boundary(id, fresh);
         fresh
@@ -2131,8 +2251,19 @@ where
 
     match prover.prove_transfer(pczt, anchor_boundary) {
         Ok(proven) => {
+            // The reservation is taken only once a broadcastable artifact exists: a proof that
+            // fails takes no locks, and a lock that fails (a rival owner: another flow committed
+            // to one of these notes first) discards the proof and leaves the transaction
+            // `Signed`.
+            let lock_owner = prover
+                .lock_spent_notes(&unproven, lock_expiry_height)
+                .map_err(ProveError::Prover)?;
             let bytes = proven.serialize().map_err(ProveError::Serialize)?;
-            Ok(ProveOutcome::Proved(ProvedTransaction { id, pczt: bytes }))
+            Ok(ProveOutcome::Proved(ProvedTransaction {
+                id,
+                pczt: bytes,
+                lock_owner,
+            }))
         }
         Err(ProveFailure::InputNotAvailable { nullifier, as_of }) => {
             Ok(interpret_input_not_available(state, id, nullifier, as_of))
@@ -2252,11 +2383,29 @@ where
         return Err(ProveError::NotReady(id));
     }
 
+    // Read before the PCZT parse ends the borrow of `tx`: the locks on the spent notes live exactly
+    // as long as the preparation that spends them can still be mined.
+    let lock_expiry_height = tx.expiry_height();
+
     let pczt = pczt::Pczt::parse(tx.pczt()).map_err(ProveError::Parse)?;
+    // Retained for the lock step below: proving installs the spend witnesses, which is exactly the
+    // marker `lock_spent_notes` reads to tell a real spend from a padding dummy.
+    let unproven = pczt.clone();
     match prover.prove_preparation(pczt, anchor) {
         Ok(proven) => {
+            // The reservation is taken only once a broadcastable artifact exists: a proof that
+            // fails takes no locks, and a lock that fails (a rival owner: another flow committed
+            // to one of these notes first) discards the proof and leaves the transaction
+            // `Signed`.
+            let lock_owner = prover
+                .lock_spent_notes(&unproven, lock_expiry_height)
+                .map_err(ProveError::Prover)?;
             let bytes = proven.serialize().map_err(ProveError::Serialize)?;
-            Ok(ProveOutcome::Proved(ProvedTransaction { id, pczt: bytes }))
+            Ok(ProveOutcome::Proved(ProvedTransaction {
+                id,
+                pczt: bytes,
+                lock_owner,
+            }))
         }
         Err(ProveFailure::InputNotAvailable { nullifier, as_of }) => {
             Ok(interpret_input_not_available(state, id, nullifier, as_of))

--- a/zcash_pool_migration/src/testing/strategies.rs
+++ b/zcash_pool_migration/src/testing/strategies.rs
@@ -17,8 +17,8 @@ use zcash_protocol::value::testing::arb_zatoshis;
 
 use crate::denomination::DenominationPlan;
 use crate::engine::{
-    MigrationState, MigrationStatus, MigrationTransaction, MigrationTransferId, MigrationTxKind,
-    MigrationTxState,
+    MigrationLockOwner, MigrationState, MigrationStatus, MigrationTransaction, MigrationTransferId,
+    MigrationTxKind, MigrationTxState,
 };
 use crate::preparation::{PrepInput, PrepOutput, PrepTransaction, PreparationPlan};
 use crate::satisfiability::{ReplanThreshold, UnsatisfiableKind};
@@ -166,11 +166,9 @@ pub fn arb_migration_status() -> impl Strategy<Value = MigrationStatus> {
     ]
 }
 
-/// An arbitrary lock-owner token: `None` (no lock held) or the raw bytes of a
-/// `zcash_client_backend::wallet::LockOwner` (opaque here — this crate does not depend on
-/// `zcash_client_backend`).
-pub fn arb_lock_owner() -> impl Strategy<Value = Option<[u8; 32]>> {
-    prop::option::of(any::<[u8; 32]>())
+/// An arbitrary lock-owner token: `None` (no lock held) or an arbitrary [`MigrationLockOwner`].
+pub fn arb_lock_owner() -> impl Strategy<Value = Option<MigrationLockOwner>> {
+    prop::option::of(any::<[u8; 32]>().prop_map(MigrationLockOwner::from_bytes))
 }
 
 /// An arbitrary lifecycle state paired with a real-spend nullifier cache the state ADMITS.

--- a/zcash_pool_migration/src/wallet.rs
+++ b/zcash_pool_migration/src/wallet.rs
@@ -37,19 +37,23 @@ use ::pczt::roles::prover::Prover;
 use ::pczt::roles::updater::{AnchorUpdateError, SpendWitnessUpdateError, Updater};
 use zcash_client_backend::data_api::{
     Account as _, InputSource, WalletCommitmentTrees, WalletRead,
+    locking::{LockError, LockOwner, OutputLockStore},
     wallet::{
         TargetHeight,
         input_selection::{LockFilter, LockedInputPolicy},
     },
 };
+use zcash_client_backend::wallet::OutputRef;
 use zcash_keys::keys::UnifiedSpendingKey;
+use zcash_primitives::transaction::TxId;
 use zcash_primitives::transaction::builder::cached_orchard_proving_key;
-use zcash_protocol::{ShieldedPool, TxId, consensus::BlockHeight, value::Zatoshis};
+use zcash_protocol::{PoolType, ShieldedPool, consensus::BlockHeight, value::Zatoshis};
 
 use crate::build::{AccountDerivation, sign_pczt};
 use crate::engine::{
-    MigrationBackend, MigrationCrypto, MigrationProver, MigrationState, MigrationTransaction,
-    MigrationTransferId, MigrationTxState, PoolMigrationRead, PoolMigrationWrite, ProveFailure,
+    MigrationBackend, MigrationCrypto, MigrationLockOwner, MigrationProver, MigrationState,
+    MigrationTransaction, MigrationTransferId, MigrationTxState, PoolMigrationRead,
+    PoolMigrationWrite, ProveFailure,
 };
 use crate::pczt_spends::RealSpendError;
 use crate::satisfiability::{ReorgSettleDepth, StepSatisfiability};
@@ -375,7 +379,7 @@ where
 /// error type ([`InputSource::Error`]); `RE` is its chain-state error type
 /// ([`WalletRead::Error`]).
 #[derive(Debug)]
-pub enum WalletProveError<TE, NE, RE> {
+pub enum WalletProveError<TE, NE, RE, LE> {
     /// The PCZT presents no well-formed set of deferred-witness Orchard spends, so it is not a
     /// deferred-anchor migration transaction awaiting proof. See [`RealSpendError`].
     RealSpends(RealSpendError),
@@ -417,15 +421,27 @@ pub enum WalletProveError<TE, NE, RE> {
     /// types and `pczt` does not export the Ironwood one, so the failure is carried as a labeled
     /// diagnostic string rather than a typed value.
     Prove(alloc::string::String),
+    /// Reserving the notes this transaction spends failed, so it did not become `Proved`.
+    ///
+    /// [`LockError::LockFailure`] is the interesting case: the named note is already locked by a
+    /// DIFFERENT owner, so another flow (typically a user payment proposed while this transaction
+    /// was being proved) has committed to spending it. That is a conflict this transaction cannot
+    /// win, because the notes it spends were fixed by its signature. It is not necessarily fatal:
+    /// the other flow may release its lock or let it expire without broadcasting, in which case a
+    /// later proving attempt succeeds. It IS fatal once the other flow's transaction mines, which
+    /// the next attempt reports as [`Self::UnknownSpentNote`].
+    Lock(LockError<LE>),
 }
 
-impl<TE, NE, RE> From<ShardTreeError<TE>> for WalletProveError<TE, NE, RE> {
+impl<TE, NE, RE, LE> From<ShardTreeError<TE>> for WalletProveError<TE, NE, RE, LE> {
     fn from(e: ShardTreeError<TE>) -> Self {
         WalletProveError::Tree(e)
     }
 }
 
-impl<TE: fmt::Debug, NE: fmt::Debug, RE: fmt::Debug> fmt::Display for WalletProveError<TE, NE, RE> {
+impl<TE: fmt::Debug, NE: fmt::Debug, RE: fmt::Debug, LE: fmt::Debug> fmt::Display
+    for WalletProveError<TE, NE, RE, LE>
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             WalletProveError::RealSpends(e) => {
@@ -474,12 +490,18 @@ impl<TE: fmt::Debug, NE: fmt::Debug, RE: fmt::Debug> fmt::Display for WalletProv
             WalletProveError::Anchor(e) => write!(f, "installing an anchor failed: {e:?}"),
             WalletProveError::Witness(e) => write!(f, "installing a spend witness failed: {e:?}"),
             WalletProveError::Prove(msg) => write!(f, "creating a bundle proof failed: {msg}"),
+            WalletProveError::Lock(e) => {
+                write!(
+                    f,
+                    "reserving the notes this transaction spends failed: {e:?}"
+                )
+            }
         }
     }
 }
 
-impl<TE: fmt::Debug, NE: fmt::Debug, RE: fmt::Debug> core::error::Error
-    for WalletProveError<TE, NE, RE>
+impl<TE: fmt::Debug, NE: fmt::Debug, RE: fmt::Debug, LE: fmt::Debug> core::error::Error
+    for WalletProveError<TE, NE, RE, LE>
 {
 }
 
@@ -489,6 +511,7 @@ type ProverError<W> = WalletProveError<
     <W as WalletCommitmentTrees>::Error,
     <W as InputSource>::Error,
     <W as WalletRead>::Error,
+    <W as OutputLockStore>::Error,
 >;
 
 /// A wallet-backed prover for migration transactions: the mutable counterpart to [`WalletMigration`].
@@ -514,6 +537,57 @@ where
     fvk: FullViewingKey,
 }
 
+/// One deferred-witness Orchard spend of a migration transaction, resolved against the account's
+/// unspent notes: which action it is, where the note sits in the commitment tree (to witness it),
+/// and how the wallet refers to the note (to lock it).
+struct ResolvedSpend {
+    /// The index of the Orchard action this spend belongs to, as the PCZT `Updater` role addresses
+    /// it when installing the witness.
+    action_index: usize,
+    /// The spent note's position in the Orchard note commitment tree.
+    position: Position,
+    /// The spent note as the wallet's lock tables key it: the output its creating transaction
+    /// produced.
+    output: OutputRef,
+}
+
+/// The BLAKE2b personalization for [`migration_lock_owner`]. Sixteen bytes, as BLAKE2b requires.
+const LOCK_OWNER_PERSONALIZATION: &[u8; 16] = b"ZcashMigLockOwnr";
+
+/// Derive the lock-owner token for a migration transaction from the notes it spends.
+///
+/// The token is the BLAKE2b-256 hash of the transaction's spent-note references, sorted so the
+/// result does not depend on action order. Deriving it rather than drawing it at random makes it
+/// RECOVERABLE: the notes a transaction spends are fixed once it is signed, so a wallet that
+/// crashed between taking the locks and persisting the token can re-derive exactly the same token
+/// from the stored PCZT and release them. A random token would be lost with the crash, stranding
+/// the reservation until the lock expiry passed or the account's locks were cleared wholesale.
+///
+/// Distinct migration transactions spend disjoint note sets (each funding note is spent once), so
+/// distinct transactions get distinct tokens; and a 256-bit hash will not collide with the random
+/// tokens other flows use.
+fn migration_lock_owner(spends: &[ResolvedSpend]) -> MigrationLockOwner {
+    let mut refs: Vec<(TxId, u32)> = spends
+        .iter()
+        .map(|s| (*s.output.txid(), s.output.output_index()))
+        .collect();
+    refs.sort_unstable();
+    refs.dedup();
+
+    let mut hasher = blake2b_simd::Params::new()
+        .hash_length(32)
+        .personal(LOCK_OWNER_PERSONALIZATION)
+        .to_state();
+    for (txid, output_index) in refs {
+        hasher.update(txid.as_ref());
+        hasher.update(&output_index.to_le_bytes());
+    }
+
+    let mut bytes = [0u8; 32];
+    bytes.copy_from_slice(hasher.finalize().as_bytes());
+    MigrationLockOwner::from_bytes(bytes)
+}
+
 impl<'a, W> WalletMigrationProver<'a, W>
 where
     W: InputSource,
@@ -536,7 +610,7 @@ where
 
 impl<'a, W> WalletMigrationProver<'a, W>
 where
-    W: WalletCommitmentTrees + InputSource + WalletRead,
+    W: WalletCommitmentTrees + InputSource + WalletRead + OutputLockStore,
     <W as InputSource>::AccountId: Copy,
 {
     /// Prove one migration transaction's Orchard bundle (and its Ironwood bundle, when it has one)
@@ -550,22 +624,31 @@ where
     /// the wallet's standard note-selection target height (the chain tip, from
     /// [`WalletRead::get_target_and_anchor_heights`]), so a note already spent by a mined migration
     /// transaction is excluded from the candidate set.
-    fn prove_orchard(
-        &mut self,
-        pczt: ::pczt::Pczt,
-        anchor_height: BlockHeight,
-    ) -> Result<::pczt::Pczt, ProverError<W>> {
+    /// Locate every deferred-witness Orchard spend of `pczt` among the account's unspent notes.
+    ///
+    /// Each such spend reveals a nullifier; recomputing every unspent note's nullifier under the
+    /// account's full viewing key identifies which note it spends, yielding both the tree position
+    /// the witness is taken at and the reference the wallet locks the note by. Shared by
+    /// [`prove_orchard`](Self::prove_orchard) and
+    /// [`lock_spent_notes`](MigrationProver::lock_spent_notes), which need the two halves of the
+    /// same lookup.
+    ///
+    /// Notes are selected at the wallet's standard note-selection target height (the chain tip,
+    /// from [`WalletRead::get_target_and_anchor_heights`]), so a note already spent by a mined
+    /// migration transaction is excluded from the candidate set and its spend is reported as
+    /// [`WalletProveError::UnknownSpentNote`] rather than silently resolved. Only the target is
+    /// needed; `min_confirmations` bounds only the (unused) anchor height, so the minimum is
+    /// passed to avoid a spurious absence near genesis.
+    ///
+    /// Lock state is deliberately NOT filtered ([`LockFilter::Unfiltered`]): this resolves notes
+    /// the transaction already commits to spending rather than choosing new ones, so a note locked
+    /// by this very transaction's earlier proof attempt, or by any other flow, must still be found.
+    fn resolve_spends(&self, pczt: &::pczt::Pczt) -> Result<Vec<ResolvedSpend>, ProverError<W>> {
         // Every Orchard action whose witness is still deferred is a real spend to witness; the padded
         // dummy spends keep their (arbitrary) witnesses from build time (ZIP 374).
-        let real_spends: Vec<(usize, Nullifier)> = crate::pczt_spends::real_spend_nullifiers(&pczt)
+        let real_spends: Vec<(usize, Nullifier)> = crate::pczt_spends::real_spend_nullifiers(pczt)
             .map_err(WalletProveError::RealSpends)?;
 
-        // Locate each spend in the wallet's note store: map every unspent Orchard note's nullifier
-        // (recomputed under the account FVK) to its commitment-tree position, then look up each spend.
-        // Select notes at the wallet's standard note-selection target height (the chain tip), not the
-        // witness anchor, so a note already spent by a mined migration transaction is excluded from
-        // consideration. Only the target is needed here; `min_confirmations` bounds only the (unused)
-        // anchor height, so the minimum is passed to avoid a spurious absence near genesis.
         let (target, _anchor) = self
             .wallet
             .get_target_and_anchor_heights(NonZeroU32::MIN)
@@ -581,25 +664,47 @@ where
                 LockFilter::Unfiltered,
             )
             .map_err(WalletProveError::Notes)?;
-        let positions: BTreeMap<Nullifier, Position> = received
+        let by_nullifier: BTreeMap<Nullifier, (Position, OutputRef)> = received
             .orchard()
             .iter()
             .map(|rn| {
+                let output = OutputRef::new(
+                    *rn.txid(),
+                    PoolType::Shielded(ShieldedPool::Orchard),
+                    rn.output_index().into(),
+                );
                 (
                     rn.note().nullifier(&self.fvk),
-                    rn.note_commitment_tree_position(),
+                    (rn.note_commitment_tree_position(), output),
                 )
             })
             .collect();
-        let spend_positions: Vec<(usize, Position)> = real_spends
+
+        real_spends
             .iter()
-            .map(|(index, nf)| {
-                positions
+            .map(|(action_index, nf)| {
+                by_nullifier
                     .get(nf)
-                    .map(|pos| (*index, *pos))
+                    .map(|(position, output)| ResolvedSpend {
+                        action_index: *action_index,
+                        position: *position,
+                        output: *output,
+                    })
                     .ok_or(WalletProveError::UnknownSpentNote(*nf))
             })
-            .collect::<Result<_, _>>()?;
+            .collect()
+    }
+
+    fn prove_orchard(
+        &mut self,
+        pczt: ::pczt::Pczt,
+        anchor_height: BlockHeight,
+    ) -> Result<::pczt::Pczt, ProverError<W>> {
+        let spend_positions: Vec<(usize, Position)> = self
+            .resolve_spends(&pczt)?
+            .into_iter()
+            .map(|s| (s.action_index, s.position))
+            .collect();
 
         // A transfer carries an Ironwood output bundle; a preparation transaction is Orchard-only.
         let has_ironwood = !pczt.ironwood().actions().is_empty();
@@ -726,7 +831,7 @@ where
 
 impl<'a, W> MigrationProver for WalletMigrationProver<'a, W>
 where
-    W: WalletCommitmentTrees + InputSource + WalletRead,
+    W: WalletCommitmentTrees + InputSource + WalletRead + OutputLockStore,
     <W as InputSource>::AccountId: Copy,
 {
     type Error = ProverError<W>;
@@ -752,6 +857,40 @@ where
     /// (by then pruned) checkpoint is looked up.
     fn anchor_bucket_interval(&self) -> AnchorBucketInterval {
         self.wallet.anchor_retention_interval()
+    }
+
+    /// Lock the account's notes that this proven transaction spends, under a token derived from
+    /// those very notes ([`migration_lock_owner`]), until `lock_expiry_height`.
+    ///
+    /// Locking is all-or-nothing at the storage layer, and re-locking under the same owner is
+    /// idempotent, so re-proving a transaction (after a crash, or a rebuild that reuses the same
+    /// funding note) simply extends its own locks rather than failing.
+    ///
+    /// A note already locked by a DIFFERENT owner means another flow has committed to spending it,
+    /// most likely a user payment created while this transaction was being proved. That is a real
+    /// conflict this transaction cannot win: the notes it spends are fixed by its signature, so
+    /// the failure is surfaced as [`WalletProveError::InputsLocked`] and the transaction stays
+    /// `Signed`. The proof just computed is discarded, which is the correct trade: the user's
+    /// payment takes precedence, and a proof over a note the wallet has promised elsewhere is
+    /// worth nothing.
+    fn lock_spent_notes(
+        &mut self,
+        pczt: &::pczt::Pczt,
+        lock_expiry_height: BlockHeight,
+    ) -> Result<Option<MigrationLockOwner>, Self::Error> {
+        let spends = self.resolve_spends(pczt)?;
+        let owner = migration_lock_owner(&spends);
+        let outputs: Vec<OutputRef> = spends.iter().map(|s| s.output).collect();
+
+        self.wallet
+            .lock_outputs(
+                &outputs,
+                LockOwner::new(*owner.as_bytes()),
+                lock_expiry_height,
+            )
+            .map_err(WalletProveError::Lock)?;
+
+        Ok(Some(owner))
     }
 }
 

--- a/zcash_pool_migration/src/wallet.rs
+++ b/zcash_pool_migration/src/wallet.rs
@@ -860,7 +860,7 @@ where
     }
 
     /// Lock the account's notes that this proven transaction spends, under a token derived from
-    /// those very notes ([`migration_lock_owner`]), until `lock_expiry_height`.
+    /// those very notes, until `lock_expiry_height`.
     ///
     /// Locking is all-or-nothing at the storage layer, and re-locking under the same owner is
     /// idempotent, so re-proving a transaction (after a crash, or a rebuild that reuses the same
@@ -869,7 +869,7 @@ where
     /// A note already locked by a DIFFERENT owner means another flow has committed to spending it,
     /// most likely a user payment created while this transaction was being proved. That is a real
     /// conflict this transaction cannot win: the notes it spends are fixed by its signature, so
-    /// the failure is surfaced as [`WalletProveError::InputsLocked`] and the transaction stays
+    /// the failure is surfaced as [`WalletProveError::Lock`] and the transaction stays
     /// `Signed`. The proof just computed is discarded, which is the correct trade: the user's
     /// payment takes precedence, and a proof over a note the wallet has promised elsewhere is
     /// worth nothing.

--- a/zcash_pool_migration/tests/engine_commit.rs
+++ b/zcash_pool_migration/tests/engine_commit.rs
@@ -375,7 +375,7 @@ fn advance_promotes_a_proved_transaction_whose_broadcast_was_never_recorded() {
             .pczt(),
     )
     .expect("the stored PCZT yields its txid");
-    state.set_transaction_proved(victim, state.transactions()[0].pczt().to_vec());
+    state.set_transaction_proved(victim, state.transactions()[0].pczt().to_vec(), None);
     assert_eq!(
         state
             .transactions()


### PR DESCRIPTION
**Taken over and reworked** per the cancel-stack design (plan D7); now stacked on #2923 (B2) ← #2921 (B1) ← #2914 (A). The original two-part design ("a migration reserves the notes it commits to, and the user always wins a conflict over them") survives intact in Part 1; Part 2 (cancel-on-conflict) moves to the Phase C PR that follows, where it merges with the user-initiated cancel as one function.

## Part 1 (original work, rebased): advisory locks at prove

`prove_transfer` / `prove_preparation` lock the transaction's spent notes via `MigrationProver::lock_spent_notes` once the proof succeeds, under a token derived (BLAKE2b-256 over the sorted spent-note refs — crash-recoverable, idempotent re-lock) and expiring at the transaction's own `expiry_height` (exact ZIP 203 alignment). Locks are advisory: default note selection steers away; a `LockedInputPolicy` override reaches every reserved note; a rival lock fails the prove and discards the proof. Ported onto the current engine: the token now rides `ProvedTransaction` so the artifact and its reservation are recorded in one act, and the lock step lives inside the `ProveOutcome` flow (no lock is taken on a `NotYetProvable`/`MarkedUnsatisfiable` answer).

## Part 2 (new): the wallet record binds at BROADCAST, not prove

Store-at-prove served the activity view but dragged in hard spend marks — freezing the migration's input notes out of the user's balance for the whole prove-to-broadcast window (days to weeks under ZIP 318), against the rule that the user always has full access to their funds. With locks as the reservation:

- `store_proved_transaction` records the proof in the migration store alone.
- New **`take_transaction_for_broadcast`** finalizes the proved PCZT, records the wallet-side transaction (sent outputs, spend marks, status-queue entry), and returns the broadcastable bytes in one database transaction — **binding at the attempt**, so a consumer that dies mid-submit has already left the record the `Proved`-row promotion sweep relies on. Moving the record also moves the `queue_tx_status` enqueue, closing a live privacy leak: the wallet previously asked lightwalletd about txids that had never been broadcast.
- A **backfill schema migration** removes the wallet records earlier releases wrote at prove for never-broadcast transactions of TERMINAL migrations (including the rows the SDK's hand-rolled `Failed`-as-cancel left in the field); pending migrations' records are kept and recreated at broadcast.

**Known follow-up, deliberately not in this PR**: pending migration transactions no longer appear in `v_transactions` before broadcast; the planned restoration is a view union over the migration store's own tables (which can show the whole committed schedule, not just the proved prefix).

---

Filed with Claude Code assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Gsndy5ri9eYvtH31DnHTQ
