### PR TITLE
Document the changelog policy in CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -558,7 +558,10 @@ artifacts of a development session, not repository history. Never commit them.
 ## Changelog & Commit Discipline
 
 - Update the crate's `CHANGELOG.md` for any public API change, bug fix, or
-  semantic change. CHANGELOG updates must **only** reflect completed changes.
+  semantic change. This includes updating the version of a dependency whose
+  types appear in the public API: types from two semver-incompatible versions
+  of a crate do not unify, so a consumer must upgrade that dependency in
+  lockstep. CHANGELOG updates must **only** reflect completed changes.
   since the last release, and never interstitial changes in APIs that have been
   changed multiple times since the last release. The CHANGELOG entry **MUST** be
   part of the commit that makes the API change. For newly added crates, the CHANGELOG
@@ -567,12 +570,12 @@ artifacts of a development session, not repository history. Never commit them.
   provide **only** the information needed for end users to adapt to API changes, and
   **never** describe implementation details or contracts that are not visible to
   a user of the public API.
-- **Never modify a CHANGELOG entry under an already-published version heading**
-  (a released `## [x.y.z] - DATE` section). Those entries are the historical
-  record of what that release shipped; they must not be altered, even to add a
-  clarification, note a later re-export, or fix a detail. Anything a user needs
-  to adapt to a new change belongs in the `## [Unreleased]` section, never
-  edited into a past release.
+- **A CHANGELOG entry under an already-published version heading** (a released
+  `## [x.y.z] - DATE` section) is the historical record of what that release
+  shipped. Correct such an entry only when it was inaccurate as written; never
+  edit it to record something that happened after the release, such as a
+  clarification or a later re-export. Anything a user needs in order to adapt
+  to a new change belongs in the `## [Unreleased]` section.
 - Commits must be discrete semantic changes — no WIP commits in final PR history.
 - Each commit that alters public API must also update docs and changelog in the same commit.
 - Use `git revise` to maintain clean history within a PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,8 +265,10 @@ to aid with PR stacking.
 - We have a strong preference for a clean commit history. We will actively
   rebase PRs to squash changes (such as bugfixes or responses to review
   comments) into the relevant earlier commits on the PR branch. We recommend
-  the use of the `git revise` tool to help maintain such a clean history within
-  the context of a single PR.
+  the use of the [git revise](https://github.com/mystor/git-revise) tool, which
+  is **extremely** useful for applying a review comment to the commit it
+  concerns, to help maintain such a clean history within the context of a
+  single PR.
 - When a commit alters the public API, fixes a bug, or changes the underlying
   semantics of existing code, the commit MUST also modify the affected
   crates' `CHANGELOG.md` files to clearly document the change. See
@@ -309,8 +311,11 @@ To get around this GitHub UI limitation, the general process we follow is:
   the PR, they avoid rebasing or force-pushing.
 - The PR author adjusts the branch as necessary to address any comments. They
   may always add new commits. If `S-please-do-not-rebase` is not present then
-  they can also force-push or rebase previous commits. In any case they push
-  the result to the branch.
+  they can also force-push or rebase previous commits; in that case, applying
+  each change to the commit that introduced the code under discussion is
+  preferred over accumulating separate "addressed review comments" commits, as
+  described under [Branch History](#branch-history). In any case they push the
+  result to the branch.
 - In cases where it is likely to aid reviewers, the PR author also posts a
   comment to the PR with a diff link between the previous branch tip and the
   new branch tip. When submitting a review for a PR, reviewers note the commit
@@ -360,26 +365,16 @@ the old PR.
   the commit message to include everyone who is responsible for the contents of
   the commit; this is important for determining who has the most complete
   understanding of the changes.
-
-#### Pull Request Review
-
-- It is acceptable and desirable to use a rebase-based workflow within the
-  context of a single pull request in order to produce a clean commit history.
-  Two important points:
-  - When changes are requested in pull request review, it is desirable to apply
-    those changes to the affected commit in order to avoid excessive noise in the
-    commit history. The [git revise](https://github.com/mystor/git-revise) plugin
-    is **extremely** useful for this purpose.
-  - If a maintainer or other user uses the GitHub `suggestion` feature to
-    suggest explicit code changes, it's usually best to accept those changes
-    via the "Apply Suggested Changes" GitHub workflow, and then to amend the
-    resulting commit to fix any related compilation or test errors or
-    formatting/lint-related changes; this ensures that correct co-author
-    metadata is included in the commit. If the changes are substantial enough
-    that it makes more sense to rewrite the original commit, make sure to
-    include co-author metadata in the commit message when doing so (squashing
-    the GitHub-generate suggestion acceptance commit(s) together with the
-    original commit in an interactive rebase can make this easy).
+- If a maintainer or other user uses the GitHub `suggestion` feature to suggest
+  explicit code changes, it's usually best to accept those changes via the
+  "Apply Suggested Changes" GitHub workflow, and then to amend the resulting
+  commit to fix any related compilation or test errors or formatting/lint-related
+  changes; this ensures that correct co-author metadata is included in the
+  commit. If the changes are substantial enough that it makes more sense to
+  rewrite the original commit, make sure to include co-author metadata in the
+  commit message when doing so (squashing the GitHub-generated suggestion
+  acceptance commit(s) together with the original commit in an interactive
+  rebase can make this easy).
 
 ### Changelog Entries
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ contributions. 🎉
 - [Suggesting Enhancements](#suggesting-enhancements)
 - [Styleguides](#styleguides)
 - [Git Usage](#git-usage)
+- [Changelog Entries](#changelog-entries)
 - [Coding Style](#coding-style)
 
 ## Code of Conduct
@@ -268,7 +269,8 @@ to aid with PR stacking.
   the context of a single PR.
 - When a commit alters the public API, fixes a bug, or changes the underlying
   semantics of existing code, the commit MUST also modify the affected
-  crates' `CHANGELOG.md` files to clearly document the change.
+  crates' `CHANGELOG.md` files to clearly document the change. See
+  [Changelog Entries](#changelog-entries) for what belongs in those entries.
 - Updated or added members of the public API MUST include complete `rustdoc`
   documentation comments.
 - It is acceptable and desirable to open pull requests in "Draft" status. Only
@@ -378,6 +380,75 @@ the old PR.
     include co-author metadata in the commit message when doing so (squashing
     the GitHub-generate suggestion acceptance commit(s) together with the
     original commit in an interactive rebase can make this easy).
+
+### Changelog Entries
+
+Each crate maintains its own `CHANGELOG.md`. These files are how downstream
+users discover what they must do in order to upgrade, so we hold them to the
+same standard as the code.
+
+An entry is required for any change to a crate's public API, any bug fix, and
+any change to the semantics of existing behavior — including changes that leave
+type signatures untouched but alter what a caller can expect, such as stricter
+validation, different equality or ordering semantics, or a previously fixed
+value becoming configurable. An update to the version of a dependency whose
+types appear in the public API requires an entry as well: types from two
+semver-incompatible versions of a crate do not unify, so a consumer has to
+upgrade that dependency in lockstep. Privacy, security, and cost properties of
+a public API count as user-facing in this sense even when they are documented
+only in code comments. A crate that has never been released is the exception:
+its changelog should contain only a line recording the initial release.
+
+#### The entry accompanies the change
+
+The entry MUST be part of the same commit that makes the change it describes,
+not a separate "update changelogs" commit at the end of a branch. A public API
+change is not a complete semantic change until the documentation of it exists,
+and keeping the two together means the entry travels with the commit when it is
+cherry-picked or forward-merged. If you have already committed the code, use
+`git revise` to fold the entry into that commit rather than appending a
+follow-up.
+
+#### Entries describe the change since the last release
+
+An entry describes the difference between the **last released version of the
+crate** and the state your change produces — not the difference from the
+previous commit, and not the difference from whatever the affected function
+last looked like.
+
+This matters whenever an API is touched more than once between releases, which
+is common in a stacked-PR workflow. An unreleased API introduced under one name
+and renamed before release yields a single entry naming the final name; the
+intermediate name was never visible to a user. An API added and then removed
+again before release leaves no entry at all. Update an existing
+`## [Unreleased]` entry in place to reflect the new net state rather than
+adding a second entry describing the delta from the first.
+
+The reference point is the last release *on the branch you are targeting*: a
+fix branched from a `maint/` branch describes its change relative to that
+branch's most recent release, which may be older than the most recent release
+on `main`.
+
+#### Entries are written for users
+
+An entry carries only what a consumer of the public API needs in order to
+adapt. `Added` entries are pointers — name the new item and let its `rustdoc`
+explain it. `Changed` entries say what a caller must do differently.
+Implementation details, internal refactors, test-fixture reworks, and contracts
+that are not observable through the public API do not belong in a changelog at
+all.
+
+#### Published sections record what shipped
+
+A released `## [x.y.z] - DATE` section is the historical record of what that
+release shipped. Correct an entry there if it was wrong when written — an
+inaccurate record is worse than an edited one — but do not use it to record
+anything that happened afterwards, such as a later re-export or a clarification
+prompted by a subsequent change. That belongs under `## [Unreleased]`, where
+the users who need it will look.
+
+The `## [Unreleased]` heading itself is permanent: it stays at the top of the
+file even when it is empty following a release.
 
 ### Coding Style
 


### PR DESCRIPTION
Documents the changelog policy in `CONTRIBUTING.md`. It was previously stated
only in `AGENTS.md`, which is addressed to AI coding agents; a human
contributor reading `CONTRIBUTING.md` found just a single bullet under "Branch
History" requiring that a commit altering the public API also update the
changelog, with nothing about what the entry should contain.

The new "Changelog Entries" section covers when an entry is required, that it
must ride in the same commit as the change it describes, that it describes the
difference from the last *release* rather than from the previous commit, what
an entry should and should not contain, and how already-published sections are
treated.

The first commit adjusts two of the `AGENTS.md` directives that the section
reproduces:

- The prohibition on editing a released `## [x.y.z] - DATE` section was
  absolute, which left an entry that was inaccurate when written permanently
  inaccurate. It now permits correcting such an entry, while continuing to
  prohibit recording post-release developments there.
- A version bump to a dependency whose types appear in the public API now
  requires an entry, since types from two semver-incompatible versions of a
  crate do not unify and a consumer has to upgrade that dependency in lockstep.

The third commit resolves the duplicate `#### Pull Request Review` headings.
The second of the two held one point that restated the "Branch History"
preference for folding a review response into the commit it concerns, and one
about preserving co-author metadata when accepting a GitHub `suggestion`. Both
are merged into the sections that already own those topics rather than renamed
in place, so the `git revise` recommendation now appears once.

Closes #1890

No crate's public API is affected, so there are no `CHANGELOG.md` entries.

---
🤖 Filed with [Claude Code](https://claude.com/claude-code) assistance.
