### PR TITLE
zcash_client_backend: Implement Debug, Display and Error for BirthdayError

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -12,6 +12,8 @@ workspace.
 
 ### Added
 - `impl Debug for zcash_client_backend::data_api::ll::wallet::PutBlocksError`
+- `zcash_client_backend::data_api::BirthdayError` now implements `Debug`,
+  `Display` and `std::error::Error`.
 - `zcash_client_backend::tor::Timeouts`
 - `zcash_client_backend::tor::Client::create_with_timeouts`
 - `zcash_client_backend::tor::http::TimeoutPhase`

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -66,7 +66,7 @@ use nonempty::NonEmpty;
 use secrecy::SecretVec;
 use std::{
     collections::{HashMap, HashSet},
-    fmt::Debug,
+    fmt::{self, Debug},
     hash::Hash,
     io,
     num::{NonZeroU32, TryFromIntError},
@@ -3154,10 +3154,36 @@ pub struct AccountBirthday {
 }
 
 /// Errors that can occur in the construction of an [`AccountBirthday`] from a [`TreeState`].
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum BirthdayError {
+    /// The block height of the [`TreeState`] was out of range for a [`BlockHeight`].
     HeightInvalid(TryFromIntError),
+    /// The note commitment tree frontiers of the [`TreeState`] could not be decoded.
     Decode(io::Error),
+}
+
+impl fmt::Display for BirthdayError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BirthdayError::HeightInvalid(e) => {
+                write!(f, "Invalid block height for account birthday: {e}")
+            }
+            BirthdayError::Decode(e) => write!(
+                f,
+                "Failed to decode the note commitment tree state for the account birthday: {e}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for BirthdayError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            BirthdayError::HeightInvalid(e) => Some(e),
+            BirthdayError::Decode(e) => Some(e),
+        }
+    }
 }
 
 impl From<TryFromIntError> for BirthdayError {


### PR DESCRIPTION
`data_api::BirthdayError` is `#[non_exhaustive]` but implemented none of
`Debug`, `Display` or `std::error::Error`, so the wildcard arm that every
consumer must now write when matching the result of
`AccountBirthday::from_treestate` had nothing it could report — neither `{}`
nor `{:?}` compiled.

This adds `#[derive(Debug)]`, a `Display` impl that interpolates the inner
error into a message naming the stage that failed, and an `Error` impl whose
`source()` returns the inner `TryFromIntError` / `io::Error`. Consumers can
then surface unrecognized variants faithfully, and the type flows through
`anyhow`/`thiserror` without a hand-written bridge. Variant docs and a
CHANGELOG entry are included.

`std::error::Error` is referred to by its full path because `data_api` already
has a child module named `error`.

Closes #2803

---
Prepared with Claude Code assistance.
