### PR TITLE
zcash_client_sqlite: flag previously-received Ironwood notes as change

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -37,8 +37,8 @@ workspace.
   `received_note_count` and `sent_note_count` rather than reporting `has_change`,
   and `v_tx_outputs` reported the account's own change as a non-change output,
   which presents it to the user as a recipient of their own transaction. Balances
-  were not affected. Notes already recorded with the wrong classification are not
-  repaired by this change; a rescan of the affected range is required.
+  were not affected. Notes already recorded with the wrong classification are
+  repaired on upgrade by a new migration; no rescan is required.
 
 ## [0.22.0-rc.4] - 2026-07-26
 

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -28,6 +28,18 @@ workspace.
   `wallet::commitment_tree::Error`, `wallet::init::WalletMigrationError`, and
   `zewif::ZewifImportError`.
 
+### Fixed
+- An Ironwood note received on an account's internal address is now classified as
+  change once the wallet learns that the same account funded the transaction.
+  This was previously applied to Sapling and Orchard notes only, so an Ironwood
+  note recorded before its transaction's spends could be linked to the wallet
+  kept the wrong classification permanently: `v_transactions` counted it in
+  `received_note_count` and `sent_note_count` rather than reporting `has_change`,
+  and `v_tx_outputs` reported the account's own change as a non-change output,
+  which presents it to the user as a recipient of their own transaction. Balances
+  were not affected. Notes already recorded with the wrong classification are not
+  repaired by this change; a rescan of the affected range is required.
+
 ## [0.22.0-rc.4] - 2026-07-26
 
 ### Changed

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -5322,9 +5322,16 @@ fn flag_previously_received_change(
         .map_err(SqliteClientError::from)
     };
 
+    // Every pool with a `{prefix}_received_notes` table must appear here. Omitting one is not
+    // merely a missed opportunity to set the flag at this call: `is_change` is only ever
+    // raised, never lowered, and nothing revisits the row afterwards, so for any note whose
+    // spends were not linkable to the wallet at the time it was scanned the omission is
+    // permanent.
     flag_received_change(ShieldedPool::Sapling)?;
     #[cfg(feature = "orchard")]
     flag_received_change(ShieldedPool::Orchard)?;
+    #[cfg(feature = "orchard")]
+    flag_received_change(ShieldedPool::Ironwood)?;
 
     Ok(())
 }
@@ -5798,7 +5805,7 @@ pub mod testing {
 mod tests {
     use std::num::NonZeroU32;
 
-    use rusqlite::Connection;
+    use rusqlite::{Connection, named_params};
     use sapling::zip32::ExtendedSpendingKey;
     use secrecy::{ExposeSecret, SecretVec};
     use uuid::Uuid;
@@ -5817,7 +5824,10 @@ mod tests {
         testing::{BlockCache, db::TestDbFactory},
     };
 
-    use super::{account_birthday, min_shared_checkpoint_height, select_truncation_height};
+    use super::{
+        KeyScope, ShieldedPool, TxRef, account_birthday, flag_previously_received_change,
+        min_shared_checkpoint_height, select_truncation_height,
+    };
 
     #[cfg(feature = "orchard")]
     use {crate::testing::db::TestDb, zcash_protocol::local_consensus::LocalNetwork};
@@ -7135,6 +7145,225 @@ mod tests {
         assert_eq!(
             table_row_count(st.wallet().conn(), "ironwood_tree_shards"),
             0
+        );
+    }
+
+    /// The name of the received-note table for a pool, written out rather than derived from
+    /// `table_constants`, so that these tests do not assert through the same mapping the code
+    /// under test uses.
+    fn received_notes_table(pool: ShieldedPool) -> &'static str {
+        match pool {
+            ShieldedPool::Sapling => "sapling_received_notes",
+            #[cfg(feature = "orchard")]
+            ShieldedPool::Orchard => "orchard_received_notes",
+            #[cfg(feature = "orchard")]
+            ShieldedPool::Ironwood => "ironwood_received_notes",
+            #[cfg(not(feature = "orchard"))]
+            other => panic!("pool {other:?} is unsupported without the `orchard` feature"),
+        }
+    }
+
+    /// Reproduces the state a wallet is left in when it scans a note before it can link the
+    /// transaction's spends to itself: one transaction, one received note recorded with
+    /// `is_change = 0` under `key_scope`, and one `sent_notes` row recording that
+    /// `funding_account` paid for the transaction.
+    ///
+    /// Returns the row id of the transaction.
+    fn seed_unflagged_received_note(
+        conn: &rusqlite::Connection,
+        pool: ShieldedPool,
+        receiving_account: i64,
+        funding_account: i64,
+        key_scope: KeyScope,
+    ) -> i64 {
+        // Placeholders for columns the repair statement never reads. They exist only to
+        // satisfy the tables' NOT NULL constraints, so any well-formed value will do.
+        const TX_ROW_ID: i64 = 1;
+        const TXID: [u8; 32] = [7; 32];
+        const OBSERVED_HEIGHT: i64 = 0;
+        const OUTPUT_INDEX: i64 = 0;
+        const DIVERSIFIER: [u8; 11] = [0; 11];
+        const NOTE_VALUE_ZATS: i64 = 1;
+        const NOTE_COMPONENT: [u8; 32] = [0; 32];
+        // `orchard_received_notes.note_version` defaults, but the Ironwood column does not,
+        // so it is supplied explicitly for both.
+        #[cfg(feature = "orchard")]
+        const NOTE_VERSION: i64 = 2;
+        // The pool a `sent_notes` row is attributed to is irrelevant here: the repair
+        // statement correlates on transaction and account only.
+        const SENT_OUTPUT_POOL: i64 = 0;
+
+        conn.execute(
+            "INSERT INTO transactions (id_tx, txid, min_observed_height)
+             VALUES (:id_tx, :txid, :min_observed_height)",
+            named_params! {
+                ":id_tx": TX_ROW_ID,
+                ":txid": &TXID[..],
+                ":min_observed_height": OBSERVED_HEIGHT,
+            },
+        )
+        .unwrap();
+
+        match pool {
+            ShieldedPool::Sapling => {
+                conn.execute(
+                    "INSERT INTO sapling_received_notes
+                     (transaction_id, output_index, account_id, diversifier, value, rcm,
+                      is_change, recipient_key_scope)
+                     VALUES (:tx, :output_index, :account, :diversifier, :value,
+                             :note_component, :is_change, :key_scope)",
+                    named_params! {
+                        ":tx": TX_ROW_ID,
+                        ":output_index": OUTPUT_INDEX,
+                        ":account": receiving_account,
+                        ":diversifier": &DIVERSIFIER[..],
+                        ":value": NOTE_VALUE_ZATS,
+                        ":note_component": &NOTE_COMPONENT[..],
+                        ":is_change": false,
+                        ":key_scope": key_scope.encode(),
+                    },
+                )
+                .unwrap();
+            }
+            // Ironwood notes are Orchard-shaped, so the two tables take the same columns.
+            #[cfg(feature = "orchard")]
+            ShieldedPool::Orchard | ShieldedPool::Ironwood => {
+                conn.execute(
+                    &format!(
+                        "INSERT INTO {} (transaction_id, action_index, account_id, diversifier,
+                                         value, rho, rseed, note_version, is_change,
+                                         recipient_key_scope)
+                         VALUES (:tx, :output_index, :account, :diversifier, :value,
+                                 :note_component, :note_component, :note_version, :is_change,
+                                 :key_scope)",
+                        received_notes_table(pool)
+                    ),
+                    named_params! {
+                        ":tx": TX_ROW_ID,
+                        ":output_index": OUTPUT_INDEX,
+                        ":account": receiving_account,
+                        ":diversifier": &DIVERSIFIER[..],
+                        ":value": NOTE_VALUE_ZATS,
+                        ":note_component": &NOTE_COMPONENT[..],
+                        ":note_version": NOTE_VERSION,
+                        ":is_change": false,
+                        ":key_scope": key_scope.encode(),
+                    },
+                )
+                .unwrap();
+            }
+            #[cfg(not(feature = "orchard"))]
+            other => panic!("pool {other:?} is unsupported without the `orchard` feature"),
+        }
+
+        conn.execute(
+            "INSERT INTO sent_notes
+             (transaction_id, output_pool, output_index, from_account_id, value)
+             VALUES (:tx, :output_pool, :output_index, :from_account, :value)",
+            named_params! {
+                ":tx": TX_ROW_ID,
+                ":output_pool": SENT_OUTPUT_POOL,
+                ":output_index": OUTPUT_INDEX,
+                ":from_account": funding_account,
+                ":value": NOTE_VALUE_ZATS,
+            },
+        )
+        .unwrap();
+
+        TX_ROW_ID
+    }
+
+    fn only_account_id(conn: &rusqlite::Connection) -> i64 {
+        conn.query_row("SELECT id FROM accounts", [], |row| row.get::<_, i64>(0))
+            .unwrap()
+    }
+
+    fn is_change(conn: &rusqlite::Connection, pool: ShieldedPool) -> bool {
+        conn.query_row(
+            &format!("SELECT is_change FROM {}", received_notes_table(pool)),
+            [],
+            |row| row.get::<_, bool>(0),
+        )
+        .unwrap()
+    }
+
+    /// A note received on the account's internal address, in a transaction that same account
+    /// funded, is change. The wallet cannot always know this when the note is first recorded,
+    /// because linking the transaction's spends requires the spent notes to already be
+    /// present, so `flag_previously_received_change` back-fills the classification when the
+    /// `sent_notes` rows are written.
+    ///
+    /// This must hold for every pool that has a received-note table. A pool left out of the
+    /// repair keeps the wrong classification forever, since `is_change` is only ever raised
+    /// and nothing revisits the row: the note is then reported as an ordinary received output
+    /// by `v_transactions` and `v_tx_outputs`, which surfaces the account's own change to the
+    /// user as a recipient of their own transaction.
+    fn assert_internal_scope_note_becomes_change(pool: ShieldedPool) {
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let account_id = only_account_id(st.wallet().conn());
+        let tx = st.wallet_mut().conn_mut().transaction().unwrap();
+
+        let tx_row_id =
+            seed_unflagged_received_note(&tx, pool, account_id, account_id, KeyScope::INTERNAL);
+        assert!(
+            !is_change(&tx, pool),
+            "{pool:?}: precondition, the note starts out unflagged"
+        );
+
+        flag_previously_received_change(&tx, TxRef(tx_row_id)).unwrap();
+
+        assert!(
+            is_change(&tx, pool),
+            "{pool:?}: an internal-scope note in a self-funded transaction must be flagged \
+             as change"
+        );
+    }
+
+    #[test]
+    fn flags_previously_received_sapling_change() {
+        assert_internal_scope_note_becomes_change(ShieldedPool::Sapling);
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn flags_previously_received_orchard_change() {
+        assert_internal_scope_note_becomes_change(ShieldedPool::Orchard);
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn flags_previously_received_ironwood_change() {
+        assert_internal_scope_note_becomes_change(ShieldedPool::Ironwood);
+    }
+
+    /// The repair is restricted to the internal key scope. A note received on the account's
+    /// external address is a payment the user made to themselves, not change, even though the
+    /// same account funded the transaction, and it must keep its classification so that it
+    /// remains visible as an output of the transaction.
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn does_not_flag_external_scope_notes_as_change() {
+        let pool = ShieldedPool::Ironwood;
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let account_id = only_account_id(st.wallet().conn());
+        let tx = st.wallet_mut().conn_mut().transaction().unwrap();
+
+        let tx_row_id =
+            seed_unflagged_received_note(&tx, pool, account_id, account_id, KeyScope::EXTERNAL);
+
+        flag_previously_received_change(&tx, TxRef(tx_row_id)).unwrap();
+
+        assert!(
+            !is_change(&tx, pool),
+            "an external-scope note must not be reclassified as change"
         );
     }
 }

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -20,6 +20,7 @@ mod ensure_default_transparent_address;
 mod ensure_orchard_ua_receiver;
 mod ephemeral_addresses;
 mod fix_bad_change_flagging;
+mod fix_bad_ironwood_change_flagging;
 mod fix_broken_commitment_trees;
 mod fix_transparent_received_outputs;
 mod fix_v_transactions_expired_unmined;
@@ -151,8 +152,10 @@ pub(super) fn all_migrations<
     //                                                   /            \      orchard_note_version
     //                                                  /              \                      \
     //                                                 /                \               ironwood_received_notes
-    //                                                /                  \                     /           \
-    //                                               /                    \    ironwood_pool_code_views   note_locking
+    //                                                /                  \              /       |           \
+    //                                               /                    \  ironwood_  |  fix_bad_ironwood_
+    //                                              /                      \ pool_code_ |  change_flagging
+    //                                             /                        \ views     note_locking
     //                                              /                      \
     //                                          ivk_item_cache    add_transparent_receiver_address_index
     //
@@ -258,6 +261,7 @@ pub(super) fn all_migrations<
         Box::new(orchard_note_version::Migration),
         Box::new(ironwood_received_notes::Migration),
         Box::new(ironwood_pool_code_views::Migration),
+        Box::new(fix_bad_ironwood_change_flagging::Migration),
         Box::new(orchard_ironwood_migration_tables::Migration),
         Box::new(tree_retained_checkpoints::Migration),
         Box::new(note_locking::Migration),
@@ -407,6 +411,7 @@ pub const CURRENT_LEAF_MIGRATIONS: &[Uuid] = &[
     add_transparent_receiver_address_index::MIGRATION_ID,
     add_transparent_value_index::MIGRATION_ID,
     ironwood_pool_code_views::MIGRATION_ID,
+    fix_bad_ironwood_change_flagging::MIGRATION_ID,
     orchard_ironwood_migration_tables::MIGRATION_ID,
     tree_retained_checkpoints::MIGRATION_ID,
     note_locking::MIGRATION_ID,

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -152,12 +152,11 @@ pub(super) fn all_migrations<
     //                                                   /            \      orchard_note_version
     //                                                  /              \                      \
     //                                                 /                \               ironwood_received_notes
-    //                                                /                  \              /       |           \
-    //                                               /                    \  ironwood_  |  fix_bad_ironwood_
-    //                                              /                      \ pool_code_ |  change_flagging
-    //                                             /                        \ views     note_locking
-    //                                              /                      \
-    //                                          ivk_item_cache    add_transparent_receiver_address_index
+    //                                                /                  \                     /        |    \
+    //                                               /                    \    ironwood_pool_code_views |  note_locking
+    //                                              /                      \                            |
+    //                                             /                        \         fix_bad_ironwood_change_flagging
+    //                                         ivk_item_cache    add_transparent_receiver_address_index
     //
     let rng = Rc::new(Mutex::new(rng));
     vec![

--- a/zcash_client_sqlite/src/wallet/init/migrations/fix_bad_ironwood_change_flagging.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/fix_bad_ironwood_change_flagging.rs
@@ -1,0 +1,528 @@
+//! Sets the `is_change` flag on Ironwood output notes received by an internal key when input value
+//! was provided from the account corresponding to that key.
+//!
+//! This is the Ironwood counterpart of [`super::fix_bad_change_flagging`], and runs that
+//! migration's statement against the Ironwood received-note table. Two pool lists had to be kept
+//! in step and only one of them was: the runtime repair, `flag_previously_received_change`,
+//! covered Sapling and Orchard but not Ironwood, so the notes that needed it were never flagged.
+//!
+//! A note received on an account's internal address is change when that same account funded the
+//! transaction. The scanner cannot always establish the second half: it infers it by matching a
+//! block's nullifiers against the notes the wallet already holds, which fails whenever a block is
+//! scanned before the block that created its inputs. The runtime repair supplies the missing
+//! classification later, when the transaction's `sent_notes` rows are written. Because `is_change`
+//! is written monotonically and nothing revisits a received note once its transaction has been
+//! recorded, an Ironwood note that missed that repair kept `is_change = 0` permanently.
+//!
+//! Sapling and Orchard need no equivalent pass here: they were in the runtime repair's pool list
+//! throughout, so any row this predicate would change was already changed when it was written.
+//! Running it for them would be harmless rather than wrong, since the predicate is exactly the one
+//! the live code applies on every sent-output write, but it would repair nothing.
+
+use std::collections::HashSet;
+
+use rusqlite::named_params;
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+
+use crate::{
+    IRONWOOD_TABLES_PREFIX,
+    wallet::{KeyScope, init::WalletMigrationError},
+};
+
+use super::ironwood_received_notes;
+
+pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xcc104d0d_54d6_4e07_9404_202676561d94);
+
+const DEPENDENCIES: &[Uuid] = &[ironwood_received_notes::MIGRATION_ID];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Sets the `is_change` flag on Ironwood output notes received by an internal key when input value was provided from the account corresponding to that key."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        // The Ironwood tables exist in the schema regardless of whether the `orchard` feature is
+        // enabled, so this repair is not feature-gated: a wallet whose notes were written by an
+        // Orchard-enabled build is repaired even when the build applying the migration is not.
+        //
+        // `is_change` only ever moves from 0 to 1, so this is idempotent: applying it twice, or
+        // applying it to a wallet that was never affected, changes nothing.
+        let table_prefix = IRONWOOD_TABLES_PREFIX;
+        transaction.execute(
+            &format!(
+                "UPDATE {table_prefix}_received_notes
+                 SET is_change = 1
+                 FROM sent_notes sn
+                 WHERE sn.transaction_id = {table_prefix}_received_notes.transaction_id
+                 AND sn.from_account_id = {table_prefix}_received_notes.account_id
+                 AND {table_prefix}_received_notes.recipient_key_scope = :internal_scope"
+            ),
+            named_params! {":internal_scope": KeyScope::INTERNAL.encode()},
+        )?;
+
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        // The pre-migration state is not recoverable: a note that this migration flagged is
+        // indistinguishable from one the wallet flagged when it was received.
+        Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::{Transaction, named_params};
+    use schemerz_rusqlite::RusqliteMigration;
+    use zcash_client_backend::data_api::testing::TestBuilder;
+    use zcash_primitives::block::BlockHash;
+    use zcash_protocol::{PoolType, ShieldedPool};
+
+    use crate::testing::db::TestDbFactory;
+    use crate::wallet::encoding::{KeyScope, pool_code};
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    /// The row id given to the single transaction each scenario builds.
+    const TX_ROW_ID: i64 = 1;
+    /// Placeholders for columns none of these scenarios reads back; they exist only to satisfy
+    /// the tables' NOT NULL constraints, so any well-formed value will do.
+    const TXID: [u8; 32] = [7; 32];
+    const OBSERVED_HEIGHT: i64 = 0;
+    const ACTION_INDEX: i64 = 0;
+    const DIVERSIFIER: [u8; 11] = [0; 11];
+    const NOTE_VALUE_ZATS: i64 = 100_000;
+    const NOTE_COMPONENT: [u8; 32] = [0; 32];
+    const NOTE_VERSION: i64 = 2;
+    /// The transparent output the shielding scenario consumes, and the earlier transaction that
+    /// paid it. Larger than the note above so the difference reads as a fee rather than as value
+    /// appearing from nowhere.
+    const TRANSPARENT_INPUT_ZATS: i64 = 125_000;
+    const TRANSPARENT_OUTPUT_ROW_ID: i64 = 1;
+    const TRANSPARENT_OUTPUT_INDEX: i64 = 0;
+    const TRANSPARENT_SCRIPT: [u8; 1] = [0];
+    const TRANSPARENT_ADDRESS: &str = "placeholder-transparent-address";
+    const FUNDING_TX_ROW_ID: i64 = 2;
+    const FUNDING_TXID: [u8; 32] = [8; 32];
+    /// The Orchard note the turnstile scenario retires. Its excess over the Ironwood output is the
+    /// fee, which is the only value the account actually parts with.
+    const ORCHARD_INPUT_ZATS: i64 = 125_000;
+    const ORCHARD_NOTE_ROW_ID: i64 = 1;
+
+    /// A migrated wallet holding a single account. Each scenario builds one and then writes the
+    /// rows it needs directly, because the states under test are ones the current code no longer
+    /// produces.
+    macro_rules! wallet_with_one_account {
+        () => {
+            TestBuilder::new()
+                .with_data_store_factory(TestDbFactory::default())
+                .with_account_from_sapling_activation(BlockHash([0; 32]))
+                .build()
+        };
+    }
+
+    /// The `accounts.id` of the wallet's only account, and the id of an address belonging to it.
+    fn account_and_address_ids(conn: &rusqlite::Connection) -> (i64, i64) {
+        let account_id = conn
+            .query_row("SELECT id FROM accounts", [], |row| row.get::<_, i64>(0))
+            .unwrap();
+        let address_id = conn
+            .query_row("SELECT id FROM addresses LIMIT 1", [], |row| {
+                row.get::<_, i64>(0)
+            })
+            .unwrap();
+
+        (account_id, address_id)
+    }
+
+    /// Reproduces the state the missing repair leaves behind: a transaction, an Ironwood note the
+    /// account received on `key_scope` recorded with `is_change = 0` because the scanner could not
+    /// yet link the transaction's spends, and the `sent_notes` row that later established the
+    /// account funded it.
+    ///
+    /// The `sent_notes` row is attributed to the Ironwood pool at the note's action index, which
+    /// is what `v_received_outputs` joins on, so the two describe one output rather than two.
+    fn seed_unflagged_ironwood_note(conn: &Transaction, account_id: i64, key_scope: KeyScope) {
+        conn.execute(
+            "INSERT INTO transactions (id_tx, txid, min_observed_height)
+             VALUES (:id_tx, :txid, :min_observed_height)",
+            named_params! {
+                ":id_tx": TX_ROW_ID,
+                ":txid": &TXID[..],
+                ":min_observed_height": OBSERVED_HEIGHT,
+            },
+        )
+        .unwrap();
+
+        conn.execute(
+            "INSERT INTO ironwood_received_notes
+             (transaction_id, action_index, account_id, diversifier, value, rho, rseed,
+              note_version, is_change, recipient_key_scope)
+             VALUES (:tx, :action_index, :account, :diversifier, :value, :note_component,
+                     :note_component, :note_version, :is_change, :key_scope)",
+            named_params! {
+                ":tx": TX_ROW_ID,
+                ":action_index": ACTION_INDEX,
+                ":account": account_id,
+                ":diversifier": &DIVERSIFIER[..],
+                ":value": NOTE_VALUE_ZATS,
+                ":note_component": &NOTE_COMPONENT[..],
+                ":note_version": NOTE_VERSION,
+                ":is_change": false,
+                ":key_scope": key_scope.encode(),
+            },
+        )
+        .unwrap();
+
+        conn.execute(
+            "INSERT INTO sent_notes
+             (transaction_id, output_pool, output_index, from_account_id, value)
+             VALUES (:tx, :output_pool, :output_index, :from_account, :value)",
+            named_params! {
+                ":tx": TX_ROW_ID,
+                ":output_pool": pool_code(PoolType::Shielded(ShieldedPool::Ironwood)),
+                ":output_index": ACTION_INDEX,
+                ":from_account": account_id,
+                ":value": NOTE_VALUE_ZATS,
+            },
+        )
+        .unwrap();
+    }
+
+    /// Gives the account a transparent output in an *earlier* transaction, and has the seeded
+    /// transaction spend it. That makes the seeded transaction shielding-shaped: every output it
+    /// spends is transparent, and every output it receives is shielded.
+    ///
+    /// The funding transaction has to be a separate one. An output received and spent within the
+    /// same transaction would contribute a transparent *received* row to that transaction, and a
+    /// shielding transaction by definition receives nothing transparent.
+    fn spend_a_transparent_output(conn: &Transaction, account_id: i64, address_id: i64) {
+        conn.execute(
+            "INSERT INTO transactions (id_tx, txid, min_observed_height)
+             VALUES (:id_tx, :txid, :min_observed_height)",
+            named_params! {
+                ":id_tx": FUNDING_TX_ROW_ID,
+                ":txid": &FUNDING_TXID[..],
+                ":min_observed_height": OBSERVED_HEIGHT,
+            },
+        )
+        .unwrap();
+
+        conn.execute(
+            "INSERT INTO transparent_received_outputs
+             (id, transaction_id, output_index, account_id, address, script, value_zat, address_id)
+             VALUES (:id, :tx, :output_index, :account, :address, :script, :value, :address_id)",
+            named_params! {
+                ":id": TRANSPARENT_OUTPUT_ROW_ID,
+                ":tx": FUNDING_TX_ROW_ID,
+                ":output_index": TRANSPARENT_OUTPUT_INDEX,
+                ":account": account_id,
+                ":address": TRANSPARENT_ADDRESS,
+                ":script": &TRANSPARENT_SCRIPT[..],
+                ":value": TRANSPARENT_INPUT_ZATS,
+                ":address_id": address_id,
+            },
+        )
+        .unwrap();
+
+        conn.execute(
+            "INSERT INTO transparent_received_output_spends
+             (transparent_received_output_id, transaction_id)
+             VALUES (:output_id, :tx)",
+            named_params! { ":output_id": TRANSPARENT_OUTPUT_ROW_ID, ":tx": TX_ROW_ID },
+        )
+        .unwrap();
+    }
+
+    /// Gives the account an Orchard note in an earlier transaction, and has the seeded transaction
+    /// spend it. Together with the Ironwood output the seeded transaction already carries, this is
+    /// a turnstile crossing: after NU6.3 no value may be added to the Orchard pool, so value
+    /// leaving Orchard can only reappear in Ironwood.
+    fn spend_an_orchard_note(conn: &Transaction, account_id: i64) {
+        conn.execute(
+            "INSERT INTO transactions (id_tx, txid, min_observed_height)
+             VALUES (:id_tx, :txid, :min_observed_height)",
+            named_params! {
+                ":id_tx": FUNDING_TX_ROW_ID,
+                ":txid": &FUNDING_TXID[..],
+                ":min_observed_height": OBSERVED_HEIGHT,
+            },
+        )
+        .unwrap();
+
+        conn.execute(
+            "INSERT INTO orchard_received_notes
+             (id, transaction_id, action_index, account_id, diversifier, value, rho, rseed,
+              is_change, recipient_key_scope)
+             VALUES (:id, :tx, :action_index, :account, :diversifier, :value, :note_component,
+                     :note_component, :is_change, :key_scope)",
+            named_params! {
+                ":id": ORCHARD_NOTE_ROW_ID,
+                ":tx": FUNDING_TX_ROW_ID,
+                ":action_index": ACTION_INDEX,
+                ":account": account_id,
+                ":diversifier": &DIVERSIFIER[..],
+                ":value": ORCHARD_INPUT_ZATS,
+                ":note_component": &NOTE_COMPONENT[..],
+                ":is_change": false,
+                ":key_scope": KeyScope::EXTERNAL.encode(),
+            },
+        )
+        .unwrap();
+
+        conn.execute(
+            "INSERT INTO orchard_received_note_spends
+             (orchard_received_note_id, transaction_id)
+             VALUES (:note_id, :tx)",
+            named_params! { ":note_id": ORCHARD_NOTE_ROW_ID, ":tx": TX_ROW_ID },
+        )
+        .unwrap();
+    }
+
+    fn note_is_change(conn: &Transaction) -> bool {
+        conn.query_row("SELECT is_change FROM ironwood_received_notes", [], |row| {
+            row.get::<_, bool>(0)
+        })
+        .unwrap()
+    }
+
+    /// The wallet's view of the transaction, as the columns a wallet UI reads.
+    struct TxSummary {
+        account_balance_delta: i64,
+        has_change: bool,
+        received_note_count: i64,
+        sent_note_count: i64,
+        is_shielding: bool,
+    }
+
+    /// Scoped to the seeded transaction: a scenario that funds it from an earlier transaction puts
+    /// that one in these views too.
+    fn tx_summary(conn: &Transaction) -> TxSummary {
+        conn.query_row(
+            "SELECT account_balance_delta, has_change, received_note_count, sent_note_count,
+                    is_shielding
+             FROM v_transactions WHERE txid = :txid",
+            named_params! { ":txid": &TXID[..] },
+            |row| {
+                Ok(TxSummary {
+                    account_balance_delta: row.get(0)?,
+                    has_change: row.get(1)?,
+                    received_note_count: row.get(2)?,
+                    sent_note_count: row.get(3)?,
+                    is_shielding: row.get(4)?,
+                })
+            },
+        )
+        .unwrap()
+    }
+
+    /// The outputs a wallet would offer as recipients: `v_tx_outputs` rows that are not change.
+    /// This is the query a light-wallet SDK runs to render "sent to".
+    fn non_change_output_count(conn: &Transaction) -> i64 {
+        conn.query_row(
+            "SELECT COUNT(*) FROM v_tx_outputs WHERE txid = :txid AND is_change = 0",
+            named_params! { ":txid": &TXID[..] },
+            |row| row.get(0),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+
+    #[test]
+    fn repairs_and_is_idempotent() {
+        let mut st = wallet_with_one_account!();
+        let (account_id, _) = account_and_address_ids(st.wallet().conn());
+        let tx = st.wallet_mut().conn_mut().transaction().unwrap();
+        seed_unflagged_ironwood_note(&tx, account_id, KeyScope::INTERNAL);
+
+        assert!(
+            !note_is_change(&tx),
+            "precondition: the note starts unflagged"
+        );
+
+        super::Migration.up(&tx).unwrap();
+        assert!(
+            note_is_change(&tx),
+            "the migration must reclassify the note"
+        );
+
+        super::Migration.up(&tx).unwrap();
+        assert!(
+            note_is_change(&tx),
+            "re-applying the migration must not disturb it"
+        );
+    }
+
+    /// The migration inherits the runtime repair's scope restriction: a note received on the
+    /// account's external address is a payment the user made to themselves, not change, and must
+    /// keep its classification so that it stays visible as an output of the transaction.
+    #[test]
+    fn leaves_external_scope_notes_alone() {
+        let mut st = wallet_with_one_account!();
+        let (account_id, _) = account_and_address_ids(st.wallet().conn());
+        let tx = st.wallet_mut().conn_mut().transaction().unwrap();
+        seed_unflagged_ironwood_note(&tx, account_id, KeyScope::EXTERNAL);
+
+        super::Migration.up(&tx).unwrap();
+
+        assert!(
+            !note_is_change(&tx),
+            "an external-scope note must not be reclassified as change"
+        );
+        assert_eq!(
+            non_change_output_count(&tx),
+            1,
+            "and it must remain visible as an output of the transaction"
+        );
+    }
+
+    /// Scenario: the wallet's own change is offered to the user as a recipient.
+    ///
+    /// A wallet renders "sent to" from the `v_tx_outputs` rows that are not change. While the
+    /// change note carries `is_change = 0`, the account's own internal address is one of those
+    /// rows, so the user is shown themselves as the recipient of their own transaction. The
+    /// transaction summary is wrong in the same direction: the wallet reports no change, and
+    /// counts the change note as both a received note and a note it sent.
+    #[test]
+    fn scenario_change_is_offered_as_a_recipient() {
+        let mut st = wallet_with_one_account!();
+        let (account_id, _) = account_and_address_ids(st.wallet().conn());
+        let tx = st.wallet_mut().conn_mut().transaction().unwrap();
+        seed_unflagged_ironwood_note(&tx, account_id, KeyScope::INTERNAL);
+
+        let before = tx_summary(&tx);
+        assert_eq!(
+            non_change_output_count(&tx),
+            1,
+            "the bug: the account's own change is offered as a recipient"
+        );
+        assert!(!before.has_change, "the bug: the wallet reports no change");
+        assert_eq!(
+            before.received_note_count, 1,
+            "the bug: change is counted as an incoming payment"
+        );
+        assert_eq!(
+            before.sent_note_count, 1,
+            "the bug: change is counted as a note the wallet sent"
+        );
+
+        super::Migration.up(&tx).unwrap();
+
+        let after = tx_summary(&tx);
+        assert_eq!(
+            non_change_output_count(&tx),
+            0,
+            "after the repair there is no recipient to show"
+        );
+        assert!(after.has_change, "and the transaction reports its change");
+        assert_eq!(after.received_note_count, 0);
+        assert_eq!(after.sent_note_count, 0);
+    }
+
+    /// Scenario: a shielding transaction stops being recognised as one.
+    ///
+    /// `v_transactions.is_shielding` requires that the wallet knows of no external outputs, which
+    /// it decides from the same non-change output set. An unflagged change note therefore reads as
+    /// an external output and the flag goes false. This one changes displayed amounts rather than
+    /// labels: a wallet that renders shielding transactions from `total_spent` and ordinary sends
+    /// from `account_balance_delta` switches formulas when the flag flips.
+    #[test]
+    fn scenario_shielding_transaction_is_no_longer_recognised() {
+        let mut st = wallet_with_one_account!();
+        let (account_id, address_id) = account_and_address_ids(st.wallet().conn());
+        let tx = st.wallet_mut().conn_mut().transaction().unwrap();
+        seed_unflagged_ironwood_note(&tx, account_id, KeyScope::INTERNAL);
+        spend_a_transparent_output(&tx, account_id, address_id);
+
+        assert!(
+            !tx_summary(&tx).is_shielding,
+            "the bug: a shielding transaction is not recognised as shielding"
+        );
+
+        super::Migration.up(&tx).unwrap();
+
+        assert!(
+            tx_summary(&tx).is_shielding,
+            "after the repair it is recognised again"
+        );
+    }
+
+    /// Scenario: an Orchard-to-Ironwood turnstile crossing is reported as an incoming payment.
+    ///
+    /// After NU6.3 no value may be added to the Orchard pool, so value leaving Orchard can only
+    /// reappear in Ironwood, and the wallet's own crossing pays itself at its internal address.
+    /// The crossing has no external recipient at all: the only thing the user should see is that
+    /// their balance moved pools and a fee was paid.
+    ///
+    /// This is the case with the widest blast radius. The turnstile makes Ironwood the pool every
+    /// post-NU6.3 shielded change output lands in, so the pool this repair was missing is the one
+    /// change now always uses. Unflagged, the whole crossed balance reads as money arriving from
+    /// outside, and the account's own internal address is offered as the recipient of a
+    /// transaction that has no recipient.
+    ///
+    /// Note that `account_balance_delta` is right throughout: the value accounting never depended
+    /// on the flag. What the bug corrupts is the story the wallet tells about the value, not the
+    /// value.
+    #[test]
+    fn scenario_turnstile_crossing_is_reported_as_an_incoming_payment() {
+        let mut st = wallet_with_one_account!();
+        let (account_id, _) = account_and_address_ids(st.wallet().conn());
+        let tx = st.wallet_mut().conn_mut().transaction().unwrap();
+        seed_unflagged_ironwood_note(&tx, account_id, KeyScope::INTERNAL);
+        spend_an_orchard_note(&tx, account_id);
+
+        let fee = ORCHARD_INPUT_ZATS - NOTE_VALUE_ZATS;
+
+        let before = tx_summary(&tx);
+        assert_eq!(
+            before.account_balance_delta, -fee,
+            "the account parts with the fee and nothing else, before and after the repair"
+        );
+        assert_eq!(
+            before.received_note_count, 1,
+            "the bug: the crossed balance reads as an incoming payment"
+        );
+        assert!(
+            !before.has_change,
+            "the bug: the crossing reports no change"
+        );
+        assert_eq!(
+            non_change_output_count(&tx),
+            1,
+            "the bug: a transaction with no recipient offers the account's own address as one"
+        );
+
+        super::Migration.up(&tx).unwrap();
+
+        let after = tx_summary(&tx);
+        assert_eq!(
+            after.account_balance_delta, -fee,
+            "the value accounting never depended on the flag"
+        );
+        assert_eq!(after.received_note_count, 0);
+        assert!(after.has_change, "the crossing is recognised as internal");
+        assert_eq!(
+            non_change_output_count(&tx),
+            0,
+            "and a transaction with no recipient offers none"
+        );
+    }
+}


### PR DESCRIPTION
Closes #2815.

## Problem

`flag_previously_received_change` repairs the classification of a received note that was recorded before the wallet could link its transaction's spends to itself. It ran over the Sapling and Orchard received-note tables, but not the Ironwood one.

`is_change` has three writers, and only this one was missing a pool:

| Writer | Condition | Pools |
| --- | --- | --- |
| `store_sent_tx` (`wallet.rs`) | recipient classified `Recipient::InternalShielded` | generic |
| `scan_block` (`zcash_client_backend/src/scanning.rs:975`) | `spent_from_accounts.contains(account)` | generic |
| `flag_previously_received_change` | internal scope + same-account `sent_notes` row | **Sapling, Orchard only** |

The third is the backstop for the second. `spent_from_accounts` is derived by matching a block's nullifiers against the wallet's known unspent set, so it is false whenever a block is scanned before the block that created its inputs. That is routine: scanning is driven by a `ScanPriority` queue rather than front to back, and `scanning.rs` collects `unlinked_nullifiers` for exactly the nullifiers the wallet cannot yet resolve.

The same two-pool list appears twice in the crate. `fix_bad_change_flagging` is the migration-time form of this repair and hardcodes the same pair. This PR adds the Ironwood arm to the runtime repair and the corresponding sibling migration.

## Why the omission is permanent

`is_change` is only ever raised (`is_change = MAX(:is_change, is_change)`), and nothing revisits a received note after its transaction has been written. An internal-scope Ironwood note that the scanner could not classify therefore keeps `is_change = 0` for the life of the wallet, and a code fix alone would not repair one already recorded.

Because the flag is monotone, a missing writer can only under-approximate: this can leave change unmarked, but can never mark a genuine payment as change.

## Why this is wider than it looks: the turnstile

After NU6.3 no value may be added to the Orchard pool, so every post-NU6.3 shielded change output lands in Ironwood. The pool this repair skipped is the pool change now always uses.

The Orchard-to-Ironwood crossing is the sharpest case. It pays the account's own internal receiver, so its output is exactly the note class affected, and it has no external recipient at all. Unflagged, the wallet reports one anyway, and the whole crossed balance reads as money arriving from outside.

## Observable effects

All of them are classification errors. `account_balance_delta` does not read the flag, so balances stay correct throughout; what degrades is the account the wallet gives of the value.

- `v_transactions` counts the change note in `received_note_count` and `sent_note_count` instead of reporting `has_change`.
- `v_tx_outputs` reports the account's own change as a non-change output. A wallet renders "sent to" from exactly that set, so the user is shown their own internal address as the recipient of their own transaction.
- `is_shielding` requires that the wallet know of no external outputs, which the leaked change output falsifies. This one moves displayed **amounts** rather than labels: a wallet that renders shielding transactions from `total_spent` and ordinary sends from `account_balance_delta` switches formulas when the flag flips.

## Change

Two commits.

**`b73dcd823c`** adds the `ShieldedPool::Ironwood` arm to `flag_previously_received_change`, gated on `orchard` to match `table_constants`, plus a comment recording why an omission there is permanent rather than transient.

**`3cdfa190b7`** adds `fix_bad_ironwood_change_flagging`, the Ironwood counterpart of `fix_bad_change_flagging`, running that migration's statement across the Ironwood received-note table so that wallets already holding a misclassified note are repaired on upgrade. Idempotent for the same monotonicity reason, so it is safe on an unaffected wallet and safe to reapply after a partial upgrade. Deliberately **not** feature-gated: the Ironwood tables exist in the schema regardless of `orchard` (`lib.rs:176-181`), so a wallet written by an Orchard-enabled build is repaired even by a build that is not.

Sapling and Orchard get no equivalent pass. They were in the runtime repair's pool list throughout, so the predicate would find nothing to change. Running it for them would be harmless rather than wrong; say the word if you would rather have the invariant re-asserted for all three.

## Tests

Ten in total, against a fully migrated wallet database rather than a hand-rolled schema, with table names written out literally so the assertions do not go through the same mapping as the code under test.

Four cover the runtime repair, one per pool plus the scope restriction. With the Ironwood arm removed:

```
test wallet::tests::flags_previously_received_orchard_change ... ok
test wallet::tests::flags_previously_received_sapling_change ... ok
test wallet::tests::flags_previously_received_ironwood_change ... FAILED
    Ironwood: an internal-scope note in a self-funded transaction must be flagged as change
```

Six cover the migration, of which three are scenarios asserting the wrong state before it and the right one after:

| Test | What it pins |
| --- | --- |
| `scenario_change_is_offered_as_a_recipient` | the account's own internal address offered as recipient of its own transaction |
| `scenario_shielding_transaction_is_no_longer_recognised` | `is_shielding` flips, moving displayed amounts |
| `scenario_turnstile_crossing_is_reported_as_an_incoming_payment` | the crossing reads as incoming; also pins `account_balance_delta` unchanged either side, to record that the value accounting never depended on the flag |
| `repairs_and_is_idempotent` | applying twice is a no-op |
| `leaves_external_scope_notes_alone` | a self-payment on the external scope stays visible as an output |
| `migrate` | the migration applies within the DAG |

## Database write atomicity

Per AGENTS.md. The runtime change adds one `UPDATE` to a function that already issues two; all three are the same idempotent statement against different tables, and both call sites (`insert_sent_output`, `put_sent_output`) already run inside a `rusqlite::Transaction`, so no new atomicity requirement arises. The migration is a single statement. Both only ever raise the flag, so a retry after a partial commit converges.

## Verification

- `cargo test -p zcash_client_sqlite --all-features`: `wallet::tests` 28 passed / 0 failed, `wallet::init::migrations` 84 passed / 0 failed
- `cargo clippy -p zcash_client_sqlite --all-features --all-targets -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- `cargo check -p zcash_client_sqlite --no-default-features`: clean

Generated with [Claude Code](https://claude.com/claude-code)
