### PR TITLE
zcash_client_sqlite: keep `test-dependencies` in step with the backend's

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7231,6 +7231,7 @@ dependencies = [
  "uuid",
  "zcash_address",
  "zcash_client_backend",
+ "zcash_client_sqlite",
  "zcash_encoding 0.4.0",
  "zcash_keys",
  "zcash_note_encryption",

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -127,6 +127,16 @@ zcash_address = { workspace = true, features = ["test-dependencies"] }
 # feature below enables; see the note there for why it may not be enabled from here.
 zcash_pool_migration = { workspace = true, features = ["test-dependencies"] }
 zip321 = { workspace = true }
+# A dev-dependency on this crate itself, so that building any test target turns this crate's
+# `test-dependencies` feature on. The line above enables `zcash_client_backend/test-dependencies`,
+# and dev-dependency features unify into the whole build, so without this the backend gains its
+# test-only trait items while this crate's impls, gated on the same-named feature *here*, do not.
+# `OutputLockStore::get_locked_outputs` is declared under that gate, so
+# `cargo check -p zcash_client_sqlite --no-default-features --tests` would otherwise fail with
+# E0046. This is the `test-dependencies` counterpart of the coupling the `orchard` feature below
+# documents: a feature that gates both a backend trait item and this crate's impl of it has to be
+# turned on for both crates together.
+zcash_client_sqlite = { path = ".", features = ["test-dependencies"] }
 
 [features]
 default = ["multicore"]


### PR DESCRIPTION
## Problem

`cargo check -p zcash_client_sqlite --no-default-features --tests` fails on `main`:

```
error[E0046]: not all trait items implemented, missing: `get_locked_outputs`
    --> zcash_client_sqlite/src/lib.rs:1598:1
error[E0046]: not all trait items implemented, missing: `get_locked_outputs`
    --> zcash_client_sqlite/src/lib.rs:1892:1
```

`OutputLockStore::get_locked_outputs` is declared under `#[cfg(any(test, feature = "test-dependencies"))]` in `zcash_client_backend` (`data_api/locking.rs`), and this crate's two impls of it carry the same-named gate. A `cfg` feature predicate is evaluated in the crate currently being compiled, so those two gates are independent conditions that happen to share a spelling.

They desynchronise in this configuration:

- This crate's dev-dependency on `zcash_client_backend` enables `test-dependencies` there.
- Dev-dependency features unify into the whole build, so with `--tests` the backend is compiled with the feature on and the trait grows the item.
- With `--no-default-features` this crate's own `test-dependencies` stays off, and the lib target has `cfg(test)` false, so the impls omit the method.

Neither gating choice alone can work: making the impls unconditional turns the failure into E0407 for a plain `--no-default-features` build, where the trait genuinely lacks the item.

## Scope

To be precise about severity: **no CI job runs this combination.** `.github/actions/prepare` defaults `test-dependencies` to `true` and appends it to every non-`--all-features` matrix state, so the gates always agree in CI. This is a local-only breakage. It is still worth fixing, because it is a plain command a developer will type and AGENTS.md asks that changes not regress `--no-default-features` or other feature combinations.

## Change

A dev-dependency on this crate itself, so that building any test target turns this crate's `test-dependencies` on for exactly the builds in which the backend's is already on. One line in the manifest, one edge in `Cargo.lock`.

This is the `test-dependencies` counterpart of a coupling this manifest already documents for `orchard`:

> This crate's storage-trait impls are gated on this feature while the backend traits grow their Orchard and Ironwood methods under theirs, so the two must turn on together or the impls stop satisfying the traits.

The same sentence applies to `test-dependencies`; only the enforcement was missing. The comment added next to the new line records that.

## No CHANGELOG entry

Nothing a consumer of the published crate can observe changes: no public API, no behaviour, no feature semantics. Per the changelog policy, entries carry what users need in order to adapt, and there is nothing to adapt to here. Happy to add one if you would rather have the build fix recorded.

## Verification

| Configuration | Before | After |
| --- | --- | --- |
| `check -p zcash_client_sqlite --no-default-features --tests` | E0046 x2 | clean |
| `check -p zcash_client_sqlite --no-default-features` | clean | clean |
| `test -p zcash_client_sqlite --all-features` | pass | pass |
| `clippy -p zcash_client_sqlite --all-features --all-targets -- -D warnings` | clean | clean |

## Left alone

With the crate now compiling in that configuration, five pre-existing `unused import` warnings become visible in `zcash_client_backend`'s `data_api/testing/pool.rs` and `data_api/testing/pool/locking.rs`. They are independent of this change: `cargo check -p zcash_client_backend --no-default-features --features test-dependencies` reproduces all five without it. They are in a different crate and unrelated to the E0046 fix, so I have not touched them here. Say the word and I will send a separate PR.

Generated with [Claude Code](https://claude.com/claude-code)