### PR TITLE
zcash_client_sqlite: record Ironwood receipts as uses of their address

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -47,6 +47,14 @@ workspace.
   in the Ironwood bundle, so this affected ordinary received payments. A
   migration corrects the affected view; no caller action is required beyond
   upgrading.
+- The funding account reported for a transparent output by
+  `zcash_client_backend::wallet::WalletTransparentOutput::funding_account` now
+  takes value spent from the Ironwood pool into account. Ironwood inputs were
+  not counted, so an output whose creating transaction was funded entirely from
+  Ironwood reported no funding account, and one funded from several pools could
+  report an account other than the largest contributor. Post-NU6.3 wallets hold
+  their shielded value in Ironwood, so this affected ordinary spends rather than
+  only unusual ones.
 
 ## [0.22.0-rc.4] - 2026-07-26
 

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -39,6 +39,14 @@ workspace.
   which presents it to the user as a recipient of their own transaction. Balances
   were not affected. Notes already recorded with the wrong classification are
   repaired on upgrade by a new migration; no rescan is required.
+- An address that had received only Ironwood notes was treated as never having
+  been used. Such an address was still considered unused by the transparent
+  address gap-limit search, so it could be handed out again, and the account
+  that received the note was not reported as being involved in the transaction
+  that paid it. Since NU6.3 every payment to an Orchard receiver is delivered
+  in the Ironwood bundle, so this affected ordinary received payments. A
+  migration corrects the affected view; no caller action is required beyond
+  upgrading.
 
 ## [0.22.0-rc.4] - 2026-07-26
 
@@ -367,8 +375,8 @@ workspace.
   `SqliteClientError::CommitmentTree` variant.
 
 ### Changed
-- Migrated to `sapling-crypto 0.7`, `orchard 0.13`, `zcash_encoding 0.4`, 
-  `zcash_protocol 0.8`, `zcash_address 0.11`, `zip321 0.7`, `zcash_transparent 0.7`, 
+- Migrated to `sapling-crypto 0.7`, `orchard 0.13`, `zcash_encoding 0.4`,
+  `zcash_protocol 0.8`, `zcash_address 0.11`, `zip321 0.7`, `zcash_transparent 0.7`,
   `zcash_primitives 0.27`, `zcash_proofs 0.27`, `zcash_keys 0.13`, `pczt 0.6`,
   `zcash_client_backend 0.22`
 - The `accounts` table now stores IVK item caches instead of FVK item caches for

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -1808,6 +1808,12 @@ CREATE VIEW v_address_uses AS
     JOIN addresses a ON a.id = orn.address_id
     JOIN transactions t ON t.id_tx = orn.transaction_id
 UNION
+    SELECT irn.address_id, irn.account_id, irn.transaction_id, t.mined_height,
+           a.key_scope, a.diversifier_index_be, a.transparent_child_index
+    FROM ironwood_received_notes irn
+    JOIN addresses a ON a.id = irn.address_id
+    JOIN transactions t ON t.id_tx = irn.transaction_id
+UNION
     SELECT srn.address_id, srn.account_id, srn.transaction_id, t.mined_height,
            a.key_scope, a.diversifier_index_be, a.transparent_child_index
     FROM sapling_received_notes srn

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -53,6 +53,7 @@ mod tx_retrieval_queue_expiry;
 mod ufvk_support;
 mod utxos_table;
 mod utxos_to_txos;
+mod v_address_uses_ironwood;
 mod v_received_output_spends_account;
 mod v_sapling_shard_unscanned_ranges;
 mod v_transactions_additional_totals;
@@ -150,13 +151,13 @@ pub(super) fn all_migrations<
     //     add_transparent_value_index  v_tx_outputs_key_scopes  standalone_p2sh    witness_stabilized_notes
     //                                                    /          \         \
     //                                                   /            \      orchard_note_version
-    //                                                  /              \                      \
-    //                                                 /                \               ironwood_received_notes
-    //                                                /                  \                     /        |    \
-    //                                               /                    \    ironwood_pool_code_views |  note_locking
+    //                                                  /              \           \
+    //                                                 /                \  ironwood_received_notes -- note_locking
+    //                                                /                  \       |               |------|     |
+    //                                               /                    \    ironwood_pool_code_views |  v_address_uses_ironwood
     //                                              /                      \                            |
-    //                                             /                        \         fix_bad_ironwood_change_flagging
-    //                                         ivk_item_cache    add_transparent_receiver_address_index
+    //                                             /                        \    fix_bad_ironwood_change_flagging
+    //                                          ivk_item_cache    add_transparent_receiver_address_index
     //
     let rng = Rc::new(Mutex::new(rng));
     vec![
@@ -261,6 +262,7 @@ pub(super) fn all_migrations<
         Box::new(ironwood_received_notes::Migration),
         Box::new(ironwood_pool_code_views::Migration),
         Box::new(fix_bad_ironwood_change_flagging::Migration),
+        Box::new(v_address_uses_ironwood::Migration),
         Box::new(orchard_ironwood_migration_tables::Migration),
         Box::new(tree_retained_checkpoints::Migration),
         Box::new(note_locking::Migration),
@@ -411,6 +413,7 @@ pub const CURRENT_LEAF_MIGRATIONS: &[Uuid] = &[
     add_transparent_value_index::MIGRATION_ID,
     ironwood_pool_code_views::MIGRATION_ID,
     fix_bad_ironwood_change_flagging::MIGRATION_ID,
+    v_address_uses_ironwood::MIGRATION_ID,
     orchard_ironwood_migration_tables::MIGRATION_ID,
     tree_retained_checkpoints::MIGRATION_ID,
     note_locking::MIGRATION_ID,

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_address_uses_ironwood.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_address_uses_ironwood.rs
@@ -1,0 +1,401 @@
+//! Adds Ironwood received notes to the `v_address_uses` view.
+//!
+//! Ironwood notes ([ZIP 2005], NU6.3) are recorded in the `ironwood_received_notes` table, which
+//! is separate from `orchard_received_notes` because the two pools have distinct note commitment
+//! trees. Both tables carry an `address_id`, written by the same code path, so an Ironwood note
+//! records which of the wallet's addresses received it just as an Orchard note does.
+//!
+//! `v_address_uses` unioned the Orchard, Sapling and transparent received-output tables and was
+//! never extended to the Ironwood one, so those rows were simply not selected. After NU6.3 every
+//! payment to an Orchard receiver is delivered in the Ironwood bundle, which makes an
+//! Ironwood-only receipt the ordinary case rather than an exotic one.
+//!
+//! Two consequences follow from the omission:
+//!
+//! - `v_address_first_use`, which aggregates `v_address_uses`, reported no first-use height for an
+//!   address whose only receipt was an Ironwood note. The transparent gap-limit search skips
+//!   addresses with a NULL first-use height, so such an address read as never used and could be
+//!   handed out again, which is an address-reuse hazard.
+//! - The set of accounts involved in a transaction, which is read from `v_address_uses`, was empty
+//!   for a transaction whose only wallet-relevant output was an Ironwood note.
+//!
+//! This migration recreates `v_address_uses` with an additional branch that unions in the
+//! `ironwood_received_notes` table. `v_address_first_use` is not recreated: SQLite resolves a
+//! view's references to other views by name when a query is compiled, so it picks up the new
+//! definition on its own.
+//!
+//! [ZIP 2005]: https://zips.z.cash/zip-2005
+
+use std::collections::HashSet;
+
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+
+use crate::wallet::init::WalletMigrationError;
+
+use super::ironwood_received_notes;
+
+pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xdab89587_cd05_43b0_a5b5_8cb64a702791);
+
+const DEPENDENCIES: &[Uuid] = &[ironwood_received_notes::MIGRATION_ID];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Adds Ironwood received notes to the address-use view."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        transaction.execute_batch(
+            "DROP VIEW v_address_uses;
+            CREATE VIEW v_address_uses AS
+                SELECT orn.address_id, orn.account_id, orn.transaction_id, t.mined_height,
+                       a.key_scope, a.diversifier_index_be, a.transparent_child_index
+                FROM orchard_received_notes orn
+                JOIN addresses a ON a.id = orn.address_id
+                JOIN transactions t ON t.id_tx = orn.transaction_id
+            UNION
+                SELECT irn.address_id, irn.account_id, irn.transaction_id, t.mined_height,
+                       a.key_scope, a.diversifier_index_be, a.transparent_child_index
+                FROM ironwood_received_notes irn
+                JOIN addresses a ON a.id = irn.address_id
+                JOIN transactions t ON t.id_tx = irn.transaction_id
+            UNION
+                SELECT srn.address_id, srn.account_id, srn.transaction_id, t.mined_height,
+                       a.key_scope, a.diversifier_index_be, a.transparent_child_index
+                FROM sapling_received_notes srn
+                JOIN addresses a ON a.id = srn.address_id
+                JOIN transactions t ON t.id_tx = srn.transaction_id
+            UNION
+                SELECT tro.address_id, tro.account_id, tro.transaction_id, t.mined_height,
+                       a.key_scope, a.diversifier_index_be, a.transparent_child_index
+                FROM transparent_received_outputs tro
+                JOIN addresses a ON a.id = tro.address_id
+                JOIN transactions t ON t.id_tx = tro.transaction_id;",
+        )?;
+
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rand_chacha::ChaChaRng;
+    use rusqlite::{OptionalExtension, named_params};
+    use secrecy::Secret;
+    use tempfile::NamedTempFile;
+    use zcash_keys::keys::UnifiedSpendingKey;
+    use zcash_protocol::consensus::Network;
+
+    use crate::{
+        WalletDb,
+        testing::db::{test_clock, test_rng},
+        util::testing::FixedClock,
+        wallet::{
+            encoding::{KeyScope, ReceiverFlags},
+            init::{WalletMigrator, migrations::tests::test_migrate},
+        },
+    };
+
+    /// The wallet type the scenarios operate on: a file-backed database with the deterministic
+    /// clock and RNG the crate's other tests use.
+    type TestWalletDb = WalletDb<rusqlite::Connection, Network, FixedClock, ChaChaRng>;
+
+    /// The network the scenario wallets are built for. Any network works; the views under test do
+    /// not consult consensus parameters.
+    const NETWORK: Network = Network::TestNetwork;
+    /// The seed the scenario wallets derive their single account from.
+    const SEED_BYTE: u8 = 0xab;
+    const SEED_LEN: usize = 32;
+
+    /// Row ids for the single account, address and transaction each scenario writes. The scenarios
+    /// seed exactly one of each, so any distinct values would do; fixing them keeps the assertions
+    /// legible.
+    const ACCOUNT_ROW_ID: i64 = 1;
+    const ADDRESS_ROW_ID: i64 = 1;
+    const TX_ROW_ID: i64 = 1;
+
+    /// Identity columns for the seeded rows. The views do not interpret them; they exist to
+    /// satisfy the tables' constraints.
+    const ACCOUNT_UUID: [u8; 16] = [1; 16];
+    const SEED_FINGERPRINT: [u8; 32] = [SEED_BYTE; 32];
+    const ZIP32_ACCOUNT_INDEX: i64 = 0;
+    const BIRTHDAY_HEIGHT: i64 = 0;
+    /// The `account_kind` discriminant for an account derived from a ZIP 32 seed.
+    const ACCOUNT_KIND_DERIVED: i64 = 0;
+    /// Whether the wallet holds the account's spending key. The seeded account is a spending
+    /// account, which is the ordinary case.
+    const HAS_SPEND_KEY: bool = true;
+    const TXID: [u8; 32] = [7; 32];
+    /// The height at which the seeded transaction is mined. This is the height the address-use
+    /// views must report as the address's first use, so it is deliberately not zero: a NULL and a
+    /// zero must not be confusable in the assertions.
+    const MINED_HEIGHT: i64 = 100;
+
+    /// The transparent child index the seeded address is derived at. The gap-limit search orders
+    /// by this column, so it must be a real index rather than NULL.
+    const TRANSPARENT_CHILD_INDEX: i64 = 0;
+    /// The big-endian diversifier index matching `TRANSPARENT_CHILD_INDEX`. The addresses table
+    /// requires a non-NULL diversifier index for any address that is not an imported foreign one.
+    const DIVERSIFIER_INDEX_BE: [u8; 11] = [0; 11];
+    /// Placeholder address encodings. The views select these columns only through `address_id`,
+    /// and never parse them.
+    const ADDRESS: &str = "placeholder-unified-address";
+    const TRANSPARENT_ADDRESS: &str = "placeholder-transparent-address";
+
+    /// Payload columns for the seeded Ironwood note. The views do not read them.
+    const ACTION_INDEX: i64 = 0;
+    const NOTE_DIVERSIFIER: [u8; 11] = [0; 11];
+    const NOTE_VALUE_ZATS: i64 = 100_000;
+    const NOTE_COMPONENT: [u8; 32] = [0; 32];
+    /// Ironwood notes are obtained from version 3 note plaintexts.
+    const IRONWOOD_NOTE_VERSION: i64 = 3;
+    /// The seeded note is a payment received from elsewhere, not the account's own change; that
+    /// is the case the address-use views exist to record.
+    const NOTE_IS_CHANGE: bool = false;
+
+    /// Writes one account, one address of that account carrying a transparent receiver, one mined
+    /// transaction, and one Ironwood note that the account received at that address in that
+    /// transaction.
+    ///
+    /// The rows are written directly rather than through the wallet API because the scenarios need
+    /// them present in a wallet that has *not* yet had this migration applied, which is the state
+    /// an upgrading wallet is in.
+    fn seed_ironwood_receipt(db_data: &mut TestWalletDb) {
+        // The UFVK and UIVK must be real encoded values, as `verify_network_compatibility` parses
+        // them when later migrations are applied.
+        let seed_bytes = vec![SEED_BYTE; SEED_LEN];
+        let usk = UnifiedSpendingKey::from_seed(&NETWORK, &seed_bytes, zip32::AccountId::ZERO)
+            .expect("the test seed is a valid seed for account zero");
+        let ufvk = usk.to_unified_full_viewing_key();
+
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO accounts (id, uuid, account_kind, hd_seed_fingerprint,
+                 hd_account_index, ufvk, uivk, has_spend_key, birthday_height)
+                 VALUES (:id, :uuid, :account_kind, :seed_fingerprint,
+                 :account_index, :ufvk, :uivk, :has_spend_key, :birthday_height)",
+                named_params![
+                    ":id": ACCOUNT_ROW_ID,
+                    ":uuid": &ACCOUNT_UUID[..],
+                    ":account_kind": ACCOUNT_KIND_DERIVED,
+                    ":has_spend_key": HAS_SPEND_KEY,
+                    ":seed_fingerprint": &SEED_FINGERPRINT[..],
+                    ":account_index": ZIP32_ACCOUNT_INDEX,
+                    ":ufvk": ufvk.encode(&NETWORK),
+                    ":uivk": ufvk.to_unified_incoming_viewing_key().encode(&NETWORK),
+                    ":birthday_height": BIRTHDAY_HEIGHT,
+                ],
+            )
+            .unwrap();
+
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO addresses (id, account_id, key_scope, diversifier_index_be, address,
+                 transparent_child_index, cached_transparent_receiver_address, receiver_flags)
+                 VALUES (:id, :account_id, :key_scope, :diversifier_index_be, :address,
+                 :transparent_child_index, :transparent_address, :receiver_flags)",
+                named_params![
+                    ":id": ADDRESS_ROW_ID,
+                    ":account_id": ACCOUNT_ROW_ID,
+                    ":key_scope": KeyScope::EXTERNAL.encode(),
+                    ":diversifier_index_be": &DIVERSIFIER_INDEX_BE[..],
+                    ":address": ADDRESS,
+                    ":transparent_child_index": TRANSPARENT_CHILD_INDEX,
+                    ":transparent_address": TRANSPARENT_ADDRESS,
+                    ":receiver_flags": (ReceiverFlags::ORCHARD | ReceiverFlags::P2PKH).bits(),
+                ],
+            )
+            .unwrap();
+
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO transactions (id_tx, txid, mined_height, min_observed_height)
+                 VALUES (:id_tx, :txid, :mined_height, :mined_height)",
+                named_params![
+                    ":id_tx": TX_ROW_ID,
+                    ":txid": &TXID[..],
+                    ":mined_height": MINED_HEIGHT,
+                ],
+            )
+            .unwrap();
+
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO ironwood_received_notes
+                 (transaction_id, action_index, account_id, address_id, diversifier, value,
+                  rho, rseed, is_change, note_version, recipient_key_scope)
+                 VALUES (:tx, :action_index, :account_id, :address_id, :diversifier, :value,
+                  :note_component, :note_component, :is_change, :note_version, :key_scope)",
+                named_params![
+                    ":is_change": NOTE_IS_CHANGE,
+                    ":tx": TX_ROW_ID,
+                    ":action_index": ACTION_INDEX,
+                    ":account_id": ACCOUNT_ROW_ID,
+                    ":address_id": ADDRESS_ROW_ID,
+                    ":diversifier": &NOTE_DIVERSIFIER[..],
+                    ":value": NOTE_VALUE_ZATS,
+                    ":note_component": &NOTE_COMPONENT[..],
+                    ":note_version": IRONWOOD_NOTE_VERSION,
+                    ":key_scope": KeyScope::EXTERNAL.encode(),
+                ],
+            )
+            .unwrap();
+    }
+
+    /// The number of `v_address_uses` rows attributing a use to the seeded address.
+    fn address_use_count(conn: &rusqlite::Connection) -> i64 {
+        conn.query_row(
+            "SELECT COUNT(*) FROM v_address_uses WHERE address_id = :address_id",
+            named_params![":address_id": ADDRESS_ROW_ID],
+            |row| row.get(0),
+        )
+        .unwrap()
+    }
+
+    /// The first-use height `v_address_first_use` reports for the seeded address, which is what
+    /// the transparent gap-limit search consults to decide whether an address has been used.
+    ///
+    /// An address with no recorded use produces no row at all, and the search treats a missing
+    /// row and a NULL height alike, so both collapse to `None` here.
+    fn address_first_use_height(conn: &rusqlite::Connection) -> Option<i64> {
+        conn.query_row(
+            "SELECT first_use_height FROM v_address_first_use WHERE address_id = :address_id",
+            named_params![":address_id": ADDRESS_ROW_ID],
+            |row| row.get::<_, Option<i64>>(0),
+        )
+        .optional()
+        .unwrap()
+        .flatten()
+    }
+
+    /// A wallet migrated to the state immediately preceding this migration, with an Ironwood
+    /// receipt seeded into it. This is the state an upgrading wallet is in.
+    ///
+    /// The temporary file is returned alongside the database because dropping it would delete the
+    /// database out from under the test.
+    fn wallet_before_migration() -> (NamedTempFile, TestWalletDb) {
+        let data_file = NamedTempFile::new().unwrap();
+        let mut db_data =
+            WalletDb::for_path(data_file.path(), NETWORK, test_clock(), test_rng()).unwrap();
+
+        WalletMigrator::new()
+            .with_seed(Secret::new(vec![SEED_BYTE; SEED_LEN]))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, super::DEPENDENCIES)
+            .unwrap();
+
+        seed_ironwood_receipt(&mut db_data);
+
+        (data_file, db_data)
+    }
+
+    /// Applies this migration to a wallet already carrying seeded data.
+    fn apply_migration(db_data: &mut TestWalletDb) {
+        WalletMigrator::new()
+            .with_seed(Secret::new(vec![SEED_BYTE; SEED_LEN]))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(db_data, &[super::MIGRATION_ID])
+            .unwrap();
+    }
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+
+    /// Scenario: an address that has received an Ironwood note reads as never used.
+    ///
+    /// `v_address_uses` is the wallet's record of which of its addresses have been seen on chain,
+    /// and `v_address_first_use` aggregates it into the first height at which each address was
+    /// used. The transparent gap-limit search selects only addresses with a non-NULL first-use
+    /// height, so an address whose sole receipt is an Ironwood note is invisible to it and remains
+    /// eligible to be handed out again.
+    #[test]
+    fn scenario_ironwood_receipt_does_not_mark_its_address_used() {
+        let (_data_file, mut db_data) = wallet_before_migration();
+
+        assert_eq!(
+            address_use_count(&db_data.conn),
+            0,
+            "the bug: an address that received an Ironwood note records no use"
+        );
+        assert_eq!(
+            address_first_use_height(&db_data.conn),
+            None,
+            "the bug: the address has no first-use height, so it reads as never used"
+        );
+
+        apply_migration(&mut db_data);
+
+        assert_eq!(
+            address_use_count(&db_data.conn),
+            1,
+            "the Ironwood receipt must be recorded as a use of the address"
+        );
+        assert_eq!(
+            address_first_use_height(&db_data.conn),
+            Some(MINED_HEIGHT),
+            "and the address's first use must be the height its receipt was mined at"
+        );
+    }
+
+    /// Scenario: a transaction whose only wallet-relevant output is an Ironwood note involves no
+    /// accounts.
+    ///
+    /// `involved_accounts` reads `v_address_uses` to decide which of the wallet's accounts a
+    /// transaction concerns. After NU6.3 every payment to an Orchard receiver is delivered in the
+    /// Ironwood bundle, so this is the shape of an ordinary received payment, and the account that
+    /// received it was reported as uninvolved.
+    #[cfg(feature = "transparent-inputs")]
+    #[test]
+    fn scenario_ironwood_receipt_leaves_its_account_uninvolved() {
+        use crate::{TxRef, wallet::involved_accounts};
+
+        let (_data_file, mut db_data) = wallet_before_migration();
+
+        assert!(
+            involved_accounts(&db_data.conn, [TxRef(TX_ROW_ID)])
+                .unwrap()
+                .is_empty(),
+            "the bug: the account that received the Ironwood note is not involved in the \
+             transaction that paid it"
+        );
+
+        apply_migration(&mut db_data);
+
+        let involved = involved_accounts(&db_data.conn, [TxRef(TX_ROW_ID)]).unwrap();
+        assert_eq!(
+            involved.len(),
+            1,
+            "the receiving account must be involved in the transaction that paid it"
+        );
+        assert!(
+            involved
+                .iter()
+                .any(|(account_ref, _, _)| account_ref.0 == ACCOUNT_ROW_ID),
+            "and it must be the account the note was received by"
+        );
+    }
+}

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -1067,6 +1067,16 @@ pub(crate) fn utxo_query_height(
 /// are ordered by total contributed value descending; ties are broken in favor of
 /// the account whose oldest contributed input has the lowest mined height (with
 /// unmined inputs sorting last), then by `accounts.id`.
+///
+/// The inner `UNION ALL` must carry one branch per pool in which the wallet can record a
+/// received output: transparent, Sapling, Orchard, and Ironwood. A missing branch does not
+/// produce an error, it silently under-counts the accounts that funded the transaction, so
+/// a pool added to the schema without a branch here changes which account this reports.
+///
+/// The pools are enumerated here rather than read from the cross-pool `v_received_outputs`
+/// view because that view has to be materialized in full to be joined by output id, which
+/// scans every received-note table. This query is run once per candidate output, so it is
+/// written to be satisfied from the spend tables' `transaction_id` indexes instead.
 fn list_funding_accounts(
     conn: &rusqlite::Connection,
     creating_tx_id: i64,
@@ -1099,6 +1109,13 @@ fn list_funding_accounts(
                    ON orns.orchard_received_note_id = orn.id
                  JOIN transactions t ON t.id_tx = orn.transaction_id
                  WHERE orns.transaction_id = :creating_tx_id
+                 UNION ALL
+                 SELECT irn.account_id, irn.value, t.mined_height
+                 FROM ironwood_received_notes irn
+                 JOIN ironwood_received_note_spends irns
+                   ON irns.ironwood_received_note_id = irn.id
+                 JOIN transactions t ON t.id_tx = irn.transaction_id
+                 WHERE irns.transaction_id = :creating_tx_id
              )
              GROUP BY account_id
          ) contribs ON contribs.account_id = a.id
@@ -4152,5 +4169,356 @@ mod tests {
         zcash_client_backend::data_api::testing::transparent::mark_transparent_addresses_exposed_unknown_address(
             TestDbFactory::default(),
         );
+    }
+
+    /// Scenarios for the funding account that a transparent output reports, which
+    /// [`super::to_unspent_transparent_output`] takes from [`super::list_funding_accounts`].
+    ///
+    /// Each scenario builds a transparent output through the wallet's own write path, then
+    /// writes the spent notes of its creating transaction directly: the wallet cannot yet be
+    /// driven to produce a transaction that spends Ironwood value, and the point under test is
+    /// what the query makes of those rows once they exist.
+    mod funding_accounts {
+        use rusqlite::named_params;
+        use secrecy::Secret;
+        use transparent::{
+            bundle::{OutPoint, TxOut},
+            keys::TransparentKeyScope,
+        };
+        use zcash_client_backend::{
+            data_api::{
+                Account as _, AccountBirthday, WalletRead as _, WalletWrite, chain::ChainState,
+                testing::TestBuilder,
+            },
+            wallet::WalletTransparentOutput,
+        };
+        use zcash_keys::keys::UnifiedAddressRequest;
+        use zcash_primitives::block::BlockHash;
+        use zcash_protocol::{consensus::BlockHeight, value::Zatoshis};
+
+        use crate::{
+            AccountUuid,
+            testing::db::TestDbFactory,
+            wallet::{get_account_ref, transparent::get_wallet_transparent_output},
+        };
+
+        /// Value of the transparent output whose funding account each scenario inspects. It
+        /// plays no part in the funding-account computation; the output just has to be
+        /// well-formed.
+        const FUNDED_OUTPUT_ZATS: Zatoshis = Zatoshis::const_from_u64(10_000);
+
+        /// Value of the Ironwood note that the creating transaction spends.
+        const IRONWOOD_INPUT_ZATS: i64 = 200_000;
+
+        /// Value of the Sapling note that the second account contributes in the mixed-pool
+        /// scenario. Strictly smaller than [`IRONWOOD_INPUT_ZATS`], so the Ironwood-holding
+        /// account is the largest contributor once Ironwood value is counted at all.
+        const MIXED_POOL_SAPLING_INPUT_ZATS: i64 = 50_000;
+        const _: () = assert!(IRONWOOD_INPUT_ZATS > MIXED_POOL_SAPLING_INPUT_ZATS);
+
+        /// Blocks between the account birthday, the transaction that funds the seeded notes,
+        /// the transaction that spends them, and the chain tip. Any positive separation will
+        /// do; these scenarios do not depend on confirmation counts.
+        const SCENARIO_BLOCK_SPACING: u32 = 10;
+
+        /// Transaction id of the transaction in which the seeded notes were received. It only
+        /// has to be distinct from the ids the wallet generates for its own transactions.
+        const NOTE_FUNDING_TXID: [u8; 32] = [0xf0; 32];
+
+        /// `note_version` for a seeded Ironwood note. Ironwood notes are obtained from version
+        /// 3 note plaintexts ([ZIP 2005]), which is what
+        /// `crate::wallet::orchard::note_version_code(NoteVersion::V3)` encodes; that helper is
+        /// not reachable here because it lives behind the `orchard` feature, while the Ironwood
+        /// tables (and these tests) exist regardless of it.
+        ///
+        /// [ZIP 2005]: https://zips.z.cash/zip-2005
+        const IRONWOOD_NOTE_VERSION: i64 = 3;
+
+        /// Placeholder note components. Nothing here decrypts or re-derives the seeded notes,
+        /// so any well-formed value satisfies the columns' `NOT NULL` constraints.
+        const NOTE_DIVERSIFIER: [u8; 11] = [0; 11];
+        const NOTE_COMPONENT: [u8; 32] = [0; 32];
+
+        /// Output/action index of each seeded note. Every seeded note is alone in its pool
+        /// within its transaction, so this satisfies the tables' uniqueness constraints.
+        const NOTE_OUTPUT_INDEX: i64 = 0;
+
+        /// A seeded note is never itself change; each is an ordinary receipt that a later
+        /// transaction spends.
+        const NOTE_IS_CHANGE: bool = false;
+
+        /// The state each scenario starts from: a wallet with two accounts, a transparent
+        /// output belonging to account A, and the internal ids needed to attach spent notes to
+        /// the transaction that created it.
+        struct Scenario {
+            account_a_uuid: AccountUuid,
+            account_a_id: i64,
+            account_b_uuid: AccountUuid,
+            account_b_id: i64,
+            outpoint: OutPoint,
+            /// `transactions.id_tx` of the transaction that created the transparent output.
+            creating_tx_id: i64,
+            /// `transactions.id_tx` of the earlier transaction in which the seeded notes were
+            /// received.
+            note_funding_tx_id: i64,
+        }
+
+        /// Builds the state described by [`Scenario`], leaving `st` holding the wallet.
+        ///
+        /// The transparent output is written through `put_received_transparent_utxo` so that
+        /// its address, script, and creating transaction are exactly what the wallet would
+        /// record for a real output.
+        macro_rules! scenario {
+            ($st:ident) => {{
+                let account_a_uuid = $st.test_account().unwrap().id();
+                let birthday = $st.test_account().unwrap().birthday().height();
+
+                let taddr = *$st
+                    .wallet()
+                    .get_last_generated_address_matching(
+                        account_a_uuid,
+                        UnifiedAddressRequest::AllAvailableKeys,
+                    )
+                    .unwrap()
+                    .unwrap()
+                    .transparent()
+                    .unwrap();
+
+                // A second account, so that a scenario can pit two accounts' contributions
+                // against each other.
+                let account_b_birthday = AccountBirthday::from_parts(
+                    ChainState::empty(birthday - 1, BlockHash([0; 32])),
+                    None,
+                );
+                let (account_b_uuid, _) = $st
+                    .wallet_mut()
+                    .create_account("b", &Secret::new(vec![42u8; 32]), &account_b_birthday, None)
+                    .unwrap();
+
+                let note_funding_height = birthday + SCENARIO_BLOCK_SPACING;
+                let created_at = note_funding_height + SCENARIO_BLOCK_SPACING;
+                $st.wallet_mut()
+                    .update_chain_tip(created_at + SCENARIO_BLOCK_SPACING)
+                    .unwrap();
+
+                let outpoint = OutPoint::fake();
+                let utxo = WalletTransparentOutput::from_parts(
+                    outpoint.clone(),
+                    TxOut::new(FUNDED_OUTPUT_ZATS, taddr.script().into()),
+                    Some(created_at),
+                    Some(account_a_uuid),
+                    Some(TransparentKeyScope::EXTERNAL),
+                    None,
+                )
+                .unwrap();
+                $st.wallet_mut()
+                    .put_received_transparent_utxo(&utxo)
+                    .unwrap();
+
+                let conn = &$st.wallet().db().conn;
+                let account_a_id = get_account_ref(conn, account_a_uuid).unwrap().0;
+                let account_b_id = get_account_ref(conn, account_b_uuid).unwrap().0;
+                let creating_tx_id = conn
+                    .query_row(
+                        "SELECT id_tx FROM transactions WHERE txid = :txid",
+                        named_params! { ":txid": &outpoint.hash()[..] },
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .unwrap();
+                let note_funding_tx_id = insert_note_funding_transaction(conn, note_funding_height);
+
+                Scenario {
+                    account_a_uuid,
+                    account_a_id,
+                    account_b_uuid,
+                    account_b_id,
+                    outpoint,
+                    creating_tx_id,
+                    note_funding_tx_id,
+                }
+            }};
+        }
+
+        /// Records the transaction in which the seeded notes were received, and returns its
+        /// `transactions.id_tx`.
+        fn insert_note_funding_transaction(
+            conn: &rusqlite::Connection,
+            mined_height: BlockHeight,
+        ) -> i64 {
+            conn.execute(
+                "INSERT INTO transactions (txid, mined_height, min_observed_height)
+                 VALUES (:txid, :mined_height, :mined_height)",
+                named_params! {
+                    ":txid": &NOTE_FUNDING_TXID[..],
+                    ":mined_height": u32::from(mined_height),
+                },
+            )
+            .unwrap();
+
+            conn.last_insert_rowid()
+        }
+
+        /// Gives `account_id` an Ironwood note in `funding_tx_id`, and records `spending_tx_id`
+        /// as having spent it.
+        fn spend_an_ironwood_note(
+            conn: &rusqlite::Connection,
+            account_id: i64,
+            funding_tx_id: i64,
+            spending_tx_id: i64,
+            value: i64,
+        ) {
+            conn.execute(
+                "INSERT INTO ironwood_received_notes
+                 (transaction_id, action_index, account_id, diversifier, value, rho, rseed,
+                  is_change, note_version)
+                 VALUES (:tx, :action_index, :account, :diversifier, :value, :note_component,
+                         :note_component, :is_change, :note_version)",
+                named_params! {
+                    ":tx": funding_tx_id,
+                    ":action_index": NOTE_OUTPUT_INDEX,
+                    ":account": account_id,
+                    ":diversifier": &NOTE_DIVERSIFIER[..],
+                    ":value": value,
+                    ":note_component": &NOTE_COMPONENT[..],
+                    ":is_change": NOTE_IS_CHANGE,
+                    ":note_version": IRONWOOD_NOTE_VERSION,
+                },
+            )
+            .unwrap();
+            let note_id = conn.last_insert_rowid();
+
+            conn.execute(
+                "INSERT INTO ironwood_received_note_spends
+                 (ironwood_received_note_id, transaction_id)
+                 VALUES (:note_id, :tx)",
+                named_params! { ":note_id": note_id, ":tx": spending_tx_id },
+            )
+            .unwrap();
+        }
+
+        /// Gives `account_id` a Sapling note in `funding_tx_id`, and records `spending_tx_id`
+        /// as having spent it.
+        fn spend_a_sapling_note(
+            conn: &rusqlite::Connection,
+            account_id: i64,
+            funding_tx_id: i64,
+            spending_tx_id: i64,
+            value: i64,
+        ) {
+            conn.execute(
+                "INSERT INTO sapling_received_notes
+                 (transaction_id, output_index, account_id, diversifier, value, rcm, is_change)
+                 VALUES (:tx, :output_index, :account, :diversifier, :value, :note_component,
+                         :is_change)",
+                named_params! {
+                    ":tx": funding_tx_id,
+                    ":output_index": NOTE_OUTPUT_INDEX,
+                    ":account": account_id,
+                    ":diversifier": &NOTE_DIVERSIFIER[..],
+                    ":value": value,
+                    ":note_component": &NOTE_COMPONENT[..],
+                    ":is_change": NOTE_IS_CHANGE,
+                },
+            )
+            .unwrap();
+            let note_id = conn.last_insert_rowid();
+
+            conn.execute(
+                "INSERT INTO sapling_received_note_spends
+                 (sapling_received_note_id, transaction_id)
+                 VALUES (:note_id, :tx)",
+                named_params! { ":note_id": note_id, ":tx": spending_tx_id },
+            )
+            .unwrap();
+        }
+
+        /// The funding account the wallet reports for the scenario's transparent output.
+        fn reported_funding_account(
+            conn: &rusqlite::Connection,
+            outpoint: &OutPoint,
+        ) -> Option<AccountUuid> {
+            get_wallet_transparent_output(conn, outpoint, None)
+                .unwrap()
+                .expect("the seeded transparent output is retrievable")
+                .funding_account()
+                .copied()
+        }
+
+        /// Scenario: a transparent output whose creating transaction was funded entirely from
+        /// the Ironwood pool has no funding account at all.
+        ///
+        /// This is the ordinary post-NU6.3 case rather than an exotic one: no value may be
+        /// added to the Orchard pool after the turnstile, so a wallet that has crossed it holds
+        /// its shielded value in Ironwood, and every deshielding transaction it makes is funded
+        /// from there. The output is the wallet's own, created by the wallet's own transaction,
+        /// and yet it reports no account as having funded it.
+        #[test]
+        fn scenario_ironwood_funded_output_reports_no_funding_account() {
+            let mut st = TestBuilder::new()
+                .with_data_store_factory(TestDbFactory::default())
+                .with_account_from_sapling_activation(BlockHash([0; 32]))
+                .build();
+            let scenario = scenario!(st);
+
+            spend_an_ironwood_note(
+                &st.wallet().db().conn,
+                scenario.account_a_id,
+                scenario.note_funding_tx_id,
+                scenario.creating_tx_id,
+                IRONWOOD_INPUT_ZATS,
+            );
+
+            assert_eq!(
+                reported_funding_account(&st.wallet().db().conn, &scenario.outpoint),
+                Some(scenario.account_a_uuid),
+                "the bug: an output funded entirely from Ironwood reports no funding account, \
+                 because the funding-account query counts no Ironwood value",
+            );
+        }
+
+        /// Scenario: on a transaction funded from two pools by two accounts, the account with
+        /// the larger contribution loses to the account with the smaller one.
+        ///
+        /// A transparent output records at most one funding account, chosen as the largest
+        /// contributor. With Ironwood value uncounted, account A's larger Ironwood
+        /// contribution is invisible, so account B wins on the strength of a smaller Sapling
+        /// note. This is worse than the scenario above: the answer is not absent but wrong, and
+        /// nothing downstream can tell that it is.
+        #[test]
+        fn scenario_largest_ironwood_contributor_loses_to_a_smaller_one() {
+            let mut st = TestBuilder::new()
+                .with_data_store_factory(TestDbFactory::default())
+                .with_account_from_sapling_activation(BlockHash([0; 32]))
+                .build();
+            let scenario = scenario!(st);
+
+            spend_an_ironwood_note(
+                &st.wallet().db().conn,
+                scenario.account_a_id,
+                scenario.note_funding_tx_id,
+                scenario.creating_tx_id,
+                IRONWOOD_INPUT_ZATS,
+            );
+            spend_a_sapling_note(
+                &st.wallet().db().conn,
+                scenario.account_b_id,
+                scenario.note_funding_tx_id,
+                scenario.creating_tx_id,
+                MIXED_POOL_SAPLING_INPUT_ZATS,
+            );
+
+            let reported = reported_funding_account(&st.wallet().db().conn, &scenario.outpoint);
+            assert_ne!(
+                reported,
+                Some(scenario.account_b_uuid),
+                "the bug: the smaller Sapling contributor is reported as the funding account, \
+                 because the larger Ironwood contribution is not counted",
+            );
+            assert_eq!(
+                reported,
+                Some(scenario.account_a_uuid),
+                "the largest contributor funds the output, whichever pool it contributed from",
+            );
+        }
     }
 }


### PR DESCRIPTION
Closes #2812. Resolves MOB-1594

## The bug

`v_address_uses` is the wallet's record of which of its addresses have been seen
on chain. It unions `orchard_received_notes`, `sapling_received_notes` and
`transparent_received_outputs`, keyed by `address_id`, and has no
`ironwood_received_notes` branch.

This is not hypothetical. `wallet::orchard::put_received_note` takes a
`shielded_pool: ShieldedPool` and serves both Orchard and Ironwood, setting
`address_id` through `ensure_address` in either case. Ironwood notes therefore
carry the column the view joins on; their rows are simply not selected.

After NU6.3 every payment to an Orchard receiver is delivered in the Ironwood
bundle, so an Ironwood-only receipt is the shape of an ordinary received
payment, not an exotic one.

## Consumers affected

- `v_address_first_use` aggregates `v_address_uses` into the first height at
  which each address was used. `wallet::transparent::find_gap_start` selects
  only addresses with `first_use_height IS NOT NULL`, so an address whose sole
  receipt is an Ironwood note is invisible to the transparent gap-limit search
  and stays eligible to be handed out again. That is an address-reuse hazard.
- `wallet::involved_accounts` reads `v_address_uses` to decide which of the
  wallet's accounts a transaction concerns, and returned the empty set for a
  transaction whose only wallet-relevant output was an Ironwood note.
- `wallet::transparent::utxo_query_height` reads `v_address_uses` directly to
  decide where to start searching for UTXOs; it inherits the same blind spot.

## The fix

An Ironwood branch is added to `v_address_uses`, both in the current-schema
definition in `wallet/db.rs` and in a new migration,
`v_address_uses_ironwood`, that recreates the view for existing wallets.

`v_address_first_use` is deliberately **not** recreated. SQLite stores a view's
definition as text and resolves its references to other views by name when a
query is compiled, so it picks up the new `v_address_uses` on its own. The
existing `account_delete_cascade` migration already relies on this: it drops and
recreates `v_address_uses` and leaves `v_address_first_use` alone, and the
schema-comparison test in `wallet/init.rs` passes on that basis today.

The migration depends on `ironwood_received_notes`, which transitively orders it
after `account_delete_cascade` (`account_delete_cascade` ->
`witness_stabilized_notes` -> `orchard_note_version` ->
`ironwood_received_notes`), so it cannot be overwritten by the older definition.
It becomes a new leaf, so `CURRENT_LEAF_MIGRATIONS` and the DAG comment are
updated; `current_leaf_migrations_are_the_dag_leaves` checks that.

## Database write atomicity

The migration issues no `INSERT`, `UPDATE` or `DELETE`. Its two statements are
DDL (`DROP VIEW` then `CREATE VIEW`), and they run in the `rusqlite::Transaction`
that `schemerz` hands to `up`, so they land together or not at all. Answering the
four questions anyway:

1. **How many writes?** Zero data writes; two DDL statements in one supplied
   transaction.
2. **Must they land together?** Yes, and they do: a committed `DROP VIEW`
   without its `CREATE VIEW` would leave the wallet without `v_address_uses`.
   The enclosing transaction guarantees it.
3. **What happens on retry?** The migration is only ever run to completion or
   rolled back, so a retry starts from the pre-migration schema and succeeds.
4. **Does any read path see only one side?** No: no reader can observe the
   intermediate state, because it is never committed.

## Tests

Three tests in the new migration module, all run under `--all-features`:

- `migrate` (`test_migrate`) - the migration applies to an empty wallet.
- `scenario_ironwood_receipt_does_not_mark_its_address_used`
- `scenario_ironwood_receipt_leaves_its_account_uninvolved`

The scenario tests migrate a wallet to the state immediately preceding this
migration, seed an account, an address, a mined transaction and an Ironwood note
received at that address directly with `named_params` (the state under test is
one an upgrading wallet is in), assert the wrong observation, then apply the
migration and assert the right one. They assert against `v_address_uses`,
`v_address_first_use` and `involved_accounts`, the surfaces consumers read, not
the underlying table.

### Proof that the tests catch the bug

With the Ironwood branch removed from both `wallet/db.rs` and the migration's
`up`, and nothing else changed:

```
running 3 tests
test wallet::init::migrations::v_address_uses_ironwood::tests::migrate ... ok
test wallet::init::migrations::v_address_uses_ironwood::tests::scenario_ironwood_receipt_does_not_mark_its_address_used ... FAILED
test wallet::init::migrations::v_address_uses_ironwood::tests::scenario_ironwood_receipt_leaves_its_account_uninvolved ... FAILED

---- ...scenario_ironwood_receipt_does_not_mark_its_address_used stdout ----
assertion `left == right` failed: the Ironwood receipt must be recorded as a use of the address
  left: 0
 right: 1

---- ...scenario_ironwood_receipt_leaves_its_account_uninvolved stdout ----
assertion `left == right` failed: the receiving account must be involved in the transaction that paid it
  left: 0
 right: 1

test result: FAILED. 1 passed; 2 failed; 0 ignored; 0 measured; 463 filtered out
```

With the fix restored, all three pass.

## Verification

- `cargo fmt --all -- --check` - clean
- `cargo clippy -p zcash_client_sqlite --all-features --all-targets -- -D warnings` - zero warnings
- `cargo test -p zcash_client_sqlite --all-features` - 464 passed, 0 failed (lib);
  2 passed (`pool_migration_prove_chain_sim`); 4 passed (doc tests)

`cargo check -p zcash_client_sqlite --tests` without `--all-features` fails on
`OutputLockStore::get_locked_outputs`, which reproduces identically on an
unmodified `main` and is unrelated to this change (being addressed in #2811).

Co-Authored-By: Claude <noreply@anthropic.com>
