### PR TITLE
zcash_client_sqlite: count Ironwood inputs when attributing a funding account

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -47,6 +47,14 @@ workspace.
   in the Ironwood bundle, so this affected ordinary received payments. A
   migration corrects the affected view; no caller action is required beyond
   upgrading.
+- The funding account reported for a transparent output by
+  `zcash_client_backend::wallet::WalletTransparentOutput::funding_account` now
+  takes value spent from the Ironwood pool into account. Ironwood inputs were
+  not counted, so an output whose creating transaction was funded entirely from
+  Ironwood reported no funding account, and one funded from several pools could
+  report an account other than the largest contributor. Post-NU6.3 wallets hold
+  their shielded value in Ironwood, so this affected ordinary spends rather than
+  only unusual ones.
 
 ## [0.22.0-rc.4] - 2026-07-26
 

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -1067,6 +1067,16 @@ pub(crate) fn utxo_query_height(
 /// are ordered by total contributed value descending; ties are broken in favor of
 /// the account whose oldest contributed input has the lowest mined height (with
 /// unmined inputs sorting last), then by `accounts.id`.
+///
+/// The inner `UNION ALL` must carry one branch per pool in which the wallet can record a
+/// received output: transparent, Sapling, Orchard, and Ironwood. A missing branch does not
+/// produce an error, it silently under-counts the accounts that funded the transaction, so
+/// a pool added to the schema without a branch here changes which account this reports.
+///
+/// The pools are enumerated here rather than read from the cross-pool `v_received_outputs`
+/// view because that view has to be materialized in full to be joined by output id, which
+/// scans every received-note table. This query is run once per candidate output, so it is
+/// written to be satisfied from the spend tables' `transaction_id` indexes instead.
 fn list_funding_accounts(
     conn: &rusqlite::Connection,
     creating_tx_id: i64,
@@ -1099,6 +1109,13 @@ fn list_funding_accounts(
                    ON orns.orchard_received_note_id = orn.id
                  JOIN transactions t ON t.id_tx = orn.transaction_id
                  WHERE orns.transaction_id = :creating_tx_id
+                 UNION ALL
+                 SELECT irn.account_id, irn.value, t.mined_height
+                 FROM ironwood_received_notes irn
+                 JOIN ironwood_received_note_spends irns
+                   ON irns.ironwood_received_note_id = irn.id
+                 JOIN transactions t ON t.id_tx = irn.transaction_id
+                 WHERE irns.transaction_id = :creating_tx_id
              )
              GROUP BY account_id
          ) contribs ON contribs.account_id = a.id
@@ -4152,5 +4169,356 @@ mod tests {
         zcash_client_backend::data_api::testing::transparent::mark_transparent_addresses_exposed_unknown_address(
             TestDbFactory::default(),
         );
+    }
+
+    /// Scenarios for the funding account that a transparent output reports, which
+    /// [`super::to_unspent_transparent_output`] takes from [`super::list_funding_accounts`].
+    ///
+    /// Each scenario builds a transparent output through the wallet's own write path, then
+    /// writes the spent notes of its creating transaction directly: the wallet cannot yet be
+    /// driven to produce a transaction that spends Ironwood value, and the point under test is
+    /// what the query makes of those rows once they exist.
+    mod funding_accounts {
+        use rusqlite::named_params;
+        use secrecy::Secret;
+        use transparent::{
+            bundle::{OutPoint, TxOut},
+            keys::TransparentKeyScope,
+        };
+        use zcash_client_backend::{
+            data_api::{
+                Account as _, AccountBirthday, WalletRead as _, WalletWrite, chain::ChainState,
+                testing::TestBuilder,
+            },
+            wallet::WalletTransparentOutput,
+        };
+        use zcash_keys::keys::UnifiedAddressRequest;
+        use zcash_primitives::block::BlockHash;
+        use zcash_protocol::{consensus::BlockHeight, value::Zatoshis};
+
+        use crate::{
+            AccountUuid,
+            testing::db::TestDbFactory,
+            wallet::{get_account_ref, transparent::get_wallet_transparent_output},
+        };
+
+        /// Value of the transparent output whose funding account each scenario inspects. It
+        /// plays no part in the funding-account computation; the output just has to be
+        /// well-formed.
+        const FUNDED_OUTPUT_ZATS: Zatoshis = Zatoshis::const_from_u64(10_000);
+
+        /// Value of the Ironwood note that the creating transaction spends.
+        const IRONWOOD_INPUT_ZATS: i64 = 200_000;
+
+        /// Value of the Sapling note that the second account contributes in the mixed-pool
+        /// scenario. Strictly smaller than [`IRONWOOD_INPUT_ZATS`], so the Ironwood-holding
+        /// account is the largest contributor once Ironwood value is counted at all.
+        const MIXED_POOL_SAPLING_INPUT_ZATS: i64 = 50_000;
+        const _: () = assert!(IRONWOOD_INPUT_ZATS > MIXED_POOL_SAPLING_INPUT_ZATS);
+
+        /// Blocks between the account birthday, the transaction that funds the seeded notes,
+        /// the transaction that spends them, and the chain tip. Any positive separation will
+        /// do; these scenarios do not depend on confirmation counts.
+        const SCENARIO_BLOCK_SPACING: u32 = 10;
+
+        /// Transaction id of the transaction in which the seeded notes were received. It only
+        /// has to be distinct from the ids the wallet generates for its own transactions.
+        const NOTE_FUNDING_TXID: [u8; 32] = [0xf0; 32];
+
+        /// `note_version` for a seeded Ironwood note. Ironwood notes are obtained from version
+        /// 3 note plaintexts ([ZIP 2005]), which is what
+        /// `crate::wallet::orchard::note_version_code(NoteVersion::V3)` encodes; that helper is
+        /// not reachable here because it lives behind the `orchard` feature, while the Ironwood
+        /// tables (and these tests) exist regardless of it.
+        ///
+        /// [ZIP 2005]: https://zips.z.cash/zip-2005
+        const IRONWOOD_NOTE_VERSION: i64 = 3;
+
+        /// Placeholder note components. Nothing here decrypts or re-derives the seeded notes,
+        /// so any well-formed value satisfies the columns' `NOT NULL` constraints.
+        const NOTE_DIVERSIFIER: [u8; 11] = [0; 11];
+        const NOTE_COMPONENT: [u8; 32] = [0; 32];
+
+        /// Output/action index of each seeded note. Every seeded note is alone in its pool
+        /// within its transaction, so this satisfies the tables' uniqueness constraints.
+        const NOTE_OUTPUT_INDEX: i64 = 0;
+
+        /// A seeded note is never itself change; each is an ordinary receipt that a later
+        /// transaction spends.
+        const NOTE_IS_CHANGE: bool = false;
+
+        /// The state each scenario starts from: a wallet with two accounts, a transparent
+        /// output belonging to account A, and the internal ids needed to attach spent notes to
+        /// the transaction that created it.
+        struct Scenario {
+            account_a_uuid: AccountUuid,
+            account_a_id: i64,
+            account_b_uuid: AccountUuid,
+            account_b_id: i64,
+            outpoint: OutPoint,
+            /// `transactions.id_tx` of the transaction that created the transparent output.
+            creating_tx_id: i64,
+            /// `transactions.id_tx` of the earlier transaction in which the seeded notes were
+            /// received.
+            note_funding_tx_id: i64,
+        }
+
+        /// Builds the state described by [`Scenario`], leaving `st` holding the wallet.
+        ///
+        /// The transparent output is written through `put_received_transparent_utxo` so that
+        /// its address, script, and creating transaction are exactly what the wallet would
+        /// record for a real output.
+        macro_rules! scenario {
+            ($st:ident) => {{
+                let account_a_uuid = $st.test_account().unwrap().id();
+                let birthday = $st.test_account().unwrap().birthday().height();
+
+                let taddr = *$st
+                    .wallet()
+                    .get_last_generated_address_matching(
+                        account_a_uuid,
+                        UnifiedAddressRequest::AllAvailableKeys,
+                    )
+                    .unwrap()
+                    .unwrap()
+                    .transparent()
+                    .unwrap();
+
+                // A second account, so that a scenario can pit two accounts' contributions
+                // against each other.
+                let account_b_birthday = AccountBirthday::from_parts(
+                    ChainState::empty(birthday - 1, BlockHash([0; 32])),
+                    None,
+                );
+                let (account_b_uuid, _) = $st
+                    .wallet_mut()
+                    .create_account("b", &Secret::new(vec![42u8; 32]), &account_b_birthday, None)
+                    .unwrap();
+
+                let note_funding_height = birthday + SCENARIO_BLOCK_SPACING;
+                let created_at = note_funding_height + SCENARIO_BLOCK_SPACING;
+                $st.wallet_mut()
+                    .update_chain_tip(created_at + SCENARIO_BLOCK_SPACING)
+                    .unwrap();
+
+                let outpoint = OutPoint::fake();
+                let utxo = WalletTransparentOutput::from_parts(
+                    outpoint.clone(),
+                    TxOut::new(FUNDED_OUTPUT_ZATS, taddr.script().into()),
+                    Some(created_at),
+                    Some(account_a_uuid),
+                    Some(TransparentKeyScope::EXTERNAL),
+                    None,
+                )
+                .unwrap();
+                $st.wallet_mut()
+                    .put_received_transparent_utxo(&utxo)
+                    .unwrap();
+
+                let conn = &$st.wallet().db().conn;
+                let account_a_id = get_account_ref(conn, account_a_uuid).unwrap().0;
+                let account_b_id = get_account_ref(conn, account_b_uuid).unwrap().0;
+                let creating_tx_id = conn
+                    .query_row(
+                        "SELECT id_tx FROM transactions WHERE txid = :txid",
+                        named_params! { ":txid": &outpoint.hash()[..] },
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .unwrap();
+                let note_funding_tx_id = insert_note_funding_transaction(conn, note_funding_height);
+
+                Scenario {
+                    account_a_uuid,
+                    account_a_id,
+                    account_b_uuid,
+                    account_b_id,
+                    outpoint,
+                    creating_tx_id,
+                    note_funding_tx_id,
+                }
+            }};
+        }
+
+        /// Records the transaction in which the seeded notes were received, and returns its
+        /// `transactions.id_tx`.
+        fn insert_note_funding_transaction(
+            conn: &rusqlite::Connection,
+            mined_height: BlockHeight,
+        ) -> i64 {
+            conn.execute(
+                "INSERT INTO transactions (txid, mined_height, min_observed_height)
+                 VALUES (:txid, :mined_height, :mined_height)",
+                named_params! {
+                    ":txid": &NOTE_FUNDING_TXID[..],
+                    ":mined_height": u32::from(mined_height),
+                },
+            )
+            .unwrap();
+
+            conn.last_insert_rowid()
+        }
+
+        /// Gives `account_id` an Ironwood note in `funding_tx_id`, and records `spending_tx_id`
+        /// as having spent it.
+        fn spend_an_ironwood_note(
+            conn: &rusqlite::Connection,
+            account_id: i64,
+            funding_tx_id: i64,
+            spending_tx_id: i64,
+            value: i64,
+        ) {
+            conn.execute(
+                "INSERT INTO ironwood_received_notes
+                 (transaction_id, action_index, account_id, diversifier, value, rho, rseed,
+                  is_change, note_version)
+                 VALUES (:tx, :action_index, :account, :diversifier, :value, :note_component,
+                         :note_component, :is_change, :note_version)",
+                named_params! {
+                    ":tx": funding_tx_id,
+                    ":action_index": NOTE_OUTPUT_INDEX,
+                    ":account": account_id,
+                    ":diversifier": &NOTE_DIVERSIFIER[..],
+                    ":value": value,
+                    ":note_component": &NOTE_COMPONENT[..],
+                    ":is_change": NOTE_IS_CHANGE,
+                    ":note_version": IRONWOOD_NOTE_VERSION,
+                },
+            )
+            .unwrap();
+            let note_id = conn.last_insert_rowid();
+
+            conn.execute(
+                "INSERT INTO ironwood_received_note_spends
+                 (ironwood_received_note_id, transaction_id)
+                 VALUES (:note_id, :tx)",
+                named_params! { ":note_id": note_id, ":tx": spending_tx_id },
+            )
+            .unwrap();
+        }
+
+        /// Gives `account_id` a Sapling note in `funding_tx_id`, and records `spending_tx_id`
+        /// as having spent it.
+        fn spend_a_sapling_note(
+            conn: &rusqlite::Connection,
+            account_id: i64,
+            funding_tx_id: i64,
+            spending_tx_id: i64,
+            value: i64,
+        ) {
+            conn.execute(
+                "INSERT INTO sapling_received_notes
+                 (transaction_id, output_index, account_id, diversifier, value, rcm, is_change)
+                 VALUES (:tx, :output_index, :account, :diversifier, :value, :note_component,
+                         :is_change)",
+                named_params! {
+                    ":tx": funding_tx_id,
+                    ":output_index": NOTE_OUTPUT_INDEX,
+                    ":account": account_id,
+                    ":diversifier": &NOTE_DIVERSIFIER[..],
+                    ":value": value,
+                    ":note_component": &NOTE_COMPONENT[..],
+                    ":is_change": NOTE_IS_CHANGE,
+                },
+            )
+            .unwrap();
+            let note_id = conn.last_insert_rowid();
+
+            conn.execute(
+                "INSERT INTO sapling_received_note_spends
+                 (sapling_received_note_id, transaction_id)
+                 VALUES (:note_id, :tx)",
+                named_params! { ":note_id": note_id, ":tx": spending_tx_id },
+            )
+            .unwrap();
+        }
+
+        /// The funding account the wallet reports for the scenario's transparent output.
+        fn reported_funding_account(
+            conn: &rusqlite::Connection,
+            outpoint: &OutPoint,
+        ) -> Option<AccountUuid> {
+            get_wallet_transparent_output(conn, outpoint, None)
+                .unwrap()
+                .expect("the seeded transparent output is retrievable")
+                .funding_account()
+                .copied()
+        }
+
+        /// Scenario: a transparent output whose creating transaction was funded entirely from
+        /// the Ironwood pool has no funding account at all.
+        ///
+        /// This is the ordinary post-NU6.3 case rather than an exotic one: no value may be
+        /// added to the Orchard pool after the turnstile, so a wallet that has crossed it holds
+        /// its shielded value in Ironwood, and every deshielding transaction it makes is funded
+        /// from there. The output is the wallet's own, created by the wallet's own transaction,
+        /// and yet it reports no account as having funded it.
+        #[test]
+        fn scenario_ironwood_funded_output_reports_no_funding_account() {
+            let mut st = TestBuilder::new()
+                .with_data_store_factory(TestDbFactory::default())
+                .with_account_from_sapling_activation(BlockHash([0; 32]))
+                .build();
+            let scenario = scenario!(st);
+
+            spend_an_ironwood_note(
+                &st.wallet().db().conn,
+                scenario.account_a_id,
+                scenario.note_funding_tx_id,
+                scenario.creating_tx_id,
+                IRONWOOD_INPUT_ZATS,
+            );
+
+            assert_eq!(
+                reported_funding_account(&st.wallet().db().conn, &scenario.outpoint),
+                Some(scenario.account_a_uuid),
+                "the bug: an output funded entirely from Ironwood reports no funding account, \
+                 because the funding-account query counts no Ironwood value",
+            );
+        }
+
+        /// Scenario: on a transaction funded from two pools by two accounts, the account with
+        /// the larger contribution loses to the account with the smaller one.
+        ///
+        /// A transparent output records at most one funding account, chosen as the largest
+        /// contributor. With Ironwood value uncounted, account A's larger Ironwood
+        /// contribution is invisible, so account B wins on the strength of a smaller Sapling
+        /// note. This is worse than the scenario above: the answer is not absent but wrong, and
+        /// nothing downstream can tell that it is.
+        #[test]
+        fn scenario_largest_ironwood_contributor_loses_to_a_smaller_one() {
+            let mut st = TestBuilder::new()
+                .with_data_store_factory(TestDbFactory::default())
+                .with_account_from_sapling_activation(BlockHash([0; 32]))
+                .build();
+            let scenario = scenario!(st);
+
+            spend_an_ironwood_note(
+                &st.wallet().db().conn,
+                scenario.account_a_id,
+                scenario.note_funding_tx_id,
+                scenario.creating_tx_id,
+                IRONWOOD_INPUT_ZATS,
+            );
+            spend_a_sapling_note(
+                &st.wallet().db().conn,
+                scenario.account_b_id,
+                scenario.note_funding_tx_id,
+                scenario.creating_tx_id,
+                MIXED_POOL_SAPLING_INPUT_ZATS,
+            );
+
+            let reported = reported_funding_account(&st.wallet().db().conn, &scenario.outpoint);
+            assert_ne!(
+                reported,
+                Some(scenario.account_b_uuid),
+                "the bug: the smaller Sapling contributor is reported as the funding account, \
+                 because the larger Ironwood contribution is not counted",
+            );
+            assert_eq!(
+                reported,
+                Some(scenario.account_a_uuid),
+                "the largest contributor funds the output, whichever pool it contributed from",
+            );
+        }
     }
 }


### PR DESCRIPTION
Closes #2813. Resolves MOB-1595

## The bug

`list_funding_accounts` (`zcash_client_sqlite/src/wallet/transparent.rs`) totals
the value each wallet account contributed to a transaction, by unioning the
wallet's spent-output tables. It carried three branches:

- `transparent_received_outputs` / `transparent_received_output_spends`
- `sapling_received_notes` / `sapling_received_note_spends`
- `orchard_received_notes` / `orchard_received_note_spends`

There was no `ironwood_received_notes` / `ironwood_received_note_spends` branch,
so value spent from the Ironwood pool contributed nothing to any account's total.

## The consumer affected

`to_unspent_transparent_output`, immediately below it, takes the largest
contributor as the `funding_account` of the `WalletTransparentOutput` it builds.
That gives two distinct failure modes:

1. A transparent output whose creating transaction was funded **entirely** from
   Ironwood reports `funding_account = None`, because the tally is empty.
2. On a transaction funded from **several pools**, the largest contributor is
   chosen from an incomplete tally, so an account whose Ironwood contribution
   would have dominated loses to an account that contributed less. This is the
   worse case: the answer is not absent but wrong, and nothing downstream can
   tell that it is.

This is not an edge case after NU6.3. No value may be added to the Orchard pool
once the turnstile is crossed, so a wallet that has crossed it holds its shielded
value in Ironwood and funds its ordinary spends from there.

Note that `WalletRead::get_funding_accounts` (the nullifier-based detection in
`zcash_client_backend`) already handles Ironwood, and is covered by
`wallet::orchard::tests::ironwood_privacy_invariants::get_funding_accounts_detects_ironwood_only_spends`.
This SQL helper is a separate path and was not covered.

## The fix

A fourth `UNION ALL` branch over `ironwood_received_notes` joined to
`ironwood_received_note_spends` on `ironwood_received_note_id`, mirroring the
Orchard branch exactly.

**No migration is required, and this was verified rather than assumed.** Both
tables are installed by the existing `ironwood_received_notes` migration and are
present in the golden schema (`wallet/db.rs`, `TABLE_IRONWOOD_RECEIVED_NOTES` and
`TABLE_IRONWOOD_RECEIVED_NOTE_SPENDS`). They are not feature-gated: they exist
whether or not the `orchard` feature is enabled. The change is confined to one
prepared statement, reads only tables that already exist, and writes nothing.

## Why the branches stay explicit

A hand-maintained per-pool list is what caused this bug, so the alternative of
driving the query from the crate's cross-pool views (`v_received_output_spends`
joined to `v_received_outputs`, the pattern `v_transactions` already uses) was
measured rather than dismissed. `EXPLAIN QUERY PLAN` on a migrated wallet:

Explicit branches (this PR) - index lookups only:

```
CO-ROUTINE contribs
  CO-ROUTINE (subquery-4)
    COMPOUND QUERY
      LEFT-MOST SUBQUERY
        SEARCH tros USING INDEX idx_transparent_received_output_spends_transaction_id (transaction_id=?)
        SEARCH tro USING INTEGER PRIMARY KEY (rowid=?)
        SEARCH t USING INTEGER PRIMARY KEY (rowid=?)
      UNION ALL
        SEARCH srns USING INDEX idx_sapling_received_note_spends_transaction_id (transaction_id=?)
        ...
      UNION ALL
        SEARCH orns USING INDEX idx_orchard_received_note_spends_transaction_id (transaction_id=?)
        ...
      UNION ALL
        SEARCH irns USING INDEX idx_ironwood_received_note_spends_transaction_id (transaction_id=?)
        SEARCH irn USING INTEGER PRIMARY KEY (rowid=?)
        SEARCH t USING INTEGER PRIMARY KEY (rowid=?)
```

Same query written over the shared views - full scans of every pool table:

```
MATERIALIZE v_received_outputs
  COMPOUND QUERY
    LEFT-MOST SUBQUERY
      SCAN sapling_received_notes
      ...
    UNION USING TEMP B-TREE
      SCAN orchard_received_notes
      ...
    UNION USING TEMP B-TREE
      SCAN ironwood_received_notes
      ...
    UNION USING TEMP B-TREE
      SCAN u
      ...
SCAN ros
BLOOM FILTER ON ro (pool=? AND id_within_pool_table=?)
SEARCH ro USING AUTOMATIC COVERING INDEX (pool=? AND id_within_pool_table=?)
```

Because the view has to be joined by output id, SQLite materializes it in full;
the predicate on the spending transaction cannot be pushed into it.
`to_unspent_transparent_output` runs this query once per candidate output while
gathering UTXOs, so the view form would turn a per-output index lookup into a
per-output scan of every note the wallet holds. That is the wrong trade for a
selection path, so the branches stay explicit and the hazard is instead recorded
in a doc comment on `list_funding_accounts`: every pool with a received-output
table must appear here, a missing branch is silent rather than an error, and the
views are deliberately not used.

If the maintainers would rather remove the hazard structurally, the shape that
would work is a `value` (and creating-transaction) column on
`v_received_output_spends` so the spend view alone is sufficient. That is a
migration and a separate change.

## Tests

Two scenario tests in `wallet::transparent::tests::funding_accounts`, gated with
the rest of the module behind `transparent-inputs`. Each builds the transparent
output through the wallet's own `put_received_transparent_utxo` path and then
seeds the creating transaction's spent notes directly, because the wallet cannot
yet be driven to build a transaction that spends Ironwood value.

- `scenario_ironwood_funded_output_reports_no_funding_account`
- `scenario_largest_ironwood_contributor_loses_to_a_smaller_one`

Both were proved to catch the bug by removing the new `UNION ALL` branch and
re-running them:

```
---- ...::scenario_ironwood_funded_output_reports_no_funding_account stdout ----
assertion `left == right` failed: the bug: an output funded entirely from Ironwood
reports no funding account, because the funding-account query counts no Ironwood value
  left: None
 right: Some(AccountUuid(81e224f0-46f8-410b-935c-fff87c46efc0))

---- ...::scenario_largest_ironwood_contributor_loses_to_a_smaller_one stdout ----
assertion `left != right` failed: the bug: the smaller Sapling contributor is reported
as the funding account, because the larger Ironwood contribution is not counted
  left: Some(AccountUuid(a30a5ea2-1845-4a95-b9f2-b75973c0ea54))
 right: Some(AccountUuid(a30a5ea2-1845-4a95-b9f2-b75973c0ea54))

test result: FAILED. 0 passed; 2 failed; 463 filtered out
```

(The second is an `assert_ne!`, so both sides printing the same value is the
failure: the reported funding account *is* account B, the smaller contributor.)

With the branch restored, both pass.

## Database write atomicity

Not applicable: this change issues **zero** writes. `list_funding_accounts` is a
read-only `SELECT`, and the fix adds a fourth read branch to it. The scenario
tests write only to their own throwaway in-memory wallets.

## Verification

- `cargo fmt --all -- --check` - clean
- `cargo clippy -p zcash_client_sqlite --all-features --all-targets -- -D warnings` - zero warnings
- `cargo test -p zcash_client_sqlite --all-features` - `463 passed; 0 failed; 2 ignored`, plus `2 passed` in `pool_migration_prove_chain_sim` and `4 passed` doc-tests

`cargo check -p zcash_client_sqlite --no-default-features --features transparent-inputs --tests` still fails on the pre-existing `OutputLockStore::get_locked_outputs` gap that #2811 addresses; that is the only error reported, and it is unrelated to this change.
