### PR TITLE
zcash_client_sqlite: cover every shielded pool in the imported-receiver reattribution

### DIFF
--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -823,11 +823,23 @@ pub(crate) fn store_address_range<P: consensus::Parameters>(
 
             // If the import was recorded under a different account, the outputs received at
             // the address follow the (derivation-proven) attribution to this account.
+            //
+            // Only the transparent update can match today: a `Foreign` row is a transparent-only
+            // import, so no shielded note can be attached to it. A shielded note's `address_id`
+            // is only ever produced by `upsert_address`, which always writes the external key
+            // scope and a non-null diversifier index, whereas the `addresses` check constraint
+            // requires a `Foreign` row to have a null diversifier index; and no code path demotes
+            // an existing row to the `Foreign` scope. The shielded pools are nonetheless updated
+            // here so that this reattribution stays complete if that invariant is ever relaxed:
+            // mis-attributing a shielded note to the wrong account is silent and permanent,
+            // whereas these statements cost nothing on a path that only runs when an import is
+            // upgraded across accounts.
             if foreign_account != account_id.0 {
                 for table in [
                     "transparent_received_outputs",
                     "sapling_received_notes",
                     "orchard_received_notes",
+                    "ironwood_received_notes",
                 ] {
                     conn.execute(
                         &format!(
@@ -3353,6 +3365,284 @@ mod tests {
             )
             .unwrap();
         assert_eq!((utxo_addr_id, utxo_account_id), (foreign_id, account_a.0));
+
+        tx.commit().unwrap();
+    }
+
+    /// When the upgrade of a standalone (`Foreign`) import moves the address record to the
+    /// deriving account, notes attached to that record follow it for *every* shielded pool that
+    /// has a received-note table, not just some of them.
+    ///
+    /// The rows this seeds are ones the current code does not produce: a `Foreign` record is a
+    /// transparent-only import, and a shielded note's `address_id` only ever comes from
+    /// `upsert_address`, which writes the external key scope and a non-null diversifier index
+    /// (see `foreign_addresses_cannot_carry_a_diversifier_index`). They are written directly so
+    /// that the reattribution is covered pool-by-pool even though nothing can reach this state
+    /// today; a pool omitted here would mis-attribute funds silently and permanently if that
+    /// invariant were ever relaxed.
+    #[test]
+    #[cfg(feature = "transparent-key-import")]
+    fn store_address_range_reattributes_shielded_notes_of_imported_receiver() {
+        use rusqlite::named_params;
+        use transparent::address::TransparentAddress;
+        use zcash_client_backend::data_api::{AccountBirthday, chain::ChainState};
+        use zcash_keys::{address::Address, encoding::AddressCodec};
+        use zcash_protocol::consensus::{NetworkUpgrade, Parameters};
+
+        use crate::wallet::encoding::{KeyScope, ReceiverFlags};
+
+        /// The transparent receiver imported under account B and derived by account A. Its
+        /// bytes are arbitrary; nothing derives from or validates them.
+        const IMPORTED_RECEIVER_HASH: [u8; 20] = [0x33; 20];
+        /// The compressed pubkey recorded against the import. Only its presence matters: the
+        /// `addresses` check constraint requires exactly one import column to be set, and
+        /// nothing here parses it as a key.
+        const IMPORTED_PUBKEY: [u8; 33] = [0x02; 33];
+        /// Above the account's default external gap limit, so no derived record already occupies
+        /// this index and the derivation below reaches the import-upgrade path.
+        const DERIVED_CHILD_INDEX: u32 = 100;
+        /// The height at which the import was recorded as exposed.
+        const IMPORT_EXPOSURE_HEIGHT: u32 = 55;
+        /// The single transaction that all of the seeded notes belong to, and the columns it
+        /// needs; the reattribution does not read any of them.
+        const TX_ROW_ID: i64 = 1;
+        const TXID: [u8; 32] = [7; 32];
+        const OBSERVED_HEIGHT: u32 = 1;
+        /// Placeholders for the note columns that these assertions never read back; they exist
+        /// only to satisfy the received-note tables' NOT NULL constraints.
+        const NOTE_INDEX: i64 = 0;
+        const DIVERSIFIER: [u8; 11] = [0; 11];
+        const NOTE_VALUE_ZATS: i64 = 100_000;
+        const NOTE_COMPONENT: [u8; 32] = [0; 32];
+        /// The note plaintext version recorded for the seeded Orchard and Ironwood notes. Only
+        /// the Ironwood table requires it, and its value is immaterial here.
+        const NOTE_VERSION: i64 = 2;
+
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let account_a_uuid = st.test_account().unwrap().id();
+        let network = *st.network();
+
+        // A second account, under which the address will be imported.
+        let birthday = AccountBirthday::from_parts(
+            ChainState::empty(
+                network.activation_height(NetworkUpgrade::Sapling).unwrap() - 1,
+                BlockHash([0; 32]),
+            ),
+            None,
+        );
+        let seed_b = Secret::new(vec![42u8; 32]);
+        let (account_b_uuid, _) = st
+            .wallet_mut()
+            .create_account("b", &seed_b, &birthday, None)
+            .unwrap();
+
+        let taddr = TransparentAddress::PublicKeyHash(IMPORTED_RECEIVER_HASH);
+        let taddr_enc = taddr.encode(&network);
+        let child_index = NonHardenedChildIndex::from_index(DERIVED_CHILD_INDEX).unwrap();
+
+        let tx = st.wallet().db().conn.unchecked_transaction().unwrap();
+        let account_a = get_account_ref(&tx, account_a_uuid).unwrap();
+        let account_b = get_account_ref(&tx, account_b_uuid).unwrap();
+
+        // The standalone (`Foreign`) row under account B.
+        tx.execute(
+            "INSERT INTO addresses
+                 (account_id, key_scope, address, cached_transparent_receiver_address,
+                  imported_transparent_receiver_pubkey, receiver_flags, exposed_at_height)
+             VALUES (:account_id, :foreign, :address, :taddr, :pubkey, :receiver_flags,
+                  :exposed_at_height)",
+            named_params! {
+                ":account_id": account_b.0,
+                ":foreign": KeyScope::Foreign.encode(),
+                ":address": &taddr_enc,
+                ":taddr": &taddr_enc,
+                ":pubkey": &IMPORTED_PUBKEY[..],
+                ":receiver_flags": ReceiverFlags::P2PKH.bits(),
+                ":exposed_at_height": IMPORT_EXPOSURE_HEIGHT,
+            },
+        )
+        .unwrap();
+        let foreign_id = tx.last_insert_rowid();
+
+        tx.execute(
+            "INSERT INTO transactions (id_tx, txid, min_observed_height)
+             VALUES (:id_tx, :txid, :min_observed_height)",
+            named_params! {
+                ":id_tx": TX_ROW_ID,
+                ":txid": &TXID[..],
+                ":min_observed_height": OBSERVED_HEIGHT,
+            },
+        )
+        .unwrap();
+
+        // One note in each shielded pool, attached to the imported record and attributed to
+        // account B.
+        tx.execute(
+            "INSERT INTO sapling_received_notes
+                 (transaction_id, output_index, account_id, address_id, diversifier, value,
+                  rcm, is_change)
+             VALUES (:tx, :note_index, :account_id, :address_id, :diversifier, :value,
+                  :note_component, :is_change)",
+            named_params! {
+                ":tx": TX_ROW_ID,
+                ":note_index": NOTE_INDEX,
+                ":account_id": account_b.0,
+                ":address_id": foreign_id,
+                ":diversifier": &DIVERSIFIER[..],
+                ":value": NOTE_VALUE_ZATS,
+                ":note_component": &NOTE_COMPONENT[..],
+                ":is_change": false,
+            },
+        )
+        .unwrap();
+
+        for table in ["orchard_received_notes", "ironwood_received_notes"] {
+            tx.execute(
+                &format!(
+                    "INSERT INTO {table}
+                         (transaction_id, action_index, account_id, address_id, diversifier,
+                          value, rho, rseed, is_change, note_version)
+                     VALUES (:tx, :note_index, :account_id, :address_id, :diversifier,
+                          :value, :note_component, :note_component, :is_change, :note_version)"
+                ),
+                named_params! {
+                    ":tx": TX_ROW_ID,
+                    ":note_index": NOTE_INDEX,
+                    ":account_id": account_b.0,
+                    ":address_id": foreign_id,
+                    ":diversifier": &DIVERSIFIER[..],
+                    ":value": NOTE_VALUE_ZATS,
+                    ":note_component": &NOTE_COMPONENT[..],
+                    ":is_change": false,
+                    ":note_version": NOTE_VERSION,
+                },
+            )
+            .unwrap();
+        }
+
+        // Account A derives the same address.
+        super::store_address_range(
+            &tx,
+            &network,
+            account_a,
+            TransparentKeyScope::EXTERNAL,
+            vec![(Address::from(taddr), taddr, child_index)],
+        )
+        .unwrap();
+
+        // Every seeded note followed the record to the deriving account.
+        for table in [
+            "sapling_received_notes",
+            "orchard_received_notes",
+            "ironwood_received_notes",
+        ] {
+            let note_account_id: i64 = tx
+                .query_row(
+                    &format!("SELECT account_id FROM {table} WHERE address_id = :address_id"),
+                    named_params! { ":address_id": foreign_id },
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(
+                note_account_id, account_a.0,
+                "{table} was not reattributed to the deriving account"
+            );
+        }
+
+        tx.commit().unwrap();
+    }
+
+    /// Pins the invariant that makes the shielded arms of the reattribution above unreachable in
+    /// practice, so that they stay provably redundant rather than quietly becoming load-bearing.
+    ///
+    /// A shielded note's `address_id` is only ever produced by `upsert_address`, which writes the
+    /// external key scope and a non-null diversifier index. The `addresses` check constraint
+    /// makes a null diversifier index and the `Foreign` key scope equivalent, so a `Foreign`
+    /// record can be neither inserted nor matched by that function, and no shielded note can
+    /// resolve to one.
+    #[test]
+    fn foreign_addresses_cannot_carry_a_diversifier_index() {
+        use rusqlite::named_params;
+        use zcash_keys::keys::{ReceiverRequirement, UnifiedAddressRequest};
+
+        use crate::wallet::{
+            encoding::{KeyScope, ReceiverFlags, encode_diversifier_index_be},
+            upsert_address,
+        };
+
+        /// An address string for the rejected insert. It is never decoded, only stored.
+        const UNUSED_ADDRESS: &str = "placeholder-address";
+
+        let st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let account = st.test_account().unwrap();
+        let account_uuid = account.id();
+        let uivk = account.uivk();
+        let network = *st.network();
+
+        let tx = st.wallet().db().conn.unchecked_transaction().unwrap();
+        let account_id = get_account_ref(&tx, account_uuid).unwrap();
+
+        // The lowest diversifier index at which this account has a shielded address, and the
+        // address itself. A Sapling receiver is required so that the address exists whether or
+        // not the `orchard` feature is enabled; the search skips the indices at which the
+        // account's Sapling key has no valid diversifier.
+        let shielded_request = UnifiedAddressRequest::custom(
+            ReceiverRequirement::Omit,
+            ReceiverRequirement::Require,
+            ReceiverRequirement::Allow,
+        )
+        .unwrap();
+        let (ua, diversifier_index) = uivk.default_address(shielded_request).unwrap();
+
+        // A `Foreign` record carrying a diversifier index is rejected by the schema.
+        let rejected = tx.execute(
+            "INSERT INTO addresses
+                 (account_id, key_scope, diversifier_index_be, address, receiver_flags)
+             VALUES (:account_id, :foreign, :diversifier_index_be, :address, :receiver_flags)",
+            named_params! {
+                ":account_id": account_id.0,
+                ":foreign": KeyScope::Foreign.encode(),
+                ":diversifier_index_be": encode_diversifier_index_be(diversifier_index),
+                ":address": UNUSED_ADDRESS,
+                ":receiver_flags": ReceiverFlags::P2PKH.bits(),
+            },
+        );
+        assert!(
+            rejected.is_err(),
+            "a Foreign address record must not carry a diversifier index"
+        );
+
+        // The records that shielded notes are attached to are the complement of that: external
+        // scope, with a diversifier index.
+        let address_id = upsert_address(
+            &tx,
+            &network,
+            account_id,
+            diversifier_index,
+            &ua,
+            None,
+            false,
+        )
+        .unwrap();
+
+        let (key_scope, has_diversifier_index): (i64, bool) = tx
+            .query_row(
+                "SELECT key_scope, diversifier_index_be IS NOT NULL
+                 FROM addresses WHERE id = :id",
+                named_params! { ":id": address_id.0 },
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(key_scope, KeyScope::EXTERNAL.encode());
+        assert!(has_diversifier_index);
 
         tx.commit().unwrap();
     }


### PR DESCRIPTION
Closes #2814.

## Investigation first: can a shielded note reference a `Foreign` address row?

No, and this is the part that decides what the right fix is.

The reattribution loop in `store_address_range` moves the account attribution of the
outputs received at an address when a standalone (`Foreign`) transparent import is
upgraded in place by a *different* account deriving the same receiver. It walked
`transparent_received_outputs`, `sapling_received_notes` and `orchard_received_notes`,
but not `ironwood_received_notes`, even though that table has the same `address_id`
column and `orchard::put_received_note` populates it for Ironwood notes exactly as it
does for Orchard ones. Issue #2814 asks whether that is a real mis-attribution bug.

It is not, and neither are the Sapling and Orchard arms reachable. Three independent
legs, each verified against the source:

1. **The schema forbids the shape.** `addresses` carries
   `CONSTRAINT ck_addr_foreign_or_diversified CHECK ((diversifier_index_be IS NULL) ==
   (key_scope = -1))` (`wallet/db.rs:232-234`). Every `Foreign` row therefore has a NULL
   diversifier index. `upsert_address` (`wallet.rs:1504-1576`) hard-codes `key_scope` to
   `KeyScope::EXTERNAL` in both the `INSERT` and the
   `ON CONFLICT (account_id, diversifier_index_be, key_scope)` target, and always binds a
   non-NULL `diversifier_index_be`. It can neither create nor match a `Foreign` row.

2. **`upsert_address` is the sole writer of shielded `address_id`.** Both
   `sapling::ensure_address` (`wallet/sapling.rs:293-334`) and `orchard::ensure_address`
   (`wallet/orchard.rs:348-387`, the path shared by Orchard and Ironwood) return either
   `None` or `upsert_address(..)`. The migration backfills go through the same function
   (`transparent_gap_limit_handling.rs:522` and `:586`); `ironwood_received_notes` is
   created empty with no backfill at all. The only `address_id` resolved by joining on a
   transparent address targets `transparent_received_outputs` alone
   (`transparent_gap_limit_handling.rs:618-621`).

3. **No row is ever demoted to `Foreign`.** `key_scope = -1` is only ever written at
   `INSERT` time, by `import_standalone_transparent_pubkey` (`wallet.rs:909`, flags
   `P2PKH`) and `import_standalone_transparent_script` (`wallet.rs:1002`, flags `P2SH`);
   both bail out early if the receiver already has a row. The one `UPDATE` that writes
   `key_scope` is the upgrade in `store_address_range` itself, which moves a row *out of*
   `Foreign`. So a `Foreign` row also never carries the `SAPLING` or `ORCHARD` receiver
   flag: it is a transparent-only import with no shielded receiver to receive a note at.

### Where the three-table list came from

It was copied from the duplicate-merge loop in `add_transparent_receiver_address_index`
(`add_transparent_receiver_address_index.rs:275-297`), as the commit that added the
runtime loop says (8754bde). **There the shielded entries are genuinely reachable**, and
that is the asymmetry that explains the whole thing: that loop repoints the rows of
*duplicate* address records, selected only by sharing a
`cached_transparent_receiver_address`, and a duplicate can be a fully derived,
external-scoped record belonging to another account, which certainly can carry shielded
notes. A `Foreign` record is explicitly excluded from being the canonical one
(`record_derives_receiver` returns `None` for it). That migration is also right to omit
`ironwood_received_notes`: whichever topological order the migrator picks for the two
sibling branches under `standalone_p2sh`, the Ironwood table is empty at that point,
since it is created empty and only the runtime scanner writes to it.

`store_address_range` matches its row with `AND key_scope = :foreign_scope`, which
restricts it to exactly the case leg 1 rules out.

## Resolution

Leaving one shielded pool out is wrong under either reading, so the choice was between
removing the shielded arms and adding Ironwood. **Ironwood is added**, with a comment
recording the invariant that makes all three shielded arms redundant.

The reasoning is asymmetric risk, not aesthetics. If the analysis above is right, the
added statement costs one no-op `UPDATE` on a path that only runs when an import is
upgraded across accounts. If it is wrong in some corner not found here, removing the
Sapling and Orchard arms would mis-attribute shielded funds to the wrong account, which
is silent and permanent. The existing code also plainly means "every pool that has a
received-note table"; Ironwood is the anomaly, and the same omission has already been a
real bug once in the sibling pool list in `flag_previously_received_change`.

The comment makes the redundancy deliberate rather than accidental, so a future reader
does not re-derive this analysis from scratch, and the tests below keep it honest.

### Schema-version safety

`store_address_range` is reachable from a migration (`transparent_gap_limit_handling.rs:147`),
so naming a table that does not yet exist there would be a hard error. It cannot happen:
the branch runs only when a `Foreign` row exists, which requires the
`imported_transparent_receiver_*` columns first added by `support_zcashd_wallet_import`,
which is a strict descendant of `transparent_gap_limit_handling` in the migration DAG.
`ironwood_received_notes` is downstream of that again. At the only migration-time call
site there are no `Foreign` rows at all and the branch is never entered; at runtime the
database is fully migrated.

## Tests

- `store_address_range_reattributes_shielded_notes_of_imported_receiver` seeds a
  `Foreign` record under account B with one directly-inserted note in each of the three
  shielded tables, has account A derive the address, and asserts all three move to
  account A. Verified to fail on Ironwood with the one-line change reverted
  (`ironwood_received_notes was not reattributed to the deriving account`), and to pass
  with it.
- `foreign_addresses_cannot_carry_a_diversifier_index` pins the invariant that makes the
  first test unreachable in production: the schema rejects a `Foreign` record carrying a
  diversifier index, and `upsert_address` produces an external-scoped record with one.
  This keeps the dead arms provably dead rather than quietly becoming load-bearing.

Both pass with `--all-features` and with `transparent-inputs,transparent-key-import`
(no `orchard`).

## Database write atomicity

The operation issues more than one write, so, per `AGENTS.md`:

1. **How many writes?** Per derived address that matches an import: one `UPDATE addresses`,
   plus (only when the import was under a different account) one `UPDATE` per pool table,
   now four instead of three. Otherwise one `INSERT`. This change adds one statement and
   does not change the shape.
2. **Must they land together?** Yes. A record upgraded to the deriving account whose
   outputs still carry the importing account's `account_id` is a wrong-balance state that
   the rest of the wallet would read as valid. They already do land together:
   `store_address_range` takes a `&rusqlite::Transaction` and never opens its own, so all
   of these run inside the caller's transaction and roll back as a unit.
3. **What happens on retry?** The operation is idempotent, and a partial commit is not
   reachable given (2). Re-deriving the same address finds the row already in its derived
   form, so the `Foreign` lookup no longer matches and the `INSERT ... ON CONFLICT DO
   NOTHING` arm is a no-op. If the row were somehow left half-updated, a retry would find
   no `Foreign` row and would not repair the notes, which is exactly why the single
   enclosing transaction is load-bearing.
4. **Does any read path see only one side?** Balance and note-selection queries read
   `*_received_notes.account_id` directly, while address-scoped queries join through
   `addresses.account_id`, so a partial write would be visible through one and not the
   other. Again, only reachable if the transaction were split.

No `WalletWrite` trait method changes, so no rustdoc atomicity sentence is added or
altered.

## No CHANGELOG entry

There is no user-visible change: the added statement cannot match a row in any state the
crate can produce. A `Fixed` entry would tell users something was broken for them, and a
`Changed` entry would describe an implementation detail invisible through the public API,
both of which `AGENTS.md` rules out. Happy to add one if you would rather record it.

## Open question for a maintainer, not addressed here

`ensure_address` builds the account's UA with `UnifiedAddressRequest::ALLOW_ALL`, so
`upsert_address` binds a `cached_transparent_receiver_address`. If a `Foreign` row already
holds that same transparent receiver, the `INSERT` conflicts on
`idx_addresses_cached_transparent_receiver_address`, which is not the `ON CONFLICT`
target, so the statement raises rather than upserting. That is a hard error on the scan
path rather than a mis-attribution, so it does not change the answer above, but it looks
like the shielded-side counterpart of the situation `store_address_range` handles on the
transparent side. Left alone deliberately to keep this PR to one concern.

Co-Authored-By: Claude <noreply@anthropic.com>
