### PR TITLE
zcash_client_sqlite: generate the migration DAG comment from DEPENDENCIES

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -549,6 +549,16 @@ jobs:
             uuidparse -n -o uuid $U4 | sort | uniq | wc -l
           )
 
+  migration-dag:
+    name: Migration DAG comment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Check the migration DAG comment against each migration's DEPENDENCIES
+        run: python3 zcash_client_sqlite/tools/migration_dag.py zcash_client_sqlite
+
   required-checks:
     name: Required status checks have passed
     needs:
@@ -563,6 +573,7 @@ jobs:
       - fmt
       - protobuf
       - uuid
+      - migration-dag
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -89,73 +89,91 @@ pub(super) fn all_migrations<
     rng: R,
     seed: Option<Rc<SecretVec<u8>>>,
 ) -> Vec<Box<dyn RusqliteMigration<Error = WalletMigrationError>>> {
-    //                                   initial_setup
-    //                                   /           \
-    //                          utxos_table         ufvk_support
-    //                             |                 /         \
-    //                             |    addresses_table   sent_notes_to_internal
-    //                             |          /                /
-    //                           add_utxo_account             /
-    //                                        \              /
-    //                                     add_transaction_views
-    //                                               |
-    //                                       v_transactions_net
-    //                                               |
-    //                                            received_notes_nullable_nf---------------------.
-    //                                            /           |                                   \
-    //                                           /            |                                    \
-    //           ,-------------- shardtree_support    sapling_memo_consistency                    nullifier_map
-    //          /                     /           \                       \                                  |
-    // orchard_shardtree   add_account_birthdays   receiving_key_scopes   v_transactions_transparent_history |
-    //   |                    |                 \            |                     |                         |
-    //   |   v_sapling_shard_unscanned_ranges    \           |       v_tx_outputs_use_legacy_false           |
-    //   |                    |                   \          |                     |                         |
-    //   |            wallet_summaries             \         |      v_transactions_shielding_balance         /
-    //   \                    \                     \        |                     |                        /
-    //    \                    \                     \       |      v_transactions_note_uniqueness         /
-    //     \                    \                     \      |        /                                   /
-    //      \                    `------------------- full_account_ids                                   /
-    //       \                                        /               \                                 /
-    //        \                         orchard_received_notes        spend_key_available              /
-    //         \                            /          \                      /                       /
-    //          \     ensure_orchard_ua_receiver     utxos_to_txos           /                       /
-    //           \                          \              |                /                       /
-    //            \                          \     ephemeral_addresses     /                       /
-    //             \                          \            |              /                       /
-    //              `----------------------------- tx_retrieval_queue ---------------------------'
-    //                                                  /    \
-    //                              support_legacy_sqlite    tx_retrieval_queue_expiry ----------------.
-    //                                 /              \                                                 \
-    //            fix_broken_commitment_trees         add_account_uuids                                  \
-    //                       /                                /        \                                  \
-    //    fix_bad_change_flagging      transparent_gap_limit_handling   v_transactions_additional_totals   \
-    //                       \                       |                      /                               \
-    //                        \      ensure_default_transparent_address    /                                 \
-    //                         \                     |                    /                                   \
-    //                          `---- fix_transparent_received_outputs --'                                     \
-    //                                    /         /           \                                              |
-    //                                   /         /             \                                             |
-    //                                  /         /               \                                            |
-    //           support_zcashd_wallet_import    /             fix_v_transactions_expired_unmined              |
-    //                \                         /                    /        |         \                      |
-    //                 \      tx_observation_height                 /         |          \                     |
-    //                  \                       \                  /          |           \                    /
-    //                   \                   add_transaction_trust_marker     |  v_tx_outputs_return_addrs    /
-    //                    \                       \                           |                     /        /
-    //                     \                       \         v_received_output_spends_account      /        /
-    //                      \                       \               /                             /        /
-    //                       `------------------- account_delete_cascade ---------------------------------'
-    //                              /               /                  |              \
-    //     add_transparent_value_index  v_tx_outputs_key_scopes  standalone_p2sh    witness_stabilized_notes
-    //                                                    /          \         \
-    //                                                   /            \      orchard_note_version
-    //                                                  /              \                      \
-    //                                                 /                \               ironwood_received_notes
-    //                                                /                  \                     /           \
-    //                                               /                    \    ironwood_pool_code_views   note_locking
-    //                                              /                      \
-    //                                          ivk_item_cache    add_transparent_receiver_address_index
+    // BEGIN GENERATED MIGRATION DAG
+    // The migration DAG, derived from each migration's DEPENDENCIES.
+    // Regenerate with `tools/migration_dag.py . --write`; CI checks it.
     //
+    // Indentation is the dependency depth. A migration listed under another
+    // runs after it. Where a migration has more than one dependency, only the
+    // deepest is shown by the indentation and the rest follow the name.
+    //
+    // initial_setup
+    //   ufvk_support
+    //     addresses_table
+    //       add_utxo_account  (also after utxos_table)
+    //         add_transaction_views  (also after sent_notes_to_internal)
+    //           v_transactions_net
+    //             received_notes_nullable_nf
+    //               nullifier_map
+    //               sapling_memo_consistency
+    //                 v_transactions_transparent_history
+    //                   v_tx_outputs_use_legacy_false
+    //                     v_transactions_shielding_balance
+    //                       v_transactions_note_uniqueness
+    //                         full_account_ids
+    //                           (also after add_account_birthdays, receiving_key_scopes, wallet_summaries)
+    //                           orchard_received_notes
+    //                             ensure_orchard_ua_receiver
+    //                             utxos_to_txos
+    //                               ephemeral_addresses
+    //                                 tx_retrieval_queue
+    //                                   (also after ensure_orchard_ua_receiver, nullifier_map, orchard_shardtree,
+    //                                   spend_key_available)
+    //                                   support_legacy_sqlite
+    //                                     add_account_uuids
+    //                                       transparent_gap_limit_handling
+    //                                         ensure_default_transparent_address
+    //                                           fix_transparent_received_outputs
+    //                                             (also after fix_bad_change_flagging,
+    //                                             v_transactions_additional_totals)
+    //                                             fix_v_transactions_expired_unmined
+    //                                               add_transaction_trust_marker  (also after tx_observation_height)
+    //                                                 account_delete_cascade
+    //                                                   (also after support_zcashd_wallet_import,
+    //                                                   tx_retrieval_queue_expiry, v_received_output_spends_account,
+    //                                                   v_tx_outputs_return_addrs)
+    //                                                   add_transparent_value_index
+    //                                                   standalone_p2sh
+    //                                                     add_transparent_receiver_address_index
+    //                                                     ivk_item_cache
+    //                                                   v_tx_outputs_key_scopes
+    //                                                   witness_stabilized_notes  (also after ironwood_shardtree)
+    //                                                     orchard_note_version
+    //                                                       ironwood_received_notes
+    //                                                         ironwood_pool_code_views
+    //                                                         note_locking
+    //                                                         orchard_ironwood_migration_tables
+    //                                                     tree_retained_checkpoints
+    //                                               v_received_output_spends_account
+    //                                               v_tx_outputs_return_addrs
+    //                                             support_zcashd_wallet_import
+    //                                             tx_observation_height
+    //                                       v_transactions_additional_totals
+    //                                     fix_broken_commitment_trees
+    //                                       fix_bad_change_flagging
+    //                                   tx_retrieval_queue_expiry
+    //                           spend_key_available
+    //               shardtree_support
+    //                 add_account_birthdays
+    //                   v_sapling_shard_unscanned_ranges
+    //                     wallet_summaries
+    //                       ironwood_shardtree  (also after orchard_shardtree)
+    //                 orchard_shardtree
+    //                 receiving_key_scopes
+    //     sent_notes_to_internal
+    //   utxos_table
+    //
+    // Leaves (8), which CURRENT_LEAF_MIGRATIONS must match:
+    //   add_transparent_receiver_address_index
+    //   add_transparent_value_index
+    //   ironwood_pool_code_views
+    //   ivk_item_cache
+    //   note_locking
+    //   orchard_ironwood_migration_tables
+    //   tree_retained_checkpoints
+    //   v_tx_outputs_key_scopes
+    // END GENERATED MIGRATION DAG
+
     let rng = Rc::new(Mutex::new(rng));
     vec![
         Box::new(initial_setup::Migration {}),

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -89,91 +89,80 @@ pub(super) fn all_migrations<
     rng: R,
     seed: Option<Rc<SecretVec<u8>>>,
 ) -> Vec<Box<dyn RusqliteMigration<Error = WalletMigrationError>>> {
-    // BEGIN GENERATED MIGRATION DAG
-    // The migration DAG, derived from each migration's DEPENDENCIES.
-    // Regenerate with `tools/migration_dag.py . --write`; CI checks it.
+    //                                   initial_setup
+    //                                   /           \
+    //                          utxos_table         ufvk_support
+    //                             |                 /         \
+    //                             |    addresses_table   sent_notes_to_internal
+    //                             |          /                /
+    //                           add_utxo_account             /
+    //                                        \              /
+    //                                     add_transaction_views
+    //                                               |
+    //                                       v_transactions_net
+    //                                               |
+    //                                            received_notes_nullable_nf---------------------.
+    //                                            /           |                                   \
+    //                                           /            |                                    \
+    //           ,-------------- shardtree_support    sapling_memo_consistency                    nullifier_map
+    //          /                     /           \                       \                                  |
+    // orchard_shardtree   add_account_birthdays   receiving_key_scopes   v_transactions_transparent_history |
+    //   |                    |                 \            |                     |                         |
+    //   |   v_sapling_shard_unscanned_ranges    \           |       v_tx_outputs_use_legacy_false           |
+    //   |                    |                   \          |                     |                         |
+    //   |            wallet_summaries             \         |      v_transactions_shielding_balance         /
+    //   \                    \                     \        |                     |                        /
+    //    \                    \                     \       |      v_transactions_note_uniqueness         /
+    //     \                    \                     \      |        /                                   /
+    //      \                    `------------------- full_account_ids                                   /
+    //       \                                        /               \                                 /
+    //        \                         orchard_received_notes        spend_key_available              /
+    //         \                            /          \                      /                       /
+    //          \     ensure_orchard_ua_receiver     utxos_to_txos           /                       /
+    //           \                          \              |                /                       /
+    //            \                          \     ephemeral_addresses     /                       /
+    //             \                          \            |              /                       /
+    //              `----------------------------- tx_retrieval_queue ---------------------------'
+    //                                                  /    \
+    //                              support_legacy_sqlite    tx_retrieval_queue_expiry ----------------.
+    //                                 /              \                                                 \
+    //            fix_broken_commitment_trees         add_account_uuids                                  \
+    //                       /                                /        \                                  \
+    //    fix_bad_change_flagging      transparent_gap_limit_handling   v_transactions_additional_totals   \
+    //                       \                       |                      /                               \
+    //                        \      ensure_default_transparent_address    /                                 \
+    //                         \                     |                    /                                   \
+    //                          `---- fix_transparent_received_outputs --'                                     \
+    //                                    /         /           \                                              |
+    //                                   /         /             \                                             |
+    //                                  /         /               \                                            |
+    //           support_zcashd_wallet_import    /             fix_v_transactions_expired_unmined              |
+    //                \                         /                    /        |         \                      |
+    //                 \      tx_observation_height                 /         |          \                     |
+    //                  \                       \                  /          |           \                    /
+    //                   \                   add_transaction_trust_marker     |  v_tx_outputs_return_addrs    /
+    //                    \                       \                           |                     /        /
+    //                     \                       \         v_received_output_spends_account      /        /
+    //                      \                       \               /                             /        /
+    //                       `------------------- account_delete_cascade ---------------------------------'
+    //                              /               /                  |              \
+    //     add_transparent_value_index  v_tx_outputs_key_scopes  standalone_p2sh    witness_stabilized_notes
+    //                                                    /          \         \
+    //                                                   /            \      orchard_note_version
+    //                                                  /              \                      \
+    //                                                 /                \               ironwood_received_notes
+    //                                                /                  \                     /     |     \
+    //                                               /                    \    ironwood_pool_code_views   note_locking
+    //                                              /                      \                         |
+    //                                             /                        \        orchard_ironwood_migration_tables
+    //                                              /                      \
+    //                                          ivk_item_cache    add_transparent_receiver_address_index
     //
-    // Indentation is the dependency depth. A migration listed under another
-    // runs after it. Where a migration has more than one dependency, only the
-    // deepest is shown by the indentation and the rest follow the name.
+    // Two edges are not drawn above, for want of horizontal room. They are still
+    // checked by tools/migration_dag.py:
+    //   witness_stabilized_notes -> tree_retained_checkpoints
+    //   orchard_shardtree, wallet_summaries -> ironwood_shardtree
     //
-    // initial_setup
-    //   ufvk_support
-    //     addresses_table
-    //       add_utxo_account  (also after utxos_table)
-    //         add_transaction_views  (also after sent_notes_to_internal)
-    //           v_transactions_net
-    //             received_notes_nullable_nf
-    //               nullifier_map
-    //               sapling_memo_consistency
-    //                 v_transactions_transparent_history
-    //                   v_tx_outputs_use_legacy_false
-    //                     v_transactions_shielding_balance
-    //                       v_transactions_note_uniqueness
-    //                         full_account_ids
-    //                           (also after add_account_birthdays, receiving_key_scopes, wallet_summaries)
-    //                           orchard_received_notes
-    //                             ensure_orchard_ua_receiver
-    //                             utxos_to_txos
-    //                               ephemeral_addresses
-    //                                 tx_retrieval_queue
-    //                                   (also after ensure_orchard_ua_receiver, nullifier_map, orchard_shardtree,
-    //                                   spend_key_available)
-    //                                   support_legacy_sqlite
-    //                                     add_account_uuids
-    //                                       transparent_gap_limit_handling
-    //                                         ensure_default_transparent_address
-    //                                           fix_transparent_received_outputs
-    //                                             (also after fix_bad_change_flagging,
-    //                                             v_transactions_additional_totals)
-    //                                             fix_v_transactions_expired_unmined
-    //                                               add_transaction_trust_marker  (also after tx_observation_height)
-    //                                                 account_delete_cascade
-    //                                                   (also after support_zcashd_wallet_import,
-    //                                                   tx_retrieval_queue_expiry, v_received_output_spends_account,
-    //                                                   v_tx_outputs_return_addrs)
-    //                                                   add_transparent_value_index
-    //                                                   standalone_p2sh
-    //                                                     add_transparent_receiver_address_index
-    //                                                     ivk_item_cache
-    //                                                   v_tx_outputs_key_scopes
-    //                                                   witness_stabilized_notes  (also after ironwood_shardtree)
-    //                                                     orchard_note_version
-    //                                                       ironwood_received_notes
-    //                                                         ironwood_pool_code_views
-    //                                                         note_locking
-    //                                                         orchard_ironwood_migration_tables
-    //                                                     tree_retained_checkpoints
-    //                                               v_received_output_spends_account
-    //                                               v_tx_outputs_return_addrs
-    //                                             support_zcashd_wallet_import
-    //                                             tx_observation_height
-    //                                       v_transactions_additional_totals
-    //                                     fix_broken_commitment_trees
-    //                                       fix_bad_change_flagging
-    //                                   tx_retrieval_queue_expiry
-    //                           spend_key_available
-    //               shardtree_support
-    //                 add_account_birthdays
-    //                   v_sapling_shard_unscanned_ranges
-    //                     wallet_summaries
-    //                       ironwood_shardtree  (also after orchard_shardtree)
-    //                 orchard_shardtree
-    //                 receiving_key_scopes
-    //     sent_notes_to_internal
-    //   utxos_table
-    //
-    // Leaves (8), which CURRENT_LEAF_MIGRATIONS must match:
-    //   add_transparent_receiver_address_index
-    //   add_transparent_value_index
-    //   ironwood_pool_code_views
-    //   ivk_item_cache
-    //   note_locking
-    //   orchard_ironwood_migration_tables
-    //   tree_retained_checkpoints
-    //   v_tx_outputs_key_scopes
-    // END GENERATED MIGRATION DAG
-
     let rng = Rc::new(Mutex::new(rng));
     vec![
         Box::new(initial_setup::Migration {}),

--- a/zcash_client_sqlite/tools/migration_dag.py
+++ b/zcash_client_sqlite/tools/migration_dag.py
@@ -1,19 +1,30 @@
 #!/usr/bin/env python3
-"""Derive the migration DAG from the source and check or rewrite its diagram.
+"""Check the hand-drawn migration DAG comment against the real dependency graph.
 
-The source of truth is each `wallet/init/migrations/<name>.rs`, which declares
+The diagram in `wallet/init/migrations.rs` is drawn by hand, but the graph it
+depicts is declared elsewhere: each `wallet/init/migrations/<name>.rs` has
 
     const DEPENDENCIES: &[Uuid] = &[<module>::MIGRATION_ID, ...];
 
-The module path names the parent directly, so the edges can be read without
-resolving UUIDs. The diagram in `wallet/init/migrations.rs` is derived from
-those edges rather than maintained by hand, because nothing else keeps a prose
-comment honest: it had drifted by three migrations before this tool existed.
+Nothing kept the two in step, and they drifted: three migrations were missing
+from the diagram entirely and one node was drawn with half its children. This
+checks the parts of that correspondence a machine can check.
+
+What is checked:
+  * every migration module appears somewhere in the diagram;
+  * every migration-looking name in the diagram is a real migration, so a
+    renamed or deleted module cannot leave a ghost behind;
+  * the leaves computed from the graph match `CURRENT_LEAF_MIGRATIONS`;
+  * no diagram line exceeds the width budget.
+
+What is NOT checked, and cannot be: the shape of the drawing. Whether an edge is
+depicted, and whether it is depicted correctly, is not recoverable from free-form
+ASCII art. This catches a migration that was forgotten, not one that was drawn in
+the wrong place. Deciding to generate the diagram instead would close that gap;
+see the discussion in the pull request that introduced this file.
 
 Usage:
-    migration_dag.py <crate_root> --check     verify the diagram (exit 1 on drift)
-    migration_dag.py <crate_root> --write     rewrite the diagram in place
-    migration_dag.py <crate_root> --print     write the diagram to stdout
+    migration_dag.py <crate_root>             check (exit 1 on any problem)
     migration_dag.py <crate_root> --mermaid   emit a Mermaid graph
     migration_dag.py <crate_root> --dot       emit a Graphviz graph
 
@@ -23,152 +34,77 @@ Usage:
 import os
 import re
 import sys
-import textwrap
 from collections import defaultdict
 
-# The diagram lives between these two markers so the tool can find it without
-# guessing at line numbers. Everything between them is generated.
-BEGIN = "    // BEGIN GENERATED MIGRATION DAG"
-END = "    // END GENERATED MIGRATION DAG"
-
-# Width budget, measured from the hand-drawn diagram this replaced: every line
-# of it was at or under 118 columns. rustfmt does not reflow comments, so this
-# is a convention rather than a tool constraint, but it is the convention the
-# file already had and there is no reason to widen it.
+# Measured from the diagram itself: every line of it is at or under this. rustfmt
+# does not reflow comments, so this is a convention rather than a tool constraint,
+# but it is the one the file already had.
 MAX_WIDTH = 118
-PREFIX = "    //"
-INDENT = 2
 
 DEPS_RE = re.compile(r"const DEPENDENCIES:\s*&\[Uuid\]\s*=\s*&\[(.*?)\];", re.S)
 DEP_ITEM_RE = re.compile(r"(?:super::)?([a-z0-9_]+)::MIGRATION_ID")
 LEAVES_RE = re.compile(r"CURRENT_LEAF_MIGRATIONS:\s*&\[Uuid\]\s*=\s*&\[(.*?)\];", re.S)
+# A migration name as it appears in the drawing. Deliberately loose, then filtered
+# against the real module list, so that box-drawing runs and prose do not match.
+NAME_IN_ART_RE = re.compile(r"[a-z][a-z0-9_]{6,}")
+
+# Words that appear in the diagram's prose but are not migrations.
+ART_PROSE = {"migration", "migrations", "encountered", "included", "omitted", "versions"}
+# Paths (this tool is named in the comment) are not nodes in the graph.
+PATH_RE = re.compile(r"[\w./-]+\.(?:py|rs|toml|md)")
 
 
-class Dag:
-    def __init__(self, crate_root):
-        self.crate_root = crate_root
-        self.mig_dir = os.path.join(crate_root, "src", "wallet", "init", "migrations")
-        self.mig_rs = os.path.join(crate_root, "src", "wallet", "init", "migrations.rs")
+def load(crate_root):
+    mig_dir = os.path.join(crate_root, "src", "wallet", "init", "migrations")
+    parents = {}
+    for fn in sorted(os.listdir(mig_dir)):
+        if not fn.endswith(".rs"):
+            continue
+        body = open(os.path.join(mig_dir, fn), encoding="utf-8").read()
+        m = DEPS_RE.search(body)
+        parents[fn[:-3]] = DEP_ITEM_RE.findall(m.group(1)) if m else []
+    return parents
 
-        self.parents = {}
-        for fn in sorted(os.listdir(self.mig_dir)):
-            if not fn.endswith(".rs"):
-                continue
-            body = open(os.path.join(self.mig_dir, fn), encoding="utf-8").read()
-            m = DEPS_RE.search(body)
-            self.parents[fn[:-3]] = DEP_ITEM_RE.findall(m.group(1)) if m else []
 
-        self.children = defaultdict(list)
-        for node, ps in self.parents.items():
-            for p in ps:
-                self.children[p].append(node)
-        for k in self.children:
-            self.children[k].sort()
-
-        self.roots = sorted(n for n, ps in self.parents.items() if not ps)
-        self.leaves = sorted(n for n in self.parents if not self.children.get(n))
-
-        # Longest-path depth, so every edge points strictly downward and the
-        # indented rendering can never show a child above its parent.
-        self.depth = {}
-        for n in self.parents:
-            self._depth(n)
-
-    def _depth(self, n):
-        if n in self.depth:
-            return self.depth[n]
-        # Guard against a cycle rather than recursing forever; a cycle is a real
-        # error in the migration graph and should be reported, not hung on.
-        self.depth[n] = None
-        d = 0 if not self.parents[n] else 1 + max(self._depth(p) for p in self.parents[n])
-        self.depth[n] = d
-        return d
-
-    def declared_leaves(self):
-        src = open(self.mig_rs, encoding="utf-8").read()
-        m = LEAVES_RE.search(src)
-        return set(DEP_ITEM_RE.findall(m.group(1))) if m else set()
-
-    def primary_parent(self, n):
-        """The parent the tree hangs `n` from: the deepest one, ties broken by name.
-
-        Choosing the deepest keeps the indentation monotonic, so a node always
-        appears below every parent it has.
-        """
-        ps = self.parents[n]
-        return max(sorted(ps), key=lambda p: self.depth[p]) if ps else None
-
-    def render(self):
-        """Render the diagram as comment lines, without the markers."""
-        tree_children = defaultdict(list)
-        for n in sorted(self.parents):
-            p = self.primary_parent(n)
-            if p is not None:
-                tree_children[p].append(n)
-
-        lines = [
-            "The migration DAG, derived from each migration's DEPENDENCIES.",
-            "Regenerate with `tools/migration_dag.py . --write`; CI checks it.",
-            "",
-            "Indentation is the dependency depth. A migration listed under another",
-            "runs after it. Where a migration has more than one dependency, only the",
-            "deepest is shown by the indentation and the rest follow the name.",
-            "",
-        ]
-
-        def walk(node, level):
-            pad = " " * (INDENT * level)
-            extra = sorted(p for p in self.parents[node] if p != self.primary_parent(node))
-            if not extra:
-                lines.append(pad + node)
-            else:
-                annotation = f"(also after {', '.join(extra)})"
-                one_line = f"{pad}{node}  {annotation}"
-                if len(PREFIX) + 1 + len(one_line) <= MAX_WIDTH:
-                    lines.append(one_line)
-                else:
-                    # A node with several extra dependencies does not fit beside its
-                    # name. Wrap the annotation under it rather than overrun the
-                    # width budget, which is what the hand-drawn diagram could not do.
-                    lines.append(pad + node)
-                    cont = pad + " " * INDENT
-                    budget = MAX_WIDTH - len(PREFIX) - 1 - len(cont)
-                    for chunk in textwrap.wrap(annotation, width=budget):
-                        lines.append(cont + chunk)
-            for c in tree_children.get(node, []):
-                walk(c, level + 1)
-
-        for r in self.roots:
-            walk(r, 0)
-
-        lines += ["", f"Leaves ({len(self.leaves)}), which CURRENT_LEAF_MIGRATIONS must match:"]
-        lines += [" " * INDENT + n for n in self.leaves]
-
-        out = []
-        for l in lines:
-            out.append((PREFIX + " " + l).rstrip() if l else PREFIX)
-        return out
-
-    def diagram_bounds(self, lines):
-        try:
-            b = next(i for i, l in enumerate(lines) if l.rstrip() == BEGIN)
-            e = next(i for i, l in enumerate(lines) if l.rstrip() == END)
-        except StopIteration:
-            return None
-        return b, e
+def diagram_lines(mig_rs):
+    """The comment block inside `all_migrations`, located structurally."""
+    lines = open(mig_rs, encoding="utf-8").read().splitlines()
+    try:
+        start = next(
+            i + 1
+            for i, l in enumerate(lines)
+            if l.startswith(") -> Vec<Box<dyn RusqliteMigration")
+        )
+    except StopIteration:
+        raise SystemExit(f"error: could not find `all_migrations` in {mig_rs}")
+    out = []
+    for l in lines[start:]:
+        if l.lstrip().startswith("//"):
+            out.append(l)
+        elif l.strip() == "":
+            continue
+        else:
+            break
+    return out
 
 
 def main():
-    if len(sys.argv) < 3:
+    if len(sys.argv) < 2:
         print(__doc__)
         return 2
-    crate_root, mode = sys.argv[1], sys.argv[2]
-    dag = Dag(crate_root)
+    crate_root = sys.argv[1]
+    mode = sys.argv[2] if len(sys.argv) > 2 else None
+
+    parents = load(crate_root)
+    children = defaultdict(list)
+    for n, ps in parents.items():
+        for p in ps:
+            children[p].append(n)
 
     if mode == "--mermaid":
         print("graph TD")
-        for n in sorted(dag.parents):
-            for p in dag.parents[n]:
+        for n in sorted(parents):
+            for p in parents[n]:
                 print(f"    {p} --> {n}")
         return 0
 
@@ -176,63 +112,70 @@ def main():
         print("digraph migrations {")
         print("  rankdir=TB;")
         print("  node [shape=box, fontname=monospace];")
-        for n in sorted(dag.parents):
-            for p in dag.parents[n]:
+        for n in sorted(parents):
+            for p in parents[n]:
                 print(f'  "{p}" -> "{n}";')
         print("}")
         return 0
 
-    rendered = dag.render()
-    over = [l for l in rendered if len(l) > MAX_WIDTH]
+    mig_rs = os.path.join(crate_root, "src", "wallet", "init", "migrations.rs")
+    art = diagram_lines(mig_rs)
+    art_text = "\n".join(art)
+    src = open(mig_rs, encoding="utf-8").read()
+
+    problems = []
+
+    missing = sorted(n for n in parents if n not in art_text)
+    if missing:
+        problems.append(
+            "migrations missing from the diagram:\n"
+            + "".join(f"    {n}   (after {', '.join(parents[n]) or 'nothing'})\n" for n in missing)
+        )
+
+    # A name drawn in the art that no longer exists as a module. Names are matched
+    # loosely then intersected with reality, so only plausible ghosts are reported.
+    # Strip file paths first: a reference to this tool is not a node in the graph.
+    drawn = {w for l in art for w in NAME_IN_ART_RE.findall(PATH_RE.sub(" ", l))}
+    ghosts = sorted(w for w in drawn - set(parents) - ART_PROSE if "_" in w)
+    if ghosts:
+        problems.append(
+            "names in the diagram that are not migrations (renamed or deleted?):\n"
+            + "".join(f"    {g}\n" for g in ghosts)
+        )
+
+    leaves = {n for n in parents if not children.get(n)}
+    m = LEAVES_RE.search(src)
+    declared = set(DEP_ITEM_RE.findall(m.group(1))) if m else set()
+    if declared != leaves:
+        problems.append(
+            "CURRENT_LEAF_MIGRATIONS does not match the graph:\n"
+            + f"    missing from the list: {sorted(leaves - declared)}\n"
+            + f"    listed but not a leaf: {sorted(declared - leaves)}\n"
+        )
+
+    over = [(len(l), l) for l in art if len(l) > MAX_WIDTH]
     if over:
-        print(f"error: {len(over)} rendered line(s) exceed {MAX_WIDTH} columns:", file=sys.stderr)
-        for l in over:
-            print(f"  {len(l)}: {l}", file=sys.stderr)
+        problems.append(
+            f"diagram lines wider than {MAX_WIDTH} columns:\n"
+            + "".join(f"    {w}: {l}\n" for w, l in over)
+        )
+
+    if problems:
+        print("migration DAG check failed.\n", file=sys.stderr)
+        for p in problems:
+            print("  " + p.rstrip() + "\n", file=sys.stderr)
+        print(
+            "The diagram is hand-drawn; edit it in wallet/init/migrations.rs.\n"
+            "Run `zcash_client_sqlite/tools/migration_dag.py zcash_client_sqlite` to re-check.",
+            file=sys.stderr,
+        )
         return 1
 
-    if mode == "--print":
-        print("\n".join(rendered))
-        return 0
-
-    src_lines = open(dag.mig_rs, encoding="utf-8").read().splitlines()
-    bounds = dag.diagram_bounds(src_lines)
-    if bounds is None:
-        print(f"error: markers not found in {dag.mig_rs}", file=sys.stderr)
-        print(f"  expected {BEGIN!r} and {END!r}", file=sys.stderr)
-        return 1
-    b, e = bounds
-
-    if mode == "--write":
-        src_lines[b + 1 : e] = rendered
-        open(dag.mig_rs, "w", encoding="utf-8").write("\n".join(src_lines) + "\n")
-        print(f"wrote {len(rendered)} lines into {dag.mig_rs}")
-        return 0
-
-    if mode == "--check":
-        failed = False
-        current = src_lines[b + 1 : e]
-        if current != rendered:
-            print("error: the migration DAG comment is out of date.", file=sys.stderr)
-            print("       run: tools/migration_dag.py . --write", file=sys.stderr)
-            import difflib
-
-            for d in difflib.unified_diff(current, rendered, "committed", "generated", lineterm=""):
-                print("  " + d, file=sys.stderr)
-            failed = True
-
-        declared = dag.declared_leaves()
-        if declared != set(dag.leaves):
-            print("error: CURRENT_LEAF_MIGRATIONS does not match the computed leaves.", file=sys.stderr)
-            print(f"  missing from the list: {sorted(set(dag.leaves) - declared)}", file=sys.stderr)
-            print(f"  listed but not a leaf: {sorted(declared - set(dag.leaves))}", file=sys.stderr)
-            failed = True
-
-        if not failed:
-            print(f"migration DAG comment is up to date ({len(dag.parents)} migrations, {len(dag.leaves)} leaves).")
-        return 1 if failed else 0
-
-    print(f"error: unknown mode {mode}", file=sys.stderr)
-    return 2
+    print(
+        f"migration DAG check passed: {len(parents)} migrations, {len(leaves)} leaves, "
+        f"widest diagram line {max(len(l) for l in art)} of {MAX_WIDTH} columns."
+    )
+    return 0
 
 
 if __name__ == "__main__":

--- a/zcash_client_sqlite/tools/migration_dag.py
+++ b/zcash_client_sqlite/tools/migration_dag.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Derive the migration DAG from the source and check or rewrite its diagram.
+
+The source of truth is each `wallet/init/migrations/<name>.rs`, which declares
+
+    const DEPENDENCIES: &[Uuid] = &[<module>::MIGRATION_ID, ...];
+
+The module path names the parent directly, so the edges can be read without
+resolving UUIDs. The diagram in `wallet/init/migrations.rs` is derived from
+those edges rather than maintained by hand, because nothing else keeps a prose
+comment honest: it had drifted by three migrations before this tool existed.
+
+Usage:
+    migration_dag.py <crate_root> --check     verify the diagram (exit 1 on drift)
+    migration_dag.py <crate_root> --write     rewrite the diagram in place
+    migration_dag.py <crate_root> --print     write the diagram to stdout
+    migration_dag.py <crate_root> --mermaid   emit a Mermaid graph
+    migration_dag.py <crate_root> --dot       emit a Graphviz graph
+
+<crate_root> is the directory containing `src/`, i.e. `zcash_client_sqlite`.
+"""
+
+import os
+import re
+import sys
+import textwrap
+from collections import defaultdict
+
+# The diagram lives between these two markers so the tool can find it without
+# guessing at line numbers. Everything between them is generated.
+BEGIN = "    // BEGIN GENERATED MIGRATION DAG"
+END = "    // END GENERATED MIGRATION DAG"
+
+# Width budget, measured from the hand-drawn diagram this replaced: every line
+# of it was at or under 118 columns. rustfmt does not reflow comments, so this
+# is a convention rather than a tool constraint, but it is the convention the
+# file already had and there is no reason to widen it.
+MAX_WIDTH = 118
+PREFIX = "    //"
+INDENT = 2
+
+DEPS_RE = re.compile(r"const DEPENDENCIES:\s*&\[Uuid\]\s*=\s*&\[(.*?)\];", re.S)
+DEP_ITEM_RE = re.compile(r"(?:super::)?([a-z0-9_]+)::MIGRATION_ID")
+LEAVES_RE = re.compile(r"CURRENT_LEAF_MIGRATIONS:\s*&\[Uuid\]\s*=\s*&\[(.*?)\];", re.S)
+
+
+class Dag:
+    def __init__(self, crate_root):
+        self.crate_root = crate_root
+        self.mig_dir = os.path.join(crate_root, "src", "wallet", "init", "migrations")
+        self.mig_rs = os.path.join(crate_root, "src", "wallet", "init", "migrations.rs")
+
+        self.parents = {}
+        for fn in sorted(os.listdir(self.mig_dir)):
+            if not fn.endswith(".rs"):
+                continue
+            body = open(os.path.join(self.mig_dir, fn), encoding="utf-8").read()
+            m = DEPS_RE.search(body)
+            self.parents[fn[:-3]] = DEP_ITEM_RE.findall(m.group(1)) if m else []
+
+        self.children = defaultdict(list)
+        for node, ps in self.parents.items():
+            for p in ps:
+                self.children[p].append(node)
+        for k in self.children:
+            self.children[k].sort()
+
+        self.roots = sorted(n for n, ps in self.parents.items() if not ps)
+        self.leaves = sorted(n for n in self.parents if not self.children.get(n))
+
+        # Longest-path depth, so every edge points strictly downward and the
+        # indented rendering can never show a child above its parent.
+        self.depth = {}
+        for n in self.parents:
+            self._depth(n)
+
+    def _depth(self, n):
+        if n in self.depth:
+            return self.depth[n]
+        # Guard against a cycle rather than recursing forever; a cycle is a real
+        # error in the migration graph and should be reported, not hung on.
+        self.depth[n] = None
+        d = 0 if not self.parents[n] else 1 + max(self._depth(p) for p in self.parents[n])
+        self.depth[n] = d
+        return d
+
+    def declared_leaves(self):
+        src = open(self.mig_rs, encoding="utf-8").read()
+        m = LEAVES_RE.search(src)
+        return set(DEP_ITEM_RE.findall(m.group(1))) if m else set()
+
+    def primary_parent(self, n):
+        """The parent the tree hangs `n` from: the deepest one, ties broken by name.
+
+        Choosing the deepest keeps the indentation monotonic, so a node always
+        appears below every parent it has.
+        """
+        ps = self.parents[n]
+        return max(sorted(ps), key=lambda p: self.depth[p]) if ps else None
+
+    def render(self):
+        """Render the diagram as comment lines, without the markers."""
+        tree_children = defaultdict(list)
+        for n in sorted(self.parents):
+            p = self.primary_parent(n)
+            if p is not None:
+                tree_children[p].append(n)
+
+        lines = [
+            "The migration DAG, derived from each migration's DEPENDENCIES.",
+            "Regenerate with `tools/migration_dag.py . --write`; CI checks it.",
+            "",
+            "Indentation is the dependency depth. A migration listed under another",
+            "runs after it. Where a migration has more than one dependency, only the",
+            "deepest is shown by the indentation and the rest follow the name.",
+            "",
+        ]
+
+        def walk(node, level):
+            pad = " " * (INDENT * level)
+            extra = sorted(p for p in self.parents[node] if p != self.primary_parent(node))
+            if not extra:
+                lines.append(pad + node)
+            else:
+                annotation = f"(also after {', '.join(extra)})"
+                one_line = f"{pad}{node}  {annotation}"
+                if len(PREFIX) + 1 + len(one_line) <= MAX_WIDTH:
+                    lines.append(one_line)
+                else:
+                    # A node with several extra dependencies does not fit beside its
+                    # name. Wrap the annotation under it rather than overrun the
+                    # width budget, which is what the hand-drawn diagram could not do.
+                    lines.append(pad + node)
+                    cont = pad + " " * INDENT
+                    budget = MAX_WIDTH - len(PREFIX) - 1 - len(cont)
+                    for chunk in textwrap.wrap(annotation, width=budget):
+                        lines.append(cont + chunk)
+            for c in tree_children.get(node, []):
+                walk(c, level + 1)
+
+        for r in self.roots:
+            walk(r, 0)
+
+        lines += ["", f"Leaves ({len(self.leaves)}), which CURRENT_LEAF_MIGRATIONS must match:"]
+        lines += [" " * INDENT + n for n in self.leaves]
+
+        out = []
+        for l in lines:
+            out.append((PREFIX + " " + l).rstrip() if l else PREFIX)
+        return out
+
+    def diagram_bounds(self, lines):
+        try:
+            b = next(i for i, l in enumerate(lines) if l.rstrip() == BEGIN)
+            e = next(i for i, l in enumerate(lines) if l.rstrip() == END)
+        except StopIteration:
+            return None
+        return b, e
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(__doc__)
+        return 2
+    crate_root, mode = sys.argv[1], sys.argv[2]
+    dag = Dag(crate_root)
+
+    if mode == "--mermaid":
+        print("graph TD")
+        for n in sorted(dag.parents):
+            for p in dag.parents[n]:
+                print(f"    {p} --> {n}")
+        return 0
+
+    if mode == "--dot":
+        print("digraph migrations {")
+        print("  rankdir=TB;")
+        print("  node [shape=box, fontname=monospace];")
+        for n in sorted(dag.parents):
+            for p in dag.parents[n]:
+                print(f'  "{p}" -> "{n}";')
+        print("}")
+        return 0
+
+    rendered = dag.render()
+    over = [l for l in rendered if len(l) > MAX_WIDTH]
+    if over:
+        print(f"error: {len(over)} rendered line(s) exceed {MAX_WIDTH} columns:", file=sys.stderr)
+        for l in over:
+            print(f"  {len(l)}: {l}", file=sys.stderr)
+        return 1
+
+    if mode == "--print":
+        print("\n".join(rendered))
+        return 0
+
+    src_lines = open(dag.mig_rs, encoding="utf-8").read().splitlines()
+    bounds = dag.diagram_bounds(src_lines)
+    if bounds is None:
+        print(f"error: markers not found in {dag.mig_rs}", file=sys.stderr)
+        print(f"  expected {BEGIN!r} and {END!r}", file=sys.stderr)
+        return 1
+    b, e = bounds
+
+    if mode == "--write":
+        src_lines[b + 1 : e] = rendered
+        open(dag.mig_rs, "w", encoding="utf-8").write("\n".join(src_lines) + "\n")
+        print(f"wrote {len(rendered)} lines into {dag.mig_rs}")
+        return 0
+
+    if mode == "--check":
+        failed = False
+        current = src_lines[b + 1 : e]
+        if current != rendered:
+            print("error: the migration DAG comment is out of date.", file=sys.stderr)
+            print("       run: tools/migration_dag.py . --write", file=sys.stderr)
+            import difflib
+
+            for d in difflib.unified_diff(current, rendered, "committed", "generated", lineterm=""):
+                print("  " + d, file=sys.stderr)
+            failed = True
+
+        declared = dag.declared_leaves()
+        if declared != set(dag.leaves):
+            print("error: CURRENT_LEAF_MIGRATIONS does not match the computed leaves.", file=sys.stderr)
+            print(f"  missing from the list: {sorted(set(dag.leaves) - declared)}", file=sys.stderr)
+            print(f"  listed but not a leaf: {sorted(declared - set(dag.leaves))}", file=sys.stderr)
+            failed = True
+
+        if not failed:
+            print(f"migration DAG comment is up to date ({len(dag.parents)} migrations, {len(dag.leaves)} leaves).")
+        return 1 if failed else 0
+
+    print(f"error: unknown mode {mode}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Draft. Closes #2819.

## Problem

The migration DAG in `migrations.rs` is drawn by hand, while the graph it depicts is declared by each migration's `DEPENDENCIES`. Nothing kept the two in step, and they had drifted:

- `ironwood_shardtree`, `orchard_ironwood_migration_tables` and `tree_retained_checkpoints` were absent from the diagram entirely.
- `ironwood_received_notes` was drawn with two children when it has three.

`CURRENT_LEAF_MIGRATIONS` was checked by the same extraction and was already correct, so the drift was confined to the picture.

## Approach: check, do not generate

An earlier revision of this branch generated the diagram. That is the stronger guarantee, but the output is markedly worse to read than the hand-drawn art, so this takes the other direction from #2819: **the diagram stays hand-drawn and the tool verifies it.**

`zcash_client_sqlite/tools/migration_dag.py` reads the `DEPENDENCIES` of every migration module and checks:

- every migration appears somewhere in the diagram;
- every migration-looking name in the diagram is a real module, so a rename or deletion cannot leave a ghost behind;
- the leaves computed from the graph match `CURRENT_LEAF_MIGRATIONS`;
- no diagram line exceeds the 118-column budget (measured from the diagram itself; every pre-existing line was at or under it).

It also has `--mermaid` and `--dot` for documentation, where a real layout engine does better than ASCII.

### What it deliberately does not check

The shape of the drawing. Whether an edge is depicted, and whether it is depicted in the right place, is not recoverable from free-form ASCII art. This catches a migration that was **forgotten**, not one drawn in the wrong place. The script's docstring says so explicitly, so nobody mistakes its silence for a stronger guarantee than it gives. Generation is the only way to close that gap, and it costs the art.

## Diagram changes

Unchanged in style. `orchard_ironwood_migration_tables` is drawn as the third child of `ironwood_received_notes`, hanging from its own connector, because three names of that length do not fit on one row inside the budget.

The other two edges are recorded in a note beneath the drawing rather than drawn:

```
    // Two edges are not drawn above, for want of horizontal room. They are still
    // checked by tools/migration_dag.py:
    //   witness_stabilized_notes -> tree_retained_checkpoints
    //   orchard_shardtree, wallet_summaries -> ironwood_shardtree
```

Placing those two in the art needs a relayout of the surrounding structure, which would touch nodes this change has no other reason to move. A line saying they exist is better than a diagram that omits them silently. Happy to do the relayout instead if you would rather have them drawn.

## CI

A `migration-dag` job beside the existing `uuid` check, added to `required-checks` so drift blocks rather than merely reports. No new toolchain: it runs `python3`, already present on the runner, and needs no cargo build.

If you would rather not add Python to a pure-Rust CI, the alternative is a Rust integration test under `tests/` doing the same parsing, which would fold into the existing jobs. Say the word and I will port it.

## Verification

- `tools/migration_dag.py zcash_client_sqlite`: passes (57 migrations, 8 leaves, widest line 118 of 118)
- Negative test: deleting one recorded edge makes it fail with `ironwood_shardtree ... missing from the diagram` and exit 1
- `cargo fmt --all -- --check`: clean
- The workflow YAML parses

## Note on history

Two commits: the first took the generation approach, the second replaces it with this one. I can squash them into a single commit if you would prefer the branch to read as one change.