### PR TITLE
zcash_client_sqlite: classify pool-crossing transactions in v_transactions

### DIFF
--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -126,6 +126,8 @@ pub struct TransactionSummary<AccountId> {
     memo_count: usize,
     expired_unmined: bool,
     is_shielding: bool,
+    is_pool_crossing: bool,
+    pool_crossing_value: Option<Zatoshis>,
 }
 
 impl<AccountId> TransactionSummary<AccountId> {
@@ -150,6 +152,8 @@ impl<AccountId> TransactionSummary<AccountId> {
         memo_count: usize,
         expired_unmined: bool,
         is_shielding: bool,
+        is_pool_crossing: bool,
+        pool_crossing_value: Option<Zatoshis>,
     ) -> Self {
         Self {
             account_id,
@@ -167,6 +171,8 @@ impl<AccountId> TransactionSummary<AccountId> {
             memo_count,
             expired_unmined,
             is_shielding,
+            is_pool_crossing,
+            pool_crossing_value,
         }
     }
 
@@ -267,6 +273,30 @@ impl<AccountId> TransactionSummary<AccountId> {
     /// above metrics.
     pub fn is_shielding(&self) -> bool {
         self.is_shielding
+    }
+
+    /// Returns `true` if this is detectably a wallet-internal transfer that moves the
+    /// account's own funds between shielded pools (for example, a ZIP 318
+    /// Orchard → Ironwood migration transfer).
+    ///
+    /// Specifically, `true` means that at a minimum:
+    /// - Every wallet-spent note and wallet-received output is shielded.
+    /// - The transaction spends at least one of the account's notes.
+    /// - At least one output was received in a pool the account spent nothing from.
+    /// - We do not know about any external outputs of the transaction.
+    ///
+    /// A payment that returns value to one of the wallet's own addresses is classified
+    /// once the wallet has observed the returned output (which the scanner marks as
+    /// change); while such a transaction is unmined it is treated as an ordinary payment.
+    pub fn is_pool_crossing(&self) -> bool {
+        self.is_pool_crossing
+    }
+
+    /// Returns the total value received in pools the account did not spend from — the
+    /// amount that crossed pools — when [`Self::is_pool_crossing`] is `true`, or `None`
+    /// otherwise.
+    pub fn pool_crossing_value(&self) -> Option<Zatoshis> {
+        self.pool_crossing_value
     }
 }
 

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -126,7 +126,6 @@ pub struct TransactionSummary<AccountId> {
     memo_count: usize,
     expired_unmined: bool,
     is_shielding: bool,
-    is_pool_crossing: bool,
     pool_crossing_value: Option<Zatoshis>,
 }
 
@@ -152,7 +151,6 @@ impl<AccountId> TransactionSummary<AccountId> {
         memo_count: usize,
         expired_unmined: bool,
         is_shielding: bool,
-        is_pool_crossing: bool,
         pool_crossing_value: Option<Zatoshis>,
     ) -> Self {
         Self {
@@ -171,7 +169,6 @@ impl<AccountId> TransactionSummary<AccountId> {
             memo_count,
             expired_unmined,
             is_shielding,
-            is_pool_crossing,
             pool_crossing_value,
         }
     }
@@ -288,13 +285,16 @@ impl<AccountId> TransactionSummary<AccountId> {
     /// A payment that returns value to one of the wallet's own addresses is classified
     /// once the wallet has observed the returned output (which the scanner marks as
     /// change); while such a transaction is unmined it is treated as an ordinary payment.
+    ///
+    /// This is exactly the condition that [`Self::pool_crossing_value`] is `Some`; the
+    /// crossed amount is what identifies the transaction, so it is the only thing stored.
     pub fn is_pool_crossing(&self) -> bool {
-        self.is_pool_crossing
+        self.pool_crossing_value.is_some()
     }
 
     /// Returns the total value received in pools the account did not spend from — the
-    /// amount that crossed pools — when [`Self::is_pool_crossing`] is `true`, or `None`
-    /// otherwise.
+    /// amount that crossed pools — when this is a pool-crossing transaction as described
+    /// by [`Self::is_pool_crossing`], or `None` otherwise.
     pub fn pool_crossing_value(&self) -> Option<Zatoshis> {
         self.pool_crossing_value
     }

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -274,7 +274,7 @@ impl<AccountId> TransactionSummary<AccountId> {
 
     /// Returns `true` if this is detectably a wallet-internal transfer that moves the
     /// account's own funds between shielded pools (for example, a ZIP 318
-    /// Orchard → Ironwood migration transfer).
+    /// Orchard -> Ironwood migration transfer).
     ///
     /// Specifically, `true` means that at a minimum:
     /// - Every wallet-spent note and wallet-received output is shielded.
@@ -292,8 +292,8 @@ impl<AccountId> TransactionSummary<AccountId> {
         self.pool_crossing_value.is_some()
     }
 
-    /// Returns the total value received in pools the account did not spend from — the
-    /// amount that crossed pools — when this is a pool-crossing transaction as described
+    /// Returns the total value received in pools the account did not spend from, which
+    /// is the amount that crossed pools, when this is a pool-crossing transaction as described
     /// by [`Self::is_pool_crossing`], or `None` otherwise.
     pub fn pool_crossing_value(&self) -> Option<Zatoshis> {
         self.pool_crossing_value

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -8570,12 +8570,12 @@ pub fn orchard_to_ironwood_payment_reports_net_value_delta<Dsf>(
             assert!(tx.has_change(), "the transaction has change ({})", $phase);
             // The payment has an external recipient, so it is not a pool crossing even though
             // its value moves from the Orchard pool into the Ironwood pool.
-            assert!(
-                !tx.is_pool_crossing(),
+            assert_eq!(
+                tx.pool_crossing_value(),
+                None,
                 "a payment to an external recipient is not a pool crossing ({})",
                 $phase,
             );
-            assert_eq!(tx.pool_crossing_value(), None);
         }};
     }
 

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -8457,7 +8457,7 @@ where
 
 /// The transaction history entry for a payment funded from the Orchard pool and delivered
 /// through the Ironwood pool reports the amount that left the account (payment plus fee) as
-/// its balance delta — not the total value of the notes spent, which would ignore the change
+/// its balance delta, not the total value of the notes spent, which would ignore the change
 /// returned to the wallet.
 #[cfg(feature = "orchard")]
 pub fn orchard_to_ironwood_payment_reports_net_value_delta<Dsf>(
@@ -8466,7 +8466,7 @@ pub fn orchard_to_ironwood_payment_reports_net_value_delta<Dsf>(
 ) where
     Dsf: DataStoreFactory,
 {
-    // A network on which NU6.3 — the version 6 transaction format — is active from height 100_000.
+    // A network on which NU6.3, the version 6 transaction format, is active from height 100_000.
     let ironwood_active_network = {
         let activation = BlockHeight::from_u32(100_000);
         LocalNetwork {
@@ -8576,15 +8576,15 @@ pub fn orchard_to_ironwood_payment_reports_net_value_delta<Dsf>(
         }};
     }
 
-    // The history entry is correct as soon as the transaction is stored…
+    // The history entry is correct as soon as the transaction is stored...
     check_history!("before mining");
 
-    // …and remains correct once the transaction is mined and scanned…
+    // ...and remains correct once the transaction is mined and scanned...
     let (h, _) = st.generate_next_block_including(txid);
     st.scan_cached_blocks(h, 1);
     check_history!("after mining");
 
-    // …and remains correct after transaction enhancement, in which the wallet retrieves the
+    // ...and remains correct after transaction enhancement, in which the wallet retrieves the
     // full transaction and re-stores it via `decrypt_and_store_transaction` (as the mobile
     // SDKs do to recover memos and fee information).
     let tx = st
@@ -8597,8 +8597,8 @@ pub fn orchard_to_ironwood_payment_reports_net_value_delta<Dsf>(
     check_history!("after enhancement");
 }
 
-/// A migration of the wallet's own funds from the Orchard pool to the Ironwood pool — a payment
-/// to the wallet's own external Orchard receiver, delivered through the Ironwood pool — leaves
+/// A migration of the wallet's own funds from the Orchard pool to the Ironwood pool, namely a
+/// payment to the wallet's own external Orchard receiver delivered through the Ironwood pool, leaves
 /// the account balance unchanged except for the fee. The payment output returned to the wallet
 /// is not recorded at transaction-creation time (it is an address payment, which the wallet
 /// expects to detect by scanning), so this exercises detection of the wallet's own Ironwood
@@ -8610,7 +8610,7 @@ pub fn orchard_to_ironwood_self_migration_reports_fee_only_delta<Dsf>(
 ) where
     Dsf: DataStoreFactory,
 {
-    // A network on which NU6.3 — the version 6 transaction format — is active from height 100_000.
+    // A network on which NU6.3, the version 6 transaction format, is active from height 100_000.
     let ironwood_active_network = {
         let activation = BlockHeight::from_u32(100_000);
         LocalNetwork {
@@ -8713,7 +8713,7 @@ pub fn orchard_to_ironwood_self_migration_reports_fee_only_delta<Dsf>(
             // Once the wallet has observed the payment output returning to its own account
             // (the scanner marks such outputs as change), the transaction presents as a
             // wallet-internal transfer between pools, and is classified as a pool crossing
-            // whose crossing value is the migrated payment amount — the quantity a wallet
+            // whose crossing value is the migrated payment amount, the quantity a wallet
             // should display for it.
             assert!(
                 tx.is_pool_crossing(),

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -59,6 +59,9 @@ use crate::{
 
 use super::{DataStoreFactory, Reset, TestCache, TestFvk, TestState};
 
+#[cfg(feature = "orchard")]
+use super::orchard::OrchardPoolTester;
+
 #[cfg(feature = "transparent-inputs")]
 use {
     crate::{
@@ -7771,7 +7774,6 @@ pub fn shielding_coinbase_to_orchard_receiver_delivers_via_ironwood<Dsf>(
     Dsf: DataStoreFactory,
     <<Dsf as DataStoreFactory>::DataStore as WalletWrite>::UtxoRef: std::fmt::Debug,
 {
-    use super::orchard::OrchardPoolTester;
     use crate::data_api::TransactionStatus;
     use zcash_protocol::consensus::COINBASE_MATURITY_BLOCKS;
 
@@ -7920,7 +7922,6 @@ pub fn propose_v5_payment_to_orchard_receiver_is_rejected<Dsf>(
 ) where
     Dsf: DataStoreFactory,
 {
-    use super::orchard::OrchardPoolTester;
     use crate::data_api::wallet::{input_selection::SpendPolicy, propose_transfer};
     use crate::proposal::ProposalError;
     use zcash_primitives::transaction::TxVersion;
@@ -7995,8 +7996,6 @@ where
     Dsf: DataStoreFactory,
     <Dsf as DataStoreFactory>::AccountId: serde::Serialize,
 {
-    use super::orchard::OrchardPoolTester;
-
     // A network on which NU6.3 — the version 6 transaction format — is active from height 100_000.
     let ironwood_active_network = {
         let activation = BlockHeight::from_u32(100_000);
@@ -8467,8 +8466,6 @@ pub fn orchard_to_ironwood_payment_reports_net_value_delta<Dsf>(
 ) where
     Dsf: DataStoreFactory,
 {
-    use super::orchard::OrchardPoolTester;
-
     // A network on which NU6.3 — the version 6 transaction format — is active from height 100_000.
     let ironwood_active_network = {
         let activation = BlockHeight::from_u32(100_000);
@@ -8613,8 +8610,6 @@ pub fn orchard_to_ironwood_self_migration_reports_fee_only_delta<Dsf>(
 ) where
     Dsf: DataStoreFactory,
 {
-    use super::orchard::OrchardPoolTester;
-
     // A network on which NU6.3 — the version 6 transaction format — is active from height 100_000.
     let ironwood_active_network = {
         let activation = BlockHeight::from_u32(100_000);
@@ -8763,7 +8758,6 @@ pub fn proposal_records_and_serializes_proposed_version<Dsf>(ds_factory: Dsf, ca
 where
     Dsf: DataStoreFactory,
 {
-    use super::orchard::OrchardPoolTester;
     use crate::data_api::wallet::{input_selection::SpendPolicy, propose_transfer};
     use zcash_primitives::transaction::TxVersion;
 

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -8568,6 +8568,14 @@ pub fn orchard_to_ironwood_payment_reports_net_value_delta<Dsf>(
                 $phase,
             );
             assert!(tx.has_change(), "the transaction has change ({})", $phase);
+            // The payment has an external recipient, so it is not a pool crossing even though
+            // its value moves from the Orchard pool into the Ironwood pool.
+            assert!(
+                !tx.is_pool_crossing(),
+                "a payment to an external recipient is not a pool crossing ({})",
+                $phase,
+            );
+            assert_eq!(tx.pool_crossing_value(), None);
         }};
     }
 
@@ -8705,6 +8713,22 @@ pub fn orchard_to_ironwood_self_migration_reports_fee_only_delta<Dsf>(
                 tx.account_value_delta(),
                 -zcash_protocol::value::ZatBalance::from(fee),
                 "the migration ({}) reduces the account balance only by the fee",
+                $phase,
+            );
+            // Once the wallet has observed the payment output returning to its own account
+            // (the scanner marks such outputs as change), the transaction presents as a
+            // wallet-internal transfer between pools, and is classified as a pool crossing
+            // whose crossing value is the migrated payment amount — the quantity a wallet
+            // should display for it.
+            assert!(
+                tx.is_pool_crossing(),
+                "a mined payment to the wallet's own address is a pool crossing ({})",
+                $phase,
+            );
+            assert_eq!(
+                tx.pool_crossing_value(),
+                Some(transfer_amount),
+                "pool_crossing_value ({}) is the migrated payment amount",
                 $phase,
             );
         }};

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -8456,6 +8456,280 @@ where
     }
 }
 
+/// The transaction history entry for a payment funded from the Orchard pool and delivered
+/// through the Ironwood pool reports the amount that left the account (payment plus fee) as
+/// its balance delta — not the total value of the notes spent, which would ignore the change
+/// returned to the wallet.
+#[cfg(feature = "orchard")]
+pub fn orchard_to_ironwood_payment_reports_net_value_delta<Dsf>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) where
+    Dsf: DataStoreFactory,
+{
+    use super::orchard::OrchardPoolTester;
+
+    // A network on which NU6.3 — the version 6 transaction format — is active from height 100_000.
+    let ironwood_active_network = {
+        let activation = BlockHeight::from_u32(100_000);
+        LocalNetwork {
+            nu6: Some(activation),
+            nu6_1: Some(activation),
+            nu6_2: Some(activation),
+            nu6_3: Some(activation),
+            ..TestBuilder::<(), ()>::DEFAULT_NETWORK
+        }
+    };
+
+    let mut st = TestDsl::from(
+        TestBuilder::new()
+            .with_network(ironwood_active_network)
+            .with_data_store_factory(ds_factory)
+            .with_block_cache(cache)
+            .with_account_from_sapling_activation(BlockHash([0; 32])),
+    )
+    .build::<OrchardPoolTester>();
+
+    // Fund the wallet with a single spendable Orchard note.
+    let note_value = Zatoshis::const_from_u64(60_000);
+    st.add_a_single_note_checking_balance(note_value);
+
+    // The destination has an Orchard receiver controlled by a separate spending key; post-NU6.3 the
+    // payment is routed through the Ironwood pool.
+    let to_extsk = OrchardPoolTester::sk(&[0xf5; 32]);
+    let to = OrchardPoolTester::sk_default_address(&to_extsk);
+    let transfer_amount = Zatoshis::const_from_u64(10_000);
+    let request = zip321::TransactionRequest::new(vec![Payment::without_memo(
+        to.to_zcash_address(st.network()),
+        transfer_amount,
+    )])
+    .unwrap();
+
+    let change_strategy =
+        single_output_change_strategy(StandardFeeRule::Zip317, None, ShieldedPool::Orchard);
+    let input_selector = GreedyInputSelector::new();
+
+    let account = st.get_account();
+    let account_id = account.id();
+    let usk = account.usk().clone();
+    let proposal = st
+        .propose_transfer(
+            account_id,
+            &input_selector,
+            &change_strategy,
+            request,
+            ConfirmationsPolicy::MIN,
+        )
+        .expect("proposal construction succeeds; the Orchard-receiver payment routes to Ironwood");
+
+    // The payment crosses from the Orchard pool into the Ironwood pool.
+    assert_eq!(
+        proposal.steps().head.payment_pools().get(&0),
+        Some(&PoolType::IRONWOOD),
+    );
+    let fee = proposal.steps().head.balance().fee_required();
+    let expected_change = (note_value - transfer_amount - fee).unwrap();
+
+    let txids = st
+        .create_proposed_transactions::<Infallible, _, Infallible, _>(
+            &usk,
+            OvkPolicy::Sender,
+            &proposal,
+        )
+        .expect("an Ironwood-routed payment builds successfully");
+    let txid = *txids.first();
+
+    // The amount that left the account is the payment plus the fee; the value of the change
+    // note returned to the wallet must not be counted as spent.
+    let expected_delta = -zcash_protocol::value::ZatBalance::from((transfer_amount + fee).unwrap());
+    macro_rules! check_history {
+        ($phase:literal) => {{
+            let tx_history = st.wallet().get_tx_history().unwrap();
+            let tx = tx_history
+                .iter()
+                .find(|tx| tx.txid() == txid)
+                .expect("the created transaction appears in the transaction history");
+            assert_eq!(
+                tx.account_value_delta(),
+                expected_delta,
+                "account_value_delta ({}) reflects the payment plus fee",
+                $phase,
+            );
+            assert_eq!(
+                tx.total_spent(),
+                note_value,
+                "total_spent ({}) is the total value of the notes spent",
+                $phase,
+            );
+            assert_eq!(
+                tx.total_received(),
+                expected_change,
+                "total_received ({}) is the change returned to the wallet",
+                $phase,
+            );
+            assert!(tx.has_change(), "the transaction has change ({})", $phase);
+        }};
+    }
+
+    // The history entry is correct as soon as the transaction is stored…
+    check_history!("before mining");
+
+    // …and remains correct once the transaction is mined and scanned…
+    let (h, _) = st.generate_next_block_including(txid);
+    st.scan_cached_blocks(h, 1);
+    check_history!("after mining");
+
+    // …and remains correct after transaction enhancement, in which the wallet retrieves the
+    // full transaction and re-stores it via `decrypt_and_store_transaction` (as the mobile
+    // SDKs do to recover memos and fee information).
+    let tx = st
+        .wallet()
+        .get_transaction(txid)
+        .unwrap()
+        .expect("the created transaction can be retrieved");
+    let network = *st.network();
+    decrypt_and_store_transaction(&network, st.wallet_mut(), &tx, Some(h)).unwrap();
+    check_history!("after enhancement");
+}
+
+/// A migration of the wallet's own funds from the Orchard pool to the Ironwood pool — a payment
+/// to the wallet's own external Orchard receiver, delivered through the Ironwood pool — leaves
+/// the account balance unchanged except for the fee. The payment output returned to the wallet
+/// is not recorded at transaction-creation time (it is an address payment, which the wallet
+/// expects to detect by scanning), so this exercises detection of the wallet's own Ironwood
+/// outputs in the scanning path.
+#[cfg(feature = "orchard")]
+pub fn orchard_to_ironwood_self_migration_reports_fee_only_delta<Dsf>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) where
+    Dsf: DataStoreFactory,
+{
+    use super::orchard::OrchardPoolTester;
+
+    // A network on which NU6.3 — the version 6 transaction format — is active from height 100_000.
+    let ironwood_active_network = {
+        let activation = BlockHeight::from_u32(100_000);
+        LocalNetwork {
+            nu6: Some(activation),
+            nu6_1: Some(activation),
+            nu6_2: Some(activation),
+            nu6_3: Some(activation),
+            ..TestBuilder::<(), ()>::DEFAULT_NETWORK
+        }
+    };
+
+    let mut st = TestDsl::from(
+        TestBuilder::new()
+            .with_network(ironwood_active_network)
+            .with_data_store_factory(ds_factory)
+            .with_block_cache(cache)
+            .with_account_from_sapling_activation(BlockHash([0; 32])),
+    )
+    .build::<OrchardPoolTester>();
+
+    // Fund the wallet with a single spendable Orchard note.
+    let note_value = Zatoshis::const_from_u64(60_000);
+    st.add_a_single_note_checking_balance(note_value);
+
+    // The payment destination is the wallet's own external Orchard receiver; post-NU6.3 the
+    // payment is routed through the Ironwood pool.
+    let own_fvk = OrchardPoolTester::test_account_fvk(&st);
+    let own_address = OrchardPoolTester::fvk_default_address(&own_fvk);
+    let transfer_amount = Zatoshis::const_from_u64(40_000);
+    let request = zip321::TransactionRequest::new(vec![Payment::without_memo(
+        own_address.to_zcash_address(st.network()),
+        transfer_amount,
+    )])
+    .unwrap();
+
+    let change_strategy =
+        single_output_change_strategy(StandardFeeRule::Zip317, None, ShieldedPool::Orchard);
+    let input_selector = GreedyInputSelector::new();
+
+    let account = st.get_account();
+    let account_id = account.id();
+    let usk = account.usk().clone();
+    let proposal = st
+        .propose_transfer(
+            account_id,
+            &input_selector,
+            &change_strategy,
+            request,
+            ConfirmationsPolicy::MIN,
+        )
+        .expect("proposal construction succeeds; the Orchard-receiver payment routes to Ironwood");
+
+    // The payment crosses from the Orchard pool into the Ironwood pool.
+    assert_eq!(
+        proposal.steps().head.payment_pools().get(&0),
+        Some(&PoolType::IRONWOOD),
+    );
+    let fee = proposal.steps().head.balance().fee_required();
+
+    let txids = st
+        .create_proposed_transactions::<Infallible, _, Infallible, _>(
+            &usk,
+            OvkPolicy::Sender,
+            &proposal,
+        )
+        .expect("an Ironwood-routed payment builds successfully");
+    let txid = *txids.first();
+
+    // Once the transaction is mined and scanned, every non-fee output has returned to the
+    // wallet: the payment output via scanning, and the change output. The account has lost
+    // only the fee.
+    let (h, _) = st.generate_next_block_including(txid);
+    st.scan_cached_blocks(h, 1);
+
+    macro_rules! check_history {
+        ($phase:literal) => {{
+            let tx_history = st.wallet().get_tx_history().unwrap();
+            let tx = tx_history
+                .iter()
+                .find(|tx| tx.txid() == txid)
+                .expect("the created transaction appears in the transaction history");
+            assert_eq!(
+                tx.total_spent(),
+                note_value,
+                "total_spent ({}) is the total value of the notes spent",
+                $phase,
+            );
+            assert_eq!(
+                tx.total_received(),
+                (note_value - fee).unwrap(),
+                "total_received ({}) covers both the migrated value and the change",
+                $phase,
+            );
+            assert_eq!(
+                tx.account_value_delta(),
+                -zcash_protocol::value::ZatBalance::from(fee),
+                "the migration ({}) reduces the account balance only by the fee",
+                $phase,
+            );
+        }};
+    }
+
+    check_history!("after mining");
+    assert_eq!(
+        st.get_total_balance(account_id),
+        (note_value - fee).unwrap(),
+        "the account retains all funds except the fee",
+    );
+
+    // The history entry remains correct after transaction enhancement, in which the wallet
+    // retrieves the full transaction and re-stores it via `decrypt_and_store_transaction`
+    // (as the mobile SDKs do to recover memos and fee information).
+    let tx = st
+        .wallet()
+        .get_transaction(txid)
+        .unwrap()
+        .expect("the created transaction can be retrieved");
+    let network = *st.network();
+    decrypt_and_store_transaction(&network, st.wallet_mut(), &tx, Some(h)).unwrap();
+    check_history!("after enhancement");
+}
+
 /// The transaction version requested at proposal time is recorded on the proposal and preserved
 /// across serialization, so that transaction building honors it. A proposal serialized without a
 /// version request (as older serializers produced) decodes with no requested version and falls

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -11,25 +11,28 @@ workspace.
 ## [Unreleased]
 
 ### Added
-- The `v_transactions` view has two new columns classifying wallet-internal
-  transfers that move an account's own funds between shielded pools (for
-  example, ZIP 318 Orchard → Ironwood migration transfers):
-  - `is_pool_crossing`: true when every wallet-spent note and wallet-received
-    output in the transaction is shielded, the account spent at least one note,
-    at least one output was received in a pool the account spent nothing from,
-    and no external outputs of the transaction are known. A payment that
-    returns value to one of the wallet's own addresses is classified once the
-    wallet has observed the returned output (which the scanner marks as
-    change); while such a transaction is unmined it is treated as an ordinary
-    payment.
-  - `pool_crossing_value`: the total value received in pools the account did
-    not spend from, when `is_pool_crossing` is true; NULL otherwise.
+- The `v_transactions` view has a new `pool_crossing_value` column, which
+  classifies wallet-internal transfers that move an account's own funds between
+  shielded pools (for example, ZIP 318 Orchard → Ironwood migration transfers)
+  and reports the amount that crossed. It is non-NULL exactly when every
+  wallet-spent note and wallet-received output in the transaction is shielded,
+  the account spent at least one note, at least one output was received in a
+  pool the account spent nothing from, and no external outputs of the
+  transaction are known; its value is then the total received in the pools the
+  account did not spend from. Use `pool_crossing_value IS NOT NULL` as the
+  classification predicate; a separate boolean column would restate that same
+  condition in a second place that could drift.
 
   For such a transaction `account_balance_delta` is just the negated fee, which
   is not a useful display quantity; clients should present `pool_crossing_value`
   as the migrated amount instead of deriving an amount from `total_spent` or
   `total_received`, both of which overstate the crossing whenever the
   transaction also returns change to a pool it spent from.
+
+  A payment that returns value to one of the wallet's own addresses is
+  classified once the wallet has observed the returned output (which the
+  scanner marks as change); while such a transaction is unmined it is treated
+  as an ordinary payment.
 
 ## [0.22.0-rc.5] - 2026-07-28
 

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -10,6 +10,27 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- The `v_transactions` view has two new columns classifying wallet-internal
+  transfers that move an account's own funds between shielded pools (for
+  example, ZIP 318 Orchard → Ironwood migration transfers):
+  - `is_pool_crossing`: true when every wallet-spent note and wallet-received
+    output in the transaction is shielded, the account spent at least one note,
+    at least one output was received in a pool the account spent nothing from,
+    and no external outputs of the transaction are known. A payment that
+    returns value to one of the wallet's own addresses is classified once the
+    wallet has observed the returned output (which the scanner marks as
+    change); while such a transaction is unmined it is treated as an ordinary
+    payment.
+  - `pool_crossing_value`: the total value received in pools the account did
+    not spend from, when `is_pool_crossing` is true; NULL otherwise.
+
+  For such a transaction `account_balance_delta` is just the negated fee, which
+  is not a useful display quantity; clients should present `pool_crossing_value`
+  as the migrated amount instead of deriving an amount from `total_spent` or
+  `total_received`, both of which overstate the crossing whenever the
+  transaction also returns change to a pool it spent from.
+
 ## [0.22.0-rc.5] - 2026-07-28
 
 ### Added

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -13,7 +13,7 @@ workspace.
 ### Added
 - The `v_transactions` view has a new `pool_crossing_value` column, which
   classifies wallet-internal transfers that move an account's own funds between
-  shielded pools (for example, ZIP 318 Orchard → Ironwood migration transfers)
+  shielded pools (for example, ZIP 318 Orchard -> Ironwood migration transfers)
   and reports the amount that crossed. It is non-NULL exactly when every
   wallet-spent note and wallet-received output in the transaction is shielded,
   the account spent at least one note, at least one output was received in a

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -934,6 +934,22 @@ pub(crate) fn shielding_coinbase_to_orchard_receiver_delivers_via_ironwood() {
 }
 
 #[cfg(feature = "orchard")]
+pub(crate) fn orchard_to_ironwood_payment_reports_net_value_delta() {
+    zcash_client_backend::data_api::testing::pool::orchard_to_ironwood_payment_reports_net_value_delta(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    );
+}
+
+#[cfg(feature = "orchard")]
+pub(crate) fn orchard_to_ironwood_self_migration_reports_fee_only_delta() {
+    zcash_client_backend::data_api::testing::pool::orchard_to_ironwood_self_migration_reports_fee_only_delta(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    );
+}
+
+#[cfg(feature = "orchard")]
 pub(crate) fn propose_v5_payment_to_orchard_receiver_is_rejected() {
     zcash_client_backend::data_api::testing::pool::propose_v5_payment_to_orchard_receiver_is_rejected(
         TestDbFactory::default(),

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -28,10 +28,10 @@
 //!   once in determining the total value sent from the wallet as a whole.
 //! - `pool_crossing_value`: non-NULL exactly when the transaction is a wallet-internal transfer
 //!   that moves the account's own funds between shielded pools (for example, a ZIP 318
-//!   Orchard → Ironwood migration transfer): every wallet-spent note and wallet-received output
+//!   Orchard -> Ironwood migration transfer): every wallet-spent note and wallet-received output
 //!   is shielded, the account spent at least one note, at least one output was received in a pool
 //!   the account spent nothing from, and no external outputs of the transaction are known. Its
-//!   value is the total received in the pools the account did not spend from — the amount that
+//!   value is the total received in the pools the account did not spend from, the amount that
 //!   crossed. For such a transaction `account_balance_delta` is just the negated fee, so this is
 //!   the amount to present to a user rather than the balance delta; deriving one from
 //!   `total_spent` or `total_received` instead overstates the crossing whenever the transaction

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -26,18 +26,21 @@
 //!   transaction, this fee amount will be repeated for each such row. Therefore, if more than one
 //!   of the wallet's accounts is involved with the transaction, this fee should be considered only
 //!   once in determining the total value sent from the wallet as a whole.
-//! - `is_pool_crossing`: a boolean flag indicating whether the transaction is a wallet-internal
-//!   transfer that moves the account's own funds between shielded pools (for example, a ZIP 318
+//! - `pool_crossing_value`: non-NULL exactly when the transaction is a wallet-internal transfer
+//!   that moves the account's own funds between shielded pools (for example, a ZIP 318
 //!   Orchard → Ironwood migration transfer): every wallet-spent note and wallet-received output
-//!   is shielded, at least one output was received in a pool the account spent nothing from, and
-//!   no external outputs of the transaction are known. For such a transaction
-//!   `account_balance_delta` is just the negated fee, so the amount to present to a user is
-//!   `pool_crossing_value`, not the balance delta. A payment that returns value to one of the
-//!   wallet's own addresses is classified once the wallet has observed the returned output
-//!   (which the scanner marks as change); while such a transaction is unmined it is treated as
-//!   an ordinary payment.
-//! - `pool_crossing_value`: when `is_pool_crossing` is true, the total value received in pools
-//!   the account did not spend from — the amount that crossed pools; NULL otherwise.
+//!   is shielded, the account spent at least one note, at least one output was received in a pool
+//!   the account spent nothing from, and no external outputs of the transaction are known. Its
+//!   value is the total received in the pools the account did not spend from — the amount that
+//!   crossed. For such a transaction `account_balance_delta` is just the negated fee, so this is
+//!   the amount to present to a user rather than the balance delta; deriving one from
+//!   `total_spent` or `total_received` instead overstates the crossing whenever the transaction
+//!   also returns change to a pool it spent from. Use `pool_crossing_value IS NOT NULL` as the
+//!   classification predicate; there is deliberately no separate boolean column, since it would
+//!   restate the same condition in a second place that could drift. A payment that returns value
+//!   to one of the wallet's own addresses is classified once the wallet has observed the returned
+//!   output (which the scanner marks as change); while such a transaction is unmined it is
+//!   treated as an ordinary payment.
 //!
 //! ### Seed Phrase with Single Account
 //!
@@ -5828,7 +5831,6 @@ pub mod testing {
                     row.get("memo_count")?,
                     row.get("expired_unmined")?,
                     row.get("is_shielding")?,
-                    row.get("is_pool_crossing")?,
                     row.get::<_, Option<i64>>("pool_crossing_value")?
                         .map(Zatoshis::from_nonnegative_i64)
                         .transpose()?,

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -26,6 +26,18 @@
 //!   transaction, this fee amount will be repeated for each such row. Therefore, if more than one
 //!   of the wallet's accounts is involved with the transaction, this fee should be considered only
 //!   once in determining the total value sent from the wallet as a whole.
+//! - `is_pool_crossing`: a boolean flag indicating whether the transaction is a wallet-internal
+//!   transfer that moves the account's own funds between shielded pools (for example, a ZIP 318
+//!   Orchard → Ironwood migration transfer): every wallet-spent note and wallet-received output
+//!   is shielded, at least one output was received in a pool the account spent nothing from, and
+//!   no external outputs of the transaction are known. For such a transaction
+//!   `account_balance_delta` is just the negated fee, so the amount to present to a user is
+//!   `pool_crossing_value`, not the balance delta. A payment that returns value to one of the
+//!   wallet's own addresses is classified once the wallet has observed the returned output
+//!   (which the scanner marks as change); while such a transaction is unmined it is treated as
+//!   an ordinary payment.
+//! - `pool_crossing_value`: when `is_pool_crossing` is true, the total value received in pools
+//!   the account did not spend from — the amount that crossed pools; NULL otherwise.
 //!
 //! ### Seed Phrase with Single Account
 //!
@@ -5816,6 +5828,10 @@ pub mod testing {
                     row.get("memo_count")?,
                     row.get("expired_unmined")?,
                     row.get("is_shielding")?,
+                    row.get("is_pool_crossing")?,
+                    row.get::<_, Option<i64>>("pool_crossing_value")?
+                        .map(Zatoshis::from_nonnegative_i64)
+                        .transpose()?,
                 ))
             })?
             .collect::<Result<Vec<_>, _>>()?;

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -1375,6 +1375,14 @@ notes AS (
          ON ros.pool = ro.pool
          AND ros.received_output_id = ro.id_within_pool_table
 ),
+-- The distinct pools from which each account spent notes in each transaction. An output
+-- received in a pool that does not appear here for its transaction is value that crossed
+-- into that pool from elsewhere.
+spent_note_pools AS (
+    SELECT account_id, transaction_id, pool
+    FROM v_received_output_spends
+    GROUP BY account_id, transaction_id, pool
+),
 -- Obtain a count of the notes that the wallet created in each transaction,
 -- not counting change notes.
 sent_note_counts AS (
@@ -1427,6 +1435,28 @@ SELECT accounts.uuid                AS account_uuid,
             -- We do not know about any external outputs of the transaction.
             AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
        ) AS is_shielding,
+       (
+            -- Every note spent and every output received by the wallet in this transaction
+            -- is shielded.
+            SUM(CASE WHEN notes.pool = 0 THEN notes.spent_note_count + notes.received_count + notes.change_note_count ELSE 0 END) = 0
+            -- The transaction spends at least one of the account's notes.
+            AND SUM(notes.spent_note_count) > 0
+            -- At least one output was received in a shielded pool from which the account
+            -- spent nothing, so value crossed between pools.
+            AND SUM(CASE WHEN spent_note_pools.pool IS NULL THEN notes.received_count + notes.change_note_count ELSE 0 END) > 0
+            -- We do not know about any external outputs of the transaction.
+            AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
+       ) AS is_pool_crossing,
+       -- The value received in pools the account did not spend from, when the transaction
+       -- is a pool crossing; NULL otherwise.
+       CASE WHEN (
+            SUM(CASE WHEN notes.pool = 0 THEN notes.spent_note_count + notes.received_count + notes.change_note_count ELSE 0 END) = 0
+            AND SUM(notes.spent_note_count) > 0
+            AND SUM(CASE WHEN spent_note_pools.pool IS NULL THEN notes.received_count + notes.change_note_count ELSE 0 END) > 0
+            AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
+       )
+       THEN SUM(CASE WHEN spent_note_pools.pool IS NULL THEN notes.received_value ELSE 0 END)
+       END AS pool_crossing_value,
        transactions.trust_status
 FROM notes
 JOIN accounts ON accounts.id = notes.account_id
@@ -1436,6 +1466,10 @@ LEFT JOIN blocks ON blocks.height = transactions.mined_height
 LEFT JOIN sent_note_counts
      ON sent_note_counts.account_id = notes.account_id
      AND sent_note_counts.transaction_id = notes.transaction_id
+LEFT JOIN spent_note_pools
+     ON spent_note_pools.account_id = notes.account_id
+     AND spent_note_pools.transaction_id = notes.transaction_id
+     AND spent_note_pools.pool = notes.pool
 GROUP BY notes.account_id, notes.transaction_id";
 
 /// Selects all outputs received by the wallet, plus any outputs sent from the wallet to

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -1435,7 +1435,10 @@ SELECT accounts.uuid                AS account_uuid,
             -- We do not know about any external outputs of the transaction.
             AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
        ) AS is_shielding,
-       (
+       -- The value that crossed pools, when this transaction is a wallet-internal transfer
+       -- between shielded pools; NULL when it is not such a transfer. A transaction is one
+       -- exactly when this column is non-NULL.
+       CASE WHEN (
             -- Every note spent and every output received by the wallet in this transaction
             -- is shielded.
             SUM(CASE WHEN notes.pool = 0 THEN notes.spent_note_count + notes.received_count + notes.change_note_count ELSE 0 END) = 0
@@ -1446,15 +1449,9 @@ SELECT accounts.uuid                AS account_uuid,
             AND SUM(CASE WHEN spent_note_pools.pool IS NULL THEN notes.received_count + notes.change_note_count ELSE 0 END) > 0
             -- We do not know about any external outputs of the transaction.
             AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
-       ) AS is_pool_crossing,
-       -- The value received in pools the account did not spend from, when the transaction
-       -- is a pool crossing; NULL otherwise.
-       CASE WHEN (
-            SUM(CASE WHEN notes.pool = 0 THEN notes.spent_note_count + notes.received_count + notes.change_note_count ELSE 0 END) = 0
-            AND SUM(notes.spent_note_count) > 0
-            AND SUM(CASE WHEN spent_note_pools.pool IS NULL THEN notes.received_count + notes.change_note_count ELSE 0 END) > 0
-            AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
        )
+       -- The total value received in pools the account did not spend from. The condition
+       -- above guarantees at least one such output, so this sum is never NULL when selected.
        THEN SUM(CASE WHEN spent_note_pools.pool IS NULL THEN notes.received_value ELSE 0 END)
        END AS pool_crossing_value,
        transactions.trust_status

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -1375,12 +1375,15 @@ notes AS (
          ON ros.pool = ro.pool
          AND ros.received_output_id = ro.id_within_pool_table
 ),
--- The distinct pools from which each account spent notes in each transaction. An output
--- received in a pool that does not appear here for its transaction is value that crossed
--- into that pool from elsewhere.
-spent_note_pools AS (
-    SELECT account_id, transaction_id, pool
-    FROM v_received_output_spends
+-- What each account spent and received in each pool, per transaction. A pool the account
+-- received value in but spent nothing from is a pool that value crossed into from
+-- elsewhere, which is what `pool_crossings` below is built on.
+notes_by_pool AS (
+    SELECT account_id, transaction_id, pool,
+           SUM(spent_note_count)                   AS spent_note_count,
+           SUM(received_count + change_note_count) AS received_note_count,
+           SUM(received_value)                     AS received_value
+    FROM notes
     GROUP BY account_id, transaction_id, pool
 ),
 -- Obtain a count of the notes that the wallet created in each transaction,
@@ -1400,6 +1403,35 @@ sent_note_counts AS (
     LEFT JOIN v_received_outputs ro ON sent_notes.id = ro.sent_note_id
     WHERE COALESCE(ro.is_change, 0) = 0
     GROUP BY account_id, sent_notes.transaction_id
+),
+-- Identifies the transactions that are wallet-internal transfers moving an account's own
+-- funds between shielded pools, and reports the value that crossed. `crossing_value` is
+-- non-NULL exactly for such a transaction, so it carries both the classification and the
+-- amount; see the `pool_crossing_value` column below.
+pool_crossings AS (
+    SELECT notes_by_pool.account_id     AS account_id,
+           notes_by_pool.transaction_id AS transaction_id,
+           CASE WHEN (
+                -- Every note spent and every output received by the wallet is shielded.
+                SUM(CASE WHEN notes_by_pool.pool = 0 THEN notes_by_pool.spent_note_count + notes_by_pool.received_note_count ELSE 0 END) = 0
+                -- The transaction spends at least one of the account's notes.
+                AND SUM(notes_by_pool.spent_note_count) > 0
+                -- At least one output was received in a pool the account spent nothing
+                -- from, so value crossed between pools.
+                AND SUM(CASE WHEN notes_by_pool.spent_note_count = 0 THEN notes_by_pool.received_note_count ELSE 0 END) > 0
+                -- We do not know about any external outputs of the transaction.
+                AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
+           )
+           -- The total value received in the pools the account did not spend from. The
+           -- condition above guarantees at least one such output, so when this branch is
+           -- taken the sum is never NULL.
+           THEN SUM(CASE WHEN notes_by_pool.spent_note_count = 0 THEN notes_by_pool.received_value ELSE 0 END)
+           END AS crossing_value
+    FROM notes_by_pool
+    LEFT JOIN sent_note_counts
+         ON sent_note_counts.account_id = notes_by_pool.account_id
+         AND sent_note_counts.transaction_id = notes_by_pool.transaction_id
+    GROUP BY notes_by_pool.account_id, notes_by_pool.transaction_id
 ),
 blocks_max_height AS (
     SELECT MAX(blocks.height) AS max_height FROM blocks
@@ -1438,22 +1470,7 @@ SELECT accounts.uuid                AS account_uuid,
        -- The value that crossed pools, when this transaction is a wallet-internal transfer
        -- between shielded pools; NULL when it is not such a transfer. A transaction is one
        -- exactly when this column is non-NULL.
-       CASE WHEN (
-            -- Every note spent and every output received by the wallet in this transaction
-            -- is shielded.
-            SUM(CASE WHEN notes.pool = 0 THEN notes.spent_note_count + notes.received_count + notes.change_note_count ELSE 0 END) = 0
-            -- The transaction spends at least one of the account's notes.
-            AND SUM(notes.spent_note_count) > 0
-            -- At least one output was received in a shielded pool from which the account
-            -- spent nothing, so value crossed between pools.
-            AND SUM(CASE WHEN spent_note_pools.pool IS NULL THEN notes.received_count + notes.change_note_count ELSE 0 END) > 0
-            -- We do not know about any external outputs of the transaction.
-            AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
-       )
-       -- The total value received in pools the account did not spend from. The condition
-       -- above guarantees at least one such output, so this sum is never NULL when selected.
-       THEN SUM(CASE WHEN spent_note_pools.pool IS NULL THEN notes.received_value ELSE 0 END)
-       END AS pool_crossing_value,
+       pool_crossings.crossing_value AS pool_crossing_value,
        transactions.trust_status
 FROM notes
 JOIN accounts ON accounts.id = notes.account_id
@@ -1463,10 +1480,9 @@ LEFT JOIN blocks ON blocks.height = transactions.mined_height
 LEFT JOIN sent_note_counts
      ON sent_note_counts.account_id = notes.account_id
      AND sent_note_counts.transaction_id = notes.transaction_id
-LEFT JOIN spent_note_pools
-     ON spent_note_pools.account_id = notes.account_id
-     AND spent_note_pools.transaction_id = notes.transaction_id
-     AND spent_note_pools.pool = notes.pool
+LEFT JOIN pool_crossings
+     ON pool_crossings.account_id = notes.account_id
+     AND pool_crossings.transaction_id = notes.transaction_id
 GROUP BY notes.account_id, notes.transaction_id";
 
 /// Selects all outputs received by the wallet, plus any outputs sent from the wallet to

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -60,6 +60,7 @@ mod v_sapling_shard_unscanned_ranges;
 mod v_transactions_additional_totals;
 mod v_transactions_net;
 mod v_transactions_note_uniqueness;
+mod v_transactions_pool_crossing;
 mod v_transactions_shielding_balance;
 mod v_transactions_transparent_history;
 mod v_tx_outputs_key_scopes;
@@ -156,6 +157,7 @@ pub mod ids {
     pub use super::v_transactions_additional_totals::MIGRATION_ID as V_TRANSACTIONS_ADDITIONAL_TOTALS;
     pub use super::v_transactions_net::MIGRATION_ID as V_TRANSACTIONS_NET;
     pub use super::v_transactions_note_uniqueness::MIGRATION_ID as V_TRANSACTIONS_NOTE_UNIQUENESS;
+    pub use super::v_transactions_pool_crossing::MIGRATION_ID as V_TRANSACTIONS_POOL_CROSSING;
     pub use super::v_transactions_shielding_balance::MIGRATION_ID as V_TRANSACTIONS_SHIELDING_BALANCE;
     pub use super::v_transactions_transparent_history::MIGRATION_ID as V_TRANSACTIONS_TRANSPARENT_HISTORY;
     pub use super::v_tx_outputs_key_scopes::MIGRATION_ID as V_TX_OUTPUTS_KEY_SCOPES;
@@ -233,15 +235,18 @@ pub(super) fn all_migrations<
     //                       `------------------- account_delete_cascade ---------------------------------'
     //                              /               /                  |              \
     //     add_transparent_value_index  v_tx_outputs_key_scopes  standalone_p2sh    witness_stabilized_notes
-    //                                                    /          \         \
-    //                                                   /            \      orchard_note_version
-    //                                                  /              \           \
-    //                                                 /                \  ironwood_received_notes -- note_locking
-    //                                                /                  \       |               |------|     |
-    //                                               /                    \    ironwood_pool_code_views |  v_address_uses_ironwood
-    //                                              /                      \                            |
-    //                                             /                        \    fix_bad_ironwood_change_flagging
-    //                                          ivk_item_cache    add_transparent_receiver_address_index
+    //                                     /                      /            \
+    //                               ivk_item_cache              /           orchard_note_version
+    //                                                          /                  \
+    //                                add_transparent_receiver_address_index        \
+    //                                                                               \
+    //                                                                      ironwood_received_notes ----------------
+    //                                                                      /         |          \                  \
+    //                                                   ironwood_pool_code_views     |      note_locking  fix_bad_ironwood_change_flagging
+    //                                                           |                    |
+    //                                                           |             v_address_uses_ironwood
+    //                                                           |
+    //                                                v_transactions_pool_crossing
     //
     let rng = Rc::new(Mutex::new(rng));
     vec![
@@ -347,6 +352,7 @@ pub(super) fn all_migrations<
         Box::new(ironwood_pool_code_views::Migration),
         Box::new(fix_bad_ironwood_change_flagging::Migration),
         Box::new(v_address_uses_ironwood::Migration),
+        Box::new(v_transactions_pool_crossing::Migration),
         Box::new(orchard_ironwood_migration_tables::Migration),
         Box::new(tree_retained_checkpoints::Migration),
         Box::new(note_locking::Migration),
@@ -546,9 +552,9 @@ pub const CURRENT_LEAF_MIGRATIONS: &[Uuid] = &[
     ivk_item_cache::MIGRATION_ID,
     add_transparent_receiver_address_index::MIGRATION_ID,
     add_transparent_value_index::MIGRATION_ID,
-    ironwood_pool_code_views::MIGRATION_ID,
     fix_bad_ironwood_change_flagging::MIGRATION_ID,
     v_address_uses_ironwood::MIGRATION_ID,
+    v_transactions_pool_crossing::MIGRATION_ID,
     orchard_ironwood_migration_tables::MIGRATION_ID,
     tree_retained_checkpoints::MIGRATION_ID,
     tx_status_observation_intent::MIGRATION_ID,
@@ -704,6 +710,7 @@ pub(crate) mod tests {
             ids::V_TRANSACTIONS_ADDITIONAL_TOTALS,
             ids::V_TRANSACTIONS_NET,
             ids::V_TRANSACTIONS_NOTE_UNIQUENESS,
+            ids::V_TRANSACTIONS_POOL_CROSSING,
             ids::V_TRANSACTIONS_SHIELDING_BALANCE,
             ids::V_TRANSACTIONS_TRANSPARENT_HISTORY,
             ids::V_TX_OUTPUTS_KEY_SCOPES,

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_pool_crossing.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_pool_crossing.rs
@@ -1,7 +1,7 @@
 //! Adds pool-crossing classification to `v_transactions`.
 //!
-//! A wallet-internal transfer that moves an account's own funds between shielded pools — for
-//! example a ZIP 318 Orchard → Ironwood migration transfer — has an `account_balance_delta` of
+//! A wallet-internal transfer that moves an account's own funds between shielded pools, for
+//! example a ZIP 318 Orchard -> Ironwood migration transfer, has an `account_balance_delta` of
 //! only the transaction fee, which is correct but is not the quantity a wallet wants to present:
 //! the user-meaningful amount is the value that crossed pools. Nothing in the view identified
 //! such transactions or carried that amount, so clients could only improvise from `total_spent`

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_pool_crossing.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_pool_crossing.rs
@@ -124,12 +124,15 @@ impl RusqliteMigration for Migration {
                      ON ros.pool = ro.pool
                      AND ros.received_output_id = ro.id_within_pool_table
             ),
-            -- The distinct pools from which each account spent notes in each transaction. An output
-            -- received in a pool that does not appear here for its transaction is value that crossed
-            -- into that pool from elsewhere.
-            spent_note_pools AS (
-                SELECT account_id, transaction_id, pool
-                FROM v_received_output_spends
+            -- What each account spent and received in each pool, per transaction. A pool the account
+            -- received value in but spent nothing from is a pool that value crossed into from
+            -- elsewhere, which is what `pool_crossings` below is built on.
+            notes_by_pool AS (
+                SELECT account_id, transaction_id, pool,
+                       SUM(spent_note_count)                   AS spent_note_count,
+                       SUM(received_count + change_note_count) AS received_note_count,
+                       SUM(received_value)                     AS received_value
+                FROM notes
                 GROUP BY account_id, transaction_id, pool
             ),
             -- Obtain a count of the notes that the wallet created in each transaction,
@@ -149,6 +152,35 @@ impl RusqliteMigration for Migration {
                 LEFT JOIN v_received_outputs ro ON sent_notes.id = ro.sent_note_id
                 WHERE COALESCE(ro.is_change, 0) = 0
                 GROUP BY account_id, sent_notes.transaction_id
+            ),
+            -- Identifies the transactions that are wallet-internal transfers moving an account's own
+            -- funds between shielded pools, and reports the value that crossed. `crossing_value` is
+            -- non-NULL exactly for such a transaction, so it carries both the classification and the
+            -- amount; see the `pool_crossing_value` column below.
+            pool_crossings AS (
+                SELECT notes_by_pool.account_id     AS account_id,
+                       notes_by_pool.transaction_id AS transaction_id,
+                       CASE WHEN (
+                            -- Every note spent and every output received by the wallet is shielded.
+                            SUM(CASE WHEN notes_by_pool.pool = 0 THEN notes_by_pool.spent_note_count + notes_by_pool.received_note_count ELSE 0 END) = 0
+                            -- The transaction spends at least one of the account's notes.
+                            AND SUM(notes_by_pool.spent_note_count) > 0
+                            -- At least one output was received in a pool the account spent nothing
+                            -- from, so value crossed between pools.
+                            AND SUM(CASE WHEN notes_by_pool.spent_note_count = 0 THEN notes_by_pool.received_note_count ELSE 0 END) > 0
+                            -- We do not know about any external outputs of the transaction.
+                            AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
+                       )
+                       -- The total value received in the pools the account did not spend from. The
+                       -- condition above guarantees at least one such output, so when this branch is
+                       -- taken the sum is never NULL.
+                       THEN SUM(CASE WHEN notes_by_pool.spent_note_count = 0 THEN notes_by_pool.received_value ELSE 0 END)
+                       END AS crossing_value
+                FROM notes_by_pool
+                LEFT JOIN sent_note_counts
+                     ON sent_note_counts.account_id = notes_by_pool.account_id
+                     AND sent_note_counts.transaction_id = notes_by_pool.transaction_id
+                GROUP BY notes_by_pool.account_id, notes_by_pool.transaction_id
             ),
             blocks_max_height AS (
                 SELECT MAX(blocks.height) AS max_height FROM blocks
@@ -187,22 +219,7 @@ impl RusqliteMigration for Migration {
                    -- The value that crossed pools, when this transaction is a wallet-internal transfer
                    -- between shielded pools; NULL when it is not such a transfer. A transaction is one
                    -- exactly when this column is non-NULL.
-                   CASE WHEN (
-                        -- Every note spent and every output received by the wallet in this transaction
-                        -- is shielded.
-                        SUM(CASE WHEN notes.pool = 0 THEN notes.spent_note_count + notes.received_count + notes.change_note_count ELSE 0 END) = 0
-                        -- The transaction spends at least one of the account's notes.
-                        AND SUM(notes.spent_note_count) > 0
-                        -- At least one output was received in a shielded pool from which the account
-                        -- spent nothing, so value crossed between pools.
-                        AND SUM(CASE WHEN spent_note_pools.pool IS NULL THEN notes.received_count + notes.change_note_count ELSE 0 END) > 0
-                        -- We do not know about any external outputs of the transaction.
-                        AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
-                   )
-                   -- The total value received in pools the account did not spend from. The condition
-                   -- above guarantees at least one such output, so this sum is never NULL when selected.
-                   THEN SUM(CASE WHEN spent_note_pools.pool IS NULL THEN notes.received_value ELSE 0 END)
-                   END AS pool_crossing_value,
+                   pool_crossings.crossing_value AS pool_crossing_value,
                    transactions.trust_status
             FROM notes
             JOIN accounts ON accounts.id = notes.account_id
@@ -212,10 +229,9 @@ impl RusqliteMigration for Migration {
             LEFT JOIN sent_note_counts
                  ON sent_note_counts.account_id = notes.account_id
                  AND sent_note_counts.transaction_id = notes.transaction_id
-            LEFT JOIN spent_note_pools
-                 ON spent_note_pools.account_id = notes.account_id
-                 AND spent_note_pools.transaction_id = notes.transaction_id
-                 AND spent_note_pools.pool = notes.pool
+            LEFT JOIN pool_crossings
+                 ON pool_crossings.account_id = notes.account_id
+                 AND pool_crossings.transaction_id = notes.transaction_id
             GROUP BY notes.account_id, notes.transaction_id;",
         )?;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_pool_crossing.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_pool_crossing.rs
@@ -8,13 +8,15 @@
 //! or `total_received`, both of which overstate the crossing whenever the transaction also
 //! returns change to a pool it spent from.
 //!
-//! This migration recreates `v_transactions` with two new columns, mirroring the shape of the
-//! existing `is_shielding` classification:
-//! - `is_pool_crossing`: true when every wallet-spent note and wallet-received output in the
-//!   transaction is shielded, the account spent at least one note, at least one output was
-//!   received in a pool the account spent nothing from, and no external outputs are known.
-//! - `pool_crossing_value`: the total value received in pools the account did not spend from,
-//!   when `is_pool_crossing` is true; NULL otherwise.
+//! This migration recreates `v_transactions` with a new `pool_crossing_value` column: the total
+//! value received in pools the account did not spend from, when every wallet-spent note and
+//! wallet-received output in the transaction is shielded, the account spent at least one note, at
+//! least one output was received in a pool the account spent nothing from, and no external outputs
+//! are known; NULL otherwise.
+//!
+//! The classification and the amount are carried by that single column rather than by a separate
+//! boolean mirroring `is_shielding`: a transaction is a pool crossing exactly when the column is
+//! non-NULL, so a boolean would restate the same predicate in a second place that could drift.
 //!
 //! A payment that returns value to one of the wallet's own addresses is classified once the
 //! wallet has observed the returned output: the scanner marks an output received by an account
@@ -40,6 +42,7 @@ pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x835d61e1_5b88_4f44_92b3_746fb91
 /// recreates; `ironwood_pool_code_views` supplies the Ironwood arms of `v_received_outputs` and
 /// `v_received_output_spends` that the crossing classification aggregates over.
 const DEPENDENCIES: &[Uuid] = &[
+    account_delete_cascade::MIGRATION_ID,
     ironwood_pool_code_views::MIGRATION_ID,
 ];
 
@@ -55,7 +58,7 @@ impl schemerz::Migration<Uuid> for Migration {
     }
 
     fn description(&self) -> &'static str {
-        "Adds pool-crossing classification (`is_pool_crossing`, `pool_crossing_value`) to v_transactions."
+        "Adds the `pool_crossing_value` classification column to v_transactions."
     }
 }
 
@@ -181,7 +184,10 @@ impl RusqliteMigration for Migration {
                         -- We do not know about any external outputs of the transaction.
                         AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
                    ) AS is_shielding,
-                   (
+                   -- The value that crossed pools, when this transaction is a wallet-internal transfer
+                   -- between shielded pools; NULL when it is not such a transfer. A transaction is one
+                   -- exactly when this column is non-NULL.
+                   CASE WHEN (
                         -- Every note spent and every output received by the wallet in this transaction
                         -- is shielded.
                         SUM(CASE WHEN notes.pool = 0 THEN notes.spent_note_count + notes.received_count + notes.change_note_count ELSE 0 END) = 0
@@ -192,15 +198,9 @@ impl RusqliteMigration for Migration {
                         AND SUM(CASE WHEN spent_note_pools.pool IS NULL THEN notes.received_count + notes.change_note_count ELSE 0 END) > 0
                         -- We do not know about any external outputs of the transaction.
                         AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
-                   ) AS is_pool_crossing,
-                   -- The value received in pools the account did not spend from, when the transaction
-                   -- is a pool crossing; NULL otherwise.
-                   CASE WHEN (
-                        SUM(CASE WHEN notes.pool = 0 THEN notes.spent_note_count + notes.received_count + notes.change_note_count ELSE 0 END) = 0
-                        AND SUM(notes.spent_note_count) > 0
-                        AND SUM(CASE WHEN spent_note_pools.pool IS NULL THEN notes.received_count + notes.change_note_count ELSE 0 END) > 0
-                        AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
                    )
+                   -- The total value received in pools the account did not spend from. The condition
+                   -- above guarantees at least one such output, so this sum is never NULL when selected.
                    THEN SUM(CASE WHEN spent_note_pools.pool IS NULL THEN notes.received_value ELSE 0 END)
                    END AS pool_crossing_value,
                    transactions.trust_status

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_pool_crossing.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_pool_crossing.rs
@@ -1,0 +1,238 @@
+//! Adds pool-crossing classification to `v_transactions`.
+//!
+//! A wallet-internal transfer that moves an account's own funds between shielded pools — for
+//! example a ZIP 318 Orchard → Ironwood migration transfer — has an `account_balance_delta` of
+//! only the transaction fee, which is correct but is not the quantity a wallet wants to present:
+//! the user-meaningful amount is the value that crossed pools. Nothing in the view identified
+//! such transactions or carried that amount, so clients could only improvise from `total_spent`
+//! or `total_received`, both of which overstate the crossing whenever the transaction also
+//! returns change to a pool it spent from.
+//!
+//! This migration recreates `v_transactions` with two new columns, mirroring the shape of the
+//! existing `is_shielding` classification:
+//! - `is_pool_crossing`: true when every wallet-spent note and wallet-received output in the
+//!   transaction is shielded, the account spent at least one note, at least one output was
+//!   received in a pool the account spent nothing from, and no external outputs are known.
+//! - `pool_crossing_value`: the total value received in pools the account did not spend from,
+//!   when `is_pool_crossing` is true; NULL otherwise.
+//!
+//! A payment that returns value to one of the wallet's own addresses is classified once the
+//! wallet has observed the returned output: the scanner marks an output received by an account
+//! that funded the transaction as change, at which point no external outputs remain and the
+//! transaction presents as a wallet-internal crossing. While such a transaction is unmined its
+//! returned output is not yet known to the wallet, so it is treated as an ordinary payment.
+
+use std::collections::HashSet;
+
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+
+use crate::wallet::init::WalletMigrationError;
+
+use super::{account_delete_cascade, ironwood_pool_code_views};
+
+/// This migration adds the `pool_crossing_value` column to `v_transactions`, identifying
+/// wallet-internal transfers that move an account's own funds between shielded pools and
+/// reporting the value that crossed.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x835d61e1_5b88_4f44_92b3_746fb9173360);
+
+/// `account_delete_cascade` is the prior owner of the `v_transactions` definition this migration
+/// recreates; `ironwood_pool_code_views` supplies the Ironwood arms of `v_received_outputs` and
+/// `v_received_output_spends` that the crossing classification aggregates over.
+const DEPENDENCIES: &[Uuid] = &[
+    ironwood_pool_code_views::MIGRATION_ID,
+];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Adds pool-crossing classification (`is_pool_crossing`, `pool_crossing_value`) to v_transactions."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        transaction.execute_batch(
+            "DROP VIEW v_transactions;
+            CREATE VIEW v_transactions AS
+            WITH
+            notes AS (
+                -- Outputs received in this transaction
+                SELECT ro.account_id              AS account_id,
+                       ro.transaction_id          AS transaction_id,
+                       ro.pool                    AS pool,
+                       id_within_pool_table,
+                       ro.value                   AS value,
+                       ro.value                   AS received_value,
+                       0                          AS spent_value,
+                       0                          AS spent_note_count,
+                       CASE
+                            WHEN ro.is_change THEN 1
+                            ELSE 0
+                       END AS change_note_count,
+                       CASE
+                            WHEN ro.is_change THEN 0
+                            ELSE 1
+                       END AS received_count,
+                       CASE
+                         WHEN (ro.memo IS NULL OR ro.memo = X'F6')
+                           THEN 0
+                         ELSE 1
+                       END AS memo_present,
+                       -- The wallet cannot receive transparent outputs in shielding transactions.
+                       CASE
+                         WHEN ro.pool = 0
+                           THEN 1
+                         ELSE 0
+                       END AS does_not_match_shielding
+                FROM v_received_outputs ro
+                UNION
+                -- Outputs spent in this transaction
+                SELECT ro.account_id              AS account_id,
+                       ros.transaction_id         AS transaction_id,
+                       ro.pool                    AS pool,
+                       id_within_pool_table,
+                       -ro.value                  AS value,
+                       0                          AS received_value,
+                       ro.value                   AS spent_value,
+                       1                          AS spent_note_count,
+                       0                          AS change_note_count,
+                       0                          AS received_count,
+                       0                          AS memo_present,
+                       -- The wallet cannot spend shielded outputs in shielding transactions.
+                       CASE
+                         WHEN ro.pool != 0
+                           THEN 1
+                         ELSE 0
+                       END AS does_not_match_shielding
+                FROM v_received_outputs ro
+                JOIN v_received_output_spends ros
+                     ON ros.pool = ro.pool
+                     AND ros.received_output_id = ro.id_within_pool_table
+            ),
+            -- The distinct pools from which each account spent notes in each transaction. An output
+            -- received in a pool that does not appear here for its transaction is value that crossed
+            -- into that pool from elsewhere.
+            spent_note_pools AS (
+                SELECT account_id, transaction_id, pool
+                FROM v_received_output_spends
+                GROUP BY account_id, transaction_id, pool
+            ),
+            -- Obtain a count of the notes that the wallet created in each transaction,
+            -- not counting change notes.
+            sent_note_counts AS (
+                SELECT sent_notes.from_account_id     AS account_id,
+                       sent_notes.transaction_id      AS transaction_id,
+                       COUNT(DISTINCT sent_notes.id)  AS sent_notes,
+                       SUM(
+                         CASE
+                           WHEN (sent_notes.memo IS NULL OR sent_notes.memo = X'F6' OR ro.transaction_id IS NOT NULL)
+                             THEN 0
+                           ELSE 1
+                         END
+                       ) AS memo_count
+                FROM sent_notes
+                LEFT JOIN v_received_outputs ro ON sent_notes.id = ro.sent_note_id
+                WHERE COALESCE(ro.is_change, 0) = 0
+                GROUP BY account_id, sent_notes.transaction_id
+            ),
+            blocks_max_height AS (
+                SELECT MAX(blocks.height) AS max_height FROM blocks
+            )
+            SELECT accounts.uuid                AS account_uuid,
+                   transactions.mined_height    AS mined_height,
+                   transactions.txid            AS txid,
+                   transactions.tx_index        AS tx_index,
+                   transactions.expiry_height   AS expiry_height,
+                   transactions.raw             AS raw,
+                   SUM(notes.value)             AS account_balance_delta,
+                   SUM(notes.spent_value)       AS total_spent,
+                   SUM(notes.received_value)    AS total_received,
+                   transactions.fee             AS fee_paid,
+                   SUM(notes.change_note_count) > 0  AS has_change,
+                   MAX(COALESCE(sent_note_counts.sent_notes, 0))  AS sent_note_count,
+                   SUM(notes.received_count)         AS received_note_count,
+                   SUM(notes.memo_present) + MAX(COALESCE(sent_note_counts.memo_count, 0)) AS memo_count,
+                   blocks.time                       AS block_time,
+                   (
+                        transactions.mined_height IS NULL
+                        AND transactions.expiry_height BETWEEN 1 AND blocks_max_height.max_height
+                   ) AS expired_unmined,
+                   SUM(notes.spent_note_count) AS spent_note_count,
+                   (
+                        -- All of the wallet-spent and wallet-received notes are consistent with a
+                        -- shielding transaction.
+                        SUM(notes.does_not_match_shielding) = 0
+                        -- The transaction contains at least one wallet-spent output.
+                        AND SUM(notes.spent_note_count) > 0
+                        -- The transaction contains at least one wallet-received note.
+                        AND (SUM(notes.received_count) + SUM(notes.change_note_count)) > 0
+                        -- We do not know about any external outputs of the transaction.
+                        AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
+                   ) AS is_shielding,
+                   (
+                        -- Every note spent and every output received by the wallet in this transaction
+                        -- is shielded.
+                        SUM(CASE WHEN notes.pool = 0 THEN notes.spent_note_count + notes.received_count + notes.change_note_count ELSE 0 END) = 0
+                        -- The transaction spends at least one of the account's notes.
+                        AND SUM(notes.spent_note_count) > 0
+                        -- At least one output was received in a shielded pool from which the account
+                        -- spent nothing, so value crossed between pools.
+                        AND SUM(CASE WHEN spent_note_pools.pool IS NULL THEN notes.received_count + notes.change_note_count ELSE 0 END) > 0
+                        -- We do not know about any external outputs of the transaction.
+                        AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
+                   ) AS is_pool_crossing,
+                   -- The value received in pools the account did not spend from, when the transaction
+                   -- is a pool crossing; NULL otherwise.
+                   CASE WHEN (
+                        SUM(CASE WHEN notes.pool = 0 THEN notes.spent_note_count + notes.received_count + notes.change_note_count ELSE 0 END) = 0
+                        AND SUM(notes.spent_note_count) > 0
+                        AND SUM(CASE WHEN spent_note_pools.pool IS NULL THEN notes.received_count + notes.change_note_count ELSE 0 END) > 0
+                        AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
+                   )
+                   THEN SUM(CASE WHEN spent_note_pools.pool IS NULL THEN notes.received_value ELSE 0 END)
+                   END AS pool_crossing_value,
+                   transactions.trust_status
+            FROM notes
+            JOIN accounts ON accounts.id = notes.account_id
+            JOIN transactions ON transactions.id_tx = notes.transaction_id
+            LEFT JOIN blocks_max_height
+            LEFT JOIN blocks ON blocks.height = transactions.mined_height
+            LEFT JOIN sent_note_counts
+                 ON sent_note_counts.account_id = notes.account_id
+                 AND sent_note_counts.transaction_id = notes.transaction_id
+            LEFT JOIN spent_note_pools
+                 ON spent_note_pools.account_id = notes.account_id
+                 AND spent_note_pools.transaction_id = notes.transaction_id
+                 AND spent_note_pools.pool = notes.pool
+            GROUP BY notes.account_id, notes.transaction_id;",
+        )?;
+
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+}

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -1035,6 +1035,16 @@ pub(crate) mod tests {
         testing::pool::propose_v5_payment_to_orchard_receiver_is_rejected();
     }
 
+    #[test]
+    fn orchard_to_ironwood_payment_reports_net_value_delta() {
+        testing::pool::orchard_to_ironwood_payment_reports_net_value_delta();
+    }
+
+    #[test]
+    fn orchard_to_ironwood_self_migration_reports_fee_only_delta() {
+        testing::pool::orchard_to_ironwood_self_migration_reports_fee_only_delta();
+    }
+
     /// `put_received_note` records a note in the received-notes table chosen by the caller,
     /// preserving the note's plaintext version in the `note_version` column. An Orchard-pool note
     /// and an Ironwood-pool note sharing an action index may both be recorded in their respective

--- a/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
+++ b/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
@@ -37,7 +37,7 @@ use pczt::roles::tx_extractor::TransactionExtractor;
 use zcash_client_backend::data_api::testing::{
     AddressType, TestBuilder, TestState, orchard::OrchardPoolTester, pool::ShieldedPoolTester,
 };
-use zcash_client_backend::data_api::{Account, WalletRead};
+use zcash_client_backend::data_api::{Account, WalletRead, WalletTest};
 // The wallet, block cache, DB factory, and Orchard-checkpoint helper come from this crate's own
 // test harness, exposed under its `test-dependencies` feature.
 use zcash_client_sqlite::testing::db::{TestDb, TestDbFactory};
@@ -48,7 +48,7 @@ use zcash_primitives::block::BlockHash;
 use zcash_protocol::consensus::BlockHeight;
 use zcash_protocol::local_consensus::LocalNetwork;
 use zcash_protocol::value::testing::zats;
-use zcash_protocol::value::{COIN, Zatoshis};
+use zcash_protocol::value::{COIN, ZatBalance, Zatoshis};
 
 use zcash_pool_migration::engine::{
     self, MigrationState, MigrationTransferId, MigrationTxKind, MigrationTxState,
@@ -439,11 +439,71 @@ impl Run {
                 "{}: Ironwood outputs per transfer",
                 scenario.label
             );
-            ironwood_notes.push(
+            let crossing_value =
                 Zatoshis::from_u64(i64::from(ironwood.value_balance()).unsigned_abs())
-                    .expect("a valid Ironwood note value"),
+                    .expect("a valid Ironwood note value");
+            ironwood_notes.push(crossing_value);
+
+            // The transfer's Orchard bundle is spend-only, so its value balance is the spent
+            // funding note's value; the Ironwood bundle is output-only, so its value balance
+            // magnitude is the crossing value. Their difference is the transfer's fee.
+            let funding_value = Zatoshis::from_u64(
+                i64::from(
+                    *tx.orchard_bundle()
+                        .expect("the transfer has an Orchard bundle")
+                        .value_balance(),
+                )
+                .unsigned_abs(),
+            )
+            .expect("a valid funding note value");
+            let transfer_fee =
+                (funding_value - crossing_value).expect("the funding note covers the crossing");
+
+            // Mine and scan the transfer, then check the wallet's view of it: the history entry
+            // must report the funding note as spent, the crossing note as received, and a balance
+            // change of only the fee — not the whole value of the notes spent.
+            let (h, _) = self.st.generate_next_block_from_tx(1, &tx);
+            self.st.scan_cached_blocks(h, 1);
+
+            let history = self
+                .st
+                .wallet()
+                .get_tx_history()
+                .expect("reads the transaction history");
+            let entry = history
+                .iter()
+                .find(|t| t.txid() == tx.txid())
+                .expect("the mined transfer appears in the transaction history");
+            assert_eq!(
+                entry.total_spent(),
+                funding_value,
+                "{}: transfer total_spent",
+                scenario.label
+            );
+            assert_eq!(
+                entry.total_received(),
+                crossing_value,
+                "{}: transfer total_received",
+                scenario.label
+            );
+            assert_eq!(
+                entry.account_value_delta(),
+                -ZatBalance::from(transfer_fee),
+                "{}: transfer balance delta is only the fee",
+                scenario.label
             );
         }
+
+        // After every transfer is mined and scanned, the wallet holds the migrated value (now in
+        // the Ironwood pool) plus the plan's change.
+        assert_eq!(
+            self.st.get_total_balance(self.account_id),
+            (scenario.expected_migrated
+                + Zatoshis::from_u64(committed.change).expect("a valid change amount"))
+            .expect("a valid final balance"),
+            "{}: balance after transfers",
+            scenario.label
+        );
 
         // The destination pool holds exactly one Ironwood note per crossing, together carrying the
         // whole migrated value.

--- a/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
+++ b/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
@@ -492,6 +492,19 @@ impl Run {
                 "{}: transfer balance delta is only the fee",
                 scenario.label
             );
+            // The transfer is classified as a pool crossing carrying the crossing value, which
+            // is the amount a wallet should display for it (the balance delta is only the fee).
+            assert!(
+                entry.is_pool_crossing(),
+                "{}: the transfer is a pool crossing",
+                scenario.label
+            );
+            assert_eq!(
+                entry.pool_crossing_value(),
+                Some(crossing_value),
+                "{}: transfer pool_crossing_value",
+                scenario.label
+            );
         }
 
         // After every transfer is mined and scanned, the wallet holds the migrated value (now in

--- a/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
+++ b/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
@@ -461,7 +461,7 @@ impl Run {
 
             // Mine and scan the transfer, then check the wallet's view of it: the history entry
             // must report the funding note as spent, the crossing note as received, and a balance
-            // change of only the fee — not the whole value of the notes spent.
+            // change of only the fee, not the whole value of the notes spent.
             let (h, _) = self.st.generate_next_block_from_tx(1, &tx);
             self.st.scan_cached_blocks(h, 1);
 


### PR DESCRIPTION
Closes #2821. Resolves MOB-1599.

For a wallet-internal transfer that moves an account's own funds between shielded pools — a ZIP 318 Orchard → Ironwood migration transfer, or a user-initiated payment to the wallet's own address routed across the turnstile — `account_balance_delta` is just the negated fee, which is correct but not the quantity a wallet wants to display. Nothing in `v_transactions` identified such transactions or carried the crossed amount, so clients could only improvise from `total_spent` or `total_received`, both of which overstate the crossing whenever the transaction also returns change to a pool it spent from.

This PR adds two columns to `v_transactions`, mirroring the shape of the existing `is_shielding` classification:

- `is_pool_crossing`: true when every wallet-spent note and wallet-received output in the transaction is shielded, the account spent at least one note, at least one output was received in a pool the account spent nothing from, and no external outputs of the transaction are known.
- `pool_crossing_value`: the total value received in pools the account did not spend from — the amount that crossed — when `is_pool_crossing` is true; NULL otherwise.

The implementation adds a `spent_note_pools` CTE (the distinct pools each account spent from, per transaction) and a per-pool LEFT JOIN, leaving the view's existing aggregation structure untouched. The view is recreated by a new `v_transactions_pool_crossing` migration depending on `account_delete_cascade` (the prior owner of the view definition) and `ironwood_pool_code_views` (the Ironwood arms of the underlying views).

One timing property to be aware of: a payment that returns value to one of the wallet's own addresses is classified once the wallet has observed the returned output — the scanner marks an output received by an account that funded the transaction as change, at which point no external outputs remain. While such a transaction is unmined, its returned output is not yet known and it is treated as an ordinary payment.

The first commit adds regression coverage for the transaction-history value accounting of every Orchard → Ironwood transaction shape (external payment, payment to the wallet's own receiver, and mined ZIP 318 migration transfers — the proving chain simulation previously extracted transfers but never mined them). The second commit adds the classification, with the chain simulation asserting that each mined transfer is classified with its crossing value, and the two payment tests pinning down the not-classified and classified-once-observed cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
