### PR TITLE
zcash_client_sqlite: anchor points for external migrations

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -11,6 +11,15 @@ workspace.
 ## [Unreleased]
 
 ### Added
+- `zcash_client_sqlite::wallet::init::migrations::ids`, behind the `unstable`
+  feature flag, exposing the identifier of each individual internal migration.
+  External migrations registered via `WalletMigrator::with_external_migrations`
+  can be anchored against a specific internal migration where the per-release
+  constants (such as `migrations::V_0_19_0`) are not precise enough — in
+  particular when depending on schema added since the most recent release. These
+  identifiers are unstable: the set of them changes between releases, so they are
+  intended for development against unreleased schema, with the anchor moved to
+  the release constant that covers it once that release exists.
 - `zcash_client_sqlite::error::SqliteClientError::BackendError` and the
   `zcash_client_sqlite::error::BackendError` it wraps, reported when a
   `zcash_client_backend` error value carries a variant this crate has no

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -11,6 +11,12 @@ workspace.
 ## [Unreleased]
 
 ### Added
+- `zcash_client_sqlite::wallet::init::migrations::V_0_20_0`, `V_0_22_0_RC1` and
+  `V_0_22_0_RC2`, the leaf migration sets for the releases published since
+  0.19.0, so that an external migration can anchor against any published state
+  of the migration graph. Release candidates are published crate versions and so
+  are covered here; versions that did not change the migration state relative to
+  the preceding constant are omitted, as before.
 - `zcash_client_sqlite::wallet::init::migrations::ids`, behind the `unstable`
   feature flag, exposing the identifier of each individual internal migration.
   External migrations registered via `WalletMigrator::with_external_migrations`

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -502,7 +502,16 @@ impl WalletMigrator {
     /// In order to enable anchoring your external migrations correctly with respect to
     /// this library's internal migrations, we provide constants in the [`migrations`]
     /// module (for each release that adds a migration) which you can include within your
-    /// [`schemerz::Migration::dependencies`] set.
+    /// [`schemerz::Migration::dependencies`] set. Prefer these release constants: each
+    /// names a state of the migration graph that a published release exposed, so it is
+    /// unaffected by the migrations that later releases add.
+    ///
+    /// When no released state is precise enough — most commonly when your migration
+    /// depends on schema that has been added since the most recent release — the
+    /// `migrations::ids` module, behind the `unstable` feature, provides the identifier
+    /// of each individual internal migration. Those identifiers are for developing
+    /// against unreleased schema; move the anchor to the release constant that covers
+    /// it once that release exists.
     ///
     /// Each migration runs inside a database transaction, which has the following
     /// implications:

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -81,6 +81,88 @@ use crate::util::Clock;
 
 use super::WalletMigrationError;
 
+/// Identifiers of the individual migrations that make up this crate's internal migration graph.
+///
+/// External migrations registered via
+/// [`WalletMigrator::with_external_migrations`] are applied as part of a single graph alongside
+/// the internal ones, so an external migration that reads or extends internal schema must
+/// declare a dependency that orders it after the migration which creates that schema.
+///
+/// These identifiers are unstable by nature, which is why they sit behind the `unstable`
+/// feature: each names an individual migration rather than a state of the graph that a
+/// published release exposed, so the set of them, and which of them are reachable, changes
+/// between releases. A release constant such as [`V_0_19_0`] carries no such risk. The
+/// intended shape is therefore to depend on an identifier here while developing against
+/// unreleased schema, and to move the anchor to the release constant that covers it once
+/// that release exists.
+///
+/// Depending on an identifier here only orders your migration *after* the named one; it does
+/// not prevent later internal migrations from being applied before yours.
+///
+/// [`WalletMigrator::with_external_migrations`]: super::WalletMigrator::with_external_migrations
+#[cfg(feature = "unstable")]
+pub mod ids {
+    pub use super::account_delete_cascade::MIGRATION_ID as ACCOUNT_DELETE_CASCADE;
+    pub use super::add_account_birthdays::MIGRATION_ID as ADD_ACCOUNT_BIRTHDAYS;
+    pub use super::add_account_uuids::MIGRATION_ID as ADD_ACCOUNT_UUIDS;
+    pub use super::add_transaction_trust_marker::MIGRATION_ID as ADD_TRANSACTION_TRUST_MARKER;
+    pub use super::add_transaction_views::MIGRATION_ID as ADD_TRANSACTION_VIEWS;
+    pub use super::add_transparent_receiver_address_index::MIGRATION_ID as ADD_TRANSPARENT_RECEIVER_ADDRESS_INDEX;
+    pub use super::add_transparent_value_index::MIGRATION_ID as ADD_TRANSPARENT_VALUE_INDEX;
+    pub use super::add_utxo_account::MIGRATION_ID as ADD_UTXO_ACCOUNT;
+    pub use super::addresses_table::MIGRATION_ID as ADDRESSES_TABLE;
+    pub use super::ensure_default_transparent_address::MIGRATION_ID as ENSURE_DEFAULT_TRANSPARENT_ADDRESS;
+    pub use super::ensure_orchard_ua_receiver::MIGRATION_ID as ENSURE_ORCHARD_UA_RECEIVER;
+    pub use super::ephemeral_addresses::MIGRATION_ID as EPHEMERAL_ADDRESSES;
+    pub use super::fix_bad_change_flagging::MIGRATION_ID as FIX_BAD_CHANGE_FLAGGING;
+    pub use super::fix_bad_ironwood_change_flagging::MIGRATION_ID as FIX_BAD_IRONWOOD_CHANGE_FLAGGING;
+    pub use super::fix_broken_commitment_trees::MIGRATION_ID as FIX_BROKEN_COMMITMENT_TREES;
+    pub use super::fix_transparent_received_outputs::MIGRATION_ID as FIX_TRANSPARENT_RECEIVED_OUTPUTS;
+    pub use super::fix_v_transactions_expired_unmined::MIGRATION_ID as FIX_V_TRANSACTIONS_EXPIRED_UNMINED;
+    pub use super::full_account_ids::MIGRATION_ID as FULL_ACCOUNT_IDS;
+    pub use super::initial_setup::MIGRATION_ID as INITIAL_SETUP;
+    pub use super::ironwood_pool_code_views::MIGRATION_ID as IRONWOOD_POOL_CODE_VIEWS;
+    pub use super::ironwood_received_notes::MIGRATION_ID as IRONWOOD_RECEIVED_NOTES;
+    pub use super::ironwood_shardtree::MIGRATION_ID as IRONWOOD_SHARDTREE;
+    pub use super::ivk_item_cache::MIGRATION_ID as IVK_ITEM_CACHE;
+    pub use super::note_locking::MIGRATION_ID as NOTE_LOCKING;
+    pub use super::nullifier_map::MIGRATION_ID as NULLIFIER_MAP;
+    pub use super::orchard_ironwood_migration_tables::MIGRATION_ID as ORCHARD_IRONWOOD_MIGRATION_TABLES;
+    pub use super::orchard_note_version::MIGRATION_ID as ORCHARD_NOTE_VERSION;
+    pub use super::orchard_received_notes::MIGRATION_ID as ORCHARD_RECEIVED_NOTES;
+    pub use super::orchard_shardtree::MIGRATION_ID as ORCHARD_SHARDTREE;
+    pub use super::received_notes_nullable_nf::MIGRATION_ID as RECEIVED_NOTES_NULLABLE_NF;
+    pub use super::receiving_key_scopes::MIGRATION_ID as RECEIVING_KEY_SCOPES;
+    pub use super::sapling_memo_consistency::MIGRATION_ID as SAPLING_MEMO_CONSISTENCY;
+    pub use super::sent_notes_to_internal::MIGRATION_ID as SENT_NOTES_TO_INTERNAL;
+    pub use super::shardtree_support::MIGRATION_ID as SHARDTREE_SUPPORT;
+    pub use super::spend_key_available::MIGRATION_ID as SPEND_KEY_AVAILABLE;
+    pub use super::standalone_p2sh::MIGRATION_ID as STANDALONE_P2SH;
+    pub use super::support_legacy_sqlite::MIGRATION_ID as SUPPORT_LEGACY_SQLITE;
+    pub use super::support_zcashd_wallet_import::MIGRATION_ID as SUPPORT_ZCASHD_WALLET_IMPORT;
+    pub use super::transparent_gap_limit_handling::MIGRATION_ID as TRANSPARENT_GAP_LIMIT_HANDLING;
+    pub use super::tree_retained_checkpoints::MIGRATION_ID as TREE_RETAINED_CHECKPOINTS;
+    pub use super::tx_observation_height::MIGRATION_ID as TX_OBSERVATION_HEIGHT;
+    pub use super::tx_retrieval_queue::MIGRATION_ID as TX_RETRIEVAL_QUEUE;
+    pub use super::tx_retrieval_queue_expiry::MIGRATION_ID as TX_RETRIEVAL_QUEUE_EXPIRY;
+    pub use super::ufvk_support::MIGRATION_ID as UFVK_SUPPORT;
+    pub use super::utxos_table::MIGRATION_ID as UTXOS_TABLE;
+    pub use super::utxos_to_txos::MIGRATION_ID as UTXOS_TO_TXOS;
+    pub use super::v_address_uses_ironwood::MIGRATION_ID as V_ADDRESS_USES_IRONWOOD;
+    pub use super::v_received_output_spends_account::MIGRATION_ID as V_RECEIVED_OUTPUT_SPENDS_ACCOUNT;
+    pub use super::v_sapling_shard_unscanned_ranges::MIGRATION_ID as V_SAPLING_SHARD_UNSCANNED_RANGES;
+    pub use super::v_transactions_additional_totals::MIGRATION_ID as V_TRANSACTIONS_ADDITIONAL_TOTALS;
+    pub use super::v_transactions_net::MIGRATION_ID as V_TRANSACTIONS_NET;
+    pub use super::v_transactions_note_uniqueness::MIGRATION_ID as V_TRANSACTIONS_NOTE_UNIQUENESS;
+    pub use super::v_transactions_shielding_balance::MIGRATION_ID as V_TRANSACTIONS_SHIELDING_BALANCE;
+    pub use super::v_transactions_transparent_history::MIGRATION_ID as V_TRANSACTIONS_TRANSPARENT_HISTORY;
+    pub use super::v_tx_outputs_key_scopes::MIGRATION_ID as V_TX_OUTPUTS_KEY_SCOPES;
+    pub use super::v_tx_outputs_return_addrs::MIGRATION_ID as V_TX_OUTPUTS_RETURN_ADDRS;
+    pub use super::v_tx_outputs_use_legacy_false::MIGRATION_ID as V_TX_OUTPUTS_USE_LEGACY_FALSE;
+    pub use super::wallet_summaries::MIGRATION_ID as WALLET_SUMMARIES;
+    pub use super::witness_stabilized_notes::MIGRATION_ID as WITNESS_STABILIZED_NOTES;
+}
+
 pub(super) fn all_migrations<
     P: consensus::Parameters + 'static,
     C: Clock + Clone + 'static,
@@ -504,6 +586,84 @@ pub(crate) mod tests {
 
         let listed_leaves: HashSet<Uuid> = super::CURRENT_LEAF_MIGRATIONS.iter().copied().collect();
         assert_eq!(computed_leaves, listed_leaves);
+    }
+
+    /// Every migration in the graph must have a publicly-exported identifier, so that an
+    /// external migration can always anchor itself precisely. Listing them here rather than
+    /// deriving them means a migration added without an `ids` entry fails this test.
+    #[test]
+    #[cfg(feature = "unstable")]
+    fn ids_module_covers_every_migration() {
+        use super::ids;
+        use schemerz::Migration;
+
+        let exported: HashSet<Uuid> = HashSet::from([
+            ids::ACCOUNT_DELETE_CASCADE,
+            ids::ADD_ACCOUNT_BIRTHDAYS,
+            ids::ADD_ACCOUNT_UUIDS,
+            ids::ADD_TRANSACTION_TRUST_MARKER,
+            ids::ADD_TRANSACTION_VIEWS,
+            ids::ADD_TRANSPARENT_RECEIVER_ADDRESS_INDEX,
+            ids::ADD_TRANSPARENT_VALUE_INDEX,
+            ids::ADD_UTXO_ACCOUNT,
+            ids::ADDRESSES_TABLE,
+            ids::ENSURE_DEFAULT_TRANSPARENT_ADDRESS,
+            ids::ENSURE_ORCHARD_UA_RECEIVER,
+            ids::EPHEMERAL_ADDRESSES,
+            ids::FIX_BAD_CHANGE_FLAGGING,
+            ids::FIX_BAD_IRONWOOD_CHANGE_FLAGGING,
+            ids::FIX_BROKEN_COMMITMENT_TREES,
+            ids::FIX_TRANSPARENT_RECEIVED_OUTPUTS,
+            ids::FIX_V_TRANSACTIONS_EXPIRED_UNMINED,
+            ids::FULL_ACCOUNT_IDS,
+            ids::INITIAL_SETUP,
+            ids::IRONWOOD_POOL_CODE_VIEWS,
+            ids::IRONWOOD_RECEIVED_NOTES,
+            ids::IRONWOOD_SHARDTREE,
+            ids::IVK_ITEM_CACHE,
+            ids::NOTE_LOCKING,
+            ids::NULLIFIER_MAP,
+            ids::ORCHARD_IRONWOOD_MIGRATION_TABLES,
+            ids::ORCHARD_NOTE_VERSION,
+            ids::ORCHARD_RECEIVED_NOTES,
+            ids::ORCHARD_SHARDTREE,
+            ids::RECEIVED_NOTES_NULLABLE_NF,
+            ids::RECEIVING_KEY_SCOPES,
+            ids::SAPLING_MEMO_CONSISTENCY,
+            ids::SENT_NOTES_TO_INTERNAL,
+            ids::SHARDTREE_SUPPORT,
+            ids::SPEND_KEY_AVAILABLE,
+            ids::STANDALONE_P2SH,
+            ids::SUPPORT_LEGACY_SQLITE,
+            ids::SUPPORT_ZCASHD_WALLET_IMPORT,
+            ids::TRANSPARENT_GAP_LIMIT_HANDLING,
+            ids::TREE_RETAINED_CHECKPOINTS,
+            ids::TX_OBSERVATION_HEIGHT,
+            ids::TX_RETRIEVAL_QUEUE,
+            ids::TX_RETRIEVAL_QUEUE_EXPIRY,
+            ids::UFVK_SUPPORT,
+            ids::UTXOS_TABLE,
+            ids::UTXOS_TO_TXOS,
+            ids::V_ADDRESS_USES_IRONWOOD,
+            ids::V_RECEIVED_OUTPUT_SPENDS_ACCOUNT,
+            ids::V_SAPLING_SHARD_UNSCANNED_RANGES,
+            ids::V_TRANSACTIONS_ADDITIONAL_TOTALS,
+            ids::V_TRANSACTIONS_NET,
+            ids::V_TRANSACTIONS_NOTE_UNIQUENESS,
+            ids::V_TRANSACTIONS_SHIELDING_BALANCE,
+            ids::V_TRANSACTIONS_TRANSPARENT_HISTORY,
+            ids::V_TX_OUTPUTS_KEY_SCOPES,
+            ids::V_TX_OUTPUTS_RETURN_ADDRS,
+            ids::V_TX_OUTPUTS_USE_LEGACY_FALSE,
+            ids::WALLET_SUMMARIES,
+            ids::WITNESS_STABILIZED_NOTES,
+        ]);
+
+        let migrations =
+            super::all_migrations(&Network::TestNetwork, test_clock(), test_rng(), None);
+        let all_ids: HashSet<Uuid> = migrations.iter().map(|m| m.id()).collect();
+
+        assert_eq!(all_ids, exported);
     }
 
     /// A synthetic set of Orchard note payload values, for exercising migrations that touch the

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -358,9 +358,30 @@ pub(super) fn all_migrations<
 /// included.
 #[allow(dead_code)] // marked as dead code so that this appears in docs with --document-private-items
 const PUBLIC_MIGRATION_STATES: &[&[Uuid]] = &[
-    V_0_4_0, V_0_6_0, V_0_8_0, V_0_9_0, V_0_10_0, V_0_10_3, V_0_11_0, V_0_11_1, V_0_11_2, V_0_12_0,
-    V_0_13_0, V_0_14_0, V_0_15_0, V_0_16_0, V_0_16_2, V_0_16_4, V_0_17_2, V_0_17_3, V_0_18_0,
-    V_0_18_5, V_0_19_0,
+    V_0_4_0,
+    V_0_6_0,
+    V_0_8_0,
+    V_0_9_0,
+    V_0_10_0,
+    V_0_10_3,
+    V_0_11_0,
+    V_0_11_1,
+    V_0_11_2,
+    V_0_12_0,
+    V_0_13_0,
+    V_0_14_0,
+    V_0_15_0,
+    V_0_16_0,
+    V_0_16_2,
+    V_0_16_4,
+    V_0_17_2,
+    V_0_17_3,
+    V_0_18_0,
+    V_0_18_5,
+    V_0_19_0,
+    V_0_20_0,
+    V_0_22_0_RC1,
+    V_0_22_0_RC2,
 ];
 
 /// Leaf migrations in the 0.4.0 release.
@@ -486,6 +507,35 @@ pub const V_0_18_5: &[Uuid] = &[
 
 /// Leaf migrations in the 0.19.0 release.
 pub const V_0_19_0: &[Uuid] = &[account_delete_cascade::MIGRATION_ID];
+
+/// Leaf migrations in the 0.20.0 release.
+pub const V_0_20_0: &[Uuid] = &[
+    v_tx_outputs_key_scopes::MIGRATION_ID,
+    ivk_item_cache::MIGRATION_ID,
+    witness_stabilized_notes::MIGRATION_ID,
+];
+
+/// Leaf migrations in the 0.22.0-rc.1 release.
+pub const V_0_22_0_RC1: &[Uuid] = &[
+    v_tx_outputs_key_scopes::MIGRATION_ID,
+    ivk_item_cache::MIGRATION_ID,
+    add_transparent_receiver_address_index::MIGRATION_ID,
+    add_transparent_value_index::MIGRATION_ID,
+    ironwood_pool_code_views::MIGRATION_ID,
+    tree_retained_checkpoints::MIGRATION_ID,
+];
+
+/// Leaf migrations in the 0.22.0-rc.2 release.
+pub const V_0_22_0_RC2: &[Uuid] = &[
+    v_tx_outputs_key_scopes::MIGRATION_ID,
+    ivk_item_cache::MIGRATION_ID,
+    add_transparent_receiver_address_index::MIGRATION_ID,
+    add_transparent_value_index::MIGRATION_ID,
+    ironwood_pool_code_views::MIGRATION_ID,
+    orchard_ironwood_migration_tables::MIGRATION_ID,
+    tree_retained_checkpoints::MIGRATION_ID,
+    note_locking::MIGRATION_ID,
+];
 
 /// Leaf migrations as of the current repository state.
 pub const CURRENT_LEAF_MIGRATIONS: &[Uuid] = &[

--- a/zcash_client_sqlite/src/wallet/init/migrations/account_delete_cascade.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/account_delete_cascade.rs
@@ -14,7 +14,9 @@ use crate::wallet::init::{
     },
 };
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x07770bfd_c549_4069_9e05_822458f81cc4);
+/// This migration adds `ON DELETE CASCADE` triggers to foreign keys throughout the database to
+/// enable deletion of account records.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x07770bfd_c549_4069_9e05_822458f81cc4);
 
 const DEPENDENCIES: &[Uuid] = &[
     tx_retrieval_queue_expiry::MIGRATION_ID,

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_account_birthdays.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_account_birthdays.rs
@@ -10,7 +10,8 @@ use crate::wallet::init::WalletMigrationError;
 
 use super::shardtree_support;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xeeec0d0d_fee0_4231_8c68_5f3a7c7c2245);
+/// This migration adds a birthday height to each account record.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xeeec0d0d_fee0_4231_8c68_5f3a7c7c2245);
 
 const DEPENDENCIES: &[Uuid] = &[shardtree_support::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_account_uuids.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_account_uuids.rs
@@ -13,7 +13,8 @@ use crate::wallet::{account_kind_code, init::WalletMigrationError};
 
 use super::support_legacy_sqlite;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xcccc623f_3243_43c7_b884_ceef25149e04);
+/// This migration adds a UUID to each account record, and adds `name` and `key_source` columns.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xcccc623f_3243_43c7_b884_ceef25149e04);
 
 const DEPENDENCIES: &[Uuid] = &[support_legacy_sqlite::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_transaction_trust_marker.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_transaction_trust_marker.rs
@@ -8,7 +8,9 @@ use uuid::Uuid;
 use super::{fix_v_transactions_expired_unmined, tx_observation_height};
 use crate::wallet::init::WalletMigrationError;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x4e68277f_6269_467e_9437_f3853cc4a41f);
+/// Adds support for marking transactions as explicitly trusted for the purpose of satisfying the
+/// ZIP 315 confirmations policy
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x4e68277f_6269_467e_9437_f3853cc4a41f);
 
 const DEPENDENCIES: &[Uuid] = &[
     fix_v_transactions_expired_unmined::MIGRATION_ID,

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_transaction_views.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_transaction_views.rs
@@ -14,7 +14,8 @@ use zcash_protocol::{
 use super::{add_utxo_account, sent_notes_to_internal};
 use crate::wallet::init::WalletMigrationError;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x282fad2e_8372_4ca0_8bed_71821320909f);
+/// Migration that adds transaction summary views & add fee information to transactions.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x282fad2e_8372_4ca0_8bed_71821320909f);
 
 const DEPENDENCIES: &[Uuid] = &[
     add_utxo_account::MIGRATION_ID,

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_transparent_receiver_address_index.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_transparent_receiver_address_index.rs
@@ -29,7 +29,8 @@ use zcash_protocol::consensus;
 use super::standalone_p2sh;
 use crate::wallet::{encoding::KeyScope, init::WalletMigrationError};
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x3d4f12d6_3da9_4ace_ac65_a0dd0a7adc32);
+/// Adds a `UNIQUE` index on `addresses.cached_transparent_receiver_address`.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x3d4f12d6_3da9_4ace_ac65_a0dd0a7adc32);
 
 // `standalone_p2sh` is the topologically-latest migration that rebuilds the `addresses` table, so
 // depending on it is sufficient to ensure the table is in its final form (including the

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_transparent_value_index.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_transparent_value_index.rs
@@ -23,7 +23,9 @@ use uuid::Uuid;
 use super::account_delete_cascade;
 use crate::wallet::init::WalletMigrationError;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x47c0e9c2_2eda_4b9c_be15_63c636c0e1c7);
+/// Adds an index on `transparent_received_outputs.value_zat` to support value-descending selection
+/// of spendable transparent outputs for an account.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x47c0e9c2_2eda_4b9c_be15_63c636c0e1c7);
 
 // `account_delete_cascade` is the topologically-latest migration that rebuilds the
 // `transparent_received_outputs` table (via `CREATE TABLE` + `INSERT INTO ... SELECT` +

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_utxo_account.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_utxo_account.rs
@@ -23,7 +23,7 @@ use {
 };
 
 /// This migration adds an account identifier column to the UTXOs table.
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x761884d6_30d8_44ef_b204_0b82551c4ca1);
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x761884d6_30d8_44ef_b204_0b82551c4ca1);
 
 const DEPENDENCIES: &[Uuid] = &[utxos_table::MIGRATION_ID, addresses_table::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/addresses_table.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/addresses_table.rs
@@ -21,7 +21,7 @@ use super::ufvk_support;
 
 /// The migration that removed the address columns from the `accounts` table, and created
 /// the `accounts` table.
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xd956978c_9c87_4d6e_815d_fb8f088d094c);
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xd956978c_9c87_4d6e_815d_fb8f088d094c);
 
 const DEPENDENCIES: &[Uuid] = &[ufvk_support::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/ensure_default_transparent_address.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ensure_default_transparent_address.rs
@@ -12,7 +12,10 @@ use zcash_protocol::consensus;
 use super::transparent_gap_limit_handling;
 use crate::wallet::init::WalletMigrationError;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x702cf97b_8395_4edc_b584_5c9f87f0ef35);
+/// Ensures that an external transparent address exists in the `addresses` table for each non-
+/// hardened child index starting at index 0 and ending at the index corresponding to default
+/// address for the account.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x702cf97b_8395_4edc_b584_5c9f87f0ef35);
 
 const DEPENDENCIES: &[Uuid] = &[transparent_gap_limit_handling::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/ensure_orchard_ua_receiver.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ensure_orchard_ua_receiver.rs
@@ -13,7 +13,8 @@ use zcash_protocol::consensus;
 use super::orchard_received_notes;
 use crate::{UA_ORCHARD, UA_TRANSPARENT, wallet::init::WalletMigrationError};
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x604349c7_5ce5_4768_bea6_12d106ccda93);
+/// This migration ensures that an Orchard receiver exists in the wallet's default Unified address.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x604349c7_5ce5_4768_bea6_12d106ccda93);
 
 const DEPENDENCIES: &[Uuid] = &[orchard_received_notes::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/ephemeral_addresses.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ephemeral_addresses.rs
@@ -21,7 +21,8 @@ use {
     zip32::DiversifierIndex,
 };
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x0e1d4274_1f8e_44e2_909d_689a4bc2967b);
+/// The migration that records ephemeral addresses for each account.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x0e1d4274_1f8e_44e2_909d_689a4bc2967b);
 
 const DEPENDENCIES: &[Uuid] = &[utxos_to_txos::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/fix_bad_change_flagging.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/fix_bad_change_flagging.rs
@@ -17,7 +17,9 @@ use crate::{
 #[cfg(feature = "orchard")]
 use crate::ORCHARD_TABLES_PREFIX;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x6d36656d_533b_4b65_ae91_dcb95c4ad289);
+/// Sets the `is_change` flag on output notes received by an internal key when input value was
+/// provided from the account corresponding to that key.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x6d36656d_533b_4b65_ae91_dcb95c4ad289);
 
 const DEPENDENCIES: &[Uuid] = &[fix_broken_commitment_trees::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/fix_bad_ironwood_change_flagging.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/fix_bad_ironwood_change_flagging.rs
@@ -32,7 +32,9 @@ use crate::{
 
 use super::ironwood_received_notes;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xcc104d0d_54d6_4e07_9404_202676561d94);
+/// Sets the `is_change` flag on Ironwood output notes received by an internal key when input value
+/// was provided from the account corresponding to that key.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xcc104d0d_54d6_4e07_9404_202676561d94);
 
 const DEPENDENCIES: &[Uuid] = &[ironwood_received_notes::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/fix_broken_commitment_trees.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/fix_broken_commitment_trees.rs
@@ -22,7 +22,9 @@ use crate::{
 #[cfg(feature = "transparent-inputs")]
 use crate::GapLimits;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x9fa43ce0_a387_45d1_be03_57a3edc76d01);
+/// Truncates away bad note commitment tree state for users whose wallets were broken by incorrect
+/// reorg handling.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x9fa43ce0_a387_45d1_be03_57a3edc76d01);
 
 const DEPENDENCIES: &[Uuid] = &[support_legacy_sqlite::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/fix_transparent_received_outputs.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/fix_transparent_received_outputs.rs
@@ -10,7 +10,8 @@ use super::{
     ensure_default_transparent_address, fix_bad_change_flagging, v_transactions_additional_totals,
 };
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xb951587c_34fd_4f02_a313_05ff7adb6268);
+/// Fixes the `transparent_received_outputs` table schema to not depend on feature flags.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xb951587c_34fd_4f02_a313_05ff7adb6268);
 
 const DEPENDENCIES: &[Uuid] = &[
     fix_bad_change_flagging::MIGRATION_ID,

--- a/zcash_client_sqlite/src/wallet/init/migrations/fix_v_transactions_expired_unmined.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/fix_v_transactions_expired_unmined.rs
@@ -8,7 +8,9 @@ use uuid::Uuid;
 
 use crate::wallet::init::{WalletMigrationError, migrations::fix_transparent_received_outputs};
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x54733173_5f3c_4870_831e_a48a4a93b1d7);
+/// This migration fixes an error in detection of whether a transaction has expired without having
+/// been mined.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x54733173_5f3c_4870_831e_a48a4a93b1d7);
 
 const DEPENDENCIES: &[Uuid] = &[fix_transparent_received_outputs::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/full_account_ids.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/full_account_ids.rs
@@ -17,7 +17,7 @@ use crate::wallet::{account_kind_code, init::WalletMigrationError};
 
 /// The migration that switched from presumed seed-derived account IDs to supporting
 /// HD accounts and all sorts of imported keys.
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x6d02ec76_8720_4cc6_b646_c4e2ce69221c);
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x6d02ec76_8720_4cc6_b646_c4e2ce69221c);
 
 pub(crate) struct Migration<P: consensus::Parameters> {
     pub(super) seed: Option<Rc<SecretVec<u8>>>,

--- a/zcash_client_sqlite/src/wallet/init/migrations/initial_setup.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/initial_setup.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 use crate::wallet::init::WalletMigrationError;
 
 /// Identifier for the migration that performs the initial setup of the wallet database.
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xbc4f5e57_d600_4b6c_990f_b3538f0bfce1);
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xbc4f5e57_d600_4b6c_990f_b3538f0bfce1);
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/ironwood_pool_code_views.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ironwood_pool_code_views.rs
@@ -21,7 +21,8 @@ use crate::wallet::init::WalletMigrationError;
 
 use super::ironwood_received_notes;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xa6ef40c7_050a_43c6_a4e2_2f034168c979);
+/// Adds Ironwood received notes to the `v_received_outputs` and `v_received_output_spends` views.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xa6ef40c7_050a_43c6_a4e2_2f034168c979);
 
 const DEPENDENCIES: &[Uuid] = &[ironwood_received_notes::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/ironwood_received_notes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ironwood_received_notes.rs
@@ -20,7 +20,8 @@ use crate::wallet::init::WalletMigrationError;
 
 use super::orchard_note_version;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xdc0d6c91_b3db_429e_9a7b_d671cc19656e);
+/// Adds tables for storage of received Ironwood notes.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xdc0d6c91_b3db_429e_9a7b_d671cc19656e);
 
 const DEPENDENCIES: &[Uuid] = &[orchard_note_version::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/ironwood_shardtree.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ironwood_shardtree.rs
@@ -13,7 +13,9 @@ use zcash_protocol::consensus::{self, BlockHeight, NetworkUpgrade};
 use super::{orchard_shardtree, wallet_summaries};
 use crate::wallet::{chain_tip_height, init::WalletMigrationError, scanning::priority_code};
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x1f5420e3_f8a0_4afd_a9e5_e20fc6fae271);
+/// This migration adds tables to the wallet database that are needed to persist Ironwood note
+/// commitment tree data using the `shardtree` crate.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x1f5420e3_f8a0_4afd_a9e5_e20fc6fae271);
 
 // Depends on `orchard_shardtree` (the Ironwood tree tables mirror the Orchard ones) and on
 // `wallet_summaries` (which adds the `blocks` output/action-count columns), so the Ironwood

--- a/zcash_client_sqlite/src/wallet/init/migrations/ivk_item_cache.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ivk_item_cache.rs
@@ -19,7 +19,8 @@ use crate::wallet::init::WalletMigrationError;
 
 use super::standalone_p2sh;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x93278b0f_77fe_473c_b88e_7f285da38dd3);
+/// Replaces FVK item cache columns with IVK item cache columns in the `accounts` table.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x93278b0f_77fe_473c_b88e_7f285da38dd3);
 
 const DEPENDENCIES: &[Uuid] = &[standalone_p2sh::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/note_locking.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/note_locking.rs
@@ -9,7 +9,8 @@ use uuid::Uuid;
 
 use crate::wallet::init::{WalletMigrationError, migrations::ironwood_received_notes};
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xa1d4a28c_7582_4457_b0f4_d3f297b62a71);
+/// This migration adds the note-locking columns to the received note/output tables.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xa1d4a28c_7582_4457_b0f4_d3f297b62a71);
 
 // This migration only appends a nullable column to each of the `sapling_received_notes`,
 // `orchard_received_notes`, `ironwood_received_notes`, and `transparent_received_outputs`

--- a/zcash_client_sqlite/src/wallet/init/migrations/nullifier_map.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/nullifier_map.rs
@@ -11,7 +11,9 @@ use crate::wallet::init::WalletMigrationError;
 
 use super::received_notes_nullable_nf;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xe2d71ac5_6a44_4c6b_a9a0_6d0a79d355f1);
+/// This migration adds a table for storing mappings from nullifiers to the transaction they are
+/// revealed in.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xe2d71ac5_6a44_4c6b_a9a0_6d0a79d355f1);
 
 const DEPENDENCIES: &[Uuid] = &[received_notes_nullable_nf::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/orchard_ironwood_migration_tables.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/orchard_ironwood_migration_tables.rs
@@ -23,7 +23,8 @@ use crate::wallet::init::WalletMigrationError;
 
 use super::ironwood_received_notes;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x7b2f6a41_9c3d_4e58_8a17_2f6b9d0c4e11);
+/// Adds tables for storage of an in-progress Orchard -> Ironwood value-pool migration.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x7b2f6a41_9c3d_4e58_8a17_2f6b9d0c4e11);
 
 // The pool-migration tables have no foreign keys into the note or shardtree tables, but the engine
 // works over both pools at runtime: it spends Orchard source notes (and their witnesses) and crosses

--- a/zcash_client_sqlite/src/wallet/init/migrations/orchard_note_version.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/orchard_note_version.rs
@@ -19,7 +19,8 @@ use crate::wallet::init::WalletMigrationError;
 
 use super::witness_stabilized_notes;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x2aa44e8e_e8a7_4760_8de4_501956c969ac);
+/// Adds a `note_version` column to the `orchard_received_notes` table.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x2aa44e8e_e8a7_4760_8de4_501956c969ac);
 
 const DEPENDENCIES: &[Uuid] = &[witness_stabilized_notes::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/orchard_received_notes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/orchard_received_notes.rs
@@ -11,7 +11,9 @@ use zcash_protocol::PoolType;
 use super::full_account_ids;
 use crate::wallet::{init::WalletMigrationError, pool_code};
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x51d7a273_aa19_4109_9325_80e4a5545048);
+/// This migration adds tables to the wallet database that are needed to persist Orchard received
+/// notes.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x51d7a273_aa19_4109_9325_80e4a5545048);
 
 const DEPENDENCIES: &[Uuid] = &[full_account_ids::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/orchard_shardtree.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/orchard_shardtree.rs
@@ -13,7 +13,9 @@ use zcash_protocol::consensus::{self, BlockHeight, NetworkUpgrade};
 use super::shardtree_support;
 use crate::wallet::{chain_tip_height, init::WalletMigrationError, scanning::priority_code};
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x3a6487f7_e068_42bb_9d12_6bb8dbe6da00);
+/// This migration adds tables to the wallet database that are needed to persist Orchard note
+/// commitment tree data using the `shardtree` crate.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x3a6487f7_e068_42bb_9d12_6bb8dbe6da00);
 
 const DEPENDENCIES: &[Uuid] = &[shardtree_support::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/received_notes_nullable_nf.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/received_notes_nullable_nf.rs
@@ -9,7 +9,9 @@ use uuid::Uuid;
 use super::v_transactions_net;
 use crate::wallet::init::WalletMigrationError;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xbdcdcedc_7b29_4f1c_8307_35f937f0d32a);
+/// A migration that renames the `received_notes` table to `sapling_received_notes` and makes the
+/// `nf` column nullable.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xbdcdcedc_7b29_4f1c_8307_35f937f0d32a);
 
 const DEPENDENCIES: &[Uuid] = &[v_transactions_net::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
@@ -33,7 +33,8 @@ use crate::{
     },
 };
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xee89ed2b_c1c2_421e_9e98_c1e3e54a7fc2);
+/// This migration adds decryption key scope to persisted information about received notes.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xee89ed2b_c1c2_421e_9e98_c1e3e54a7fc2);
 
 const DEPENDENCIES: &[Uuid] = &[shardtree_support::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/sapling_memo_consistency.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/sapling_memo_consistency.rs
@@ -24,7 +24,9 @@ use crate::{
 
 use super::received_notes_nullable_nf;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x7029b904_6557_4aa1_9da5_6904b65d2ba5);
+/// This migration reads the wallet's raw transaction data and updates the `sent_notes` table to
+/// ensure that memo entries are consistent with the decrypted transaction's outputs.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x7029b904_6557_4aa1_9da5_6904b65d2ba5);
 
 const DEPENDENCIES: &[Uuid] = &[received_notes_nullable_nf::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/sent_notes_to_internal.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/sent_notes_to_internal.rs
@@ -9,7 +9,7 @@ use super::ufvk_support;
 use crate::wallet::init::WalletMigrationError;
 
 /// This migration adds the `to_account` field to the `sent_notes` table.
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x0ddbe561_8259_4212_9ab7_66fdc4a74e1d);
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x0ddbe561_8259_4212_9ab7_66fdc4a74e1d);
 
 const DEPENDENCIES: &[Uuid] = &[ufvk_support::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/shardtree_support.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/shardtree_support.rs
@@ -28,7 +28,10 @@ use crate::{
     },
 };
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x7da6489d_e835_4657_8be5_f512bcce6cbf);
+/// This migration adds tables to the wallet database that are needed to persist Sapling note
+/// commitment tree data using the `shardtree` crate, and migrates existing witness data into these
+/// data structures.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x7da6489d_e835_4657_8be5_f512bcce6cbf);
 
 const DEPENDENCIES: &[Uuid] = &[received_notes_nullable_nf::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/spend_key_available.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/spend_key_available.rs
@@ -8,7 +8,8 @@ use crate::wallet::init::WalletMigrationError;
 
 use super::full_account_ids;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x07610aac_b0e3_4ba8_aaa6_cda606f0fd7b);
+/// The migration that records ephemeral addresses for each account.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x07610aac_b0e3_4ba8_aaa6_cda606f0fd7b);
 
 const DEPENDENCIES: &[Uuid] = &[full_account_ids::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/standalone_p2sh.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/standalone_p2sh.rs
@@ -11,7 +11,10 @@ use crate::wallet::init::WalletMigrationError;
 
 use super::account_delete_cascade;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x944f8a1e_bdfa_4d52_90ca_663dee8efc62);
+/// This migration relaxes the addresses table constraint to allow standalone P2SH addresses that
+/// have an imported transparent receiver script but no imported public key and no transparent child
+/// index.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x944f8a1e_bdfa_4d52_90ca_663dee8efc62);
 
 const DEPENDENCIES: &[Uuid] = &[account_delete_cascade::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/support_legacy_sqlite.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/support_legacy_sqlite.rs
@@ -6,7 +6,8 @@ use uuid::Uuid;
 
 use crate::wallet::init::{WalletMigrationError, migrations::tx_retrieval_queue};
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x156d8c8f_2173_4b59_89b6_75697d5a2103);
+/// Modifies definitions to avoid keywords that may not be available in older SQLite versions.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x156d8c8f_2173_4b59_89b6_75697d5a2103);
 
 const DEPENDENCIES: &[Uuid] = &[tx_retrieval_queue::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/support_zcashd_wallet_import.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/support_zcashd_wallet_import.rs
@@ -11,7 +11,8 @@ use crate::wallet::{
 
 use super::fix_transparent_received_outputs;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x254d4f20_f0f6_4635_80ed_9d52c536d5df);
+/// Adds support for storing key material required for zcashd wallet import.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x254d4f20_f0f6_4635_80ed_9d52c536d5df);
 
 const DEPENDENCIES: &[Uuid] = &[fix_transparent_received_outputs::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/transparent_gap_limit_handling.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/transparent_gap_limit_handling.rs
@@ -36,7 +36,9 @@ use {
     zip32::DiversifierIndex,
 };
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xc41dfc0e_e870_4859_be47_d2f572f5ca73);
+/// Add support for general transparent gap limit handling, and unify the `addresses` and
+/// `ephemeral_addresses` tables.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xc41dfc0e_e870_4859_be47_d2f572f5ca73);
 
 const DEPENDENCIES: &[Uuid] = &[add_account_uuids::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/tree_retained_checkpoints.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/tree_retained_checkpoints.rs
@@ -12,7 +12,8 @@ use uuid::Uuid;
 use super::witness_stabilized_notes;
 use crate::wallet::init::WalletMigrationError;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x62032f4a_88b5_454d_a591_10f3d4c4d2b7);
+/// Migration that adds tables for tracking explicitly-retained shardtree checkpoints ("anchors").
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x62032f4a_88b5_454d_a591_10f3d4c4d2b7);
 
 const DEPENDENCIES: &[Uuid] = &[witness_stabilized_notes::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/tx_observation_height.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/tx_observation_height.rs
@@ -11,7 +11,8 @@ use crate::wallet::{
     mempool_height,
 };
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xab1be47e_dbfd_439a_876a_55a7e4a0ea0b);
+/// Adds minimum observation height to transaction records.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xab1be47e_dbfd_439a_876a_55a7e4a0ea0b);
 
 const DEPENDENCIES: &[Uuid] = &[fix_transparent_received_outputs::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue.rs
@@ -15,7 +15,9 @@ use super::{
     spend_key_available,
 };
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xfec02b61_3988_4b4f_9699_98977fac9e7f);
+/// Adds tables for tracking transactions to be downloaded for transparent output and/or memo
+/// retrieval.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xfec02b61_3988_4b4f_9699_98977fac9e7f);
 
 #[cfg(feature = "transparent-inputs")]
 use {

--- a/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue_expiry.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue_expiry.rs
@@ -10,7 +10,8 @@ use crate::wallet::{chain_tip_height, init::WalletMigrationError};
 
 use super::tx_retrieval_queue;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x9ffe82d4_3bf5_459a_9a21_7affd9e88e95);
+/// Adds expiration to transaction enhancement requests.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x9ffe82d4_3bf5_459a_9a21_7affd9e88e95);
 
 const DEPENDENCIES: &[Uuid] = &[tx_retrieval_queue::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/ufvk_support.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ufvk_support.rs
@@ -27,7 +27,8 @@ use crate::{
     },
 };
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xbe57ef3b_388e_42ea_97e2_678dafcf9754);
+/// Migration that adds support for unified full viewing keys.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xbe57ef3b_388e_42ea_97e2_678dafcf9754);
 
 const DEPENDENCIES: &[Uuid] = &[initial_setup::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/utxos_table.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/utxos_table.rs
@@ -6,7 +6,8 @@ use uuid::Uuid;
 
 use crate::wallet::init::{WalletMigrationError, migrations::initial_setup};
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xa2e0ed2e_8852_475e_b0a4_f154b15b9dbe);
+/// The migration that adds initial support for transparent UTXOs to the wallet.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xa2e0ed2e_8852_475e_b0a4_f154b15b9dbe);
 
 const DEPENDENCIES: &[Uuid] = &[initial_setup::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/utxos_to_txos.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/utxos_to_txos.rs
@@ -7,7 +7,9 @@ use uuid::Uuid;
 
 use crate::wallet::init::{WalletMigrationError, migrations::orchard_received_notes};
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x3a2562b3_f174_46a1_aa8c_1d122ca2e884);
+/// A migration that brings transparent UTXO handling into line with that for shielded outputs, and
+/// adds `spent_note_count` and `is_shielding` to `v_transactions`.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x3a2562b3_f174_46a1_aa8c_1d122ca2e884);
 
 const DEPENDENCIES: &[Uuid] = &[orchard_received_notes::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_address_uses_ironwood.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_address_uses_ironwood.rs
@@ -35,7 +35,8 @@ use crate::wallet::init::WalletMigrationError;
 
 use super::ironwood_received_notes;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xdab89587_cd05_43b0_a5b5_8cb64a702791);
+/// Adds Ironwood received notes to the `v_address_uses` view.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xdab89587_cd05_43b0_a5b5_8cb64a702791);
 
 const DEPENDENCIES: &[Uuid] = &[ironwood_received_notes::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_received_output_spends_account.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_received_output_spends_account.rs
@@ -8,7 +8,9 @@ use uuid::Uuid;
 
 use crate::wallet::init::{WalletMigrationError, migrations::fix_v_transactions_expired_unmined};
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x50fd092d_97b9_44cf_ade9_86b526e4cd50);
+/// This migration revises the `v_received_output_spends` view to add the account ID to the returned
+/// fields.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x50fd092d_97b9_44cf_ade9_86b526e4cd50);
 
 const DEPENDENCIES: &[Uuid] = &[fix_v_transactions_expired_unmined::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_sapling_shard_unscanned_ranges.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_sapling_shard_unscanned_ranges.rs
@@ -13,7 +13,9 @@ use crate::wallet::{init::WalletMigrationError, scanning::priority_code};
 
 use super::add_account_birthdays;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xfa934bdc_97b6_4980_8a83_b2cb1ac465fd);
+/// This migration adds a view that returns the un-scanned ranges associated with each sapling note
+/// commitment tree shard.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xfa934bdc_97b6_4980_8a83_b2cb1ac465fd);
 
 const DEPENDENCIES: &[Uuid] = &[add_account_birthdays::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_additional_totals.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_additional_totals.rs
@@ -10,7 +10,9 @@ use crate::wallet::init::WalletMigrationError;
 
 use super::add_account_uuids;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x7f2fd1b3_1872_4b90_88ba_7d02b470090f);
+/// This migration adds `total_spent` and `total_received` columns to the `v_transactions` view to
+/// aid wallets in distinguishing shielding transactions.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x7f2fd1b3_1872_4b90_88ba_7d02b470090f);
 
 const DEPENDENCIES: &[Uuid] = &[add_account_uuids::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_net.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_net.rs
@@ -11,7 +11,9 @@ use zcash_protocol::PoolType;
 use super::add_transaction_views;
 use crate::wallet::{init::WalletMigrationError, pool_code};
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x2aa4d24f_51aa_4a4c_8d9b_e5b8a762865f);
+/// Migration that fixes a bug in v_transactions that caused the change to be incorrectly ignored as
+/// received value.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x2aa4d24f_51aa_4a4c_8d9b_e5b8a762865f);
 
 const DEPENDENCIES: &[Uuid] = &[add_transaction_views::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_note_uniqueness.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_note_uniqueness.rs
@@ -10,7 +10,9 @@ use crate::wallet::init::WalletMigrationError;
 
 use super::v_transactions_shielding_balance;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xdba47c86_13b5_4601_94b2_0cde0abe1e45);
+/// This migration fixes a bug in `v_transactions` where distinct but otherwise identical notes were
+/// being incorrectly deduplicated.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xdba47c86_13b5_4601_94b2_0cde0abe1e45);
 
 const DEPENDENCIES: &[Uuid] = &[v_transactions_shielding_balance::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_shielding_balance.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_shielding_balance.rs
@@ -10,7 +10,9 @@ use crate::wallet::init::WalletMigrationError;
 
 use super::v_tx_outputs_use_legacy_false;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xb8fe5112_4365_473c_8b42_2b07c0f0adaf);
+/// This migration reworks transaction history views to correctly include spent transparent utxo
+/// value.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xb8fe5112_4365_473c_8b42_2b07c0f0adaf);
 
 const DEPENDENCIES: &[Uuid] = &[v_tx_outputs_use_legacy_false::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_transparent_history.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_transparent_history.rs
@@ -10,7 +10,9 @@ use crate::wallet::init::WalletMigrationError;
 
 use super::sapling_memo_consistency;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xaa0a4168_b41b_44c5_a47d_c4c66603cfab);
+/// This migration reworks transaction history views to correctly include history of transparent
+/// utxos for which we lack complete transaction information.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xaa0a4168_b41b_44c5_a47d_c4c66603cfab);
 
 const DEPENDENCIES: &[Uuid] = &[sapling_memo_consistency::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_tx_outputs_key_scopes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_tx_outputs_key_scopes.rs
@@ -7,7 +7,9 @@ use uuid::Uuid;
 
 use crate::wallet::init::{WalletMigrationError, migrations::account_delete_cascade};
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x97ac36a9_196f_4dd9_993d_722bde95bebc);
+/// This migration adds missing key scope information to the `v_received_outputs` and `v_tx_outputs`
+/// views.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x97ac36a9_196f_4dd9_993d_722bde95bebc);
 
 const DEPENDENCIES: &[Uuid] = &[account_delete_cascade::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_tx_outputs_return_addrs.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_tx_outputs_return_addrs.rs
@@ -8,7 +8,9 @@ use uuid::Uuid;
 
 use crate::wallet::init::{WalletMigrationError, migrations::fix_v_transactions_expired_unmined};
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x894574e0_663e_401a_8426_820b1f75149a);
+/// This migration revises the `v_tx_outputs` view to add address and diversifier index information
+/// to the returned fields.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x894574e0_663e_401a_8426_820b1f75149a);
 
 const DEPENDENCIES: &[Uuid] = &[fix_v_transactions_expired_unmined::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_tx_outputs_use_legacy_false.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_tx_outputs_use_legacy_false.rs
@@ -11,7 +11,9 @@ use crate::wallet::init::WalletMigrationError;
 
 use super::v_transactions_transparent_history;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xb3e21434_286f_41f3_8d71_44cce968ab2b);
+/// This migration revises the `v_tx_outputs` view to support SQLite 3.19.x which did not define
+/// `TRUE` and `FALSE` constants.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xb3e21434_286f_41f3_8d71_44cce968ab2b);
 
 const DEPENDENCIES: &[Uuid] = &[v_transactions_transparent_history::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/wallet_summaries.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/wallet_summaries.rs
@@ -9,7 +9,8 @@ use crate::wallet::init::WalletMigrationError;
 
 use super::v_sapling_shard_unscanned_ranges;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0xc5bf7f71_2297_41ff_89e1_75e07c4e8838);
+/// This migration adds views and database changes required to provide accurate wallet summaries.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xc5bf7f71_2297_41ff_89e1_75e07c4e8838);
 
 const DEPENDENCIES: &[Uuid] = &[v_sapling_shard_unscanned_ranges::MIGRATION_ID];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/witness_stabilized_notes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/witness_stabilized_notes.rs
@@ -14,7 +14,10 @@ use super::{account_delete_cascade, ironwood_shardtree};
 use crate::wallet::init::WalletMigrationError;
 use crate::wallet::scanning::mark_stabilized_notes;
 
-pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x64925567_65ae_495e_b6cf_d5f56e99e422);
+/// Adds a `witness_stabilized` flag to received-note tables, indicating that the note's containing
+/// shard's block extent has been fully scanned and that the shard's end height has received at
+/// least `PRUNING_DEPTH` confirmations.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x64925567_65ae_495e_b6cf_d5f56e99e422);
 
 // This migration invokes `block_max_scanned`, which reads the `ironwood_commitment_tree_size`
 // column of the `blocks` table; that column is added by `ironwood_shardtree`, so this migration


### PR DESCRIPTION
External migrations registered via `WalletMigrator::with_external_migrations` are applied as part
of a single graph alongside the internal ones, so an external migration that reads or extends
internal schema must order itself after the migration that creates that schema. The anchors this
crate offers for that are the per-release leaf constants — but they stopped at 0.19.0, so nothing
added since had any published state to anchor against, including every Ironwood table.

Two commits, addressing that from both ends.

## Add the leaf sets for the releases since 0.19.0

Release candidates are published crate versions, and a wallet built against one is as real as any
other, so they get constants too. Three states have been exposed since 0.19.0:

| Constant | Covers | Change |
| --- | --- | --- |
| `V_0_20_0` | 0.20.0 – 0.21.1 | `v_tx_outputs_key_scopes`, `ivk_item_cache`, `witness_stabilized_notes` |
| `V_0_22_0_RC1` | 0.22.0-rc.1 | adds the two transparent indexes, `ironwood_pool_code_views` and `tree_retained_checkpoints`; `witness_stabilized_notes` gains dependents |
| `V_0_22_0_RC2` | 0.22.0-rc.2 – rc.4 | adds `orchard_ironwood_migration_tables` and `note_locking` |

Versions whose migration state is unchanged relative to the preceding constant are omitted, which
is the convention the module documentation already records.

The leaves were computed from each published version's own migration graph, by the rule
`current_leaf_migrations_are_the_dag_leaves` uses: every migration that no other migration in that
graph depends on. `migrate_between_releases_without_data` then walks the new states in order and
asserts the migration state changes at each, exercising them against the real migrator.

Note that `0.22.0-rc.1`, `-rc.3` and `-rc.4` are published on crates.io but have no git tag; only
`zcash_client_sqlite-0.22.0-rc.2` is tagged. Their leaf sets here were computed from the published
crate sources. It made no difference to the outcome — rc.3 and rc.4 match rc.2 — but the missing
tags look like a release-process slip worth fixing separately.

## Expose the identifier of each internal migration, behind `unstable`

A release constant cannot name schema added since the most recent release, so an external
migration that depends on such schema still has no correct dependency to declare: it either
anchors too early, or hard-codes a private identifier that would resolve to
`DependencyError::UnknownId` — a wallet that fails to open — if that migration were reshaped
before release.

Each migration's `MIGRATION_ID` becomes public within its still-private module, re-exported
through a new `migrations::ids` facade:

```rust
use zcash_client_sqlite::wallet::init::migrations::ids;

fn dependencies(&self) -> HashSet<Uuid> {
    [ids::IRONWOOD_RECEIVED_NOTES].into_iter().collect()
}
```

The facade sits behind the `unstable` feature, because these identifiers are unstable by nature:
each names an individual migration rather than a state of the graph that a published release
exposed, so the set of them changes between releases. The intended shape is to depend on an
identifier while developing against unreleased schema, and to move the anchor to the release
constant that covers it once that release exists — which is what the first commit makes possible
for everything released so far.

A facade rather than 59 public modules keeps the public names decoupled from the internal module
names, keeps rustdoc to one extra module, and gives a single place to document how to choose an
anchor. `#![deny(missing_docs)]` means each identifier also carries a summary of what its
migration does; five already had hand-written docs and keep them, and the rest take the first
sentence of their module's `//!` doc, or of `description()` for the two modules that have none.

`ids_module_covers_every_migration` lists the exported identifiers explicitly and compares them
against the graph, in the same style as `current_leaf_migrations_are_the_dag_leaves`. Listing
rather than deriving is deliberate: a migration added without an `ids` entry fails the test rather
than silently going unexported.

---
Opened with Claude Code assistance.
