### PR TITLE
zcash_client_sqlite: correct the v_tx_outputs_key_scopes description

### DIFF
--- a/zcash_client_sqlite/src/wallet/init/migrations/v_tx_outputs_key_scopes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_tx_outputs_key_scopes.rs
@@ -23,7 +23,7 @@ impl schemerz::Migration<Uuid> for Migration {
     }
 
     fn description(&self) -> &'static str {
-        "Adds `ON DELETE CASCADE` to foreign keys to support account deletion."
+        "Adds missing key scope information to the received-output and transaction-output views."
     }
 }
 


### PR DESCRIPTION
`v_tx_outputs_key_scopes`'s `description` is a copy of `account_delete_cascade`'s, so the migrator
reports that this migration adds `ON DELETE CASCADE` to foreign keys to support account deletion.

It adds missing key scope information to the `v_received_outputs` and `v_tx_outputs` views, as its
module documentation says.

---
Opened with Claude Code assistance.
