### PR TITLE
Limit transaction status requests to fully-transparent transactions

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -32,6 +32,15 @@ workspace.
   `tor::grpc::GrpcError`, and `tor::http::HttpError`.
 
 ### Fixed
+- `data_api::ll::wallet::store_decrypted_tx` now classifies a transaction
+  containing an Ironwood bundle as detectable via chain scanning. Previously
+  only Sapling and Orchard bundles were considered, so an as-yet-unmined
+  Ironwood-only transaction stored via transaction enhancement was queued for
+  txid-based status retrieval, even though ordinary compact-block scanning
+  detects such a transaction and sets its mined height, making the status
+  request redundant. Since NU6.3 every
+  shielded spend or output involving an Orchard receiver is carried in the
+  Ironwood bundle, so this affected ordinary transactions.
 - The Tor HTTP and gRPC transports now reject a URL whose scheme is neither
   `http` nor `https` (for example `ftp` or `ws`) with `tor::http::HttpError::NonHttpUrl`.
   Previously such a URL was silently treated as plaintext HTTP, contradicting the

--- a/zcash_client_backend/src/data_api/ll/wallet.rs
+++ b/zcash_client_backend/src/data_api/ll/wallet.rs
@@ -1088,6 +1088,9 @@ where
         #[cfg(feature = "orchard")]
         let detectable_via_scanning =
             detectable_via_scanning | d_tx.tx().orchard_bundle().is_some();
+        #[cfg(feature = "orchard")]
+        let detectable_via_scanning =
+            detectable_via_scanning | d_tx.tx().ironwood_bundle().is_some();
 
         if d_tx.mined_height().is_none() && !detectable_via_scanning {
             wallet_db.queue_tx_retrieval(std::iter::once(d_tx.tx().txid()), None)?

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -3852,6 +3852,238 @@ where
     );
 }
 
+/// A wallet's own shielded send must never generate a `GetStatus` transaction data request, at
+/// any chain tip height: its mined status is learned via ordinary chain scanning, and a
+/// txid-scoped status query for it is redundant; status requests are limited to
+/// fully-transparent transactions, which scanning cannot detect.
+pub fn shielded_send_generates_no_status_requests<T: ShieldedPoolTester, Dsf: DataStoreFactory>(
+    dsf: Dsf,
+    cache: impl TestCache,
+) {
+    use zcash_primitives::transaction::builder::DEFAULT_TX_EXPIRY_DELTA;
+
+    let mut st = TestDsl::with_sapling_birthday_account(dsf, cache).build::<T>();
+
+    // Add funds to the wallet in a single note.
+    st.add_a_single_note_checking_balance(Zatoshis::const_from_u64(60000));
+
+    let to_extsk = T::sk(&[0xf5; 32]);
+    let to: Address = T::sk_default_address(&to_extsk);
+    let request = zip321::TransactionRequest::new(vec![Payment::without_memo(
+        to.to_zcash_address(st.network()),
+        Zatoshis::const_from_u64(10000),
+    )])
+    .unwrap();
+
+    let change_strategy =
+        single_output_change_strategy(StandardFeeRule::Zip317, None, T::SHIELDED_PROTOCOL);
+    let input_selector = GreedyInputSelector::new();
+
+    let account = st.get_account();
+    let proposal = st
+        .propose_transfer(
+            account.id(),
+            &input_selector,
+            &change_strategy,
+            request,
+            ConfirmationsPolicy::MIN,
+        )
+        .unwrap();
+
+    let sent_tx_id = st.create_proposed_expecting(&proposal, 1)[0];
+
+    let assert_no_requests_for = |st: &TestState<_, Dsf::DataStore, _>, txid| {
+        let requests = st.wallet().transaction_data_requests().unwrap();
+        assert!(
+            !requests
+                .iter()
+                .any(|req| req == &TransactionDataRequest::GetStatus(txid)
+                    || req == &TransactionDataRequest::Enhancement(txid)),
+            "unexpected transaction data request for {txid} in {requests:?}",
+        );
+    };
+
+    // The as-yet-unmined shielded send must not produce any transaction data request.
+    assert_no_requests_for(&st, sent_tx_id);
+
+    // Advancing the chain tip must not produce a status request either, no matter how far the
+    // tip advances (including beyond the transaction's expiry height).
+    st.add_empty_blocks(5);
+    assert_no_requests_for(&st, sent_tx_id);
+    st.add_empty_blocks(usize::try_from(DEFAULT_TX_EXPIRY_DELTA).unwrap());
+    assert_no_requests_for(&st, sent_tx_id);
+
+    // Mining the transaction and scanning the block containing it sets its mined height without
+    // any `set_transaction_status` call, and still produces no request for it.
+    let (h, _) = st.generate_next_block_including(sent_tx_id);
+    st.scan_cached_blocks(h, 1);
+    assert_eq!(
+        st.get_tx_from_history(sent_tx_id)
+            .unwrap()
+            .expect("sent transaction is in history")
+            .mined_height(),
+        Some(h)
+    );
+    assert_no_requests_for(&st, sent_tx_id);
+}
+
+/// The status of a fully-transparent transaction cannot be observed via compact-block scanning,
+/// so `Status`-type retrieval queue entries must continue to generate `GetStatus` requests across
+/// not-yet-mined `set_transaction_status` answers, until the transaction reaches a terminal
+/// state: either it is mined, or it is confirmed to have remained unmined at or beyond its expiry
+/// height.
+#[cfg(feature = "transparent-inputs")]
+pub fn transparent_status_requests_persist_until_terminal<T: ShieldedPoolTester, Dsf>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) where
+    Dsf: DataStoreFactory,
+{
+    use crate::data_api::TransactionStatus;
+
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    let account = st.test_account().cloned().unwrap();
+    let account_id = account.id();
+    let dfvk = T::test_account_fvk(&st);
+    let tex_addr = Address::Tex([0x4; 20]);
+
+    let add_funds = |st: &mut TestState<_, Dsf::DataStore, _>, value| {
+        let (h, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
+        st.scan_cached_blocks(h, 1);
+        h
+    };
+
+    let value = Zatoshis::const_from_u64(100000);
+    let transfer_amount = Zatoshis::const_from_u64(50000);
+
+    // Creates a ZIP 320 transaction pair paying `tex_addr`; the first transaction is shielded,
+    // and the second (which sweeps the ephemeral output to the TEX address) is fully
+    // transparent.
+    let send_to_tex = |st: &mut TestState<_, Dsf::DataStore, _>| {
+        let proposal = st
+            .propose_standard_transfer::<Infallible>(
+                account_id,
+                StandardFeeRule::Zip317,
+                ConfirmationsPolicy::MIN,
+                &tex_addr,
+                transfer_amount,
+                None,
+                None,
+                T::SHIELDED_PROTOCOL,
+            )
+            .unwrap();
+        let result = st.create_proposed_transactions::<Infallible, _, Infallible, _>(
+            account.usk(),
+            OvkPolicy::Sender,
+            &proposal,
+        );
+        assert_matches!(&result, Ok(txids) if txids.len() == 2);
+        result.unwrap()
+    };
+
+    let contains_status_request = |st: &TestState<_, Dsf::DataStore, _>, txid| {
+        st.wallet()
+            .transaction_data_requests()
+            .unwrap()
+            .contains(&TransactionDataRequest::GetStatus(txid))
+    };
+
+    // Part 1: not-yet-mined answers must not stop the polling; a `Mined` answer is terminal.
+    add_funds(&mut st, value);
+    let txids = send_to_tex(&mut st);
+    let shielded_txid = *txids.first();
+    let transparent_txid = *txids.last();
+
+    // The fully-transparent transaction is queued for status retrieval; the shielded step must
+    // not generate a status request.
+    assert!(contains_status_request(&st, transparent_txid));
+    assert!(!contains_status_request(&st, shielded_txid));
+
+    // Repeated not-yet-mined answers prior to the transaction's expiry must leave the request in
+    // place; the wallet must keep asking, since a `NotInMainChain` answer for an unexpired
+    // transaction is not terminal.
+    for _ in 0..2 {
+        st.wallet_mut()
+            .set_transaction_status(transparent_txid, TransactionStatus::NotInMainChain)
+            .unwrap();
+        assert!(contains_status_request(&st, transparent_txid));
+        assert!(!contains_status_request(&st, shielded_txid));
+    }
+
+    // Mine the transaction pair. Scanning detects the shielded transaction and sets its mined
+    // height without any `set_transaction_status` call, but cannot detect the fully-transparent
+    // transaction, which therefore continues to be polled.
+    let mut mined_height = None;
+    for txid in txids.iter() {
+        let (h, _) = st.generate_next_block_including(*txid);
+        st.scan_cached_blocks(h, 1);
+        mined_height = Some(h);
+    }
+    let mined_height = mined_height.expect("blocks were mined");
+
+    assert_eq!(
+        st.get_tx_from_history(shielded_txid)
+            .unwrap()
+            .expect("shielded transaction is in history")
+            .mined_height(),
+        Some(mined_height - 1)
+    );
+    assert_eq!(
+        st.get_tx_from_history(transparent_txid)
+            .unwrap()
+            .expect("transparent transaction is in history")
+            .mined_height(),
+        None
+    );
+    assert!(contains_status_request(&st, transparent_txid));
+    assert!(!contains_status_request(&st, shielded_txid));
+
+    // A `Mined` answer is terminal: the request is deleted and the mined height is recorded.
+    st.wallet_mut()
+        .set_transaction_status(transparent_txid, TransactionStatus::Mined(mined_height))
+        .unwrap();
+    assert!(!contains_status_request(&st, transparent_txid));
+    assert_eq!(
+        st.get_tx_from_history(transparent_txid)
+            .unwrap()
+            .expect("transparent transaction is in history")
+            .mined_height(),
+        Some(mined_height)
+    );
+
+    // Part 2: confirmation that the transaction remained unmined at or beyond its expiry height
+    // is terminal.
+    add_funds(&mut st, value);
+    let txids = send_to_tex(&mut st);
+    let transparent_txid = *txids.last();
+    assert!(contains_status_request(&st, transparent_txid));
+
+    // A not-yet-mined answer before expiry is not terminal.
+    st.wallet_mut()
+        .set_transaction_status(transparent_txid, TransactionStatus::NotInMainChain)
+        .unwrap();
+    assert!(contains_status_request(&st, transparent_txid));
+
+    // Advance the chain tip to the transaction's expiry height. The request must remain in place
+    // until confirmation that the transaction remained unmined arrives.
+    let expiry_height = st
+        .get_tx_from_history(transparent_txid)
+        .unwrap()
+        .expect("transparent transaction is in history")
+        .expiry_height()
+        .expect("expiry height is known");
+    let chain_tip = st.wallet().chain_height().unwrap().unwrap();
+    st.add_empty_blocks(usize::try_from(u32::from(expiry_height) - u32::from(chain_tip)).unwrap());
+    assert!(contains_status_request(&st, transparent_txid));
+
+    // Confirmation that the transaction remained unmined at its expiry height is terminal.
+    st.wallet_mut()
+        .set_transaction_status(transparent_txid, TransactionStatus::NotInMainChain)
+        .unwrap();
+    assert!(!contains_status_request(&st, transparent_txid));
+}
+
 // FIXME: This requires fixes to the test framework.
 #[allow(dead_code)]
 pub fn birthday_in_anchor_shard<T: ShieldedPoolTester>(
@@ -7835,6 +8067,26 @@ pub fn shielding_coinbase_to_orchard_receiver_delivers_via_ironwood<Dsf>(
         Ok(txids) if txids.len() == 1,
         "create_proposed_transactions must succeed for proposal {:?}",
         proposal,
+    );
+    let sent_tx_id = build_result.unwrap().head;
+
+    // The transaction's Ironwood bundle makes it detectable via chain scanning, so storing it
+    // as an unmined decrypted transaction must not queue it for status retrieval: a txid-scoped
+    // status query for it would be redundant and out of scope for the retrieval queue.
+    let tx = st
+        .wallet()
+        .get_transaction(sent_tx_id)
+        .unwrap()
+        .expect("created transaction was stored");
+    decrypt_and_store_transaction(&params, st.wallet_mut(), &tx, None).unwrap();
+
+    let requests = st.wallet().transaction_data_requests().unwrap();
+    assert!(
+        !requests
+            .iter()
+            .any(|req| req == &TransactionDataRequest::GetStatus(sent_tx_id)
+                || req == &TransactionDataRequest::Enhancement(sent_tx_id)),
+        "unexpected transaction data request for {sent_tx_id} in {requests:?}",
     );
 }
 

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -29,6 +29,30 @@ workspace.
   `zewif::ZewifImportError`.
 
 ### Fixed
+- `GetStatus` transaction data requests are no longer produced for transactions
+  having shielded components. Previously, every wallet transaction whose mined
+  height was unknown — including the wallet's own shielded sends — was polled
+  for status by txid (a behavior introduced in commit `406875adc`, first shipped
+  in `zcash_client_sqlite 0.18.5`), and a transaction detected via scanning for
+  which raw data was already present was queued for a status check by txid.
+  Each such txid-scoped query was redundant and out of scope: status requests
+  exist for transactions that compact-block scanning cannot detect.
+  The mined status of a transaction with any shielded
+  component (Sapling, Orchard, or Ironwood) is now learned exclusively via
+  chain scanning; `GetStatus` requests are produced only for fully-transparent
+  transactions, which are invisible to compact-block scanning and have no other
+  status oracle. As part of this change:
+  - `WalletWrite::set_transaction_status` now retains the status-check queue
+    entry for a fully-transparent transaction when the answer is not terminal
+    (i.e. the transaction is not yet mined and has not been confirmed unmined
+    at or beyond its expiry height), so that an as-yet-unmined transparent
+    transaction continues to be polled instead of silently being dropped after
+    a single not-yet-mined answer.
+  - Transactions containing only an Ironwood shielded bundle are now correctly
+    classified as detectable via scanning, and so are no longer queued for
+    txid-based retrieval when stored unmined.
+  - A new migration removes previously-queued status-check entries for
+    transactions with shielded components from existing wallet databases.
 - An Ironwood note received on an account's internal address is now classified as
   change once the wallet learns that the same account funded the transaction.
   This was previously applied to Sapling and Orchard notes only, so an Ironwood

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -2879,7 +2879,7 @@ impl<'a, C: Borrow<rusqlite::Transaction<'a>>, P: consensus::Parameters, CL: Clo
         tx_ref: Self::TxRef,
         d_tx: &DecryptedTransaction<Transaction, Self::AccountId>,
     ) -> Result<(), Self::Error> {
-        wallet::queue_transparent_input_retrieval(self.conn.borrow(), tx_ref, d_tx)
+        wallet::queue_transparent_input_retrieval(self.conn.borrow(), &self.params, tx_ref, d_tx)
     }
 
     fn queue_tx_retrieval(
@@ -2887,7 +2887,7 @@ impl<'a, C: Borrow<rusqlite::Transaction<'a>>, P: consensus::Parameters, CL: Clo
         txids: impl Iterator<Item = TxId>,
         dependent_tx_ref: Option<Self::TxRef>,
     ) -> Result<(), Self::Error> {
-        wallet::queue_tx_retrieval(self.conn.borrow(), txids, dependent_tx_ref)
+        wallet::queue_tx_retrieval(self.conn.borrow(), &self.params, txids, dependent_tx_ref)
     }
 
     fn delete_retrieval_queue_entries(&mut self, txid: TxId) -> Result<(), Self::Error> {

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -289,6 +289,21 @@ pub(crate) fn shield_transparent<T: ShieldedPoolTester>() {
     )
 }
 
+pub(crate) fn shielded_send_generates_no_status_requests<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::shielded_send_generates_no_status_requests::<T, _>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
+#[cfg(feature = "transparent-inputs")]
+pub(crate) fn transparent_status_requests_persist_until_terminal<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::transparent_status_requests_persist_until_terminal::<T, _>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
 // FIXME: This requires fixes to the test framework.
 #[allow(dead_code)]
 pub(crate) fn birthday_in_anchor_shard<T: ShieldedPoolTester>() {

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -3718,7 +3718,7 @@ pub(crate) fn store_transaction_to_be_sent<P: consensus::Parameters>(
     // at present for fully transparent transactions, because any transaction with a shielded
     // component will be detected via ordinary chain scanning and/or nullifier checking.
     if !detectable_via_scanning {
-        queue_tx_retrieval(conn, std::iter::once(sent_tx.tx().txid()), None)?;
+        queue_tx_retrieval(conn, params, std::iter::once(sent_tx.tx().txid()), None)?;
     }
 
     Ok(())
@@ -3733,22 +3733,24 @@ pub(crate) fn set_transaction_status<P: consensus::Parameters>(
 ) -> Result<(), SqliteClientError> {
     let chain_tip = chain_tip_height(conn)?.ok_or(SqliteClientError::ChainHeightUnknown)?;
 
-    // It is safe to unconditionally delete the request from `tx_retrieval_queue` below (both in
-    // the expired case and the case where it has been mined), because we already have all the data
-    // we need about this transaction:
-    // * if the status is being set in response to a `GetStatus` request, we know that we already
-    //   have the transaction data (`GetStatus` requests are only generated if we already have that
-    //   data)
-    // * if it is being set in response to an `Enhancement` request, we know that the status must
-    //   be `TxidNotRecognized` because otherwise the transaction data should have been provided to
-    //   the backend directly instead of calling `set_transaction_status`
+    // Because `tx_retrieval_queue` is the sole source of transaction data requests (transactions
+    // having shielded components are never polled for status, as their mined status is learned
+    // via chain scanning, making a txid-scoped status query for them redundant), a
+    // `Status`-type queue entry must not be deleted until the
+    // transaction it refers to has reached a terminal state; otherwise, an as-yet-unmined
+    // fully-transparent transaction would silently stop being polled after a single
+    // not-yet-mined answer.
     //
-    // In general `Enhancement` requests are only generated in response to situations where a
-    // transaction has already been mined - either the transaction was detected by scanning the
-    // chain of `CompactBlock` values, or was discovered by walking backward from the inputs of a
-    // transparent transaction; in the case that a transaction was read from the mempool, complete
-    // transaction data will have been available and the only question that we are concerned with
-    // is whether that transaction ends up being mined or expires.
+    // * `Enhancement`-type entries may always be deleted: if the status of such a request is
+    //   being set via this method, the status must be `TxidNotRecognized`, because otherwise the
+    //   transaction data would have been provided to the backend directly instead of calling
+    //   `set_transaction_status`, and no more information about such a transaction can be
+    //   obtained by asking again.
+    // * `Status`-type entries are deleted only when the answer is terminal: either the
+    //   transaction has been mined, or we have positive confirmation that it remained unmined at
+    //   a height at which it can no longer be mined. For transactions with a known expiry height
+    //   of 0, we continue to query indefinitely; such transactions should be rebroadcast by the
+    //   wallet until they are either mined or conflict with another mined transaction.
     match status {
         TransactionStatus::TxidNotRecognized | TransactionStatus::NotInMainChain => {
             conn.execute(
@@ -3759,6 +3761,49 @@ pub(crate) fn set_transaction_status<P: consensus::Parameters>(
                 named_params![
                     ":txid": txid.as_ref(),
                     ":chain_tip": u32::from(chain_tip)
+                ],
+            )?;
+
+            // Delete the queue entry unless it is a `Status`-type entry for a transaction that
+            // may yet be mined. A transaction is in a terminal state if:
+            // * it has been mined (its queue entry, if any, is no longer needed), or
+            // * a nonzero expiry height is known for it, and we have confirmation that it
+            //   remained unmined at a height greater than or equal to that expiry height, or
+            // * its expiry height is unknown, and we have confirmation that it remained unmined
+            //   after the default expiry height for it entered the stable block range according
+            //   to the `PRUNING_DEPTH`.
+            conn.execute(
+                "DELETE FROM tx_retrieval_queue
+                 WHERE txid = :txid
+                 AND (
+                    query_type = :enhancement_type
+                    OR NOT EXISTS (
+                        SELECT 1 FROM transactions t
+                        WHERE t.txid = :txid
+                        AND t.mined_height IS NULL
+                        AND (
+                            -- the transaction will never expire; poll indefinitely
+                            t.expiry_height = 0
+                            -- a nonzero expiry height is known, and we have no confirmation that
+                            -- the transaction remained unmined at or beyond that height
+                            OR (
+                                t.expiry_height > 0
+                                AND t.confirmed_unmined_at_height < t.expiry_height
+                            )
+                            -- the expiry height is unknown, and the default expiry height for the
+                            -- transaction is not yet in the stable block range
+                            OR (
+                                t.expiry_height IS NULL
+                                AND t.confirmed_unmined_at_height
+                                    < t.min_observed_height + :certainty_depth
+                            )
+                        )
+                    )
+                 )",
+                named_params![
+                    ":txid": txid.as_ref(),
+                    ":enhancement_type": TxQueryType::Enhancement.code(),
+                    ":certainty_depth": PRUNING_DEPTH + DEFAULT_TX_EXPIRY_DELTA,
                 ],
             )?;
         }
@@ -3794,10 +3839,11 @@ pub(crate) fn set_transaction_status<P: consensus::Parameters>(
 
             #[cfg(feature = "transparent-inputs")]
             transparent::update_gap_limits(conn, _params, gap_limits, txid, height)?;
+
+            // Mined status is terminal, so the queue entry is unconditionally deleted.
+            delete_retrieval_queue_entries(conn, txid)?;
         }
     }
-
-    delete_retrieval_queue_entries(conn, txid)?;
 
     Ok(())
 }
@@ -5083,7 +5129,17 @@ pub(crate) fn put_tx_data(
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum TxQueryType {
+    /// A request for the chain's view of the mined status of a transaction.
+    ///
+    /// INVARIANT: `Status`-type entries may only be created for transactions that ordinary
+    /// compact-block scanning cannot detect, i.e. fully-transparent transactions. A transaction
+    /// having any shielded component (Sapling, Orchard, or Ironwood) must never be the subject of
+    /// a status request: its mined status is always learned via chain scanning, so a
+    /// txid-scoped status query for it is redundant and out of scope for this queue.
+    /// This invariant is enforced by [`queue_tx_retrieval`], the sole producer of
+    /// queue entries.
     Status,
+    /// A request for the complete data of a transaction, identified by its txid.
     Enhancement,
 }
 
@@ -5105,8 +5161,9 @@ impl TxQueryType {
 }
 
 #[cfg(feature = "transparent-inputs")]
-pub(crate) fn queue_transparent_input_retrieval<AccountId>(
+pub(crate) fn queue_transparent_input_retrieval<P: consensus::Parameters, AccountId>(
     conn: &rusqlite::Transaction<'_>,
+    params: &P,
     tx_ref: TxRef,
     d_tx: &DecryptedTransaction<Transaction, AccountId>,
 ) -> Result<(), SqliteClientError> {
@@ -5116,6 +5173,7 @@ pub(crate) fn queue_transparent_input_retrieval<AccountId>(
         // queue the transparent inputs for enhancement
         queue_tx_retrieval(
             conn,
+            params,
             b.vin.iter().map(|txin| *txin.prevout().txid()),
             Some(tx_ref),
         )?;
@@ -5124,39 +5182,100 @@ pub(crate) fn queue_transparent_input_retrieval<AccountId>(
     Ok(())
 }
 
-pub(crate) fn queue_tx_retrieval(
+/// Adds entries to the transaction retrieval queue for the given txids, if they would not be
+/// redundant.
+///
+/// The type of request queued for each txid depends upon the wallet's knowledge of the
+/// transaction:
+/// * If the wallet does not have the complete transaction data, an
+///   [`Enhancement`][TxQueryType::Enhancement] entry is created in order to retrieve it.
+/// * If the wallet has the complete transaction data for a fully-transparent transaction whose
+///   mined status is unknown, a [`Status`][TxQueryType::Status] entry is created. Mined status
+///   for fully-transparent transactions can only be learned by actively querying, because such
+///   transactions are invisible to compact-block scanning.
+/// * If the wallet has the complete transaction data for a transaction having any shielded
+///   component, no entry is created: the wallet will learn the transaction's mined status via
+///   ordinary chain scanning, so a txid-scoped status query for it would be redundant and is
+///   out of scope for this queue. See [`TxQueryType::Status`] for a statement
+///   of this invariant.
+pub(crate) fn queue_tx_retrieval<P: consensus::Parameters>(
     conn: &rusqlite::Transaction<'_>,
+    params: &P,
     txids: impl Iterator<Item = TxId>,
     dependent_tx_ref: Option<TxRef>,
 ) -> Result<(), SqliteClientError> {
+    let chain_tip = chain_tip_height(conn)?;
+
+    let mut stmt_tx_data = conn.prepare_cached(
+        "SELECT raw, mined_height
+         FROM transactions
+         WHERE txid = :txid",
+    )?;
+
     // Add an entry to the transaction retrieval queue if it would not be redundant.
     let mut stmt_insert_tx = conn.prepare_cached(
         "INSERT INTO tx_retrieval_queue (txid, query_type, dependent_transaction_id)
-         SELECT
-            :txid,
-            IIF(
-                EXISTS (SELECT 1 FROM transactions WHERE txid = :txid AND raw IS NOT NULL),
-                :status_type,
-                :enhancement_type
-            ),
-            :dependent_transaction_id
-        ON CONFLICT (txid) DO UPDATE
-        SET query_type =
-            IIF(
-                EXISTS (SELECT 1 FROM transactions WHERE txid = :txid AND raw IS NOT NULL),
-                :status_type,
-                :enhancement_type
-            ),
-            dependent_transaction_id = IFNULL(:dependent_transaction_id, dependent_transaction_id)",
+         VALUES (:txid, :query_type, :dependent_transaction_id)
+         ON CONFLICT (txid) DO UPDATE
+         SET query_type = :query_type,
+             dependent_transaction_id = IFNULL(:dependent_transaction_id, dependent_transaction_id)",
     )?;
 
     for txid in txids {
-        stmt_insert_tx.execute(named_params! {
-            ":txid": txid.as_ref(),
-            ":status_type": TxQueryType::Status.code(),
-            ":enhancement_type": TxQueryType::Enhancement.code(),
-            ":dependent_transaction_id": dependent_tx_ref.map(|r| r.0),
-        })?;
+        let tx_data = stmt_tx_data
+            .query_row(named_params![":txid": txid.as_ref()], |row| {
+                Ok((
+                    row.get::<_, Option<Vec<u8>>>("raw")?,
+                    row.get::<_, Option<u32>>("mined_height")?
+                        .map(BlockHeight::from),
+                ))
+            })
+            .optional()?;
+
+        let query_type = match tx_data {
+            // We already have the complete transaction data, so the only information that could
+            // still be required is the transaction's mined status.
+            Some((Some(raw), mined_height)) => {
+                if mined_height.is_some() {
+                    // The transaction is already known to have been mined; no request of any kind
+                    // is required.
+                    None
+                } else {
+                    // We assume that unmined transactions were created under the current
+                    // consensus branch.
+                    let branch_id = chain_tip
+                        .map_or(BranchId::Sapling, |h| BranchId::for_height(params, h + 1));
+
+                    match Transaction::read(&raw[..], branch_id) {
+                        Ok(tx) => {
+                            let detectable_via_scanning = tx.sapling_bundle().is_some()
+                                || tx.orchard_bundle().is_some()
+                                || tx.ironwood_bundle().is_some();
+
+                            // Only fully-transparent transactions may be the subject of `Status`
+                            // requests; the mined status of a transaction having any shielded
+                            // component will be learned via chain scanning, making a status
+                            // request for it by txid redundant.
+                            (!detectable_via_scanning).then_some(TxQueryType::Status)
+                        }
+                        // If the stored transaction data cannot be parsed, we cannot rule out
+                        // that the transaction has shielded components, so we treat it as out
+                        // of scope and do not create a status request for it.
+                        Err(_) => None,
+                    }
+                }
+            }
+            // We do not have complete transaction data, so request enhancement.
+            _ => Some(TxQueryType::Enhancement),
+        };
+
+        if let Some(query_type) = query_type {
+            stmt_insert_tx.execute(named_params! {
+                ":txid": txid.as_ref(),
+                ":query_type": query_type.code(),
+                ":dependent_transaction_id": dependent_tx_ref.map(|r| r.0),
+            })?;
+        }
     }
 
     Ok(())
@@ -5164,60 +5283,35 @@ pub(crate) fn queue_tx_retrieval(
 
 /// Returns the vector of [`TransactionDataRequest`]s that represents the information needed by the
 /// wallet backend in order to be able to present a complete view of wallet history and memo data.
+///
+/// Requests are drawn exclusively from the `tx_retrieval_queue` table; entries are only added to
+/// that queue for transactions that cannot be detected via ordinary compact-block scanning.
+/// [`TransactionDataRequest::GetStatus`] entries exist solely for fully-transparent transactions,
+/// which have no shielded component whose mining could be observed by scanning;
+/// [`TransactionDataRequest::Enhancement`] entries exist for transactions discovered by walking
+/// the transparent input graph. Transactions having any shielded component are deliberately never
+/// the subject of status requests: their mined status is always learned via chain scanning, so a
+/// txid-scoped status query for them is redundant and out of scope for the queue.
 pub(crate) fn transaction_data_requests(
     conn: &rusqlite::Connection,
 ) -> Result<Vec<TransactionDataRequest>, SqliteClientError> {
-    // We will return both explicitly constructed status requests, and a status request for each
-    // transaction that is known to the wallet for which we don't have the mined height,
-    // and for which we have no positive confirmation that the transaction expired unmined.
-    //
-    // For transactions with a known expiry height of 0, we will continue to query indefinitely.
-    // Such transactions should be rebroadcast by the wallet until they are either mined or
-    // conflict with another mined transaction.
-    let mut tx_retrieval_stmt = conn.prepare_cached(
-        "SELECT txid, query_type FROM tx_retrieval_queue
-         UNION
-         SELECT txid, :status_type
-         FROM transactions
-         WHERE mined_height IS NULL
-         AND (
-            -- we have no confirmation of expiry
-            confirmed_unmined_at_height IS NULL
-            -- a nonzero expiry height is known, and we have confirmation that the transaction was
-            -- not unmined as of a height greater than or equal to that expiry height
-            OR (
-                expiry_height > 0
-                AND confirmed_unmined_at_height < expiry_height
-            )
-            -- the expiry height is unknown and the default expiry height for it is not yet in the
-            -- stable block range according to the PRUNING_DEPTH
-            OR (
-                expiry_height IS NULL
-                AND confirmed_unmined_at_height < min_observed_height + :certainty_depth
-            )
-        )",
-    )?;
+    let mut tx_retrieval_stmt =
+        conn.prepare_cached("SELECT txid, query_type FROM tx_retrieval_queue")?;
 
     let result = tx_retrieval_stmt
-        .query_and_then(
-            named_params![
-                ":status_type": TxQueryType::Status.code(),
-                ":certainty_depth": PRUNING_DEPTH + DEFAULT_TX_EXPIRY_DELTA
-            ],
-            |row| {
-                let txid = row.get(0).map(TxId::from_bytes)?;
-                let query_type = row.get(1).map(TxQueryType::from_code)?.ok_or_else(|| {
-                    SqliteClientError::CorruptedData(
-                        "Unrecognized transaction data request type.".to_owned(),
-                    )
-                })?;
+        .query_and_then([], |row| {
+            let txid = row.get(0).map(TxId::from_bytes)?;
+            let query_type = row.get(1).map(TxQueryType::from_code)?.ok_or_else(|| {
+                SqliteClientError::CorruptedData(
+                    "Unrecognized transaction data request type.".to_owned(),
+                )
+            })?;
 
-                Ok::<TransactionDataRequest, SqliteClientError>(match query_type {
-                    TxQueryType::Status => TransactionDataRequest::GetStatus(txid),
-                    TxQueryType::Enhancement => TransactionDataRequest::Enhancement(txid),
-                })
-            },
-        )?
+            Ok::<TransactionDataRequest, SqliteClientError>(match query_type {
+                TxQueryType::Status => TransactionDataRequest::GetStatus(txid),
+                TxQueryType::Enhancement => TransactionDataRequest::Enhancement(txid),
+            })
+        })?
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(result)
@@ -5996,6 +6090,154 @@ mod tests {
             ),
             Err(SqliteClientError::AccountUnknown)
         );
+    }
+
+    /// `Status`-type entries in `tx_retrieval_queue` are the sole source of `GetStatus` requests,
+    /// so a not-yet-mined `set_transaction_status` answer must only delete an entry once the
+    /// transaction has reached a terminal state:
+    /// * a transaction with a known expiry height of 0 never expires, and is polled indefinitely;
+    /// * a transaction with a known nonzero expiry height is terminal once it is confirmed to
+    ///   have remained unmined at or beyond that height;
+    /// * a transaction with an unknown expiry height is terminal once it is confirmed to have
+    ///   remained unmined at or beyond `min_observed_height + PRUNING_DEPTH +
+    ///   DEFAULT_TX_EXPIRY_DELTA`.
+    #[test]
+    fn status_request_retention_terminal_conditions() {
+        use zcash_client_backend::data_api::{TransactionDataRequest, TransactionStatus};
+        use zcash_primitives::transaction::builder::DEFAULT_TX_EXPIRY_DELTA;
+        use zcash_protocol::TxId;
+
+        use super::TxQueryType;
+        use crate::PRUNING_DEPTH;
+
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_block_cache(BlockCache::new())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        // Scan a few blocks so that the wallet has a chain tip.
+        let dfvk = ExtendedSpendingKey::master(&[]).to_diversifiable_full_viewing_key();
+        let value = Zatoshis::const_from_u64(10000);
+        let start_height = st.sapling_activation_height();
+        st.generate_block_at(
+            start_height,
+            BlockHash([0; 32]),
+            &[FakeCompactOutput::new(
+                &dfvk,
+                AddressType::DefaultExternal,
+                value,
+            )],
+            0,
+            0,
+            0,
+            false,
+        );
+        for _ in 1..5 {
+            st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
+        }
+        st.scan_cached_blocks(start_height, 5);
+
+        let tip = u32::from(start_height) + 4;
+        let certainty_depth = PRUNING_DEPTH + DEFAULT_TX_EXPIRY_DELTA;
+
+        // Inserts an unmined transaction row along with a `Status`-type retrieval queue entry
+        // for it. The queue entries are inserted directly because these code paths do not read
+        // the raw transaction data, which lets each terminal condition be exercised precisely.
+        let insert_status_request =
+            |conn: &Connection, txid: &TxId, expiry_height: Option<u32>, min_observed: u32| {
+                conn.execute(
+                    "INSERT INTO transactions (txid, expiry_height, min_observed_height)
+                     VALUES (:txid, :expiry_height, :min_observed_height)",
+                    named_params![
+                        ":txid": txid.as_ref(),
+                        ":expiry_height": expiry_height,
+                        ":min_observed_height": min_observed,
+                    ],
+                )
+                .unwrap();
+                conn.execute(
+                    "INSERT INTO tx_retrieval_queue (txid, query_type)
+                     VALUES (:txid, :query_type)",
+                    named_params![
+                        ":txid": txid.as_ref(),
+                        ":query_type": TxQueryType::Status.code(),
+                    ],
+                )
+                .unwrap();
+            };
+
+        // A transaction with expiry height 0 never expires; its entry survives a confirmed-
+        // unmined answer regardless of how old the transaction is.
+        let tx_no_expiry = TxId::from_bytes([1; 32]);
+        insert_status_request(
+            st.wallet().conn(),
+            &tx_no_expiry,
+            Some(0),
+            tip - certainty_depth,
+        );
+
+        // A transaction whose known expiry height is above the chain tip is not yet terminal.
+        let tx_unexpired = TxId::from_bytes([2; 32]);
+        insert_status_request(st.wallet().conn(), &tx_unexpired, Some(tip + 10), tip);
+
+        // A transaction whose known expiry height is at or below the chain tip becomes terminal
+        // as soon as it is confirmed unmined.
+        let tx_expired = TxId::from_bytes([3; 32]);
+        insert_status_request(st.wallet().conn(), &tx_expired, Some(tip), tip - 50);
+
+        // A transaction with an unknown expiry height that was first observed recently is not
+        // yet terminal.
+        let tx_unknown_expiry_recent = TxId::from_bytes([4; 32]);
+        insert_status_request(st.wallet().conn(), &tx_unknown_expiry_recent, None, tip);
+
+        // A transaction with an unknown expiry height becomes terminal once confirmed unmined at
+        // or beyond `min_observed_height + certainty_depth`.
+        let tx_unknown_expiry_old = TxId::from_bytes([5; 32]);
+        insert_status_request(
+            st.wallet().conn(),
+            &tx_unknown_expiry_old,
+            None,
+            tip - certainty_depth,
+        );
+
+        let contains_status_request = |st: &TestState<_, crate::testing::db::TestDb, _>, txid| {
+            st.wallet()
+                .transaction_data_requests()
+                .unwrap()
+                .contains(&TransactionDataRequest::GetStatus(txid))
+        };
+
+        for txid in [
+            tx_no_expiry,
+            tx_unexpired,
+            tx_expired,
+            tx_unknown_expiry_recent,
+            tx_unknown_expiry_old,
+        ] {
+            assert!(contains_status_request(&st, txid));
+            st.wallet_mut()
+                .set_transaction_status(txid, TransactionStatus::NotInMainChain)
+                .unwrap();
+        }
+
+        // Non-terminal transactions are still being polled after the confirmed-unmined answer.
+        assert!(contains_status_request(&st, tx_no_expiry));
+        assert!(contains_status_request(&st, tx_unexpired));
+        assert!(contains_status_request(&st, tx_unknown_expiry_recent));
+
+        // Terminal transactions are no longer polled.
+        assert!(!contains_status_request(&st, tx_expired));
+        assert!(!contains_status_request(&st, tx_unknown_expiry_old));
+
+        // A `Mined` answer is terminal even for a transaction that never expires.
+        st.wallet_mut()
+            .set_transaction_status(
+                tx_no_expiry,
+                TransactionStatus::Mined(BlockHeight::from(tip)),
+            )
+            .unwrap();
+        assert!(!contains_status_request(&st, tx_no_expiry));
     }
 
     #[test]

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -50,6 +50,7 @@ mod tree_retained_checkpoints;
 mod tx_observation_height;
 mod tx_retrieval_queue;
 mod tx_retrieval_queue_expiry;
+mod tx_status_queue_scoping;
 mod ufvk_support;
 mod utxos_table;
 mod utxos_to_txos;
@@ -159,6 +160,9 @@ pub(super) fn all_migrations<
     //                                             /                        \    fix_bad_ironwood_change_flagging
     //                                          ivk_item_cache    add_transparent_receiver_address_index
     //
+    // (not shown above: tx_status_queue_scoping, which depends on tx_retrieval_queue and
+    // account_delete_cascade)
+    //
     let rng = Rc::new(Mutex::new(rng));
     vec![
         Box::new(initial_setup::Migration {}),
@@ -266,6 +270,9 @@ pub(super) fn all_migrations<
         Box::new(orchard_ironwood_migration_tables::Migration),
         Box::new(tree_retained_checkpoints::Migration),
         Box::new(note_locking::Migration),
+        Box::new(tx_status_queue_scoping::Migration {
+            params: params.clone(),
+        }),
     ]
 }
 
@@ -417,6 +424,7 @@ pub const CURRENT_LEAF_MIGRATIONS: &[Uuid] = &[
     orchard_ironwood_migration_tables::MIGRATION_ID,
     tree_retained_checkpoints::MIGRATION_ID,
     note_locking::MIGRATION_ID,
+    tx_status_queue_scoping::MIGRATION_ID,
 ];
 
 pub(super) fn verify_network_compatibility<P: consensus::Parameters>(

--- a/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue.rs
@@ -275,6 +275,8 @@ fn queue_unmined_tx_retrieval<AccountId>(
     let detectable_via_scanning = d_tx.tx().sapling_bundle().is_some();
     #[cfg(feature = "orchard")]
     let detectable_via_scanning = detectable_via_scanning | d_tx.tx().orchard_bundle().is_some();
+    #[cfg(feature = "orchard")]
+    let detectable_via_scanning = detectable_via_scanning | d_tx.tx().ironwood_bundle().is_some();
 
     if d_tx.mined_height().is_none() && !detectable_via_scanning {
         queue_tx_retrieval(conn, std::iter::once(d_tx.tx().txid()), None)?

--- a/zcash_client_sqlite/src/wallet/init/migrations/tx_status_queue_scoping.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/tx_status_queue_scoping.rs
@@ -1,0 +1,315 @@
+//! Removes out-of-scope status requests for transactions with shielded components from the
+//! transaction retrieval queue.
+
+use rusqlite::named_params;
+use schemerz_rusqlite::RusqliteMigration;
+use std::collections::HashSet;
+use uuid::Uuid;
+
+use zcash_primitives::transaction::Transaction;
+use zcash_protocol::consensus::{self, BlockHeight, BranchId};
+
+use crate::wallet::{TxQueryType, chain_tip_height, init::WalletMigrationError};
+
+use super::{account_delete_cascade, tx_retrieval_queue};
+
+pub(super) const MIGRATION_ID: Uuid = Uuid::from_u128(0x2c4d3ff6_9e19_4fbf_ae08_9d1263a3a455);
+
+const DEPENDENCIES: &[Uuid] = &[
+    tx_retrieval_queue::MIGRATION_ID,
+    account_delete_cascade::MIGRATION_ID,
+];
+
+pub(super) struct Migration<P> {
+    pub(super) params: P,
+}
+
+impl<P> schemerz::Migration<Uuid> for Migration<P> {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Removes out-of-scope status requests for transactions with shielded components from the transaction retrieval queue."
+    }
+}
+
+impl<P: consensus::Parameters> RusqliteMigration for Migration<P> {
+    type Error = WalletMigrationError;
+
+    fn up(&self, conn: &rusqlite::Transaction) -> Result<(), WalletMigrationError> {
+        // Status-type entries in `tx_retrieval_queue` may only exist for fully-transparent
+        // transactions: the mined status of a transaction having any shielded component is
+        // learned via ordinary chain scanning, so a txid-scoped status query for it is
+        // redundant and out of scope for the queue.
+        //
+        // Prior versions of this crate violated that invariant in several ways:
+        // * transactions detected via scanning for which complete transaction data was already
+        //   available (in particular, the wallet's own shielded sends) were queued for status
+        //   retrieval when their mined transaction was scanned;
+        // * transactions whose data was stored via enhancement were classified as undetectable
+        //   via scanning if they contained only an Ironwood shielded bundle, and were then
+        //   queued for status retrieval when unmined;
+        // * prevouts of transparent inputs whose complete transaction data was already available
+        //   were queued for status retrieval even when the referenced transaction had shielded
+        //   components.
+        //
+        // This migration deletes the resulting stale entries. Status entries are retained only
+        // for as-yet-unmined transactions whose stored transaction data demonstrates that they
+        // are fully transparent.
+        let chain_tip = chain_tip_height(conn)?;
+
+        let mut stale_txids: Vec<Vec<u8>> = vec![];
+        {
+            let mut stmt = conn.prepare(
+                "SELECT q.txid, t.raw, t.mined_height
+                 FROM tx_retrieval_queue q
+                 LEFT OUTER JOIN transactions t ON t.txid = q.txid
+                 WHERE q.query_type = :status_type",
+            )?;
+            let mut rows = stmt.query(named_params![":status_type": TxQueryType::Status.code()])?;
+            while let Some(row) = rows.next()? {
+                let txid = row.get::<_, Vec<u8>>(0)?;
+                let raw = row.get::<_, Option<Vec<u8>>>(1)?;
+                let mined_height = row.get::<_, Option<u32>>(2)?.map(BlockHeight::from);
+
+                let retain = match (raw, mined_height) {
+                    // The transaction is already known to have been mined; its status no longer
+                    // needs to be queried.
+                    (_, Some(_)) => false,
+                    (Some(raw), None) => {
+                        // We assume that unmined transactions were created under the current
+                        // consensus branch.
+                        let branch_id = chain_tip.map_or(BranchId::Sapling, |h| {
+                            BranchId::for_height(&self.params, h + 1)
+                        });
+
+                        match Transaction::read(&raw[..], branch_id) {
+                            Ok(tx) => {
+                                tx.sapling_bundle().is_none()
+                                    && tx.orchard_bundle().is_none()
+                                    && tx.ironwood_bundle().is_none()
+                            }
+                            // If the stored transaction data cannot be parsed, we cannot rule
+                            // out that the transaction has shielded components, so we treat it
+                            // as out of scope and delete the status request.
+                            Err(_) => false,
+                        }
+                    }
+                    // A status request cannot be satisfied for a transaction for which we have
+                    // no data, so it should never have been created; `TxidNotRecognized` would be
+                    // the only possible answer for a transaction the chain does not contain.
+                    (None, None) => false,
+                };
+
+                if !retain {
+                    stale_txids.push(txid);
+                }
+            }
+        }
+
+        let mut stmt_delete = conn.prepare(
+            "DELETE FROM tx_retrieval_queue
+             WHERE txid = :txid
+             AND query_type = :status_type",
+        )?;
+        for txid in stale_txids {
+            stmt_delete.execute(named_params![
+                ":txid": txid,
+                ":status_type": TxQueryType::Status.code(),
+            ])?;
+        }
+
+        Ok(())
+    }
+
+    fn down(&self, _: &rusqlite::Transaction) -> Result<(), WalletMigrationError> {
+        Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::strategy::{Strategy, ValueTree};
+    use proptest::test_runner::{Config, RngAlgorithm, TestRng, TestRunner};
+    use rusqlite::named_params;
+    use secrecy::Secret;
+    use tempfile::NamedTempFile;
+
+    use ::transparent::{
+        address::{Script, TransparentAddress},
+        bundle::{OutPoint, TxIn, TxOut},
+    };
+    use zcash_primitives::transaction::{
+        Authorized, Transaction, TransactionData, TxVersion, testing as tx_testing,
+    };
+    use zcash_protocol::{
+        TxId,
+        consensus::{BranchId, Network},
+        value::Zatoshis,
+    };
+
+    use crate::{
+        WalletDb,
+        testing::db::{test_clock, test_rng},
+        wallet::{TxQueryType, init::WalletMigrator, init::migrations::tests::test_migrate},
+    };
+
+    use super::{DEPENDENCIES, MIGRATION_ID};
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[MIGRATION_ID]);
+    }
+
+    /// Returns a deterministically-sampled transaction having at least one shielded bundle.
+    fn fake_shielded_tx() -> Transaction {
+        let mut runner = TestRunner::new_with_rng(
+            Config::default(),
+            TestRng::from_seed(RngAlgorithm::ChaCha, &[7; 32]),
+        );
+        loop {
+            let tx_data = tx_testing::arb_txdata(BranchId::Nu5)
+                .new_tree(&mut runner)
+                .unwrap()
+                .current();
+            if tx_data.sapling_bundle().is_some() || tx_data.orchard_bundle().is_some() {
+                return tx_data.freeze().unwrap();
+            }
+        }
+    }
+
+    /// Returns a fully-transparent transaction.
+    fn fake_transparent_tx() -> Transaction {
+        TransactionData::<Authorized>::from_parts(
+            TxVersion::V5,
+            BranchId::Nu5,
+            0,
+            12345678.into(),
+            #[cfg(all(zcash_unstable = "nu7", feature = "zip-233"))]
+            Zatoshis::ZERO,
+            Some(transparent::bundle::Bundle {
+                vin: vec![TxIn::from_parts(OutPoint::fake(), Script::default(), 0)],
+                vout: vec![TxOut::new(
+                    Zatoshis::const_from_u64(10_000),
+                    TransparentAddress::PublicKeyHash([7; 20]).script().into(),
+                )],
+                authorization: transparent::bundle::Authorized,
+            }),
+            None,
+            None,
+            None,
+        )
+        .freeze()
+        .unwrap()
+    }
+
+    #[test]
+    fn migrate_with_data() {
+        let data_file = NamedTempFile::new().unwrap();
+        let mut db_data = WalletDb::for_path(
+            data_file.path(),
+            Network::TestNetwork,
+            test_clock(),
+            test_rng(),
+        )
+        .unwrap();
+
+        let seed_bytes = vec![0xab; 32];
+
+        // Migrate to database state just prior to this migration.
+        WalletMigrator::new()
+            .with_seed(Secret::new(seed_bytes.clone()))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, DEPENDENCIES)
+            .unwrap();
+
+        // Add transactions and stale queue entries that exercise the data migration.
+        let add_tx_to_wallet = |tx: &Transaction, mined_height: Option<u32>| {
+            let txid = tx.txid();
+            let mut raw_tx = vec![];
+            tx.write(&mut raw_tx).unwrap();
+            db_data
+                .conn
+                .execute(
+                    "INSERT INTO transactions (txid, raw, mined_height, min_observed_height)
+                     VALUES (:txid, :raw, :mined_height, :min_observed_height)",
+                    named_params! {
+                        ":txid": txid.as_ref(),
+                        ":raw": raw_tx,
+                        ":mined_height": mined_height,
+                        ":min_observed_height": mined_height.unwrap_or(1_000_000),
+                    },
+                )
+                .unwrap();
+        };
+        let add_queue_entry = |txid: &TxId, query_type: TxQueryType| {
+            db_data
+                .conn
+                .execute(
+                    "INSERT INTO tx_retrieval_queue (txid, query_type)
+                     VALUES (:txid, :query_type)",
+                    named_params! {
+                        ":txid": txid.as_ref(),
+                        ":query_type": query_type.code(),
+                    },
+                )
+                .unwrap();
+        };
+
+        // An unmined fully-transparent transaction with a status request: the request is valid
+        // and must be retained.
+        let transparent_tx = fake_transparent_tx();
+        add_tx_to_wallet(&transparent_tx, None);
+        add_queue_entry(&transparent_tx.txid(), TxQueryType::Status);
+
+        // An unmined shielded transaction with a status request: the transaction is detectable
+        // via scanning, so the request is out of scope and must be deleted.
+        let shielded_tx = fake_shielded_tx();
+        add_tx_to_wallet(&shielded_tx, None);
+        add_queue_entry(&shielded_tx.txid(), TxQueryType::Status);
+
+        // A status request for a txid the wallet has no data for is unsatisfiable and must be
+        // deleted.
+        let unknown_status_txid = TxId::from_bytes([0x77; 32]);
+        add_queue_entry(&unknown_status_txid, TxQueryType::Status);
+
+        // An enhancement request must be unaffected by this migration.
+        let enhancement_txid = TxId::from_bytes([0x88; 32]);
+        add_queue_entry(&enhancement_txid, TxQueryType::Enhancement);
+
+        // Check that we can apply this migration.
+        WalletMigrator::new()
+            .with_seed(Secret::new(seed_bytes))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, &[MIGRATION_ID])
+            .unwrap();
+
+        let queued: Vec<(Vec<u8>, i64)> = db_data
+            .conn
+            .prepare("SELECT txid, query_type FROM tx_retrieval_queue ORDER BY txid")
+            .unwrap()
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+
+        let mut expected = vec![
+            (
+                transparent_tx.txid().as_ref().to_vec(),
+                TxQueryType::Status.code(),
+            ),
+            (
+                enhancement_txid.as_ref().to_vec(),
+                TxQueryType::Enhancement.code(),
+            ),
+        ];
+        expected.sort();
+
+        assert_eq!(queued, expected);
+    }
+}

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -853,6 +853,17 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn shielded_send_generates_no_status_requests() {
+        testing::pool::shielded_send_generates_no_status_requests::<OrchardPoolTester>()
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-inputs")]
+    fn transparent_status_requests_persist_until_terminal() {
+        testing::pool::transparent_status_requests_persist_until_terminal::<OrchardPoolTester>()
+    }
+
+    #[test]
     fn birthday_in_anchor_shard() {
         testing::pool::birthday_in_anchor_shard::<OrchardPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -617,6 +617,17 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn shielded_send_generates_no_status_requests() {
+        testing::pool::shielded_send_generates_no_status_requests::<SaplingPoolTester>()
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-inputs")]
+    fn transparent_status_requests_persist_until_terminal() {
+        testing::pool::transparent_status_requests_persist_until_terminal::<SaplingPoolTester>()
+    }
+
+    #[test]
     fn birthday_in_anchor_shard() {
         testing::pool::birthday_in_anchor_shard::<SaplingPoolTester>()
     }


### PR DESCRIPTION
## Summary

`TransactionDataRequest::GetStatus` is a query by transaction id, and it exists for transactions that ordinary compact-block scanning cannot detect — i.e. fully-transparent ones. A transaction with any shielded component is detected by scanning, which sets its mined height, so a status request for it is redundant and out of scope. Two paths did not hold to that scoping:

- `transaction_data_requests` synthesized a `GetStatus` request for **every** transaction whose mined height was unknown, regardless of its bundles (the fallback added in 406875adc, first shipped in `zcash_client_sqlite` 0.18.5).
- `queue_tx_retrieval` created `Status`-type queue entries for transactions with shielded components whenever raw transaction data was already present — which happens for scanned wallet transactions and for transparent input prevouts (e.g. the shielded first step of a ZIP 320 pair).

Additionally, two places classified scannability from Sapling and Orchard bundles only, omitting Ironwood. Since NU6.3 carries payments involving Orchard receivers in the Ironwood bundle, ordinary transactions were affected.

## Changes

- `transaction_data_requests` now reads exclusively from `tx_retrieval_queue`; the blanket fallback over unmined transactions is removed.
- Because the queue is now the sole source of requests, `set_transaction_status` retains a `Status`-type queue entry when a not-yet-mined answer is not terminal, so an unresolved fully-transparent transaction keeps being queried. Terminal means: mined; or confirmed unmined at or beyond a known nonzero expiry height; or, for an unknown expiry height, confirmed unmined at or beyond `min_observed_height + PRUNING_DEPTH + DEFAULT_TX_EXPIRY_DELTA`. Expiry height 0 is polled indefinitely. This mirrors the semantics the removed clause encoded.
- `queue_tx_retrieval` enforces the scoping directly: when raw transaction data is available it is parsed, and no request is created for a transaction with a Sapling, Orchard, or Ironwood bundle, nor for one already known to be mined.
- `zcash_client_backend`'s `store_decrypted_tx` and the `tx_retrieval_queue` migration now count Ironwood bundles when classifying scannability, matching `store_transaction_to_be_sent`.
- A new migration removes previously-queued status-check entries for transactions with shielded components from existing wallet databases.

## Tests

- `shielded_send_generates_no_status_requests` (per pool): an unmined shielded send produces no `GetStatus` or `Enhancement` request at any chain tip height, including past expiry, and scanning alone sets its mined height.
- `transparent_status_requests_persist_until_terminal` (per pool): a fully-transparent ZIP 320 second-step transaction is queued and keeps being polled across not-yet-mined answers, stopping only once mined or confirmed unmined at its expiry height; the shielded first step is not queued.
- `status_request_retention_terminal_conditions`: the terminal-condition matrix for expiry height 0, known nonzero, and unknown expiry heights.
- Migration tests covering that shielded and unsatisfiable entries are purged while fully-transparent `Status` entries and all `Enhancement` entries are preserved.

`cargo test -p zcash_client_sqlite --all-features` (485 passed) and `cargo test -p zcash_client_backend --all-features` (119 passed) are green, as are `cargo fmt --all -- --check` and `cargo clippy --all-features --all-targets -- -D warnings`.

A backport of these commits onto the `zcash_client_sqlite 0.22.0-rc.4` release commit is available at `pacu/status-request-scoping-0.22.0-rc.4` if an interim branch is useful.