### PR TITLE
wallet: preserve transaction status observation intent

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -30,8 +30,14 @@ workspace.
   `proto::{CompactFormatError, ProposalDecodingError}`, `scanning::ScanError`,
   `sync::Error`, `sync::decryptor::TryQueueError`, `tor::Error`,
   `tor::grpc::GrpcError`, and `tor::http::HttpError`.
+- `zcash_client_backend::data_api::ll::LowLevelWalletWrite` has added method
+  `queue_tx_status`, which records durable status-observation intent for
+  transactions whose mined status cannot be learned by compact-block scanning.
 
 ### Fixed
+- `data_api::ll::wallet::store_decrypted_tx` now distinguishes a wallet-observable
+  shielded spend or output from mere shielded bundle presence when deciding
+  whether txid-based status observation is required.
 - The Tor HTTP and gRPC transports now reject a URL whose scheme is neither
   `http` nor `https` (for example `ftp` or `ws`) with `tor::http::HttpError::NonHttpUrl`.
   Previously such a URL was silently treated as plaintext HTTP, contradicting the

--- a/zcash_client_backend/src/data_api/ll.rs
+++ b/zcash_client_backend/src/data_api/ll.rs
@@ -618,6 +618,15 @@ pub trait LowLevelWalletWrite: LowLevelWalletRead {
         dependent_tx_ref: Option<Self::TxRef>,
     ) -> Result<(), Self::Error>;
 
+    /// Adds a [`TransactionDataRequest::GetStatus`] request for a transaction whose mined status
+    /// cannot be learned through ordinary compact-block scanning.
+    ///
+    /// The request intent must remain durable while the transaction is mined, so that it becomes
+    /// active again if a chain rewind un-mines the transaction.
+    ///
+    /// [`TransactionDataRequest::GetStatus`]: super::TransactionDataRequest
+    fn queue_tx_status(&mut self, txid: TxId) -> Result<(), Self::Error>;
+
     /// Adds a [`TransactionDataRequest::TransactionsInvolvingAddress`] request to the transaction
     /// data request queue. When the transparent output of `tx_ref` at output index `output_index`
     /// (which must have been received at `receiving_address`) is detected as having been spent,
@@ -650,8 +659,9 @@ pub trait LowLevelWalletWrite: LowLevelWalletRead {
         d_tx: &super::DecryptedTransaction<Transaction, Self::AccountId>,
     ) -> Result<(), Self::Error>;
 
-    /// Deletes all [`TransactionDataRequest::Enhancement`] requests for the given transaction ID
-    /// from the transaction data request queue.
+    /// Deletes the [`TransactionDataRequest::Enhancement`] request for the given transaction ID
+    /// from the transaction data request queue, without removing any durable status-observation
+    /// intent for the transaction.
     ///
     /// [`TransactionDataRequest::Enhancement`]: super::TransactionDataRequest
     fn delete_retrieval_queue_entries(&mut self, txid: TxId) -> Result<(), Self::Error>;

--- a/zcash_client_backend/src/data_api/ll/wallet.rs
+++ b/zcash_client_backend/src/data_api/ll/wallet.rs
@@ -406,7 +406,7 @@ where
                 .map_err(PutBlocksError::Storage)?;
 
             // Mark notes as spent and remove them from the scanning cache
-            mark_notes_spent(
+            let _ = mark_notes_spent(
                 wallet_db,
                 tx_ref,
                 #[cfg(feature = "transparent-inputs")]
@@ -925,7 +925,7 @@ where
         wallet_db.set_transaction_status(d_tx.tx().txid(), TransactionStatus::Mined(height))?;
     }
 
-    mark_notes_spent(
+    let has_wallet_shielded_spend = mark_notes_spent(
         wallet_db,
         tx_ref,
         #[cfg(feature = "transparent-inputs")]
@@ -1078,20 +1078,16 @@ where
         wallet_db.queue_transparent_input_retrieval(tx_ref, &d_tx)?
     }
 
+    // Receiving complete transaction data satisfies enhancement intent, but must not erase a
+    // durable status-observation intent created when the transaction was sent.
     wallet_db.delete_retrieval_queue_entries(d_tx.tx().txid())?;
 
-    // If the decrypted transaction is unmined and has no shielded components, add it to
-    // the queue for status retrieval.
-    #[cfg(feature = "transparent-inputs")]
+    // A shielded bundle is observable through compact-block scanning only when this wallet can
+    // match one of its real nullifiers or decrypt one of its outputs. Transactions without either
+    // capability require explicit status observation by txid.
+    if d_tx.mined_height().is_none() && !(has_wallet_shielded_spend || d_tx.has_decrypted_outputs())
     {
-        let detectable_via_scanning = d_tx.tx().sapling_bundle().is_some();
-        #[cfg(feature = "orchard")]
-        let detectable_via_scanning =
-            detectable_via_scanning | d_tx.tx().orchard_bundle().is_some();
-
-        if d_tx.mined_height().is_none() && !detectable_via_scanning {
-            wallet_db.queue_tx_retrieval(std::iter::once(d_tx.tx().txid()), None)?
-        }
+        wallet_db.queue_tx_status(d_tx.tx().txid())?;
     }
 
     Ok(())
@@ -1214,10 +1210,12 @@ fn mark_notes_spent<'a, DbT>(
     sapling_nfs: impl Iterator<Item = &'a sapling::Nullifier>,
     #[cfg(feature = "orchard")] orchard_nfs: impl Iterator<Item = &'a orchard::note::Nullifier>,
     #[cfg(feature = "orchard")] ironwood_nfs: impl Iterator<Item = &'a orchard::note::Nullifier>,
-) -> Result<(), <DbT as LowLevelWalletRead>::Error>
+) -> Result<bool, <DbT as LowLevelWalletRead>::Error>
 where
     DbT: LowLevelWalletWrite,
 {
+    let mut has_wallet_shielded_spend = false;
+
     // If any of the utxos spent in the transaction are ours, mark them as spent.
     #[cfg(feature = "transparent-inputs")]
     for outpoint in transparent_prevouts {
@@ -1226,22 +1224,22 @@ where
 
     // Mark Sapling notes as spent when we observe their nullifiers.
     for nf in sapling_nfs {
-        wallet_db.mark_sapling_note_spent(nf, tx_ref)?;
+        has_wallet_shielded_spend |= wallet_db.mark_sapling_note_spent(nf, tx_ref)?;
     }
 
     // Mark Orchard notes as spent when we observe their nullifiers.
     #[cfg(feature = "orchard")]
     for nf in orchard_nfs {
-        wallet_db.mark_orchard_note_spent(nf, tx_ref)?;
+        has_wallet_shielded_spend |= wallet_db.mark_orchard_note_spent(nf, tx_ref)?;
     }
 
     // Mark Ironwood notes as spent when we observe their nullifiers.
     #[cfg(feature = "orchard")]
     for nf in ironwood_nfs {
-        wallet_db.mark_ironwood_note_spent(nf, tx_ref)?;
+        has_wallet_shielded_spend |= wallet_db.mark_ironwood_note_spent(nf, tx_ref)?;
     }
 
-    Ok(())
+    Ok(has_wallet_shielded_spend)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -3773,8 +3773,17 @@ where
         )
         .unwrap();
     assert_eq!(txids.len(), 1);
+    let shielding_txid = *txids.first();
 
-    let tx_summary = st.get_tx_from_history(*txids.first()).unwrap().unwrap();
+    assert!(
+        !st.wallet()
+            .transaction_data_requests()
+            .unwrap()
+            .contains(&TransactionDataRequest::GetStatus(shielding_txid)),
+        "a wallet-owned shielded output makes the transaction observable by scanning",
+    );
+
+    let tx_summary = st.get_tx_from_history(shielding_txid).unwrap().unwrap();
     assert_eq!(tx_summary.spent_note_count(), 1);
     assert!(tx_summary.has_change());
     assert_eq!(tx_summary.received_note_count(), 0);
@@ -3782,11 +3791,11 @@ where
     assert!(tx_summary.is_shielding());
 
     // Generate and scan the block including the transaction
-    let (h, _) = st.generate_next_block_including(*txids.first());
+    let (h, _) = st.generate_next_block_including(shielding_txid);
     let scan_result = st.scan_cached_blocks(h, 1);
 
     // Ensure that the transaction metadata is still correct after the update produced by scanning.
-    let tx_summary = st.get_tx_from_history(*txids.first()).unwrap().unwrap();
+    let tx_summary = st.get_tx_from_history(shielding_txid).unwrap().unwrap();
     assert_eq!(tx_summary.spent_note_count(), 1);
     assert!(tx_summary.has_change());
     assert_eq!(tx_summary.received_note_count(), 0);
@@ -7760,6 +7769,7 @@ pub fn shielding_coinbase_to_orchard_receiver_delivers_via_ironwood<Dsf>(
     <<Dsf as DataStoreFactory>::DataStore as WalletWrite>::UtxoRef: std::fmt::Debug,
 {
     use super::orchard::OrchardPoolTester;
+    use crate::data_api::TransactionStatus;
     use zcash_protocol::consensus::COINBASE_MATURITY_BLOCKS;
 
     // A network on which Ironwood (NU6.3) is active from the Sapling activation height.
@@ -7835,6 +7845,63 @@ pub fn shielding_coinbase_to_orchard_receiver_delivers_via_ironwood<Dsf>(
         Ok(txids) if txids.len() == 1,
         "create_proposed_transactions must succeed for proposal {:?}",
         proposal,
+    );
+    let sent_txid = build_result.unwrap().head;
+
+    // This transaction has a shielded bundle, but it is not observable by this wallet through
+    // compact-block scanning: it has only transparent wallet inputs, its shielded output belongs
+    // to another wallet, and it has no change. The sender therefore requires a txid-based status
+    // request to learn its outcome.
+    assert!(
+        st.wallet()
+            .transaction_data_requests()
+            .unwrap()
+            .contains(&TransactionDataRequest::GetStatus(sent_txid))
+    );
+
+    let (mined_height, _) = st.generate_next_block_including(sent_txid);
+    st.scan_cached_blocks(mined_height, 1);
+    assert_eq!(
+        st.get_tx_from_history(sent_txid)
+            .unwrap()
+            .expect("sent transaction is in history")
+            .mined_height(),
+        None,
+        "compact scanning cannot detect an external shielding transaction",
+    );
+
+    st.wallet_mut()
+        .set_transaction_status(sent_txid, TransactionStatus::Mined(mined_height))
+        .unwrap();
+    assert_eq!(
+        st.get_tx_from_history(sent_txid)
+            .unwrap()
+            .expect("sent transaction is in history")
+            .mined_height(),
+        Some(mined_height),
+    );
+    assert!(
+        !st.wallet()
+            .transaction_data_requests()
+            .unwrap()
+            .contains(&TransactionDataRequest::GetStatus(sent_txid)),
+        "status intent is dormant while the transaction is mined",
+    );
+
+    st.truncate_to_height(mined_height - 1);
+    assert_eq!(
+        st.get_tx_from_history(sent_txid)
+            .unwrap()
+            .expect("sent transaction is retained across the rewind")
+            .mined_height(),
+        None,
+    );
+    assert!(
+        st.wallet()
+            .transaction_data_requests()
+            .unwrap()
+            .contains(&TransactionDataRequest::GetStatus(sent_txid)),
+        "rewinding the mined block reactivates the durable status intent",
     );
 }
 

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -44,6 +44,14 @@ workspace.
   `zewif::ZewifImportError`.
 
 ### Fixed
+- Transaction status requests are now generated from explicit, durable
+  observation intent. A sent transaction is queried by txid when this wallet
+  cannot observe one of its shielded spends or outputs, including transactions
+  funded entirely by transparent inputs whose shielded outputs all belong to
+  another wallet. Status intent remains dormant while a transaction is mined
+  and becomes active again after a chain rewind. Redundant status requests
+  previously synthesized for wallet-observable shielded transactions are no
+  longer produced.
 - An Ironwood note received on an account's internal address is now classified as
   change once the wallet learns that the same account funded the transaction.
   This was previously applied to Sapling and Orchard notes only, so an Ironwood

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -2890,6 +2890,10 @@ impl<'a, C: Borrow<rusqlite::Transaction<'a>>, P: consensus::Parameters, CL: Clo
         wallet::queue_tx_retrieval(self.conn.borrow(), txids, dependent_tx_ref)
     }
 
+    fn queue_tx_status(&mut self, txid: TxId) -> Result<(), Self::Error> {
+        wallet::queue_tx_status(self.conn.borrow(), txid)
+    }
+
     fn delete_retrieval_queue_entries(&mut self, txid: TxId) -> Result<(), Self::Error> {
         wallet::delete_retrieval_queue_entries(self.conn.borrow(), txid)
     }

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -3509,17 +3509,17 @@ pub(crate) fn store_transaction_to_be_sent<P: consensus::Parameters>(
     // Assumes that create_spend_to_address() will never be called in parallel, which is a
     // reasonable assumption for a light client such as a mobile phone.
     if let Some(bundle) = sent_tx.tx().sapling_bundle() {
-        detectable_via_scanning = true;
         for spend in bundle.shielded_spends() {
-            sapling::mark_sapling_note_spent(conn, tx_ref, spend.nullifier())?;
+            detectable_via_scanning |=
+                sapling::mark_sapling_note_spent(conn, tx_ref, spend.nullifier())?;
         }
     }
     if let Some(_bundle) = sent_tx.tx().orchard_bundle() {
         #[cfg(feature = "orchard")]
         {
-            detectable_via_scanning = true;
             for action in _bundle.actions() {
-                orchard::mark_orchard_note_spent(conn, tx_ref, action.nullifier())?;
+                detectable_via_scanning |=
+                    orchard::mark_orchard_note_spent(conn, tx_ref, action.nullifier())?;
             }
         }
 
@@ -3529,9 +3529,9 @@ pub(crate) fn store_transaction_to_be_sent<P: consensus::Parameters>(
     if let Some(_bundle) = sent_tx.tx().ironwood_bundle() {
         #[cfg(feature = "orchard")]
         {
-            detectable_via_scanning = true;
             for action in _bundle.actions() {
-                orchard::mark_ironwood_note_spent(conn, tx_ref, action.nullifier())?;
+                detectable_via_scanning |=
+                    orchard::mark_ironwood_note_spent(conn, tx_ref, action.nullifier())?;
             }
         }
 
@@ -3601,49 +3601,55 @@ pub(crate) fn store_transaction_to_be_sent<P: consensus::Parameters>(
                 receiving_account,
                 note,
                 ..
-            } => match note.as_ref() {
-                Note::Sapling(note) => {
-                    sapling::put_received_note(
-                        conn,
-                        params,
-                        &DecryptedOutput::new(
-                            output.output_index(),
-                            note.clone(),
-                            ShieldedPool::Sapling,
-                            *receiving_account,
-                            output
-                                .memo()
-                                .map_or_else(MemoBytes::empty, |memo| memo.clone()),
-                            TransferType::AccountInternal,
-                        ),
-                        tx_ref,
-                        Some(sent_tx.target_height().into()),
-                        None,
-                    )?;
-                }
-                #[cfg(feature = "orchard")]
-                orchard_note @ Note::Orchard { note, pool } => {
-                    let shielded_pool = orchard_note.pool();
-                    orchard::put_received_note(
-                        conn,
-                        params,
-                        shielded_pool,
-                        &DecryptedOutput::new(
-                            output.output_index(),
-                            (*note, *pool),
+            } => {
+                // An internal shielded output is decryptable by this wallet during ordinary
+                // compact-block scanning.
+                detectable_via_scanning = true;
+
+                match note.as_ref() {
+                    Note::Sapling(note) => {
+                        sapling::put_received_note(
+                            conn,
+                            params,
+                            &DecryptedOutput::new(
+                                output.output_index(),
+                                note.clone(),
+                                ShieldedPool::Sapling,
+                                *receiving_account,
+                                output
+                                    .memo()
+                                    .map_or_else(MemoBytes::empty, |memo| memo.clone()),
+                                TransferType::AccountInternal,
+                            ),
+                            tx_ref,
+                            Some(sent_tx.target_height().into()),
+                            None,
+                        )?;
+                    }
+                    #[cfg(feature = "orchard")]
+                    orchard_note @ Note::Orchard { note, pool } => {
+                        let shielded_pool = orchard_note.pool();
+                        orchard::put_received_note(
+                            conn,
+                            params,
                             shielded_pool,
-                            *receiving_account,
-                            output
-                                .memo()
-                                .map_or_else(MemoBytes::empty, |memo| memo.clone()),
-                            TransferType::AccountInternal,
-                        ),
-                        tx_ref,
-                        Some(sent_tx.target_height().into()),
-                        None,
-                    )?;
+                            &DecryptedOutput::new(
+                                output.output_index(),
+                                (*note, *pool),
+                                shielded_pool,
+                                *receiving_account,
+                                output
+                                    .memo()
+                                    .map_or_else(MemoBytes::empty, |memo| memo.clone()),
+                                TransferType::AccountInternal,
+                            ),
+                            tx_ref,
+                            Some(sent_tx.target_height().into()),
+                            None,
+                        )?;
+                    }
                 }
-            },
+            }
             #[cfg(feature = "transparent-inputs")]
             Recipient::EphemeralTransparent {
                 ephemeral_address,
@@ -3714,11 +3720,12 @@ pub(crate) fn store_transaction_to_be_sent<P: consensus::Parameters>(
         }
     }
 
-    // Add the transaction to the set to be queried for transaction status. This is only necessary
-    // at present for fully transparent transactions, because any transaction with a shielded
-    // component will be detected via ordinary chain scanning and/or nullifier checking.
+    // Query by txid when compact-block scanning cannot observe either a wallet-owned shielded
+    // spend or a wallet-owned shielded output. In particular, a transaction funded entirely by
+    // transparent inputs and sending shielded funds exclusively to another wallet is not
+    // detectable merely because it contains a shielded bundle.
     if !detectable_via_scanning {
-        queue_tx_retrieval(conn, std::iter::once(sent_tx.tx().txid()), None)?;
+        queue_tx_status(conn, sent_tx.tx().txid())?;
     }
 
     Ok(())
@@ -3733,22 +3740,6 @@ pub(crate) fn set_transaction_status<P: consensus::Parameters>(
 ) -> Result<(), SqliteClientError> {
     let chain_tip = chain_tip_height(conn)?.ok_or(SqliteClientError::ChainHeightUnknown)?;
 
-    // It is safe to unconditionally delete the request from `tx_retrieval_queue` below (both in
-    // the expired case and the case where it has been mined), because we already have all the data
-    // we need about this transaction:
-    // * if the status is being set in response to a `GetStatus` request, we know that we already
-    //   have the transaction data (`GetStatus` requests are only generated if we already have that
-    //   data)
-    // * if it is being set in response to an `Enhancement` request, we know that the status must
-    //   be `TxidNotRecognized` because otherwise the transaction data should have been provided to
-    //   the backend directly instead of calling `set_transaction_status`
-    //
-    // In general `Enhancement` requests are only generated in response to situations where a
-    // transaction has already been mined - either the transaction was detected by scanning the
-    // chain of `CompactBlock` values, or was discovered by walking backward from the inputs of a
-    // transparent transaction; in the case that a transaction was read from the mempool, complete
-    // transaction data will have been available and the only question that we are concerned with
-    // is whether that transaction ends up being mined or expires.
     match status {
         TransactionStatus::TxidNotRecognized | TransactionStatus::NotInMainChain => {
             conn.execute(
@@ -3761,10 +3752,45 @@ pub(crate) fn set_transaction_status<P: consensus::Parameters>(
                     ":chain_tip": u32::from(chain_tip)
                 ],
             )?;
+
+            // Enhancement is complete once the server has reported that it cannot provide the
+            // transaction. A status-observation intent remains active until the transaction is
+            // confirmed to be terminal.
+            delete_retrieval_queue_entry(conn, txid, TxQueryType::Enhancement)?;
+            conn.execute(
+                "DELETE FROM tx_retrieval_queue
+                 WHERE txid = :txid
+                 AND query_type = :status_type
+                 AND NOT EXISTS (
+                    SELECT 1
+                    FROM transactions t
+                    WHERE t.txid = :txid
+                    AND t.mined_height IS NULL
+                    AND (
+                        t.expiry_height = 0
+                        OR (
+                            t.expiry_height > 0
+                            AND t.confirmed_unmined_at_height < t.expiry_height
+                        )
+                        OR (
+                            t.expiry_height IS NULL
+                            AND t.confirmed_unmined_at_height
+                                < t.min_observed_height + :certainty_depth
+                        )
+                    )
+                 )",
+                named_params![
+                    ":txid": txid.as_ref(),
+                    ":status_type": TxQueryType::Status.code(),
+                    ":certainty_depth": PRUNING_DEPTH + DEFAULT_TX_EXPIRY_DELTA,
+                ],
+            )?;
         }
         TransactionStatus::Mined(height) => {
-            // The transaction has been mined, so we can set its mined height, associate it with
-            // the appropriate block, and remove it from the retrieval queue.
+            // The transaction has been mined, so we can set its mined height and associate it with
+            // the appropriate block. A status-observation intent is retained but remains dormant
+            // while the mined height is known, so that it automatically becomes active if a
+            // subsequent chain rewind un-mines the transaction.
             let sql_args = named_params![
                 ":txid": txid.as_ref(),
                 ":height": u32::from(height)
@@ -3794,10 +3820,10 @@ pub(crate) fn set_transaction_status<P: consensus::Parameters>(
 
             #[cfg(feature = "transparent-inputs")]
             transparent::update_gap_limits(conn, _params, gap_limits, txid, height)?;
+
+            delete_retrieval_queue_entry(conn, txid, TxQueryType::Enhancement)?;
         }
     }
-
-    delete_retrieval_queue_entries(conn, txid)?;
 
     Ok(())
 }
@@ -5129,35 +5155,50 @@ pub(crate) fn queue_tx_retrieval(
     txids: impl Iterator<Item = TxId>,
     dependent_tx_ref: Option<TxRef>,
 ) -> Result<(), SqliteClientError> {
-    // Add an entry to the transaction retrieval queue if it would not be redundant.
+    // This operation represents enhancement intent only. If complete transaction data is already
+    // present, no request is needed. In particular, the presence of raw data must not implicitly
+    // turn an enhancement request into a status request.
     let mut stmt_insert_tx = conn.prepare_cached(
         "INSERT INTO tx_retrieval_queue (txid, query_type, dependent_transaction_id)
          SELECT
             :txid,
-            IIF(
-                EXISTS (SELECT 1 FROM transactions WHERE txid = :txid AND raw IS NOT NULL),
-                :status_type,
-                :enhancement_type
-            ),
+            :enhancement_type,
             :dependent_transaction_id
-        ON CONFLICT (txid) DO UPDATE
-        SET query_type =
-            IIF(
-                EXISTS (SELECT 1 FROM transactions WHERE txid = :txid AND raw IS NOT NULL),
-                :status_type,
-                :enhancement_type
-            ),
-            dependent_transaction_id = IFNULL(:dependent_transaction_id, dependent_transaction_id)",
+         WHERE NOT EXISTS (
+            SELECT 1 FROM transactions WHERE txid = :txid AND raw IS NOT NULL
+         )
+        ON CONFLICT (txid, query_type) DO UPDATE
+        SET dependent_transaction_id =
+            IFNULL(:dependent_transaction_id, dependent_transaction_id)",
     )?;
 
     for txid in txids {
         stmt_insert_tx.execute(named_params! {
             ":txid": txid.as_ref(),
-            ":status_type": TxQueryType::Status.code(),
             ":enhancement_type": TxQueryType::Enhancement.code(),
             ":dependent_transaction_id": dependent_tx_ref.map(|r| r.0),
         })?;
     }
+
+    Ok(())
+}
+
+/// Records that the wallet must query by txid in order to learn the mined status of a
+/// transaction. The entry is durable across mined states so that it can become active again
+/// following a chain rewind.
+pub(crate) fn queue_tx_status(
+    conn: &rusqlite::Transaction<'_>,
+    txid: TxId,
+) -> Result<(), SqliteClientError> {
+    conn.execute(
+        "INSERT INTO tx_retrieval_queue (txid, query_type)
+         VALUES (:txid, :status_type)
+         ON CONFLICT (txid, query_type) DO NOTHING",
+        named_params![
+            ":txid": txid.as_ref(),
+            ":status_type": TxQueryType::Status.code(),
+        ],
+    )?;
 
     Ok(())
 }
@@ -5167,41 +5208,35 @@ pub(crate) fn queue_tx_retrieval(
 pub(crate) fn transaction_data_requests(
     conn: &rusqlite::Connection,
 ) -> Result<Vec<TransactionDataRequest>, SqliteClientError> {
-    // We will return both explicitly constructed status requests, and a status request for each
-    // transaction that is known to the wallet for which we don't have the mined height,
-    // and for which we have no positive confirmation that the transaction expired unmined.
-    //
-    // For transactions with a known expiry height of 0, we will continue to query indefinitely.
-    // Such transactions should be rebroadcast by the wallet until they are either mined or
-    // conflict with another mined transaction.
     let mut tx_retrieval_stmt = conn.prepare_cached(
-        "SELECT txid, query_type FROM tx_retrieval_queue
-         UNION
-         SELECT txid, :status_type
-         FROM transactions
-         WHERE mined_height IS NULL
-         AND (
-            -- we have no confirmation of expiry
-            confirmed_unmined_at_height IS NULL
-            -- a nonzero expiry height is known, and we have confirmation that the transaction was
-            -- not unmined as of a height greater than or equal to that expiry height
-            OR (
-                expiry_height > 0
-                AND confirmed_unmined_at_height < expiry_height
+        "SELECT q.txid, q.query_type
+         FROM tx_retrieval_queue q
+         LEFT JOIN transactions t ON t.txid = q.txid
+         WHERE q.query_type = :enhancement_type
+         OR (
+            q.query_type = :status_type
+            AND t.mined_height IS NULL
+            AND (
+                t.confirmed_unmined_at_height IS NULL
+                OR t.expiry_height = 0
+                OR (
+                    t.expiry_height > 0
+                    AND t.confirmed_unmined_at_height < t.expiry_height
+                )
+                OR (
+                    t.expiry_height IS NULL
+                    AND t.confirmed_unmined_at_height
+                        < t.min_observed_height + :certainty_depth
+                )
             )
-            -- the expiry height is unknown and the default expiry height for it is not yet in the
-            -- stable block range according to the PRUNING_DEPTH
-            OR (
-                expiry_height IS NULL
-                AND confirmed_unmined_at_height < min_observed_height + :certainty_depth
-            )
-        )",
+         )",
     )?;
 
     let result = tx_retrieval_stmt
         .query_and_then(
             named_params![
                 ":status_type": TxQueryType::Status.code(),
+                ":enhancement_type": TxQueryType::Enhancement.code(),
                 ":certainty_depth": PRUNING_DEPTH + DEFAULT_TX_EXPIRY_DELTA
             ],
             |row| {
@@ -5227,9 +5262,22 @@ pub(crate) fn delete_retrieval_queue_entries(
     conn: &rusqlite::Transaction<'_>,
     txid: TxId,
 ) -> Result<(), SqliteClientError> {
+    delete_retrieval_queue_entry(conn, txid, TxQueryType::Enhancement)
+}
+
+fn delete_retrieval_queue_entry(
+    conn: &rusqlite::Transaction<'_>,
+    txid: TxId,
+    query_type: TxQueryType,
+) -> Result<(), SqliteClientError> {
     conn.execute(
-        "DELETE FROM tx_retrieval_queue WHERE txid = :txid",
-        named_params![":txid": txid.as_ref()],
+        "DELETE FROM tx_retrieval_queue
+         WHERE txid = :txid
+         AND query_type = :query_type",
+        named_params![
+            ":txid": txid.as_ref(),
+            ":query_type": query_type.code(),
+        ],
     )?;
 
     Ok(())
@@ -5810,13 +5858,14 @@ mod tests {
     use secrecy::{ExposeSecret, SecretVec};
     use uuid::Uuid;
     use zcash_client_backend::data_api::{
-        Account as _, AccountSource, WalletRead, WalletWrite,
+        Account as _, AccountSource, TransactionDataRequest, TransactionStatus, WalletRead,
+        WalletWrite,
         testing::{AddressType, DataStoreFactory, FakeCompactOutput, TestBuilder, TestState},
         wallet::ConfirmationsPolicy,
     };
     use zcash_keys::keys::UnifiedAddressRequest;
     use zcash_primitives::block::BlockHash;
-    use zcash_protocol::{consensus::BlockHeight, value::Zatoshis};
+    use zcash_protocol::{TxId, consensus::BlockHeight, value::Zatoshis};
 
     use crate::{
         AccountUuid,
@@ -5825,8 +5874,9 @@ mod tests {
     };
 
     use super::{
-        KeyScope, ShieldedPool, TxRef, account_birthday, flag_previously_received_change,
-        min_shared_checkpoint_height, select_truncation_height,
+        KeyScope, ShieldedPool, TxQueryType, TxRef, account_birthday,
+        flag_previously_received_change, min_shared_checkpoint_height, queue_tx_retrieval,
+        select_truncation_height,
     };
 
     #[cfg(feature = "orchard")]
@@ -5996,6 +6046,86 @@ mod tests {
             ),
             Err(SqliteClientError::AccountUnknown)
         );
+    }
+
+    #[test]
+    fn status_intent_persists_until_the_transaction_is_terminal() {
+        const TEST_VALUE: Zatoshis = Zatoshis::const_from_u64(10_000);
+        const FUTURE_EXPIRY_OFFSET: u32 = 10;
+        const UNEXPIRED_TXID_BYTES: [u8; 32] = [1; 32];
+        const EXPIRED_TXID_BYTES: [u8; 32] = [2; 32];
+
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_block_cache(BlockCache::new())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let dfvk = ExtendedSpendingKey::master(&[]).to_diversifiable_full_viewing_key();
+        let tip = st.sapling_activation_height();
+        st.generate_block_at(
+            tip,
+            BlockHash([0; 32]),
+            &[FakeCompactOutput::new(
+                &dfvk,
+                AddressType::DefaultExternal,
+                TEST_VALUE,
+            )],
+            0,
+            0,
+            0,
+            false,
+        );
+        st.scan_cached_blocks(tip, 1);
+
+        let unexpired_txid = TxId::from_bytes(UNEXPIRED_TXID_BYTES);
+        let expired_txid = TxId::from_bytes(EXPIRED_TXID_BYTES);
+        for (txid, expiry_height) in [
+            (unexpired_txid, u32::from(tip) + FUTURE_EXPIRY_OFFSET),
+            (expired_txid, u32::from(tip)),
+        ] {
+            st.wallet()
+                .conn()
+                .execute(
+                    "INSERT INTO transactions (txid, expiry_height, min_observed_height)
+                     VALUES (:txid, :expiry_height, :min_observed_height)",
+                    named_params![
+                        ":txid": txid.as_ref(),
+                        ":expiry_height": expiry_height,
+                        ":min_observed_height": u32::from(tip),
+                    ],
+                )
+                .unwrap();
+            st.wallet()
+                .conn()
+                .execute(
+                    "INSERT INTO tx_retrieval_queue (txid, query_type)
+                     VALUES (:txid, :query_type)",
+                    named_params![
+                        ":txid": txid.as_ref(),
+                        ":query_type": TxQueryType::Status.code(),
+                    ],
+                )
+                .unwrap();
+        }
+
+        for txid in [unexpired_txid, expired_txid] {
+            st.wallet_mut()
+                .set_transaction_status(txid, TransactionStatus::NotInMainChain)
+                .unwrap();
+        }
+
+        let requests = st.wallet().transaction_data_requests().unwrap();
+        assert!(requests.contains(&TransactionDataRequest::GetStatus(unexpired_txid)));
+        assert!(!requests.contains(&TransactionDataRequest::GetStatus(expired_txid)));
+
+        let db_tx = st.wallet().conn().unchecked_transaction().unwrap();
+        queue_tx_retrieval(&db_tx, std::iter::once(unexpired_txid), None).unwrap();
+        db_tx.commit().unwrap();
+
+        let requests = st.wallet().transaction_data_requests().unwrap();
+        assert!(requests.contains(&TransactionDataRequest::GetStatus(unexpired_txid)));
+        assert!(requests.contains(&TransactionDataRequest::Enhancement(unexpired_txid)));
     }
 
     #[test]

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -898,10 +898,11 @@ CREATE INDEX idx_sent_notes_transaction_id ON sent_notes (
 ///   to blockchain scanning.
 pub(super) const TABLE_TX_RETRIEVAL_QUEUE: &str = r#"
 CREATE TABLE "tx_retrieval_queue" (
-    txid BLOB NOT NULL UNIQUE,
+    txid BLOB NOT NULL,
     query_type INTEGER NOT NULL,
     dependent_transaction_id INTEGER
-        REFERENCES transactions(id_tx) ON DELETE CASCADE
+        REFERENCES transactions(id_tx) ON DELETE CASCADE,
+    CONSTRAINT tx_retrieval_intent UNIQUE (txid, query_type)
 )"#;
 pub(super) const INDEX_TX_RETIREVAL_QUEUE_DEPENDENT_TX: &str = r#"
 CREATE INDEX idx_tx_retrieval_queue_dependent_tx ON tx_retrieval_queue (

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -50,6 +50,7 @@ mod tree_retained_checkpoints;
 mod tx_observation_height;
 mod tx_retrieval_queue;
 mod tx_retrieval_queue_expiry;
+mod tx_status_observation_intent;
 mod ufvk_support;
 mod utxos_table;
 mod utxos_to_txos;
@@ -145,6 +146,7 @@ pub mod ids {
     pub use super::tx_observation_height::MIGRATION_ID as TX_OBSERVATION_HEIGHT;
     pub use super::tx_retrieval_queue::MIGRATION_ID as TX_RETRIEVAL_QUEUE;
     pub use super::tx_retrieval_queue_expiry::MIGRATION_ID as TX_RETRIEVAL_QUEUE_EXPIRY;
+    pub use super::tx_status_observation_intent::MIGRATION_ID as TX_STATUS_OBSERVATION_INTENT;
     pub use super::ufvk_support::MIGRATION_ID as UFVK_SUPPORT;
     pub use super::utxos_table::MIGRATION_ID as UTXOS_TABLE;
     pub use super::utxos_to_txos::MIGRATION_ID as UTXOS_TO_TXOS;
@@ -348,6 +350,7 @@ pub(super) fn all_migrations<
         Box::new(orchard_ironwood_migration_tables::Migration),
         Box::new(tree_retained_checkpoints::Migration),
         Box::new(note_locking::Migration),
+        Box::new(tx_status_observation_intent::Migration),
     ]
 }
 
@@ -548,7 +551,7 @@ pub const CURRENT_LEAF_MIGRATIONS: &[Uuid] = &[
     v_address_uses_ironwood::MIGRATION_ID,
     orchard_ironwood_migration_tables::MIGRATION_ID,
     tree_retained_checkpoints::MIGRATION_ID,
-    note_locking::MIGRATION_ID,
+    tx_status_observation_intent::MIGRATION_ID,
 ];
 
 pub(super) fn verify_network_compatibility<P: consensus::Parameters>(
@@ -691,6 +694,7 @@ pub(crate) mod tests {
             ids::TX_OBSERVATION_HEIGHT,
             ids::TX_RETRIEVAL_QUEUE,
             ids::TX_RETRIEVAL_QUEUE_EXPIRY,
+            ids::TX_STATUS_OBSERVATION_INTENT,
             ids::UFVK_SUPPORT,
             ids::UTXOS_TABLE,
             ids::UTXOS_TO_TXOS,

--- a/zcash_client_sqlite/src/wallet/init/migrations/tx_status_observation_intent.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/tx_status_observation_intent.rs
@@ -1,0 +1,134 @@
+//! Separates transaction enhancement intent from durable status observation intent, and removes
+//! status requests for transactions that the wallet can observe through shielded compact-block
+//! scanning.
+
+use std::collections::HashSet;
+
+use rusqlite::named_params;
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+
+use crate::wallet::{
+    TxQueryType,
+    init::{
+        WalletMigrationError,
+        migrations::{note_locking, tx_retrieval_queue},
+    },
+};
+
+/// This migration permits independent enhancement and status intents for a transaction, and
+/// removes status requests whose transactions have wallet-observable shielded spends or outputs.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xd7ab0ab2_1487_4cb7_ba74_72ece5fdba2f);
+
+const DEPENDENCIES: &[Uuid] = &[note_locking::MIGRATION_ID, tx_retrieval_queue::MIGRATION_ID];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Separates transaction enhancement from status observation and removes redundant status requests."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, conn: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        // A status request is redundant only when the wallet has a concrete shielded association
+        // that compact-block scanning can observe: either a note belonging to the wallet or a
+        // spend of such a note. Bundle presence alone is insufficient because a transaction may
+        // be funded entirely by transparent inputs and send its shielded outputs to another
+        // wallet.
+        conn.execute(
+            "DELETE FROM tx_retrieval_queue
+             WHERE query_type = :status_type
+             AND EXISTS (
+                SELECT 1
+                FROM transactions t
+                WHERE t.txid = tx_retrieval_queue.txid
+                AND (
+                    EXISTS (
+                        SELECT 1 FROM sapling_received_notes n
+                        WHERE n.transaction_id = t.id_tx
+                    )
+                    OR EXISTS (
+                        SELECT 1 FROM sapling_received_note_spends s
+                        WHERE s.transaction_id = t.id_tx
+                    )
+                    OR EXISTS (
+                        SELECT 1 FROM orchard_received_notes n
+                        WHERE n.transaction_id = t.id_tx
+                    )
+                    OR EXISTS (
+                        SELECT 1 FROM orchard_received_note_spends s
+                        WHERE s.transaction_id = t.id_tx
+                    )
+                    OR EXISTS (
+                        SELECT 1 FROM ironwood_received_notes n
+                        WHERE n.transaction_id = t.id_tx
+                    )
+                    OR EXISTS (
+                        SELECT 1 FROM ironwood_received_note_spends s
+                        WHERE s.transaction_id = t.id_tx
+                    )
+                )
+             )",
+            named_params![":status_type": TxQueryType::Status.code()],
+        )?;
+
+        // Enhancement and status observation have independent lifecycles. A transaction can need
+        // enhancement in order to discover transparent wallet relevance while also needing
+        // durable status observation because compact-block scanning cannot reveal its outcome.
+        conn.execute_batch(
+            "CREATE TABLE tx_retrieval_queue_new (
+                txid BLOB NOT NULL,
+                query_type INTEGER NOT NULL,
+                dependent_transaction_id INTEGER
+                    REFERENCES transactions(id_tx) ON DELETE CASCADE,
+                CONSTRAINT tx_retrieval_intent UNIQUE (txid, query_type)
+            );
+
+            INSERT INTO tx_retrieval_queue_new (
+                txid,
+                query_type,
+                dependent_transaction_id
+            )
+            SELECT
+                txid,
+                query_type,
+                dependent_transaction_id
+            FROM tx_retrieval_queue;
+
+            DROP TABLE tx_retrieval_queue;
+
+            ALTER TABLE tx_retrieval_queue_new RENAME TO tx_retrieval_queue;
+
+            CREATE INDEX idx_tx_retrieval_queue_dependent_tx
+            ON tx_retrieval_queue (dependent_transaction_id);",
+        )?;
+
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+}


### PR DESCRIPTION
## Summary

- record an explicit durable status-observation intent for transactions whose outcome cannot be learned through compact-block scanning
- determine scan observability from actual wallet-owned shielded spends and outputs instead of shielded bundle presence
- keep status intent dormant while mined and reactivate it automatically after a chain rewind
- represent status observation and transaction enhancement as independent intents
- migrate obsolete inferred status entries

This supersedes the bundle-presence approach discussed in #2825. In particular, it handles external shielding transactions, out-of-order scanning, transaction discovery/recovery, enhancement of a transaction already under status observation, and reorgs without causing the wallet to silently stop observing transaction outcomes.

## Database write atomicity

1. **How many writes?** Sending or storing a transaction already performs multiple wallet writes; this change adds the status-intent write within that existing operation. Status updates can update transaction metadata and remove completed queue intent. The migration deletes obsolete rows and transactionally rebuilds the queue with a `(txid, query_type)` uniqueness constraint.
2. **Must they land together?** Yes for transaction storage, status updates, and the schema migration. Runtime operations execute through existing transaction-scoped wallet APIs. The migration receives a `rusqlite::Transaction`, so its cleanup and table replacement commit or roll back together.
3. **What happens on retry?** Queue insertion is an idempotent upsert per intent. Status updates and queue cleanup are also idempotent. Migration rollback preserves the old table and schemerz retries the complete migration.
4. **Can reads see only one side?** No committed partial state is exposed because each multi-write path shares an enclosing SQLite transaction. Status and enhancement may intentionally coexist as independent rows. Mined status intents remain stored but are filtered from request reads until a rewind clears the mined height.

## Testing

- `cargo check --workspace --all-features`
- `cargo check -p zcash_client_sqlite --no-default-features`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo test -p zcash_client_sqlite --all-features`
- focused regression coverage for coexisting `Status` and `Enhancement` intents
- `git diff --check`