### PR TITLE
Release zcash_client_sqlite version 0.22.0-rc.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7332,7 +7332,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_pool_migration"
-version = "0.1.0-rc.3"
+version = "0.1.0-rc.4"
 dependencies = [
  "corez",
  "getset",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7428,7 +7428,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "corez",
  "document-features",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.4"
+version = "0.24.0-rc.5"
 dependencies = [
  "ambassador",
  "arti-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7186,7 +7186,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.4"
+version = "0.22.0-rc.5"
 dependencies = [
  "ambassador",
  "assert_matches",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7280,7 +7280,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "assert_matches",
  "bech32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ zcash_client_backend = { version = "0.24.0-rc.5", path = "zcash_client_backend" 
 # time, then flip this back to `path = "components/zcash_encoding"` at "0.5".
 zcash_encoding = { version = "0.4", default-features = false }
 zcash_keys = { version = "0.16.1", path = "zcash_keys", default-features = false  }
-zcash_pool_migration = { version = "0.1.0-rc.3", path = "zcash_pool_migration" }
+zcash_pool_migration = { version = "0.1.0-rc.4", path = "zcash_pool_migration" }
 zcash_protocol = { version = "0.10.2", path = "components/zcash_protocol", default-features = false }
 zip321 = { version = "0.9.0-rc.1", path = "components/zip321" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ zcash_client_backend = { version = "0.24.0-rc.4", path = "zcash_client_backend" 
 zcash_encoding = { version = "0.4", default-features = false }
 zcash_keys = { version = "0.16.0", path = "zcash_keys", default-features = false  }
 zcash_pool_migration = { version = "0.1.0-rc.3", path = "zcash_pool_migration" }
-zcash_protocol = { version = "0.10.0", path = "components/zcash_protocol", default-features = false }
+zcash_protocol = { version = "0.10.2", path = "components/zcash_protocol", default-features = false }
 zip321 = { version = "0.9.0-rc.1", path = "components/zip321" }
 
 zcash_note_encryption = "0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ categories = ["cryptography::cryptocurrencies"]
 # Intra-workspace dependencies
 equihash = { version = "0.3", path = "components/equihash", default-features = false }
 zcash_address = { version = "0.13.0", path = "components/zcash_address", default-features = false }
-zcash_client_backend = { version = "0.24.0-rc.4", path = "zcash_client_backend" }
+zcash_client_backend = { version = "0.24.0-rc.5", path = "zcash_client_backend" }
 # zcash_encoding 0.5.0 is a breaking release (MSRV bump + `CompactSize::write` now
 # rejects values above `MAX_COMPACT_SIZE`). To avoid forcing every dependent to
 # migrate at once, the workspace default stays pinned to the published 0.4; only

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ zcash_client_backend = { version = "0.24.0-rc.4", path = "zcash_client_backend" 
 # explicit path dependency on the local 0.5. Migrate the remaining crates one at a
 # time, then flip this back to `path = "components/zcash_encoding"` at "0.5".
 zcash_encoding = { version = "0.4", default-features = false }
-zcash_keys = { version = "0.16.0", path = "zcash_keys", default-features = false  }
+zcash_keys = { version = "0.16.1", path = "zcash_keys", default-features = false  }
 zcash_pool_migration = { version = "0.1.0-rc.3", path = "zcash_pool_migration" }
 zcash_protocol = { version = "0.10.2", path = "components/zcash_protocol", default-features = false }
 zip321 = { version = "0.9.0-rc.1", path = "components/zip321" }

--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -10,6 +10,8 @@ workspace.
 
 ## [Unreleased]
 
+## [0.10.2] - 2026-07-28
+
 ### Added
 - `zcash_protocol::zip318`, the ZIP 318 pool-migration protocol parameters:
   - `DENOM_CAP`, `MAX_RESIDUAL_VALUE`, and `is_canonical_denomination`, the

--- a/components/zcash_protocol/Cargo.toml
+++ b/components/zcash_protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_protocol"
 description = "Zcash protocol network constants and value types."
-version = "0.10.1"
+version = "0.10.2"
 authors = [
     "Jack Grigg <jack@electriccoin.co>",
     "Kris Nuttycombe <kris@nutty.land>",

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,6 +1,10 @@
 
 # cargo-vet imports lock
 
+[[unpublished.zcash_client_backend]]
+version = "0.24.0-rc.5"
+audited_as = "0.24.0-rc.4"
+
 [[unpublished.zcash_keys]]
 version = "0.16.1"
 audited_as = "0.16.0"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -17,6 +17,10 @@ audited_as = "0.22.0-rc.3"
 version = "0.1.0-rc.3"
 audited_as = "0.1.0-rc.2"
 
+[[unpublished.zcash_protocol]]
+version = "0.10.2"
+audited_as = "0.10.1"
+
 [[publisher.bumpalo]]
 version = "3.16.0"
 when = "2024-04-08"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,21 +1,9 @@
 
 # cargo-vet imports lock
 
-[[unpublished.pczt]]
-version = "0.9.1"
-audited_as = "0.9.0"
-
-[[unpublished.zcash_client_backend]]
-version = "0.24.0-rc.4"
-audited_as = "0.24.0-rc.3"
-
-[[unpublished.zcash_client_sqlite]]
-version = "0.22.0-rc.4"
-audited_as = "0.22.0-rc.3"
-
-[[unpublished.zcash_pool_migration]]
-version = "0.1.0-rc.3"
-audited_as = "0.1.0-rc.2"
+[[unpublished.zcash_keys]]
+version = "0.16.1"
+audited_as = "0.16.0"
 
 [[unpublished.zcash_protocol]]
 version = "0.10.2"
@@ -113,8 +101,8 @@ user-login = "ebfull"
 user-name = "Sean Bowe"
 
 [[publisher.pczt]]
-version = "0.9.0"
-when = "2026-07-26"
+version = "0.9.1"
+when = "2026-07-27"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -469,15 +457,15 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_client_backend]]
-version = "0.24.0-rc.3"
-when = "2026-07-26"
+version = "0.24.0-rc.4"
+when = "2026-07-27"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_client_sqlite]]
-version = "0.22.0-rc.3"
-when = "2026-07-26"
+version = "0.22.0-rc.4"
+when = "2026-07-27"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -511,8 +499,8 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_pool_migration]]
-version = "0.1.0-rc.2"
-when = "2026-07-26"
+version = "0.1.0-rc.3"
+when = "2026-07-27"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -9,6 +9,10 @@ audited_as = "0.24.0-rc.4"
 version = "0.16.1"
 audited_as = "0.16.0"
 
+[[unpublished.zcash_pool_migration]]
+version = "0.1.0-rc.4"
+audited_as = "0.1.0-rc.3"
+
 [[unpublished.zcash_protocol]]
 version = "0.10.2"
 audited_as = "0.10.1"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -5,6 +5,10 @@
 version = "0.24.0-rc.5"
 audited_as = "0.24.0-rc.4"
 
+[[unpublished.zcash_client_sqlite]]
+version = "0.22.0-rc.5"
+audited_as = "0.22.0-rc.4"
+
 [[unpublished.zcash_keys]]
 version = "0.16.1"
 audited_as = "0.16.0"

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -10,6 +10,8 @@ workspace.
 
 ## [Unreleased]
 
+## [0.24.0-rc.5] - 2026-07-28
+
 ### Added
 - `zcash_client_backend::proposal::Step::{is_canonical_crossing, ironwood_bundle_padding}`
 - `zcash_client_backend::fees::canonical_crossing_fee`

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_backend"
 description = "APIs for creating shielded Zcash light clients"
-version = "0.24.0-rc.4"
+version = "0.24.0-rc.5"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -36,6 +36,7 @@ workspace.
   compilation failure.
 
 ### Changed
+- Migrated to `zcash_client_backend 0.24.0-rc.5`.
 - Every public error enum in this crate is now `#[non_exhaustive]`, so that
   future variants can be added without a breaking release. A `match` over any
   of them must now include a wildcard arm: `error::SqliteClientError`,

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -36,7 +36,8 @@ workspace.
   compilation failure.
 
 ### Changed
-- Migrated to `zcash_client_backend 0.24.0-rc.5`.
+- Migrated to `zcash_client_backend 0.24.0-rc.5`,
+  `zcash_pool_migration 0.1.0-rc.4`.
 - Every public error enum in this crate is now `#[non_exhaustive]`, so that
   future variants can be added without a breaking release. A `match` over any
   of them must now include a wildcard arm: `error::SqliteClientError`,

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -10,6 +10,8 @@ workspace.
 
 ## [Unreleased]
 
+## [0.22.0-rc.5] - 2026-07-28
+
 ### Added
 - `zcash_client_sqlite::wallet::init::migrations::V_0_20_0`, `V_0_22_0_RC1` and
   `V_0_22_0_RC2`, the leaf migration sets for the releases published since

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_sqlite"
 description = "An SQLite-based Zcash light client"
-version = "0.22.0-rc.4"
+version = "0.22.0-rc.5"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_keys/CHANGELOG.md
+++ b/zcash_keys/CHANGELOG.md
@@ -9,6 +9,8 @@ workspace.
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-07-28
+
 ### Added
 - `impl Debug for zcash_keys::keys::transparent::gap_limits::GapAddressesError`
 

--- a/zcash_keys/Cargo.toml
+++ b/zcash_keys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_keys"
 description = "Zcash key and address management"
-version = "0.16.0"
+version = "0.16.1"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -19,6 +19,7 @@ and this library adheres to Rust's notion of
   committed migration's transfers that still need proofs.
 
 ### Changed
+- Migrated to `zcash_client_backend 0.24.0-rc.5`.
 - The ZIP 318 constants this crate defined are now defined by `zcash_protocol::zip318`
   and re-exported from their existing paths. `denomination::MIGRATION_MAX_DENOMINATION_ZEC`
   is renamed to `denomination::DENOM_CAP` and `denomination::RESIDUAL_MIGRATION_MIN` to

--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -7,6 +7,8 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.1.0-rc.4] - 2026-07-28
+
 ### Added
 - `zcash_pool_migration::build::AccountDerivation`, the ZIP 32 account whose
   spending key authorizes a migration's Orchard spends. Behind the `orchard`

--- a/zcash_pool_migration/Cargo.toml
+++ b/zcash_pool_migration/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_pool_migration"
 description = "Backend-agnostic value-pool migration engine for Zcash wallets"
-version = "0.1.0-rc.3"
+version = "0.1.0-rc.4"
 authors = [
     "Danny Willems <be.danny.willems@gmail.com>",
     "John Boyd <john@coldnoise.net>",


### PR DESCRIPTION
Release preparation for `zcash_client_sqlite 0.22.0-rc.5` and the crates beneath it, covering everything merged to `main` since the rc.4 round — principally the ZIP 318 canonical crossing work (#2826) and durable transaction-status observation intent (#2828).

| Crate | Version |
| --- | --- |
| `zcash_protocol` | 0.10.1 → 0.10.2 |
| `zcash_keys` | 0.16.0 → 0.16.1 |
| `zcash_client_backend` | 0.24.0-rc.4 → 0.24.0-rc.5 |
| `zcash_pool_migration` | 0.1.0-rc.3 → 0.1.0-rc.4 |
| `zcash_client_sqlite` | 0.22.0-rc.4 → 0.22.0-rc.5 |

`zcash_protocol` and `zcash_keys` are patch releases: `zcash_protocol` gains the `zip318` module (which `zcash_client_backend` and `zcash_pool_migration` now source their ZIP 318 constants from, so its published minimum must be 0.10.2), and `zcash_keys` gains `impl Debug for GapAddressesError`.

Each release commit moves that crate's `## [Unreleased]` changelog content under a dated version heading, bumps the crate version and the workspace dependency requirement, and refreshes `Cargo.lock` and the `cargo-vet` metadata. Where a released crate's version is semver-visible to a dependent, the dependent's `## [Unreleased]` section records the migration.

Prepared with Claude Code assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
