### PR TITLE
AGENTS.md: run only the tests a change affects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,6 +283,25 @@ cargo test --workspace --all-features --features expensive-tests
 RUSTFLAGS='--cfg zcash_unstable="nu7"' cargo test --workspace --all-features
 ```
 
+### Run only the tests your change affects
+
+Because the suite is this expensive, **do not run the whole test suite** while iterating.
+Run only the tests the change adds or touches, and name them explicitly:
+
+```sh
+# Only the tests this patch adds or affects
+cargo test --release -p <crate_name> --all-features -- <test_name> <other_test_name>
+```
+
+CI runs the full workspace across the feature matrix; that is what a green PR rests on, so
+reproducing it locally buys little and costs a great deal of wall-clock time. Reach for a
+broader run only when there is a specific reason to expect wider fallout — for example, a
+change to a shared SQL view, trait signature, or serialization format — and then still
+scope it to the affected crate rather than the workspace.
+
+Report which tests were actually run. Never describe a change as "tests pass" on the
+strength of a narrower run than that phrase implies.
+
 ## Lint & Format
 
 ```sh


### PR DESCRIPTION
The workspace's test suite is computationally expensive — `AGENTS.md` already
says so under **Test Performance**, and explains the `[profile.test]`
`opt-level = 3` trade-off. What it does not say is the practical consequence:
an agent iterating on a change should not be running the whole suite.

Running `cargo test --workspace --all-features` locally can cost many minutes
of proving time to re-establish something CI already checks across the full
feature matrix. The guidance was ambiguous enough that "run the tests" reads as
"run all of them", so this adds a short subsection saying to run only the tests
the change adds or touches, naming them explicitly.

It also carves out the case where a broader run genuinely is warranted — a
change to a shared SQL view, a trait signature, or a serialization format,
where fallout is expected beyond the tests you edited — while still scoping to
the affected crate rather than the workspace.

Finally, it asks that agents report which tests they actually ran. "Tests pass"
after a single filtered test is misleading to a reviewer, and it is a failure
mode worth naming explicitly in a file addressed to AI agents.

Documentation only; no code or CI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)