### PR TITLE
zcash_client_sqlite: repair orchard_ironwood_migrations schema drift

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -72,6 +72,19 @@ workspace.
   `zewif::ZewifImportError`.
 
 ### Fixed
+- A wallet created by a build that predates the addition of the
+  `anchor_bucket_interval` column to `orchard_ironwood_migrations` no longer
+  fails every scan. The column was added to the `orchard_ironwood_migration_tables`
+  DDL in place; a wallet that had already applied that migration never acquired
+  the column, and the committed-grid query issued by `put_blocks` then failed at
+  prepare time with `no such column: anchor_bucket_interval`, regardless of
+  whether a pool migration was in progress. Because that query runs on every
+  scan, no block could be written and no transaction acquired a mined height. A
+  new `orchard_ironwood_migration_anchor_interval` migration adds the column
+  where it is missing. An existing row is backfilled with the ZIP 318 grid,
+  which is exact on the production network but a reconstruction on a test
+  network, where a migration planned under a custom grid will be reported as
+  `AnchorIntervalMismatch` and must be re-planned.
 - Transaction status requests are now generated from explicit, durable
   observation intent. A sent transaction is queried by txid when this wallet
   cannot observe one of its shielded spends or outputs, including transactions

--- a/zcash_client_sqlite/src/pool_migration/store.rs
+++ b/zcash_client_sqlite/src/pool_migration/store.rs
@@ -75,6 +75,11 @@ pub(crate) struct Tables {
 // ---------------------------------------------------------------------------
 
 fn create_migrations_sql(t: &Tables) -> String {
+    // `anchor_bucket_interval` carries a `DEFAULT` only so that this DDL and the `ADD COLUMN` in
+    // the `orchard_ironwood_migration_anchor_interval` schema migration produce the same stored
+    // schema text: SQLite cannot add a `NOT NULL` column without one. The store always binds the
+    // column explicitly, so no insert ever falls back to it.
+    //
     // `account_id` is a foreign key into the wallet's `accounts` table: the pool-migration tables
     // live in the wallet database alongside `accounts`, so an account's migration is owned by its
     // account row and removed with it. Deleting an account cascades to its migration here, whose
@@ -90,9 +95,10 @@ fn create_migrations_sql(t: &Tables) -> String {
             note_split_prep_fees INTEGER NOT NULL,
             note_split_total_input INTEGER NOT NULL,
             note_split_total_migratable INTEGER NOT NULL,
-            anchor_bucket_interval INTEGER NOT NULL
+            anchor_bucket_interval INTEGER NOT NULL DEFAULT {}
         )",
-        t.migrations
+        t.migrations,
+        AnchorBucketInterval::ZIP_318.block_count()
     )
 }
 

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -609,7 +609,13 @@ CREATE INDEX idx_ironwood_received_note_spends_transaction_id ON ironwood_receiv
 /// `anchor_bucket_interval` records the anchor retention grid the migration was committed against,
 /// in blocks. Every transfer's `anchor_boundary` lies on that grid, and it is provable only while
 /// the wallet still retains those checkpoints, so a mismatch against the wallet's current interval
-/// is reported as an error rather than left to surface as a missing checkpoint at proving time.
+/// is reported as an error rather than left to surface as a missing checkpoint at proving time. Its
+/// `DEFAULT` is [`AnchorBucketInterval::ZIP_318`] (144 blocks), present only so that a table created
+/// by the `orchard_ironwood_migration_tables` DDL and one repaired by the
+/// `orchard_ironwood_migration_anchor_interval` `ADD COLUMN` share this schema text; the store
+/// always writes the column explicitly.
+///
+/// [`AnchorBucketInterval::ZIP_318`]: zcash_protocol::zip318::AnchorBucketInterval::ZIP_318
 pub(super) const TABLE_ORCHARD_IRONWOOD_MIGRATIONS: &str = "
 CREATE TABLE orchard_ironwood_migrations (
     id INTEGER PRIMARY KEY,
@@ -620,7 +626,7 @@ CREATE TABLE orchard_ironwood_migrations (
     note_split_prep_fees INTEGER NOT NULL,
     note_split_total_input INTEGER NOT NULL,
     note_split_total_migratable INTEGER NOT NULL,
-    anchor_bucket_interval INTEGER NOT NULL
+    anchor_bucket_interval INTEGER NOT NULL DEFAULT 144
 )";
 /// The denomination crossing values (an ordered list of zatoshi amounts). The funding-note values
 /// have no table of their own: each is its crossing value plus the denomination fee buffer.

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -32,6 +32,7 @@ mod ironwood_shardtree;
 mod ivk_item_cache;
 mod note_locking;
 mod nullifier_map;
+mod orchard_ironwood_migration_anchor_interval;
 mod orchard_ironwood_migration_tables;
 mod orchard_note_version;
 mod orchard_received_notes;
@@ -129,6 +130,7 @@ pub mod ids {
     pub use super::ivk_item_cache::MIGRATION_ID as IVK_ITEM_CACHE;
     pub use super::note_locking::MIGRATION_ID as NOTE_LOCKING;
     pub use super::nullifier_map::MIGRATION_ID as NULLIFIER_MAP;
+    pub use super::orchard_ironwood_migration_anchor_interval::MIGRATION_ID as ORCHARD_IRONWOOD_MIGRATION_ANCHOR_INTERVAL;
     pub use super::orchard_ironwood_migration_tables::MIGRATION_ID as ORCHARD_IRONWOOD_MIGRATION_TABLES;
     pub use super::orchard_note_version::MIGRATION_ID as ORCHARD_NOTE_VERSION;
     pub use super::orchard_received_notes::MIGRATION_ID as ORCHARD_RECEIVED_NOTES;
@@ -357,6 +359,7 @@ pub(super) fn all_migrations<
         Box::new(tree_retained_checkpoints::Migration),
         Box::new(note_locking::Migration),
         Box::new(tx_status_observation_intent::Migration),
+        Box::new(orchard_ironwood_migration_anchor_interval::Migration),
     ]
 }
 
@@ -555,7 +558,7 @@ pub const CURRENT_LEAF_MIGRATIONS: &[Uuid] = &[
     fix_bad_ironwood_change_flagging::MIGRATION_ID,
     v_address_uses_ironwood::MIGRATION_ID,
     v_transactions_pool_crossing::MIGRATION_ID,
-    orchard_ironwood_migration_tables::MIGRATION_ID,
+    orchard_ironwood_migration_anchor_interval::MIGRATION_ID,
     tree_retained_checkpoints::MIGRATION_ID,
     tx_status_observation_intent::MIGRATION_ID,
 ];
@@ -682,6 +685,7 @@ pub(crate) mod tests {
             ids::IVK_ITEM_CACHE,
             ids::NOTE_LOCKING,
             ids::NULLIFIER_MAP,
+            ids::ORCHARD_IRONWOOD_MIGRATION_ANCHOR_INTERVAL,
             ids::ORCHARD_IRONWOOD_MIGRATION_TABLES,
             ids::ORCHARD_NOTE_VERSION,
             ids::ORCHARD_RECEIVED_NOTES,

--- a/zcash_client_sqlite/src/wallet/init/migrations/orchard_ironwood_migration_anchor_interval.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/orchard_ironwood_migration_anchor_interval.rs
@@ -1,0 +1,202 @@
+//! Adds the `anchor_bucket_interval` column to `orchard_ironwood_migrations` where it is missing.
+//!
+//! The column records the anchor retention grid a pool migration was committed under. It was
+//! introduced by editing the [`orchard_ironwood_migration_tables`] DDL in place, on the assumption
+//! that no wallet had yet applied that migration. That assumption does not hold for a wallet built
+//! from a git revision between the two commits: such a wallet has `orchard_ironwood_migrations`
+//! without the column and has already recorded [`orchard_ironwood_migration_tables`] as applied, so
+//! its `CREATE TABLE IF NOT EXISTS` never runs again and the column can never appear.
+//!
+//! The consequence is not confined to pool migration. [`WalletDb::put_blocks`] reads the committed
+//! grids on every scan once NU6.3 has an activation height, and "no such column" is a prepare-time
+//! error, so it fires even when no migration is in progress and the table is empty. Every scan then
+//! fails, no block is ever written, and no transaction ever acquires a mined height.
+//!
+//! This migration adds the column where it is absent. On a wallet whose table was created after the
+//! DDL edit the column is already present and this is a no-op, so both paths converge on the schema
+//! in [`crate::wallet::db::TABLE_ORCHARD_IRONWOOD_MIGRATIONS`].
+//!
+//! [`WalletDb::put_blocks`]: crate::WalletDb
+
+use std::collections::HashSet;
+use std::num::NonZeroU32;
+
+use rusqlite::named_params;
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+use zcash_protocol::zip318::AnchorBucketInterval;
+
+use super::orchard_ironwood_migration_tables;
+use crate::wallet::init::WalletMigrationError;
+
+/// Adds the `anchor_bucket_interval` column to `orchard_ironwood_migrations` where it is missing.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x1ab3caf9_ef1e_482c_93a3_a3f1080038df);
+
+const DEPENDENCIES: &[Uuid] = &[orchard_ironwood_migration_tables::MIGRATION_ID];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Adds the anchor_bucket_interval column to orchard_ironwood_migrations where missing."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        // A wallet whose table was created from the current DDL already has the column; adding it
+        // again is an error rather than a no-op, so the presence check is load-bearing.
+        let has_column = transaction.query_row(
+            "SELECT EXISTS (
+                SELECT 1 FROM pragma_table_info('orchard_ironwood_migrations')
+                WHERE name = :column_name
+             )",
+            named_params![":column_name": COLUMN_NAME],
+            |row| row.get::<_, bool>(0),
+        )?;
+
+        if !has_column {
+            // The grid an existing row was committed under is not recoverable: it came from the
+            // `SchedulingParams` the application planned with, which this migration cannot see. The
+            // ZIP 318 grid is the only defensible reconstruction, and it is exact on the production
+            // network, where a wallet MUST use it. It can be wrong on a test network, where a
+            // shorter grid is legitimate: such a row is then rejected by the committed-vs-configured
+            // check as `ProveError::AnchorIntervalMismatch` (or the `RebuildError` equivalent).
+            // That is a loud, diagnosable failure of a migration that must be re-planned, not a
+            // silent one — and it is confined to a test-network wallet that both planned under a
+            // custom grid and was built from the affected revision range.
+            //
+            // The `DEFAULT` matches the one carried by the current `CREATE TABLE`, so the two paths
+            // agree on the stored schema text; the store always binds the column explicitly, so no
+            // insert ever falls back to it.
+            transaction.execute_batch(&format!(
+                "ALTER TABLE orchard_ironwood_migrations
+                 ADD COLUMN {COLUMN_NAME} INTEGER NOT NULL DEFAULT {}",
+                default_interval()
+            ))?;
+        }
+
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
+    }
+}
+
+const COLUMN_NAME: &str = "anchor_bucket_interval";
+
+/// The grid a pre-existing row is assumed to have been committed under. This is a reconstruction,
+/// not a recovered value: the real grid came from the planning `SchedulingParams`, which is not
+/// recorded anywhere this migration can read.
+///
+/// It is exact on the production network, where a wallet MUST use [`AnchorBucketInterval::ZIP_318`]
+/// and [`AnchorBucketInterval::custom`] is documented as test-network-only. On a test network a
+/// shorter grid is legitimate, so this can be wrong; see the comment at the `ADD COLUMN` for what
+/// that costs.
+///
+/// [`AnchorBucketInterval::ZIP_318`]: zcash_protocol::zip318::AnchorBucketInterval::ZIP_318
+/// [`AnchorBucketInterval::custom`]: zcash_protocol::zip318::AnchorBucketInterval::custom
+fn default_interval() -> NonZeroU32 {
+    AnchorBucketInterval::ZIP_318.block_count()
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    use super::*;
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[MIGRATION_ID]);
+    }
+
+    /// The pre-fix schema: `orchard_ironwood_migrations` without `anchor_bucket_interval`, which is
+    /// what a wallet built from the affected revision range has on disk.
+    fn create_pre_fix_table(conn: &Connection) {
+        conn.execute_batch(
+            "CREATE TABLE orchard_ironwood_migrations (
+                id INTEGER PRIMARY KEY,
+                account_id INTEGER NOT NULL,
+                status TEXT NOT NULL,
+                note_split_fee_buffer INTEGER NOT NULL,
+                note_split_change INTEGER,
+                note_split_prep_fees INTEGER NOT NULL,
+                note_split_total_input INTEGER NOT NULL,
+                note_split_total_migratable INTEGER NOT NULL
+            )",
+        )
+        .unwrap();
+    }
+
+    fn has_anchor_column(conn: &Connection) -> bool {
+        conn.query_row(
+            "SELECT EXISTS (
+                SELECT 1 FROM pragma_table_info('orchard_ironwood_migrations')
+                WHERE name = 'anchor_bucket_interval'
+             )",
+            [],
+            |row| row.get::<_, bool>(0),
+        )
+        .unwrap()
+    }
+
+    /// The upgrade path: the column is added, and an existing row is backfilled with the ZIP 318
+    /// grid rather than being dropped.
+    #[test]
+    fn adds_column_and_backfills_existing_rows() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        create_pre_fix_table(&conn);
+        conn.execute_batch(
+            "INSERT INTO orchard_ironwood_migrations (
+                id, account_id, status, note_split_fee_buffer, note_split_change,
+                note_split_prep_fees, note_split_total_input, note_split_total_migratable
+             )
+             VALUES (1, 1, 'planned', 100, NULL, 200, 300, 400)",
+        )
+        .unwrap();
+
+        let tx = conn.transaction().unwrap();
+        RusqliteMigration::up(&Migration, &tx).unwrap();
+        tx.commit().unwrap();
+
+        assert!(has_anchor_column(&conn));
+
+        let (id, interval) = conn
+            .query_row(
+                "SELECT id, anchor_bucket_interval FROM orchard_ironwood_migrations",
+                [],
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, u32>(1)?)),
+            )
+            .unwrap();
+        assert_eq!(id, 1);
+        assert_eq!(interval, default_interval().get());
+    }
+
+    /// The fresh path: the table already carries the column, so `up` must leave it alone rather
+    /// than fail with "duplicate column name".
+    #[test]
+    fn is_a_no_op_when_the_column_is_present() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        crate::pool_migration::orchard_ironwood::init_migration_tables(&conn).unwrap();
+        assert!(has_anchor_column(&conn));
+
+        let tx = conn.transaction().unwrap();
+        RusqliteMigration::up(&Migration, &tx).unwrap();
+        tx.commit().unwrap();
+
+        assert!(has_anchor_column(&conn));
+    }
+}


### PR DESCRIPTION
Resolves MOB-1598
Resolves MOB-1592

## Problem

A wallet built from a git revision in `a0e937819e..b24a42723b` fails **every** scan with:

```
Error while scanning blocks: The underlying datasource produced the following error:
no such column: anchor_bucket_interval in
SELECT DISTINCT anchor_bucket_interval FROM orchard_ironwood_migrations WHERE status <> ? at offset 16
```

`b24a42723b` added `anchor_bucket_interval` to the `orchard_ironwood_migration_tables` DDL **in place**, on the stated assumption that the migration was "not yet released". That holds for tagged releases (every tagged `zcash_client_sqlite` containing `a0e937819e` also contains `b24a42723b`), but not for a wallet built from a git revision inside that 165-commit window. Such a wallet has the table without the column and has already recorded `7b2f6a41-…` as applied, so its `CREATE TABLE IF NOT EXISTS` never runs again and the column can never appear. There is no `ALTER TABLE` anywhere in the tree.

The blast radius is not confined to pool migration. `WalletDb::put_blocks` reads the committed grids on every scan once NU6.3 has an activation height (`lib.rs:2175`), and "no such column" is a **prepare-time** error, so it fires even when no migration is in progress and the table is empty. Every scan then fails, no block is written, and no transaction ever acquires a mined height — which surfaces to the user as every transaction being stuck "pending" indefinitely, and later flipping to "expired" once the tip passes `expiry_height`.

## Fix

A new `orchard_ironwood_migration_anchor_interval` migration adds the column where it is absent. The presence check is load-bearing rather than defensive: on a wallet whose table was created after the DDL edit the column already exists, and `ADD COLUMN` would fail with "duplicate column name".

I chose `ADD COLUMN` over a table rebuild because `orchard_ironwood_migrations` has five child tables with `ON DELETE CASCADE`, and dropping the parent to add one column is a lot of risk for the benefit. To keep a repaired table and a freshly created one byte-identical in `sqlite_schema` — SQLite cannot add a `NOT NULL` column without a default — the creating DDL carries a matching `DEFAULT`. `verify_schema` confirms the two agree. The store always binds the column explicitly, so no insert relies on the default.

### On the backfill value

The grid an existing row was committed under is **not recoverable**: it came from the planning `SchedulingParams` (`engine.rs:949`, `:2637`), which is not recorded anywhere the migration can read. The ZIP 318 grid (144) is the only defensible reconstruction, and it is exact on the production network, where a wallet MUST use it and `AnchorBucketInterval::custom` is documented test-network-only.

It can be wrong on a **test** network, where a shorter grid is legitimate — note that `with_anchor_retention_interval` (`78229dd3d8`) itself landed inside the affected window. Such a row is then rejected by the committed-vs-configured check as `ProveError::AnchorIntervalMismatch` (`engine.rs:1566`) and must be re-planned. That is loud and diagnosable rather than silent, and it does not prune checkpoints: `put_blocks` unions the committed grids with the wallet's *current* interval, so a testnet wallet still configured at its custom grid keeps retaining it.

The alternative — making the column nullable and treating `NULL` as "unknown, skip the check" — is strictly more accurate for affected wallets, but changes `MigrationState::anchor_bucket_interval` and the store from `NonZeroU32` to `Option<NonZeroU32>`, weakening the invariant `b24a42723b` introduced for every wallet to accommodate a handful of dev testnet ones. Happy to take that direction instead if reviewers prefer it.

## Tests

- New: upgrade path adds the column and backfills an existing row; fresh path is a no-op; `test_migrate`.
- `verify_schema` — confirms repaired and fresh schemas agree.
- `current_leaf_migrations_are_the_dag_leaves`, `ids_module_covers_every_migration`, `migrate_between_releases_without_data`.
- 15 `pool_migration::orchard_ironwood` store tests.

`cargo fmt --check` and `cargo clippy --all-features --all-targets` are clean. I ran the tests above rather than the full crate suite.

## Worth a second look

Any other recent commit that edited an already-applied migration's DDL in place on the same "not yet released" reasoning has the same defect. Tag status is not a sufficient test when consumers build from git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)