### PR TITLE
ci: resolve zizmor security findings

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -29,6 +29,12 @@ outputs:
   feature-flags:
     description: 'Feature flags'
     value: ${{ steps.prepare.outputs.flags || steps.prepare-all.outputs.flags }}
+  feature-list:
+    description: 'Space-separated feature names, empty when all features are enabled'
+    value: ${{ steps.prepare.outputs.features }}
+  all-features:
+    description: 'Whether all features are enabled'
+    value: ${{ inputs.all-features }}
 runs:
   using: 'composite'
   steps:
@@ -47,29 +53,35 @@ runs:
       run: echo "feature=test-dependencies" >> $GITHUB_OUTPUT
       if: inputs.test-dependencies == 'true'
 
-    # `steps.pools.outputs.features` and `steps.test.outputs.feature` cannot
-    # expand into attacker-controllable code because the previous steps only
-    # enable them to have one of two fixed values.
-    - name: Prepare feature flags # zizmor: ignore[template-injection]
+    - name: Prepare feature flags
       id: prepare
       shell: bash
-      run: >
-        echo "flags=--features '
-        bundled-prover
-        download-params
-        lightwalletd-tonic
-        sync
-        temporary-zcashd
-        unstable
-        unstable-serialization
-        unstable-spanning-tree
-        ${EXTRA_FEATURES}
-        ${{ steps.transparent-pool.outputs.features }}
-        ${{ steps.orchard-pool.outputs.features }}
-        ${{ steps.test.outputs.feature }}
-        '" >> $GITHUB_OUTPUT
+      run: |
+        read -ra extra_features <<< "$EXTRA_FEATURES"
+        read -ra transparent_features <<< "$TRANSPARENT_FEATURES"
+        read -ra orchard_features <<< "$ORCHARD_FEATURES"
+        read -ra test_features <<< "$TEST_FEATURES"
+        features=(
+          bundled-prover
+          download-params
+          lightwalletd-tonic
+          sync
+          temporary-zcashd
+          unstable
+          unstable-serialization
+          unstable-spanning-tree
+          "${extra_features[@]}"
+          "${transparent_features[@]}"
+          "${orchard_features[@]}"
+          "${test_features[@]}"
+        )
+        echo "features=${features[*]}" >> "$GITHUB_OUTPUT"
+        echo "flags=--features '${features[*]}'" >> "$GITHUB_OUTPUT"
       env:
         EXTRA_FEATURES: ${{ inputs.extra-features }}
+        ORCHARD_FEATURES: ${{ steps.orchard-pool.outputs.features }}
+        TEST_FEATURES: ${{ steps.test.outputs.feature }}
+        TRANSPARENT_FEATURES: ${{ steps.transparent-pool.outputs.features }}
       if: inputs.all-features == 'false'
 
     - id: prepare-all

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
   schedule:
     interval: daily
     timezone: Etc/UTC
+  cooldown:
+    default-days: 7
   open-pull-requests-limit: 10
   reviewers:
   - str4d

--- a/.github/workflows/audits.yml
+++ b/.github/workflows/audits.yml
@@ -16,8 +16,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         id: toolchain
+        with:
+          toolchain: stable
       - run: rustup override set "${TOOLCHAIN}"
         env:
           TOOLCHAIN: ${{steps.toolchain.outputs.name}}

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -23,20 +23,28 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           all-features: true
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         id: toolchain
+        with:
+          toolchain: nightly
       - run: rustup override set "${TOOLCHAIN}"
         env:
           TOOLCHAIN: ${{steps.toolchain.outputs.name}}
 
       - name: Build latest rustdocs
-        run: >
-          cargo doc
-          --no-deps
-          --workspace
-          ${{ steps.prepare.outputs.feature-flags }}
+        shell: bash
         env:
+          ALL_FEATURES: ${{ steps.prepare.outputs.all-features }}
+          FEATURES: ${{ steps.prepare.outputs.feature-list }}
           RUSTDOCFLAGS: -Z unstable-options --enable-index-page --cfg docsrs
+        run: |
+          feature_flags=()
+          if [[ "$ALL_FEATURES" == true ]]; then
+            feature_flags+=(--all-features)
+          elif [[ -n "$FEATURES" ]]; then
+            feature_flags+=(--features "$FEATURES")
+          fi
+          cargo doc --no-deps --workspace "${feature_flags[@]}"
 
       - name: Move latest rustdocs into book
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,18 @@ jobs:
           shared-key: msrv
           save-if: ${{ matrix.state == 'all-features' }}
       - name: Run tests
-        run: >
-          cargo test
-          --workspace
-          ${{ steps.prepare.outputs.feature-flags }}
+        shell: bash
+        env:
+          ALL_FEATURES: ${{ steps.prepare.outputs.all-features }}
+          FEATURES: ${{ steps.prepare.outputs.feature-list }}
+        run: |
+          feature_flags=()
+          if [[ "$ALL_FEATURES" == true ]]; then
+            feature_flags+=(--all-features)
+          elif [[ -n "$FEATURES" ]]; then
+            feature_flags+=(--features "$FEATURES")
+          fi
+          cargo test --workspace "${feature_flags[@]}"
       - name: Verify working directory is clean
         run: git diff --exit-code
 
@@ -143,10 +151,18 @@ jobs:
           shared-key: msrv
           save-if: ${{ matrix.state == 'all-features' && matrix.target != 'Windows' }}
       - name: Run tests
-        run: >
-          cargo test
-          --workspace
-          ${{ steps.prepare.outputs.feature-flags }}
+        shell: bash
+        env:
+          ALL_FEATURES: ${{ steps.prepare.outputs.all-features }}
+          FEATURES: ${{ steps.prepare.outputs.feature-list }}
+        run: |
+          feature_flags=()
+          if [[ "$ALL_FEATURES" == true ]]; then
+            feature_flags+=(--all-features)
+          elif [[ -n "$FEATURES" ]]; then
+            feature_flags+=(--features "$FEATURES")
+          fi
+          cargo test --workspace "${feature_flags[@]}"
       - name: Verify working directory is clean
         run: git diff --exit-code
 
@@ -201,11 +217,18 @@ jobs:
           shared-key: msrv
           save-if: "false"
       - name: Run slow tests
-        run: >
-          cargo test
-          --workspace
-          ${{ steps.prepare.outputs.feature-flags }}
-          --features expensive-tests
+        shell: bash
+        env:
+          ALL_FEATURES: ${{ steps.prepare.outputs.all-features }}
+          FEATURES: ${{ steps.prepare.outputs.feature-list }}
+        run: |
+          feature_flags=()
+          if [[ "$ALL_FEATURES" == true ]]; then
+            feature_flags+=(--all-features)
+          elif [[ -n "$FEATURES" ]]; then
+            feature_flags+=(--features "$FEATURES")
+          fi
+          cargo test --workspace "${feature_flags[@]}" --features expensive-tests
       - name: Verify working directory is clean
         run: git diff --exit-code
 
@@ -234,8 +257,10 @@ jobs:
       - name: Ensure rustup proxies take precedence
         shell: bash
         run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         id: toolchain
+        with:
+          toolchain: stable
       - run: rustup override set "${TOOLCHAIN}"
         shell: sh
         env:
@@ -243,12 +268,18 @@ jobs:
       - name: Remove lockfile to build with latest dependencies
         run: rm Cargo.lock
       - name: Build crates
-        run: >
-          cargo build
-          --workspace
-          --all-targets
-          ${{ steps.prepare.outputs.feature-flags }}
-          --verbose
+        shell: bash
+        env:
+          ALL_FEATURES: ${{ steps.prepare.outputs.all-features }}
+          FEATURES: ${{ steps.prepare.outputs.feature-list }}
+        run: |
+          feature_flags=()
+          if [[ "$ALL_FEATURES" == true ]]; then
+            feature_flags+=(--all-features)
+          elif [[ -n "$FEATURES" ]]; then
+            feature_flags+=(--features "$FEATURES")
+          fi
+          cargo build --workspace --all-targets "${feature_flags[@]}" --verbose
       - name: Verify working directory is clean (excluding lockfile)
         run: git diff --exit-code ':!Cargo.lock'
 
@@ -422,9 +453,10 @@ jobs:
       # We can't currently use only the common feature set (to exclude checking of
       # unstable in-progress code) because this action doesn't support spaces within CLI
       # arguments. Once it does, switch back to `prepare` instead of `--all-features`.
-      - uses: dtolnay/rust-toolchain@beta
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         id: toolchain
         with:
+          toolchain: beta
           components: clippy
       - run: rustup override set "${TOOLCHAIN}"
         shell: sh
@@ -452,22 +484,29 @@ jobs:
           persist-credentials: false
       - id: prepare
         uses: ./.github/actions/prepare
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         id: toolchain
+        with:
+          toolchain: nightly
       - run: rustup override set "${TOOLCHAIN}"
         env:
           TOOLCHAIN: ${{steps.toolchain.outputs.name}}
       - run: cargo fetch
       # Requires #![deny(rustdoc::broken_intra_doc_links)] in crates.
       - name: Check intra-doc links
-        run: >
-          cargo doc
-          --no-deps
-          --workspace
-          ${{ steps.prepare.outputs.feature-flags }}
-          --document-private-items
+        shell: bash
         env:
+          ALL_FEATURES: ${{ steps.prepare.outputs.all-features }}
+          FEATURES: ${{ steps.prepare.outputs.feature-list }}
           RUSTDOCFLAGS: -Z unstable-options --enable-index-page --cfg docsrs
+        run: |
+          feature_flags=()
+          if [[ "$ALL_FEATURES" == true ]]; then
+            feature_flags+=(--all-features)
+          elif [[ -n "$FEATURES" ]]; then
+            feature_flags+=(--features "$FEATURES")
+          fi
+          cargo doc --no-deps --workspace "${feature_flags[@]}" --document-private-items
 
   fmt:
     name: Rustfmt
@@ -506,10 +545,18 @@ jobs:
           version: '25.1'
           subPath: 'bin'
       - name: Trigger protobuf regeneration
-        run: >
-          cargo check
-          --workspace
-          ${{ steps.prepare.outputs.feature-flags }}
+        shell: bash
+        env:
+          ALL_FEATURES: ${{ steps.prepare.outputs.all-features }}
+          FEATURES: ${{ steps.prepare.outputs.feature-list }}
+        run: |
+          feature_flags=()
+          if [[ "$ALL_FEATURES" == true ]]; then
+            feature_flags+=(--all-features)
+          elif [[ -n "$FEATURES" ]]; then
+            feature_flags+=(--features "$FEATURES")
+          fi
+          cargo check --workspace "${feature_flags[@]}"
       - name: run cargo-fmt to handle the case that regeneration sometimes produces unformatted output
         run: cargo fmt
       - name: Verify working directory is clean

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -87,8 +87,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         id: toolchain
+        with:
+          toolchain: stable
       - run: rustup override set "${TOOLCHAIN}"
         shell: sh
         env:
@@ -96,7 +98,9 @@ jobs:
       - uses: taiki-e/install-action@18b1216eba7f8039b0f8d131d5473787f0edce68 # v2.85.3
         with:
           tool: cargo-mutants
-      - run: cargo mutants --package "${{ matrix.package }}" --all-features -vV --in-place
+      - run: cargo mutants --package "${PACKAGE}" --all-features -vV --in-place
+        env:
+          PACKAGE: ${{ matrix.package }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:


### PR DESCRIPTION
## Summary

- pass generated feature flags and matrix package names through environment variables instead of expanding them directly into shell source
- pin every `dtolnay/rust-toolchain` invocation to the reviewed master commit and select stable, beta, or nightly through the explicit `toolchain` input
- apply a seven-day cooldown to routine Dependabot GitHub Actions updates

## Security impact

This resolves all currently open zizmor template-injection, unpinned-action, and Dependabot cooldown findings. It also fixes the same patterns in the mutation workflow before they become separate alerts.

## Validation

- `uvx zizmor==1.28.0 .github` — no findings
- parsed every workflow and `dependabot.yml` as YAML
- `git diff --check`

The cooldown applies to routine version updates; Dependabot security updates are unaffected.