### PR TITLE
security: filter noisy CodeQL queries

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,11 @@
+name: librustzcash CodeQL configuration
+
+# These heuristic queries have produced no actionable results in this
+# repository. Keep the remainder of CodeQL's default Rust and C/C++ suites.
+query-filters:
+  - exclude:
+      id: rust/hard-coded-cryptographic-value
+  - exclude:
+      id: rust/cleartext-storage-database
+  - exclude:
+      id: rust/cleartext-logging

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+name: CodeQL
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "17 9 * * 1"
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: Analyze ${{ matrix.language }}
+    if: ${{ vars.CODEQL_ADVANCED_SETUP == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - c-cpp
+          - rust
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        with:
+          build-mode: none
+          config-file: ./.github/codeql/codeql-config.yml
+          languages: ${{ matrix.language }}
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Summary

- add an advanced CodeQL workflow for Rust and C/C++ using buildless extraction
- retain the default query suite except for three Rust queries that have produced no actionable results
- pin the CodeQL Action to an immutable v4 commit
- gate the advanced jobs behind the `CODEQL_ADVANCED_SETUP` repository variable for a no-gap transition from default setup

## Excluded queries

- `rust/hard-coded-cryptographic-value`
- `rust/cleartext-storage-database`
- `rust/cleartext-logging`

The 19 currently open findings from these queries were reviewed against their source and the Zcash security policy. They are false positives involving public protocol selector bits, test vectors and diagnostics, enum discriminator values, and read-only wallet queries. Historical CodeQL results show the same noise pattern.

## Retained coverage

All other default Rust and C/C++ CodeQL queries remain enabled. GitHub Actions security analysis remains covered by zizmor.

## Validation

- parsed the workflow and CodeQL configuration as YAML
- `uvx zizmor==1.28.0 .github/workflows/codeql.yml` — no findings
- CodeQL Rust and C/C++ initialization and analysis completed; uploads were rejected only because default setup was still active, as GitHub documents
- `git diff --check`

## Activation after merge

1. Disable CodeQL default setup.
2. Set the repository Actions variable `CODEQL_ADVANCED_SETUP` to `true`.
3. Manually dispatch the `CodeQL` workflow and confirm both language uploads.

Until those steps are performed, the advanced jobs skip and existing default setup remains authoritative. This avoids both duplicate configurations and a scanning gap.