### PR TITLE
Migration-shaped note selection: chain-age order, single-note canonical funding

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -12,6 +12,18 @@ workspace.
 
 ### Added
 - `zcash_client_backend::data_api::anchor_retention::AnchorRetention::retained_in_range`
+- `zcash_client_backend::data_api::wallet::input_selection::NoteSelection`
+- `zcash_client_backend::data_api::wallet::input_selection::SpendPolicy::{with_note_selection, note_selection}`
+- `zcash_client_backend::data_api::InputSource::select_single_spendable_note`, with a
+  best-effort default implementation
+- `zcash_client_backend::data_api::ReceivedNotes::{is_empty, into_single_covering}`
+
+### Changed
+- `zcash_client_backend::data_api::wallet::propose_transfer` now funds a canonical
+  ZIP 318 crossing attempt from the single oldest Orchard note that covers the
+  payment and its fee, falling back to ordinary accumulation when no such note
+  exists. Payments of canonical denominations that previously lost the canonical
+  shape to multi-note funding now take it whenever a single covering note exists.
 
 ### Fixed
 - `zcash_client_backend::data_api::ll::wallet::put_blocks` now creates (and retains) a

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -1171,6 +1171,75 @@ impl<NoteRef> ReceivedNotes<NoteRef> {
             .ok_or(BalanceError::Overflow);
     }
 
+    /// Returns whether the collection contains no notes in any pool.
+    pub fn is_empty(&self) -> bool {
+        #[cfg(not(feature = "orchard"))]
+        return self.sapling.is_empty();
+
+        #[cfg(feature = "orchard")]
+        return self.sapling.is_empty() && self.orchard.is_empty() && self.ironwood.is_empty();
+    }
+
+    /// Consumes this collection, returning one holding only the OLDEST single note whose value
+    /// alone is at least `value`, drawn from the first pool in `sources` that holds one; the
+    /// result is empty when no single note qualifies. Age is the note's commitment tree
+    /// position, which is assigned in strict chain order.
+    ///
+    /// This is the best-effort reduction behind the default implementation of
+    /// [`InputSource::select_single_spendable_note`]: it can only choose among the notes it
+    /// holds, so a covering note the producing selection did not surface cannot be found here.
+    pub fn into_single_covering(mut self, value: Zatoshis, sources: &[ShieldedPool]) -> Self {
+        fn take_oldest_covering<NoteRef, N>(
+            notes: &mut Vec<ReceivedNote<NoteRef, N>>,
+            covers: impl Fn(&ReceivedNote<NoteRef, N>) -> bool,
+        ) -> Option<ReceivedNote<NoteRef, N>> {
+            let idx = notes
+                .iter()
+                .enumerate()
+                .filter(|(_, n)| covers(n))
+                .min_by_key(|(_, n)| n.note_commitment_tree_position())
+                .map(|(idx, _)| idx)?;
+            Some(notes.swap_remove(idx))
+        }
+
+        for pool in sources {
+            match pool {
+                ShieldedPool::Sapling => {
+                    if let Some(note) = take_oldest_covering(&mut self.sapling, |n| {
+                        n.note_value().is_ok_and(|v| v >= value)
+                    }) {
+                        return Self::new(
+                            vec![note],
+                            #[cfg(feature = "orchard")]
+                            vec![],
+                            #[cfg(feature = "orchard")]
+                            vec![],
+                        );
+                    }
+                }
+                #[cfg(feature = "orchard")]
+                ShieldedPool::Orchard => {
+                    if let Some(note) = take_oldest_covering(&mut self.orchard, |n| {
+                        n.note_value().is_ok_and(|v| v >= value)
+                    }) {
+                        return Self::new(vec![], vec![note], vec![]);
+                    }
+                }
+                #[cfg(feature = "orchard")]
+                ShieldedPool::Ironwood => {
+                    if let Some(note) = take_oldest_covering(&mut self.ironwood, |n| {
+                        n.note_value().is_ok_and(|v| v >= value)
+                    }) {
+                        return Self::new(vec![], vec![], vec![note]);
+                    }
+                }
+                #[cfg(not(feature = "orchard"))]
+                ShieldedPool::Orchard | ShieldedPool::Ironwood => {}
+            }
+        }
+        Self::empty()
+    }
+
     /// Consumes this [`ReceivedNotes`] value and produces a vector of
     /// [`ReceivedNote<NoteRef, Note>`] values.
     pub fn into_vec(
@@ -1727,6 +1796,43 @@ pub trait InputSource {
         exclude: &[Self::NoteRef],
         lock_filter: LockFilter<'_>,
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error>;
+
+    /// Returns the OLDEST single spendable note whose value alone is at least `value`, drawn
+    /// from the first pool in `sources` (in the given preference order) that holds one. The
+    /// returned collection contains at most one note; it is empty when no single eligible note
+    /// covers the value.
+    ///
+    /// This is the selection primitive behind
+    /// [`NoteSelection::PreferSingle`](crate::data_api::wallet::input_selection::NoteSelection):
+    /// a ZIP 318 migration transfer spends exactly one note, so a canonical pool crossing must
+    /// be funded from one.
+    ///
+    /// The default implementation is BEST-EFFORT: it reports a note only when
+    /// [`Self::select_spendable_notes`] happens to surface one that covers the value on its
+    /// own. An implementation backed by a queryable store should override it with a direct
+    /// query, so that a covering note is found whenever one exists.
+    #[allow(clippy::too_many_arguments)]
+    fn select_single_spendable_note(
+        &self,
+        account: Self::AccountId,
+        value: Zatoshis,
+        sources: &[ShieldedPool],
+        target_height: TargetHeight,
+        confirmations_policy: ConfirmationsPolicy,
+        exclude: &[Self::NoteRef],
+        lock_filter: LockFilter<'_>,
+    ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
+        self.select_spendable_notes(
+            account,
+            TargetValue::AtLeast(value),
+            sources,
+            target_height,
+            confirmations_policy,
+            exclude,
+            lock_filter,
+        )
+        .map(|notes| notes.into_single_covering(value, sources))
+    }
 
     /// Returns the list of notes belonging to the wallet that are unspent as of the specified
     /// target height. Locked outputs are selected according to `lock_filter` (see [`LockFilter`];

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -9357,6 +9357,125 @@ pub fn multi_note_crossing_is_not_bucketed<Dsf: DataStoreFactory>(
     );
 }
 
+/// A canonical payment is funded from the single oldest covering note even when accumulation
+/// would have reached the target through several smaller notes first.
+///
+/// Oldest-first accumulation crosses the target through small notes whenever the oldest notes
+/// are small, funding the payment while losing the single-input canonical shape. The canonical
+/// attempt therefore PREFERS single-note funding ([`NoteSelection::PreferSingle`]): when any
+/// single eligible note covers the payment and its fee, that note is chosen and the transaction
+/// takes the migration shape. Ordinary (non-canonical) payments keep accumulating.
+///
+/// [`NoteSelection::PreferSingle`]:
+///     crate::data_api::wallet::input_selection::NoteSelection::PreferSingle
+#[cfg(feature = "orchard")]
+pub fn canonical_crossing_prefers_single_note<Dsf: DataStoreFactory>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) {
+    let interval = AnchorRetentionInterval::custom(NonZeroU32::new(12).expect("nonzero"));
+    let activation = BlockHeight::from_u32(100_000);
+    let network = LocalNetwork {
+        nu6: Some(activation),
+        nu6_1: Some(activation),
+        nu6_2: Some(activation),
+        nu6_3: Some(activation),
+        ..TestBuilder::<(), ()>::DEFAULT_NETWORK
+    };
+
+    let mut st = TestDsl::from(
+        TestBuilder::new()
+            .with_network(network)
+            .with_data_store_factory(ds_factory)
+            .with_block_cache(cache)
+            .with_anchor_retention_interval(interval)
+            .with_account_from_sapling_activation(BlockHash([0; 32])),
+    )
+    .build::<OrchardPoolTester>();
+
+    let account = st.test_account().cloned().unwrap();
+    let fvk = OrchardPoolTester::test_account_fvk(&st);
+    let recipient = OrchardPoolTester::fvk_default_address(&fvk).to_zcash_address(st.network());
+
+    // Two OLDER notes that together cover the payment, then one LARGER note that covers it
+    // alone. Accumulation reaches the target at the second note and never touches the third,
+    // so which shape the proposal takes distinguishes the two selection behaviors.
+    let small_value = Zatoshis::const_from_u64(600_000);
+    let large_value = Zatoshis::const_from_u64(1_200_000);
+    let (first_height, _, _) = st.add_a_single_note_checking_balance(small_value);
+    st.generate_next_block(&fvk, AddressType::DefaultExternal, small_value);
+    st.generate_next_block(&fvk, AddressType::DefaultExternal, large_value);
+    st.scan_cached_blocks(first_height + 1, 2);
+
+    let interval_blocks = interval.block_count().get();
+    let tip = u32::from(interval.boundary_at_or_above(first_height)) + 3 * interval_blocks + 5;
+    let not_our_fvk = OrchardPoolTester::sk_to_fvk(&OrchardPoolTester::sk(&[0xf5; 32]));
+    let filler_count = tip - u32::from(first_height) - 2;
+    for _ in 0..filler_count {
+        st.generate_next_block(
+            &not_our_fvk,
+            AddressType::DefaultExternal,
+            Zatoshis::const_from_u64(10_000),
+        );
+    }
+    st.scan_cached_blocks(first_height + 3, filler_count as usize);
+
+    let input_selector = GreedyInputSelector::new();
+    let change_strategy =
+        single_output_change_strategy(StandardFeeRule::Zip317, None, ShieldedPool::Orchard);
+    let propose = |st: &mut TestState<_, _, _>, amount: Zatoshis| {
+        let request =
+            TransactionRequest::new(vec![Payment::without_memo(recipient.clone(), amount)])
+                .unwrap();
+        st.propose_transfer(
+            account.id(),
+            &input_selector,
+            &change_strategy,
+            request,
+            ConfirmationsPolicy::MIN,
+        )
+    };
+
+    // The canonical payment takes the single-note shape, spending the LARGE note.
+    let canonical = propose(&mut st, MAX_RESIDUAL_VALUE).expect("the wallet can fund this");
+    let step = canonical.steps().first();
+    let zip318 = st.wallet().pool_migration_params();
+    let canonical_fee = crate::fees::canonical_crossing_fee(
+        st.network(),
+        BlockHeight::from(canonical.min_target_height()),
+    )
+    .expect("the canonical shape is a valid input to the ZIP 317 rule");
+    assert_eq!(
+        step.input_count_in_pool(PoolType::ORCHARD),
+        1,
+        "the canonical payment must be funded from a single note"
+    );
+    assert!(step.is_canonical_crossing(&zip318, canonical_fee));
+    let spent = step
+        .shielded_inputs()
+        .expect("a shielded step spends notes")
+        .notes()
+        .first()
+        .note()
+        .value();
+    assert_eq!(
+        spent, large_value,
+        "the single covering note funds the payment, not the older small notes"
+    );
+
+    // An ordinary payment of a NON-canonical amount still accumulates the oldest notes.
+    let ordinary = propose(
+        &mut st,
+        (MAX_RESIDUAL_VALUE + Zatoshis::const_from_u64(1)).unwrap(),
+    )
+    .expect("the wallet can fund this too");
+    let step = ordinary.steps().first();
+    assert!(
+        step.input_count_in_pool(PoolType::ORCHARD) > 1,
+        "single-note preference must not leak into ordinary selection"
+    );
+}
+
 /// Self-migration does not stall once the wallet holds Ironwood notes.
 ///
 /// A user moving their own funds across the turnstile sends themselves canonical amounts

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -6482,6 +6482,53 @@ pub fn scan_cached_blocks_detects_spends_out_of_order<T: ShieldedPoolTester, Dsf
     );
 }
 
+/// Note selection draws the OLDEST eligible notes first, where age is chain order — the note's
+/// commitment tree position — not discovery order. Priority scanning discovers recent blocks
+/// before back-filling history, so a restored wallet's newest notes carry its lowest row ids;
+/// ordering by id would spend fresh change while far older notes sat idle. The ordering must
+/// therefore survive scanning blocks out of order.
+pub fn oldest_note_is_selected_first<T: ShieldedPoolTester, Dsf>(
+    ds_factory: Dsf,
+    cache: impl TestCache,
+) where
+    Dsf: DataStoreFactory,
+{
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+    let account = st.test_account().cloned().unwrap();
+    let dfvk = T::test_account_fvk(&st);
+
+    // Two notes; the OLDER one is larger, so which note a small selection returns identifies
+    // the ordering in use.
+    let older_value = Zatoshis::const_from_u64(500_000);
+    let newer_value = Zatoshis::const_from_u64(300_000);
+    let (older_height, _, _) =
+        st.generate_next_block(&dfvk, AddressType::DefaultExternal, older_value);
+    let (newer_height, _, _) =
+        st.generate_next_block(&dfvk, AddressType::DefaultExternal, newer_value);
+
+    // Scan the NEWER block first: its note is discovered first and takes the lower row id,
+    // exactly as happens to recent notes when a restored wallet syncs tip-first.
+    st.scan_cached_blocks(newer_height, 1);
+    st.scan_cached_blocks(older_height, 1);
+
+    // Either note alone covers the target, so selection returns exactly one — the OLDER.
+    let selected = T::select_spendable_notes(
+        &st,
+        account.id(),
+        TargetValue::AtLeast(Zatoshis::const_from_u64(200_000)),
+        TargetHeight::from(newer_height + 1),
+        ConfirmationsPolicy::MIN,
+        &[],
+    )
+    .unwrap();
+    assert_eq!(selected.len(), 1, "a single note covers the target");
+    assert_eq!(
+        T::note_value(selected.first().expect("nonempty").note()),
+        older_value,
+        "the oldest sufficient note must be drawn first, not the first-discovered"
+    );
+}
+
 pub fn metadata_queries_exclude_unwanted_notes<T: ShieldedPoolTester, Dsf, TC>(
     ds_factory: Dsf,
     cache: TC,

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -858,9 +858,17 @@ where
         // canonical path to attempt.
         .filter(|_| spend_policy.permits_shielded(ShieldedPool::Orchard))
         .map(|bucketed_policy| {
+            // Single-note funding is PREFERRED, not merely hoped for: a migration transfer
+            // spends exactly one note, and accumulation reaches the target through several
+            // small notes whenever the oldest notes are small — funding perfectly well while
+            // losing the canonical shape. Preferring the oldest single covering note makes the
+            // canonical outcome the common one; when no single note covers the payment, the
+            // fallback accumulation funds it and the shape check below discards the attempt,
+            // exactly as before.
             let orchard_only =
                 input_selection::SpendPolicy::shielded_pools([ShieldedPool::Orchard])
-                    .with_locked_input_policy(spend_policy.locked_input_policy().clone());
+                    .with_locked_input_policy(spend_policy.locked_input_policy().clone())
+                    .with_note_selection(input_selection::NoteSelection::PreferSingle);
 
             input_selector.propose_transaction(
                 params,

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -492,6 +492,22 @@ pub struct SpendPolicy {
     #[cfg(feature = "transparent-inputs")]
     transparent: Option<TransparentSpendPolicy>,
     locked_input_policy: LockedInputPolicy,
+    note_selection: NoteSelection,
+}
+
+/// How an [`InputSelector`] chooses among eligible notes when funding a payment.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum NoteSelection {
+    /// Accumulate the oldest eligible notes until the target value is covered.
+    #[default]
+    Accumulate,
+    /// Prefer funding from a SINGLE note — the oldest eligible note whose value alone covers the
+    /// target — falling back to accumulation when no such note exists.
+    ///
+    /// A ZIP 318 migration transfer spends exactly one note, so a canonical pool crossing is
+    /// achievable only under single-note funding; multi-note funding is not an error, but the
+    /// resulting proposal does not have the canonical shape.
+    PreferSingle,
 }
 
 impl Default for SpendPolicy {
@@ -515,6 +531,7 @@ impl SpendPolicy {
             #[cfg(feature = "transparent-inputs")]
             transparent: None,
             locked_input_policy: LockedInputPolicy::Exclude,
+            note_selection: NoteSelection::Accumulate,
         }
     }
 
@@ -550,6 +567,18 @@ impl SpendPolicy {
     /// Returns the policy governing selection of locked outputs.
     pub fn locked_input_policy(&self) -> &LockedInputPolicy {
         &self.locked_input_policy
+    }
+
+    /// Sets how the selector chooses among eligible notes (default:
+    /// [`NoteSelection::Accumulate`]).
+    pub fn with_note_selection(mut self, note_selection: NoteSelection) -> Self {
+        self.note_selection = note_selection;
+        self
+    }
+
+    /// Returns how the selector chooses among eligible notes.
+    pub fn note_selection(&self) -> NoteSelection {
+        self.note_selection
     }
 }
 
@@ -1417,17 +1446,42 @@ impl<DbT: InputSource> InputSelector for GreedyInputSelector<DbT> {
             // in-flight proposal and spending it would recreate the conflict that locking exists
             // to prevent; the `PreferUnlocked`/`PreferLocked` overrides let a caller draw through
             // a lock it recognizes (e.g. its own pool-migration PCZTs).
-            shielded_inputs = wallet_db
-                .select_spendable_notes(
-                    account,
-                    TargetValue::AtLeast(amount_required),
-                    &pool_preference,
-                    target_height,
-                    confirmations_policy,
-                    &exclude,
-                    LockFilter::Policy(spend_policy.locked_input_policy()),
+            //
+            // Under `NoteSelection::PreferSingle`, the single oldest note covering the required
+            // amount alone is tried first; when no pool holds one, selection falls back to
+            // ordinary accumulation, which still funds the payment but cannot produce the
+            // single-input shape the caller preferred.
+            let single_note = match spend_policy.note_selection() {
+                NoteSelection::PreferSingle => Some(
+                    wallet_db
+                        .select_single_spendable_note(
+                            account,
+                            amount_required,
+                            &pool_preference,
+                            target_height,
+                            confirmations_policy,
+                            &exclude,
+                            LockFilter::Policy(spend_policy.locked_input_policy()),
+                        )
+                        .map_err(InputSelectorError::DataSource)?,
                 )
-                .map_err(InputSelectorError::DataSource)?;
+                .filter(|notes| !notes.is_empty()),
+                NoteSelection::Accumulate => None,
+            };
+            shielded_inputs = match single_note {
+                Some(single) => single,
+                None => wallet_db
+                    .select_spendable_notes(
+                        account,
+                        TargetValue::AtLeast(amount_required),
+                        &pool_preference,
+                        target_height,
+                        confirmations_policy,
+                        &exclude,
+                        LockFilter::Policy(spend_policy.locked_input_policy()),
+                    )
+                    .map_err(InputSelectorError::DataSource)?,
+            };
 
             let new_available = shielded_inputs.total_value()?;
             if new_available <= prior_available && !transparent_inputs_changed {

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -34,6 +34,12 @@ workspace.
   scanner marks as change); while such a transaction is unmined it is treated
   as an ordinary payment.
 
+### Fixed
+- Note selection now draws the oldest eligible notes first, ordering by note
+  commitment tree position (chain order). Previously notes were drawn in
+  scan-discovery order, which for a restored wallet prefers its most recently
+  discovered — typically newest — notes.
+
 ## [0.22.0-rc.5] - 2026-07-28
 
 ### Added

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -86,6 +86,7 @@ use zcash_protocol::{
     ShieldedPool,
     consensus::{self, BlockHeight, TxIndex},
     memo::Memo,
+    value::Zatoshis,
 };
 use zip32::{DiversifierIndex, fingerprint::SeedFingerprint};
 
@@ -822,6 +823,77 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> InputSour
                 vec![]
             },
         ))
+    }
+
+    fn select_single_spendable_note(
+        &self,
+        account: Self::AccountId,
+        value: Zatoshis,
+        sources: &[ShieldedPool],
+        target_height: TargetHeight,
+        confirmations_policy: ConfirmationsPolicy,
+        exclude: &[Self::NoteRef],
+        lock_filter: LockFilter<'_>,
+    ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
+        // Pools are tried in the caller's preference order; the first pool holding a covering
+        // note supplies it.
+        for pool in sources {
+            match pool {
+                ShieldedPool::Sapling => {
+                    if let Some(note) = wallet::sapling::select_single_spendable_sapling_note(
+                        self.conn.borrow(),
+                        &self.params,
+                        account,
+                        value,
+                        target_height,
+                        confirmations_policy,
+                        exclude,
+                        lock_filter,
+                    )? {
+                        return Ok(ReceivedNotes::new(
+                            vec![note],
+                            #[cfg(feature = "orchard")]
+                            vec![],
+                            #[cfg(feature = "orchard")]
+                            vec![],
+                        ));
+                    }
+                }
+                #[cfg(feature = "orchard")]
+                ShieldedPool::Orchard => {
+                    if let Some(note) = wallet::orchard::select_single_spendable_orchard_note(
+                        self.conn.borrow(),
+                        &self.params,
+                        account,
+                        value,
+                        target_height,
+                        confirmations_policy,
+                        exclude,
+                        lock_filter,
+                    )? {
+                        return Ok(ReceivedNotes::new(vec![], vec![note], vec![]));
+                    }
+                }
+                #[cfg(feature = "orchard")]
+                ShieldedPool::Ironwood => {
+                    if let Some(note) = wallet::orchard::select_single_spendable_ironwood_note(
+                        self.conn.borrow(),
+                        &self.params,
+                        account,
+                        value,
+                        target_height,
+                        confirmations_policy,
+                        exclude,
+                        lock_filter,
+                    )? {
+                        return Ok(ReceivedNotes::new(vec![], vec![], vec![note]));
+                    }
+                }
+                #[cfg(not(feature = "orchard"))]
+                ShieldedPool::Orchard | ShieldedPool::Ironwood => {}
+            }
+        }
+        Ok(ReceivedNotes::empty())
     }
 
     fn select_unspent_notes(

--- a/zcash_client_sqlite/src/testing/db.rs
+++ b/zcash_client_sqlite/src/testing/db.rs
@@ -42,6 +42,7 @@ use zcash_primitives::{
 };
 use zcash_protocol::{
     ShieldedPool, consensus, consensus::BlockHeight, local_consensus::LocalNetwork, memo::Memo,
+    value::Zatoshis,
 };
 use zip32::DiversifierIndex;
 

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -320,6 +320,13 @@ pub(crate) fn anchor_checkpoints_retained_across_deep_scan<T: ShieldedPoolTester
     }
 }
 
+pub(crate) fn oldest_note_is_selected_first<T: ShieldedPoolTester>() {
+    zcash_client_backend::data_api::testing::pool::oldest_note_is_selected_first::<T, _>(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
 /// Runs the empty-boundary retention check at a short interval, so a handful of filler blocks
 /// crosses two boundaries.
 #[cfg(feature = "orchard")]

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -358,6 +358,14 @@ pub(crate) fn canonical_crossing_builds_at_empty_boundary_block() {
 }
 
 #[cfg(feature = "orchard")]
+pub(crate) fn canonical_crossing_prefers_single_note() {
+    zcash_client_backend::data_api::testing::pool::canonical_crossing_prefers_single_note(
+        TestDbFactory::default(),
+        BlockCache::new(),
+    )
+}
+
+#[cfg(feature = "orchard")]
 pub(crate) fn multi_note_crossing_is_not_bucketed() {
     zcash_client_backend::data_api::testing::pool::multi_note_crossing_is_not_bucketed(
         TestDbFactory::default(),

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -377,6 +377,7 @@ where
             params,
             account,
             zats,
+            ValueSelection::Accumulate,
             target_height,
             anchor_height,
             confirmations_policy,
@@ -387,6 +388,54 @@ where
         ),
     }
 }
+
+/// Selects the single OLDEST spendable note of the given protocol whose value alone is at least
+/// `value`, or `None` when no single eligible note covers it. Age is the note's commitment tree
+/// position, which is assigned in strict chain order.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn select_single_spendable_note<P: consensus::Parameters, F, Note>(
+    conn: &Connection,
+    params: &P,
+    account: AccountUuid,
+    value: Zatoshis,
+    target_height: TargetHeight,
+    confirmations_policy: ConfirmationsPolicy,
+    exclude: &[ReceivedNoteId],
+    protocol: ShieldedPool,
+    to_spendable_note: F,
+    lock_filter: LockFilter<'_>,
+) -> Result<Option<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError>
+where
+    F: Fn(
+        &P,
+        ShieldedPool,
+        &Row,
+    ) -> Result<Option<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError>,
+{
+    let Some(anchor_height) =
+        get_anchor_height(conn, target_height, confirmations_policy.trusted())?
+    else {
+        return Ok(None);
+    };
+
+    Ok(select_spendable_notes_matching_value(
+        conn,
+        params,
+        account,
+        value,
+        ValueSelection::SingleCovering,
+        target_height,
+        anchor_height,
+        confirmations_policy,
+        exclude,
+        protocol,
+        &to_spendable_note,
+        lock_filter,
+    )?
+    .into_iter()
+    .next())
+}
+
 /// Selects all the unspent notes with value greater than [`zip317::MARGINAL_FEE`] and for the
 /// specified shielded protocols from a given account, excepting any explicitly excluded note
 /// identifiers.
@@ -562,9 +611,23 @@ where
         .collect()
 }
 
+/// The shape of a value-targeted note selection: accumulate the oldest notes toward the target,
+/// or draw only the single oldest note that covers it alone.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ValueSelection {
+    /// Accumulate the oldest eligible notes until the target value is covered.
+    Accumulate,
+    /// Select only the oldest eligible notes whose individual values cover the target alone,
+    /// oldest first.
+    SingleCovering,
+}
+
 /// Selects the set of spendable notes whose sum will be equal or greater that the
 /// specified ``target_value`` in Zatoshis from the specified shielded protocols excluding
 /// the ones present in the ``exclude`` slice.
+///
+/// Under [`ValueSelection::SingleCovering`], instead returns the notes whose individual value
+/// covers ``target_value`` alone, oldest first; callers take the head.
 ///
 /// - Implementation details
 ///   - Notes with individual value *below* the ``MARGINAL_FEE`` will be ignored
@@ -575,6 +638,7 @@ fn select_spendable_notes_matching_value<P: consensus::Parameters, F, Note>(
     params: &P,
     account: AccountUuid,
     target_value: Zatoshis,
+    selection: ValueSelection,
     target_height: TargetHeight,
     anchor_height: BlockHeight,
     confirmations_policy: ConfirmationsPolicy,
@@ -638,6 +702,32 @@ where
     };
     let crossing_note_subquery =
         "SELECT * from eligible WHERE so_far >= :target_value ORDER BY so_far LIMIT 1";
+    let result_columns = format!(
+        "id, txid, {output_index_col},
+                diversifier, value, {note_reconstruction_cols}, commitment_tree_position,
+                ufvk, recipient_key_scope,
+                mined_height, witness_stabilized, trust_status,
+                max_shielding_input_height, min_shielding_input_trust"
+    );
+    // The `eligible` CTE is shared; only the selection over it differs by shape. Accumulation
+    // takes every note below the running-sum threshold plus the threshold-crossing note;
+    // single-covering takes the individually sufficient notes, oldest first, and relies on the
+    // caller to take the head (the Rust-side confirmations filter below may drop leading rows,
+    // so the limit cannot be applied in SQL).
+    let selection_tail = match selection {
+        ValueSelection::Accumulate => format!(
+            "SELECT {result_columns}
+         FROM eligible WHERE so_far < :target_value
+         UNION
+         SELECT {result_columns}
+         FROM ({crossing_note_subquery})"
+        ),
+        ValueSelection::SingleCovering => format!(
+            "SELECT {result_columns}
+         FROM eligible WHERE value >= :target_value
+         ORDER BY commitment_tree_position"
+        ),
+    };
     let eligible_condition = output_eligible_condition(lock_filter, "rn");
     let mut stmt_select_notes = conn.prepare_cached(&format!(
         "WITH eligible AS (
@@ -687,19 +777,7 @@ where
              AND ({eligible_condition}) -- the note is eligible under the lock filter
              GROUP BY rn.id
          )
-         SELECT id, txid, {output_index_col},
-                diversifier, value, {note_reconstruction_cols}, commitment_tree_position,
-                ufvk, recipient_key_scope,
-                mined_height, witness_stabilized, trust_status,
-                max_shielding_input_height, min_shielding_input_trust
-         FROM eligible WHERE so_far < :target_value
-         UNION
-         SELECT id, txid, {output_index_col},
-                diversifier, value, {note_reconstruction_cols}, commitment_tree_position,
-                ufvk, recipient_key_scope,
-                mined_height, witness_stabilized, trust_status,
-                max_shielding_input_height, min_shielding_input_trust
-         FROM ({crossing_note_subquery})",
+         {selection_tail}",
         spent_notes_clause(table_prefix),
     ))?;
 

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -616,24 +616,28 @@ where
     //    well as a single note for which the sum was greater than or equal to the
     //    required value, bringing the sum of all selected notes across the threshold.
     //
+    // AGE is the note's commitment tree position: positions are assigned in strict chain
+    // order, so ordering by position is ordering by the age of the note on chain. The row
+    // id is NOT a usable proxy for age — ids are assigned in SCAN order, and priority
+    // scanning visits recent blocks before back-filling history, so a restored wallet's
+    // newest notes carry its lowest ids.
+    //
     // A `LockFilter::Policy` that prefers one lock tier (`PreferUnlocked`/`PreferLocked`)
-    // accumulates the running sum in tier order (via the window `ORDER BY`) so that the
-    // preferred tier is drawn upon first; the age order (`rn.id`) is retained as a secondary
+    // accumulates the running sum in tier order (via the leading window `ORDER BY` key) so
+    // that the preferred tier is drawn upon first; age order is retained as the secondary
     // key so that within each tier the oldest notes are still selected first. Because the
-    // tiered window order need not match the CTE's physical output order, the threshold-
-    // crossing note is chosen as the note with the smallest running sum at or above the
-    // target (`ORDER BY so_far`). For `Exclude`/`Unfiltered` the window and crossing-note
-    // selection are unchanged.
+    // window order need not match the CTE's physical output order, the threshold-crossing
+    // note is chosen as the note with the smallest running sum at or above the target
+    // (`ORDER BY so_far`).
     let tier_key = locked_tier_order_key(lock_filter, "rn");
     let window_frame = match &tier_key {
-        Some(tier_key) => format!("ORDER BY {tier_key}, rn.id ROWS UNBOUNDED PRECEDING"),
-        None => "ROWS UNBOUNDED PRECEDING".to_string(),
+        Some(tier_key) => {
+            format!("ORDER BY {tier_key}, rn.commitment_tree_position ROWS UNBOUNDED PRECEDING")
+        }
+        None => "ORDER BY rn.commitment_tree_position ROWS UNBOUNDED PRECEDING".to_string(),
     };
-    let crossing_note_subquery = if tier_key.is_some() {
-        "SELECT * from eligible WHERE so_far >= :target_value ORDER BY so_far LIMIT 1"
-    } else {
-        "SELECT * from eligible WHERE so_far >= :target_value LIMIT 1"
-    };
+    let crossing_note_subquery =
+        "SELECT * from eligible WHERE so_far >= :target_value ORDER BY so_far LIMIT 1";
     let eligible_condition = output_eligible_condition(lock_filter, "rn");
     let mut stmt_select_notes = conn.prepare_cached(&format!(
         "WITH eligible AS (

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -878,6 +878,11 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn oldest_note_is_selected_first() {
+        testing::pool::oldest_note_is_selected_first::<OrchardPoolTester>()
+    }
+
+    #[test]
     fn metadata_queries_exclude_unwanted_notes() {
         testing::pool::metadata_queries_exclude_unwanted_notes::<OrchardPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -21,6 +21,7 @@ use zcash_primitives::transaction::TxId;
 use zcash_protocol::{
     PoolType, ShieldedPool,
     consensus::{self, BlockHeight},
+    value::Zatoshis,
 };
 use zip32::Scope;
 
@@ -235,6 +236,56 @@ pub(crate) fn select_spendable_orchard_notes<P: consensus::Parameters>(
         confirmations_policy,
         exclude,
         ShieldedPool::Orchard,
+        to_received_note,
+        lock_filter,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn select_single_spendable_orchard_note<P: consensus::Parameters>(
+    conn: &Connection,
+    params: &P,
+    account: AccountUuid,
+    value: Zatoshis,
+    target_height: TargetHeight,
+    confirmations_policy: ConfirmationsPolicy,
+    exclude: &[ReceivedNoteId],
+    lock_filter: LockFilter<'_>,
+) -> Result<Option<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError> {
+    super::common::select_single_spendable_note(
+        conn,
+        params,
+        account,
+        value,
+        target_height,
+        confirmations_policy,
+        exclude,
+        ShieldedPool::Orchard,
+        to_received_note,
+        lock_filter,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn select_single_spendable_ironwood_note<P: consensus::Parameters>(
+    conn: &Connection,
+    params: &P,
+    account: AccountUuid,
+    value: Zatoshis,
+    target_height: TargetHeight,
+    confirmations_policy: ConfirmationsPolicy,
+    exclude: &[ReceivedNoteId],
+    lock_filter: LockFilter<'_>,
+) -> Result<Option<ReceivedNote<ReceivedNoteId, Note>>, SqliteClientError> {
+    super::common::select_single_spendable_note(
+        conn,
+        params,
+        account,
+        value,
+        target_height,
+        confirmations_policy,
+        exclude,
+        ShieldedPool::Ironwood,
         to_received_note,
         lock_filter,
     )
@@ -895,6 +946,11 @@ pub(crate) mod tests {
     #[test]
     fn canonical_crossing_builds_at_empty_boundary_block() {
         testing::pool::canonical_crossing_builds_at_empty_boundary_block()
+    }
+
+    #[test]
+    fn canonical_crossing_prefers_single_note() {
+        testing::pool::canonical_crossing_prefers_single_note()
     }
 
     #[test]

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -19,6 +19,7 @@ use zcash_keys::keys::{UnifiedAddressRequest, UnifiedFullViewingKey};
 use zcash_protocol::{
     ShieldedPool, TxId,
     consensus::{self, BlockHeight},
+    value::Zatoshis,
 };
 use zip32::Scope;
 
@@ -174,6 +175,31 @@ pub(crate) fn select_spendable_sapling_notes<P: consensus::Parameters>(
         params,
         account,
         target_value,
+        target_height,
+        confirmations_policy,
+        exclude,
+        ShieldedPool::Sapling,
+        to_received_note,
+        lock_filter,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn select_single_spendable_sapling_note<P: consensus::Parameters>(
+    conn: &Connection,
+    params: &P,
+    account: AccountUuid,
+    value: Zatoshis,
+    target_height: TargetHeight,
+    confirmations_policy: ConfirmationsPolicy,
+    exclude: &[ReceivedNoteId],
+    lock_filter: LockFilter<'_>,
+) -> Result<Option<ReceivedNote<ReceivedNoteId, sapling::Note>>, SqliteClientError> {
+    super::common::select_single_spendable_note(
+        conn,
+        params,
+        account,
+        value,
         target_height,
         confirmations_policy,
         exclude,

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -643,6 +643,11 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn oldest_note_is_selected_first() {
+        testing::pool::oldest_note_is_selected_first::<SaplingPoolTester>()
+    }
+
+    #[test]
     fn metadata_queries_exclude_unwanted_notes() {
         testing::pool::metadata_queries_exclude_unwanted_notes::<SaplingPoolTester>()
     }


### PR DESCRIPTION
Closes #2847. Stacked on #2849; only the top two commits are new here, and this should be rebased onto `main` once #2849 merges.

Two changes that together let ordinary wallets reliably produce canonical ZIP 318 crossings:

**`zcash_client_sqlite`: order note selection by chain age, not discovery.** The running-sum selection window ordered by row id (or not at all in the unfiltered case). Ids are assigned in scan order, and priority scanning visits recent blocks before back-filling history, so a restored wallet's newest notes carry its lowest ids: selection spent freshly received change while far older notes sat idle. The window now orders by note commitment tree position — assigned in strict chain order — with the lock-tier key, where present, remaining the leading key. The new test scans two notes out of chain order (so the newer note takes the lower id) and asserts that a selection either note could satisfy returns the older one.

**`zcash_client_backend`: fund canonical crossings from a single note.** A migration transfer spends exactly one note, but the canonical-crossing attempt ran ordinary greedy accumulation, which reaches the target through several small notes whenever the oldest notes are small — funding the payment while losing the canonical shape. `SpendPolicy` now carries a `NoteSelection` preference; under `PreferSingle` the selector first asks the data source for the single oldest note covering the required amount alone (the new `InputSource::select_single_spendable_note`, with a best-effort default and a direct-query sqlite implementation sharing the eligibility CTE), falling back to accumulation when no pool holds one. `propose_transfer` sets the preference only on its canonical attempt, so no changes are needed in the FFI, the mobile SDKs, or applications. The new test funds a wallet with two older small notes plus one larger covering note and asserts the canonical payment takes the single-note shape while a non-canonical amount still accumulates.

Age *filtering* required no new code: the bucketed anchor already raises the confirmation floor so only sufficiently-old notes are eligible for the canonical attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
