### PR TITLE
zcash_client_backend: model dummy outputs in proposals

### DIFF
--- a/zcash_client_backend/proto/proposal.proto
+++ b/zcash_client_backend/proto/proposal.proto
@@ -139,6 +139,16 @@ message TransactionBalance {
     repeated ChangeValue proposedChange = 1;
     // The fee to be paid by the proposed transaction, in zatoshis.
     uint64 feeRequired = 2;
+    // The exact number of dummy outputs in each shielded bundle. Omitted by
+    // proposals created before transaction shape was modelled explicitly.
+    DummyOutputs dummyOutputs = 3;
+}
+
+// Exact per-pool dummy-output counts for the proposed transaction.
+message DummyOutputs {
+    uint32 sapling = 1;
+    uint32 orchard = 2;
+    uint32 ironwood = 3;
 }
 
 // A proposed change or ephemeral output. If the transparent value pool is

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -8666,23 +8666,56 @@ pub fn canonical_crossing_is_bucketed_and_unpadded<Dsf: DataStoreFactory>(
     // comparison above must be proposed while funds remain. The built transaction takes the ZIP 318
     // rolling expiry rather than the builder's per-transaction one — every crossing in the same
     // modulus period shares it, so it identifies nothing.
-    // ROUND TRIP. The change strategy records the padding it charged the fee against; the builder
-    // reads that back rather than deciding again. Assert both ends and the transaction between
-    // them, so that a future change breaking the link fails here rather than at the builder's
-    // exact-balance check, or worse, silently on-chain.
+    // ROUND TRIP. The proposal records the exact dummy outputs costed by the fee model; the
+    // builder reads that transaction shape back rather than deciding again.
     assert_eq!(
         canonical
             .steps()
             .first()
             .balance()
-            .ironwood_bundle_padding(),
-        BundlePadding::UNPADDED,
-        "the fee model must record the unpadded shape it costed"
+            .dummy_outputs()
+            .expect("the fee model records dummy outputs")
+            .ironwood(),
+        0,
+        "a canonical crossing has no Ironwood dummy output"
     );
     assert_eq!(
         canonical.steps().first().ironwood_bundle_padding(),
         BundlePadding::UNPADDED,
         "and the step must report the recorded value to the builder"
+    );
+
+    // The proposal crosses the FFI boundary before it is built as a PCZT. Preserve all per-pool
+    // dummy-output counts through that serialization round-trip.
+    let proto = crate::proto::proposal::Proposal::from_standard_proposal(&canonical);
+    let serialized_dummy_outputs = proto.steps[0]
+        .balance
+        .as_ref()
+        .expect("a proposal step carries a balance")
+        .dummy_outputs
+        .as_ref()
+        .expect("new proposals serialize their dummy outputs");
+    assert_eq!(
+        (
+            serialized_dummy_outputs.sapling,
+            serialized_dummy_outputs.orchard,
+            serialized_dummy_outputs.ironwood,
+        ),
+        (0, 1, 0)
+    );
+    let canonical = proto
+        .try_into_standard_proposal(st.network(), st.wallet())
+        .expect("the canonical proposal must deserialize");
+    assert_eq!(
+        canonical
+            .steps()
+            .first()
+            .balance()
+            .dummy_outputs()
+            .expect("dummy outputs survive proposal decoding")
+            .ironwood(),
+        0,
+        "the PCZT proposal round-trip must preserve the Ironwood dummy-output count"
     );
 
     let txids = st.create_proposed_expecting(&canonical, 1);

--- a/zcash_client_backend/src/fees.rs
+++ b/zcash_client_backend/src/fees.rs
@@ -5,8 +5,6 @@ use std::{
 };
 
 use ::transparent::bundle::OutPoint;
-#[cfg(feature = "orchard")]
-use zcash_primitives::transaction::builder::BundlePadding;
 use zcash_primitives::transaction::fees::{
     FeeRule,
     transparent::{self, InputSize},
@@ -262,12 +260,54 @@ pub struct TransactionBalance {
     // cache the resulting value.
     total: Zatoshis,
 
-    // The Ironwood bundle padding this fee was computed for. RECORDED rather than re-derived: the
-    // transaction builder must produce exactly the action count the fee was charged against, and
-    // deriving the same answer twice from the same inputs is an invariant that has to be
-    // maintained, whereas carrying it is one that cannot be broken.
+    // The exact number of dummy outputs in each shielded bundle this balance was costed for.
+    // `None` is retained for compatibility with callers and serialized proposals that predate
+    // explicit transaction-shape modelling.
+    dummy_outputs: Option<DummyOutputCounts>,
+}
+
+/// The number of dummy outputs in each shielded value pool.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DummyOutputCounts {
+    sapling: usize,
     #[cfg(feature = "orchard")]
-    ironwood_bundle_padding: BundlePadding,
+    orchard: usize,
+    #[cfg(feature = "orchard")]
+    ironwood: usize,
+}
+
+impl DummyOutputCounts {
+    /// Constructs per-pool dummy-output counts.
+    pub fn new(
+        sapling: usize,
+        #[cfg(feature = "orchard")] orchard: usize,
+        #[cfg(feature = "orchard")] ironwood: usize,
+    ) -> Self {
+        Self {
+            sapling,
+            #[cfg(feature = "orchard")]
+            orchard,
+            #[cfg(feature = "orchard")]
+            ironwood,
+        }
+    }
+
+    /// Returns the number of Sapling dummy outputs.
+    pub fn sapling(&self) -> usize {
+        self.sapling
+    }
+
+    /// Returns the number of Orchard dummy outputs.
+    #[cfg(feature = "orchard")]
+    pub fn orchard(&self) -> usize {
+        self.orchard
+    }
+
+    /// Returns the number of Ironwood dummy outputs.
+    #[cfg(feature = "orchard")]
+    pub fn ironwood(&self) -> usize {
+        self.ironwood
+    }
 }
 
 impl TransactionBalance {
@@ -287,29 +327,19 @@ impl TransactionBalance {
             proposed_change,
             fee_required,
             total,
-            #[cfg(feature = "orchard")]
-            ironwood_bundle_padding: BundlePadding::DEFAULT,
+            dummy_outputs: None,
         })
     }
 
-    /// Records the Ironwood bundle padding this fee was computed for.
-    ///
-    /// A [`ChangeStrategy`] that costs a transaction's Ironwood bundle as unpadded MUST record it
-    /// here, so that the builder produces the same action count the fee was charged against. The
-    /// default is [`BundlePadding::DEFAULT`].
-    #[cfg(feature = "orchard")]
-    pub fn with_ironwood_bundle_padding(mut self, padding: BundlePadding) -> Self {
-        self.ironwood_bundle_padding = padding;
+    /// Records the exact dummy-output counts this balance was computed for.
+    pub fn with_dummy_outputs(mut self, dummy_outputs: DummyOutputCounts) -> Self {
+        self.dummy_outputs = Some(dummy_outputs);
         self
     }
 
-    /// The Ironwood bundle padding this fee was computed for.
-    ///
-    /// The transaction builder takes its padding from here rather than deciding for itself; see
-    /// [`Self::with_ironwood_bundle_padding`].
-    #[cfg(feature = "orchard")]
-    pub fn ironwood_bundle_padding(&self) -> BundlePadding {
-        self.ironwood_bundle_padding
+    /// Returns the exact dummy-output counts this balance was computed for, when recorded.
+    pub fn dummy_outputs(&self) -> Option<DummyOutputCounts> {
+        self.dummy_outputs
     }
 
     /// The change values proposed by the [`ChangeStrategy`] that computed this balance.

--- a/zcash_client_backend/src/fees/common.rs
+++ b/zcash_client_backend/src/fees/common.rs
@@ -10,10 +10,8 @@ use zcash_primitives::transaction::fees::{
 use zcash_protocol::zip318::PoolMigrationConstants;
 
 use crate::data_api::anchor_retention::PoolMigrationParams;
-#[cfg(feature = "orchard")]
-use zcash_protocol::PoolType;
 use zcash_protocol::{
-    ShieldedPool,
+    PoolType, ShieldedPool,
     consensus::{self, BlockHeight, NetworkUpgrade},
     memo::MemoBytes,
     value::{BalanceError, Zatoshis},
@@ -22,8 +20,8 @@ use zcash_protocol::{
 use crate::data_api::{AccountMeta, wallet::TargetHeight};
 
 use super::{
-    ChangeError, ChangeValue, DustAction, DustOutputPolicy, EphemeralBalance, SplitPolicy,
-    TransactionBalance, sapling as sapling_fees,
+    ChangeError, ChangeValue, DummyOutputCounts, DustAction, DustOutputPolicy, EphemeralBalance,
+    SplitPolicy, TransactionBalance, sapling as sapling_fees,
 };
 
 #[cfg(feature = "transparent-inputs")]
@@ -432,8 +430,8 @@ where
     // output whose value is a canonical ZIP 318 denomination, which is exactly the shape of a
     // ZIP 318 migration transfer. Building it unpadded puts an ordinary turnstile-crossing
     // payment into that anonymity set rather than leaving it distinguishable by action count.
-    // `Step::ironwood_bundle_padding` decides the same question from the finished proposal, and
-    // the two must agree or the builder's exact-balance check will reject the transaction.
+    // The resulting dummy-output count is recorded below. `Step::ironwood_bundle_padding`
+    // reconstructs the builder's action target from that finished transaction shape.
     //
     // The value is only known here when the sole output is a PAYMENT, i.e. `change_count == 0`;
     // an Ironwood change value is what this function is in the middle of solving for. That costs
@@ -833,40 +831,51 @@ where
             .map(ChangeValue::ephemeral_transparent),
     );
 
-    // Record the padding the fee above was actually charged against, derived from the change set
-    // finally chosen rather than from any candidate considered along the way. The builder reads
-    // this back instead of re-deciding, so the two cannot disagree.
-    #[cfg(feature = "orchard")]
-    let ironwood_padding = {
-        let final_change = OutputManifest {
-            transparent: change
-                .iter()
-                .filter(|c| c.output_pool() == PoolType::TRANSPARENT)
-                .count(),
-            sapling: change
-                .iter()
-                .filter(|c| c.output_pool() == PoolType::SAPLING)
-                .count(),
-            orchard: change
-                .iter()
-                .filter(|c| c.output_pool() == PoolType::ORCHARD)
-                .count(),
-            ironwood: change
-                .iter()
-                .filter(|c| c.output_pool() == PoolType::IRONWOOD)
-                .count(),
-        };
-        if ironwood_is_canonical_crossing(final_change) {
-            BundlePadding::UNPADDED
-        } else {
-            BundlePadding::DEFAULT
-        }
+    // Record the exact number of dummy outputs in each shielded bundle. This is transaction
+    // shape, rather than a builder policy; it can therefore be serialized in a proposal and
+    // reproduced by every construction path without re-running the fee model.
+    let final_change = OutputManifest {
+        transparent: change
+            .iter()
+            .filter(|c| c.output_pool() == PoolType::TRANSPARENT)
+            .count(),
+        sapling: change
+            .iter()
+            .filter(|c| c.output_pool() == PoolType::SAPLING)
+            .count(),
+        orchard: change
+            .iter()
+            .filter(|c| c.output_pool() == PoolType::ORCHARD)
+            .count(),
+        ironwood: change
+            .iter()
+            .filter(|c| c.output_pool() == PoolType::IRONWOOD)
+            .count(),
     };
-
-    let balance = TransactionBalance::new(change, fee).map_err(|_| overflow())?;
+    let sapling_real_outputs = sapling.outputs().len() + final_change.sapling();
+    let sapling_dummy_outputs = sapling_output_count(final_change.sapling())?
+        .checked_sub(sapling_real_outputs)
+        .expect("the Sapling action count includes every real output");
     #[cfg(feature = "orchard")]
-    let balance = balance.with_ironwood_bundle_padding(ironwood_padding);
-    Ok(balance)
+    let orchard_dummy_outputs = orchard_action_count(final_change.orchard())?
+        .checked_sub(orchard.outputs().len() + final_change.orchard())
+        .expect("the Orchard action count includes every real output");
+    #[cfg(feature = "orchard")]
+    let ironwood_dummy_outputs = ironwood_action_count(final_change)?
+        .checked_sub(ironwood.outputs().len() + final_change.ironwood())
+        .expect("the Ironwood action count includes every real output");
+
+    TransactionBalance::new(change, fee)
+        .map(|balance| {
+            balance.with_dummy_outputs(DummyOutputCounts::new(
+                sapling_dummy_outputs,
+                #[cfg(feature = "orchard")]
+                orchard_dummy_outputs,
+                #[cfg(feature = "orchard")]
+                ironwood_dummy_outputs,
+            ))
+        })
+        .map_err(|_| overflow())
 }
 
 /// Returns a `[ChangeStrategy::DustInputs]` error if some of the inputs provided

--- a/zcash_client_backend/src/fees/zip317.rs
+++ b/zcash_client_backend/src/fees/zip317.rs
@@ -899,14 +899,12 @@ mod tests {
         );
     }
 
-    /// The change strategy RECORDS the Ironwood padding it charged the fee against, so the builder
-    /// can reproduce that action count instead of deriving it a second time. A canonical crossing
-    /// is costed unpadded; a payment one zatoshi off a canonical denomination, identical in every
-    /// other respect, is costed padded.
+    /// The change strategy records the exact dummy outputs it charged the fee against, so the
+    /// builder can reproduce that action count. A canonical crossing has no Ironwood dummy output;
+    /// a payment one zatoshi off the denomination grid has one.
     #[test]
     #[cfg(feature = "orchard")]
-    fn the_change_strategy_records_the_padding_it_costed() {
-        use zcash_primitives::transaction::builder::BundlePadding;
+    fn the_change_strategy_records_the_dummy_outputs_it_costed() {
         use zcash_protocol::zip318::{AnchorBucketInterval, MAX_RESIDUAL_VALUE};
 
         use crate::data_api::wallet::TargetHeight;
@@ -964,13 +962,15 @@ mod tests {
                     &(),
                 )
                 .expect("the input covers the payment and its fee")
-                .ironwood_bundle_padding()
+                .dummy_outputs()
+                .expect("the change strategy records dummy outputs")
+                .ironwood()
         };
 
-        assert_eq!(recorded_for(MAX_RESIDUAL_VALUE), BundlePadding::UNPADDED);
+        assert_eq!(recorded_for(MAX_RESIDUAL_VALUE), 0);
         assert_eq!(
             recorded_for((MAX_RESIDUAL_VALUE + Zatoshis::const_from_u64(1)).unwrap()),
-            BundlePadding::DEFAULT
+            1
         );
     }
 

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -997,7 +997,23 @@ impl<NoteRef> Step<NoteRef> {
     /// [`ChangeStrategy`]: crate::fees::ChangeStrategy
     #[cfg(feature = "orchard")]
     pub fn ironwood_bundle_padding(&self) -> BundlePadding {
-        self.balance().ironwood_bundle_padding()
+        let Some(dummy_outputs) = self.balance().dummy_outputs() else {
+            return BundlePadding::DEFAULT;
+        };
+
+        let real_outputs = self.output_count_in_pool(PoolType::IRONWOOD)
+            + self.change_count_in_pool(PoolType::IRONWOOD);
+        let target_actions = real_outputs + dummy_outputs.ironwood();
+
+        // `pad_to_minimum` is only an 8-bit floor. If the requested transaction is larger than
+        // that, its real spends and outputs already force the required action count, so no floor
+        // is needed.
+        u8::try_from(target_actions).map_or(BundlePadding::UNPADDED, |minimum| BundlePadding {
+            bundle_required: target_actions > 0
+                && self.input_count_in_pool(PoolType::IRONWOOD) == 0
+                && real_outputs == 0,
+            pad_to_minimum: Some(minimum.max(1)),
+        })
     }
 
     #[cfg(feature = "orchard")]
@@ -1124,7 +1140,7 @@ mod tests {
     use super::{Proposal, ProposalError, ShieldedInputs, Step};
     use crate::{
         data_api::wallet::{ConfirmationsPolicy, TargetHeight},
-        fees::{ChangeValue, TransactionBalance},
+        fees::{ChangeValue, DummyOutputCounts, TransactionBalance},
         wallet::Note,
     };
 
@@ -1254,7 +1270,7 @@ mod tests {
             prior_step_inputs: vec![],
             balance: TransactionBalance::new(change, canonical_fee())
                 .unwrap()
-                .with_ironwood_bundle_padding(BundlePadding::UNPADDED),
+                .with_dummy_outputs(DummyOutputCounts::new(0, 0, 0)),
             is_shielding: false,
         }
     }

--- a/zcash_client_backend/src/proto.rs
+++ b/zcash_client_backend/src/proto.rs
@@ -32,7 +32,7 @@ use crate::{
         chain::ChainState,
         wallet::{ConfirmationsPolicy, TargetHeight, input_selection::LockFilter},
     },
-    fees::{ChangeValue, StandardFeeRule, TransactionBalance},
+    fees::{ChangeValue, DummyOutputCounts, StandardFeeRule, TransactionBalance},
     proposal::{
         Proposal, ProposalError, ShieldedInputs, Step, StepOutput, StepOutputIndex,
         produces_shielded_bundle,
@@ -751,6 +751,28 @@ impl proposal::Proposal {
                         })
                         .collect(),
                     fee_required: step.balance().fee_required().into(),
+                    dummy_outputs: step.balance().dummy_outputs().map(|counts| {
+                        proposal::DummyOutputs {
+                            sapling: counts
+                                .sapling()
+                                .try_into()
+                                .expect("Sapling dummy-output count fits into u32"),
+                            #[cfg(feature = "orchard")]
+                            orchard: counts
+                                .orchard()
+                                .try_into()
+                                .expect("Orchard dummy-output count fits into u32"),
+                            #[cfg(not(feature = "orchard"))]
+                            orchard: 0,
+                            #[cfg(feature = "orchard")]
+                            ironwood: counts
+                                .ironwood()
+                                .try_into()
+                                .expect("Ironwood dummy-output count fits into u32"),
+                            #[cfg(not(feature = "orchard"))]
+                            ironwood: 0,
+                        }
+                    }),
                 });
 
                 proposal::ProposalStep {
@@ -1013,6 +1035,21 @@ impl proposal::Proposal {
                             .map_err(|_| ProposalDecodingError::BalanceInvalid)?,
                     )
                     .map_err(|_| ProposalDecodingError::BalanceInvalid)?;
+                    let balance = match proto_balance.dummy_outputs.as_ref() {
+                        Some(counts) => {
+                            #[cfg(feature = "orchard")]
+                            let dummy_outputs = DummyOutputCounts::new(
+                                counts.sapling as usize,
+                                counts.orchard as usize,
+                                counts.ironwood as usize,
+                            );
+                            #[cfg(not(feature = "orchard"))]
+                            let dummy_outputs = DummyOutputCounts::new(counts.sapling as usize);
+                            balance.with_dummy_outputs(dummy_outputs)
+                        }
+                        // Older proposals did not explicitly model their dummy outputs.
+                        None => balance,
+                    };
 
                     // The `anchorHeight` field's zero value is the wire sentinel for a step that
                     // carries no anchor. Only a purely transparent step may lack one: any step that

--- a/zcash_client_backend/src/proto/proposal.rs
+++ b/zcash_client_backend/src/proto/proposal.rs
@@ -137,6 +137,20 @@ pub struct TransactionBalance {
     /// The fee to be paid by the proposed transaction, in zatoshis.
     #[prost(uint64, tag = "2")]
     pub fee_required: u64,
+    /// The exact number of dummy outputs in each shielded bundle. Omitted by
+    /// proposals created before transaction shape was modelled explicitly.
+    #[prost(message, optional, tag = "3")]
+    pub dummy_outputs: ::core::option::Option<DummyOutputs>,
+}
+/// Exact per-pool dummy-output counts for the proposed transaction.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct DummyOutputs {
+    #[prost(uint32, tag = "1")]
+    pub sapling: u32,
+    #[prost(uint32, tag = "2")]
+    pub orchard: u32,
+    #[prost(uint32, tag = "3")]
+    pub ironwood: u32,
 }
 /// A proposed change or ephemeral output. If the transparent value pool is
 /// selected, the `memo` field must be null.


### PR DESCRIPTION
## Summary

Models the exact number of dummy outputs for the Sapling, Orchard, and Ironwood bundles in transaction proposals, and preserves those counts across proposal serialization.

## Root cause

A canonical Orchard-to-Ironwood crossing has no Ironwood dummy output and is priced with one Ironwood action (15,000 zats). Proposal protobuf serialization previously omitted this transaction shape. On deserialization, the builder used the default two-action shape, which added one dummy output, required 20,000 zats, and failed with an apparent 5,000-zat insufficient-funds error.

This affects ordinary software-wallet sends as well: they cross the proposal protobuf boundary before being built as PCZTs. Older proposals that omit the new counts retain the previous default behavior.

## Validation

- `cargo test -p zcash_client_backend --lib --features orchard,pczt`
- `cargo test -p zcash_client_sqlite canonical_crossing_is_bucketed_and_unpadded --features orchard`
- Reproduced with the affected mobile wallet database and recipient: proposal creation, PCZT creation, and transaction authorization all succeeded with this change (without broadcast).
