### PR TITLE
zcash_client_sqlite: preserve lock-tier preference in single-note selection

### DIFF
--- a/zcash_client_backend/src/data_api/testing/pool/locking.rs
+++ b/zcash_client_backend/src/data_api/testing/pool/locking.rs
@@ -14,19 +14,18 @@ use zcash_protocol::{PoolType, TxId, consensus::BlockHeight, value::Zatoshis};
 use zip321::Payment;
 
 #[cfg(feature = "transparent-inputs")]
-use crate::data_api::{
-    InputSource, WalletRead, WalletWrite,
-    wallet::{
-        TargetHeight,
-        input_selection::{LockFilter, LockedInputPolicy},
-    },
-};
+use crate::data_api::WalletWrite;
 use crate::{
     data_api::{
-        self, Account as _, OutputLockStore, WalletTest,
+        self, Account as _, InputSource, OutputLockStore, WalletRead, WalletTest,
         error::LockError,
         testing::{DataStoreFactory, TestCache, single_output_change_strategy},
-        wallet::{ConfirmationsPolicy, input_selection::GreedyInputSelector},
+        wallet::{
+            ConfirmationsPolicy, TargetHeight,
+            input_selection::{
+                GreedyInputSelector, LockFilter, LockedInputPolicy, NonEmptyBTreeSet,
+            },
+        },
     },
     fees::StandardFeeRule,
     wallet::{LockOwner, OutputRef, OvkPolicy},
@@ -1260,4 +1259,80 @@ where
         .get(taddr)
         .expect("the address has a balance entry");
     assert_eq!(bal.spendable_value(), value);
+}
+
+/// Single-note selection preserves the caller's lock-tier preference: the lock tier is the
+/// primary sort key and chain age the secondary, matching the accumulation path's window order.
+/// Without this, when `PreferUnlocked` or `PreferLocked` admits both tiers, the single oldest
+/// covering note can come from the NON-preferred tier — in particular, `PreferUnlocked` could
+/// reuse an acknowledged in-flight locked input merely because it is older than an unlocked
+/// alternative.
+pub fn single_note_selection_honors_lock_tier_preference<T: ShieldedPoolTester>(
+    ds_factory: impl DataStoreFactory,
+    cache: impl TestCache,
+) {
+    let mut st = TestDsl::with_sapling_birthday_account(ds_factory, cache).build::<T>();
+
+    // Two notes in successive blocks, each singly covering the target below. The OLDER note is
+    // then locked, so tier preference and age preference disagree about which note to pick.
+    let older_locked_value = Zatoshis::const_from_u64(50_000);
+    let newer_unlocked_value = Zatoshis::const_from_u64(40_000);
+    st.add_notes_checking_balance([[older_locked_value], [newer_unlocked_value]]);
+
+    let account_id = st.test_account().unwrap().id();
+    let older_ref = st.note_ref_by_value(older_locked_value);
+    let owner = LockOwner::new([0xA1; 32]);
+    assert_eq!(
+        st.wallet_mut()
+            .lock_outputs(&[older_ref], owner, BlockHeight::from(u32::MAX))
+            .unwrap(),
+        1
+    );
+
+    let target_height = TargetHeight::from(
+        st.wallet()
+            .chain_height()
+            .unwrap()
+            .expect("the chain has been scanned")
+            + 1,
+    );
+    // Below either note's value, so both are covering candidates.
+    let value = Zatoshis::const_from_u64(30_000);
+    let select = |policy: &LockedInputPolicy| {
+        st.wallet()
+            .select_single_spendable_note(
+                account_id,
+                value,
+                &[T::SHIELDED_PROTOCOL],
+                target_height,
+                ConfirmationsPolicy::MIN,
+                &[],
+                LockFilter::Policy(policy),
+            )
+            .unwrap()
+    };
+
+    // `PreferUnlocked` admits both tiers, but must draw the unlocked tier first even though the
+    // locked note is older.
+    let unlocked_pref = LockedInputPolicy::PreferUnlocked(NonEmptyBTreeSet::singleton(owner));
+    assert_eq!(
+        select(&unlocked_pref).total_value().unwrap(),
+        newer_unlocked_value,
+        "PreferUnlocked must not reach for an older locked note past an unlocked alternative"
+    );
+
+    // `PreferLocked` draws the locked tier first.
+    let locked_pref = LockedInputPolicy::PreferLocked(NonEmptyBTreeSet::singleton(owner));
+    assert_eq!(
+        select(&locked_pref).total_value().unwrap(),
+        older_locked_value,
+        "PreferLocked must draw the locked tier first"
+    );
+
+    // `Exclude` admits only the unlocked note at all.
+    assert_eq!(
+        select(&LockedInputPolicy::Exclude).total_value().unwrap(),
+        newer_unlocked_value,
+        "Exclude must never surface a locked note"
+    );
 }

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -25,7 +25,7 @@ use crate::{
     wallet::{
         get_anchor_height,
         locking::{
-            locked_tier_order_key, output_eligible_condition, overridable_owners_rarray,
+            locked_tier_expr, output_eligible_condition, overridable_owners_rarray,
             push_lock_params,
         },
         pool_code,
@@ -693,13 +693,21 @@ where
     // window order need not match the CTE's physical output order, the threshold-crossing
     // note is chosen as the note with the smallest running sum at or above the target
     // (`ORDER BY so_far`).
-    let tier_key = locked_tier_order_key(lock_filter, "rn");
-    let window_frame = match &tier_key {
-        Some(tier_key) => {
-            format!("ORDER BY {tier_key}, rn.commitment_tree_position ROWS UNBOUNDED PRECEDING")
-        }
+    let tier = locked_tier_expr(lock_filter, "rn");
+    let window_frame = match &tier {
+        Some((expr, direction)) => format!(
+            "ORDER BY {expr} {direction}, rn.commitment_tree_position ROWS UNBOUNDED PRECEDING"
+        ),
         None => "ORDER BY rn.commitment_tree_position ROWS UNBOUNDED PRECEDING".to_string(),
     };
+    // The single-covering tail selects FROM the CTE, where `rn` is out of scope, so the tier
+    // expression is materialized as a CTE column with the direction applied at the ordering
+    // site; a constant stands in when the lock filter admits only one tier and no preference
+    // applies.
+    let (tier_column, tier_direction) = tier
+        .as_ref()
+        .map(|(expr, direction)| (expr.as_str(), *direction))
+        .unwrap_or(("0", "ASC"));
     let crossing_note_subquery =
         "SELECT * from eligible WHERE so_far >= :target_value ORDER BY so_far LIMIT 1";
     let result_columns = format!(
@@ -711,9 +719,11 @@ where
     );
     // The `eligible` CTE is shared; only the selection over it differs by shape. Accumulation
     // takes every note below the running-sum threshold plus the threshold-crossing note;
-    // single-covering takes the individually sufficient notes, oldest first, and relies on the
-    // caller to take the head (the Rust-side confirmations filter below may drop leading rows,
-    // so the limit cannot be applied in SQL).
+    // single-covering takes the individually sufficient notes ordered by lock tier first and
+    // age second — the same key order the accumulation window uses, so a `PreferUnlocked` or
+    // `PreferLocked` caller draws its preferred tier before an older note of the other tier —
+    // and relies on the caller to take the head (the Rust-side confirmations filter below may
+    // drop leading rows, so the limit cannot be applied in SQL).
     let selection_tail = match selection {
         ValueSelection::Accumulate => format!(
             "SELECT {result_columns}
@@ -725,7 +735,7 @@ where
         ValueSelection::SingleCovering => format!(
             "SELECT {result_columns}
          FROM eligible WHERE value >= :target_value
-         ORDER BY commitment_tree_position"
+         ORDER BY lock_tier {tier_direction}, commitment_tree_position"
         ),
     };
     let eligible_condition = output_eligible_condition(lock_filter, "rn");
@@ -735,6 +745,7 @@ where
                  rn.id AS id, t.txid, rn.{output_index_col},
                  rn.diversifier, rn.value,
                  {note_reconstruction_cols}, rn.commitment_tree_position,
+                 {tier_column} AS lock_tier,
                  SUM(value) OVER ({window_frame}) AS so_far,
                  accounts.ufvk as ufvk, rn.recipient_key_scope,
                  t.block AS mined_height,

--- a/zcash_client_sqlite/src/wallet/locking.rs
+++ b/zcash_client_sqlite/src/wallet/locking.rs
@@ -329,8 +329,9 @@ pub(crate) fn push_lock_params<'a>(
     }
 }
 
-/// Returns the tier-preference sort key `(<lock tier>) ASC|DESC` for a [`LockFilter`] that prefers
-/// one lock tier over the other, or `None` when no tier preference applies
+/// Returns the tier-preference sort key for a [`LockFilter`] that prefers one lock tier over the
+/// other, as its constituent parts — the tier EXPRESSION and the sort DIRECTION (`ASC`/`DESC`)
+/// realizing the preference — or `None` when no tier preference applies
 /// ([`LockedInputPolicy::Exclude`] and [`LockFilter::Unfiltered`], which draw on a single admitted
 /// tier or apply no lock filtering).
 ///
@@ -342,7 +343,10 @@ pub(crate) fn push_lock_params<'a>(
 ///
 /// This key is a *preference* over an eligible set: callers must combine it with the existing
 /// within-tier ordering (age or value) as a secondary key so that ordering is preserved within
-/// each tier.
+/// each tier. The parts are returned separately so that a query which must materialize the tier
+/// as a column (an `ORDER BY` over a CTE cannot reference the underlying table's alias) can apply
+/// the direction at the ordering site; callers ordering on the expression directly compose
+/// `"{expr} {direction}"`.
 ///
 /// # Usage requirements
 /// - `tbl` must be set to the SQL alias for the received notes/outputs table.
@@ -351,7 +355,10 @@ pub(crate) fn push_lock_params<'a>(
 /// [`LockedInputPolicy::Exclude`]: zcash_client_backend::data_api::wallet::input_selection::LockedInputPolicy::Exclude
 /// [`LockedInputPolicy::PreferUnlocked`]: zcash_client_backend::data_api::wallet::input_selection::LockedInputPolicy::PreferUnlocked
 /// [`LockedInputPolicy::PreferLocked`]: zcash_client_backend::data_api::wallet::input_selection::LockedInputPolicy::PreferLocked
-pub(crate) fn locked_tier_order_key(lock_filter: LockFilter<'_>, tbl: &str) -> Option<String> {
+pub(crate) fn locked_tier_expr(
+    lock_filter: LockFilter<'_>,
+    tbl: &str,
+) -> Option<(String, &'static str)> {
     match lock_filter {
         LockFilter::Policy(policy) if policy.admits_locked() => {
             let direction = if policy.prefers_locked() {
@@ -359,9 +366,12 @@ pub(crate) fn locked_tier_order_key(lock_filter: LockFilter<'_>, tbl: &str) -> O
             } else {
                 "ASC"
             };
-            Some(format!(
-                "(CASE WHEN {tbl}.lock_expiry_height IS NOT NULL \
-                  AND {tbl}.lock_expiry_height >= :target_height THEN 1 ELSE 0 END) {direction}"
+            Some((
+                format!(
+                    "(CASE WHEN {tbl}.lock_expiry_height IS NOT NULL \
+                      AND {tbl}.lock_expiry_height >= :target_height THEN 1 ELSE 0 END)"
+                ),
+                direction,
             ))
         }
         _ => None,
@@ -424,7 +434,7 @@ mod tests {
     ///   - `Policy(PreferUnlocked | PreferLocked)` additionally admits outputs whose `lock_owner` is
     ///     one of the policy's overridable owners, and never an output locked by any other owner.
     /// - Greedy value-target selection is TIERED under a preference policy
-    ///   (`locked_tier_order_key`): `PreferUnlocked` draws unlocked outputs before owned-locked
+    ///   (`locked_tier_expr`): `PreferUnlocked` draws unlocked outputs before owned-locked
     ///   ones and `PreferLocked` the reverse, each retaining age order within a tier; `Exclude` and
     ///   `Unfiltered` impose no tier preference.
     /// - A lock may be (re)acquired when no lock exists, when the existing lock has expired as of
@@ -443,7 +453,7 @@ mod tests {
         };
 
         use crate::wallet::locking::{
-            locked_tier_order_key, output_eligible_condition, output_lockable_condition,
+            locked_tier_expr, output_eligible_condition, output_lockable_condition,
             overridable_owners_rarray, push_lock_params,
         };
 
@@ -576,7 +586,8 @@ mod tests {
         ) -> Vec<i64> {
             let conn = candidates_db(candidates);
             let eligible_condition = output_eligible_condition(lock_filter, "t");
-            let tier_key = locked_tier_order_key(lock_filter, "t");
+            let tier_key = locked_tier_expr(lock_filter, "t")
+                .map(|(expr, direction)| format!("{expr} {direction}"));
             let window_frame = match &tier_key {
                 Some(k) => format!("ORDER BY {k}, t.id ROWS UNBOUNDED PRECEDING"),
                 None => "ROWS UNBOUNDED PRECEDING".to_string(),
@@ -1164,6 +1175,14 @@ mod tests {
             )
         }
 
+        #[test]
+        fn single_note_selection_honors_lock_tier_preference() {
+            pool::single_note_selection_honors_lock_tier_preference::<SaplingPoolTester>(
+                TestDbFactory::default(),
+                BlockCache::new(),
+            )
+        }
+
         proptest::proptest! {
             // Each case builds a fresh wallet and replays an operation sequence, so keep the
             // case count moderate; the sequences themselves explore the expiry boundaries.
@@ -1253,6 +1272,14 @@ mod tests {
         #[test]
         fn unlock_proposal_inputs_releases_locks() {
             pool::unlock_proposal_inputs_releases_locks::<OrchardPoolTester>(
+                TestDbFactory::default(),
+                BlockCache::new(),
+            )
+        }
+
+        #[test]
+        fn single_note_selection_honors_lock_tier_preference() {
+            pool::single_note_selection_honors_lock_tier_preference::<OrchardPoolTester>(
                 TestDbFactory::default(),
                 BlockCache::new(),
             )

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -82,7 +82,7 @@ use crate::{
 };
 // Used only by the value-target transparent selection, which is gated on transparent inputs.
 #[cfg(feature = "transparent-inputs")]
-use crate::wallet::locking::locked_tier_order_key;
+use crate::wallet::locking::locked_tier_expr;
 
 pub(crate) mod ephemeral;
 
@@ -1597,8 +1597,10 @@ pub(crate) fn select_spendable_transparent_outputs<P: consensus::Parameters>(
     // `LockFilter::Policy` that prefers one lock tier prefixes the value ordering with a lock-tier
     // key (Part B): the preferred tier is drawn upon first, with value-descending order retained as
     // a secondary key within each tier. For `Exclude`/`Unfiltered` the ordering is unchanged.
-    let order_by_sql = match locked_tier_order_key(lock_filter, "u") {
-        Some(tier_key) => format!("{tier_key}, u.value_zat DESC, u.output_index"),
+    let order_by_sql = match locked_tier_expr(lock_filter, "u") {
+        Some((expr, direction)) => {
+            format!("{expr} {direction}, u.value_zat DESC, u.output_index")
+        }
         None => "u.value_zat DESC, u.output_index".to_string(),
     };
 


### PR DESCRIPTION
Addresses the post-merge review feedback on #2850: https://github.com/zcash/librustzcash/pull/2850#issuecomment-5124366640

The `ValueSelection::SingleCovering` query ordered its candidates only by `commitment_tree_position`, so when `PreferUnlocked` or `PreferLocked` admitted both lock tiers, the single oldest covering note could come from the non-preferred tier — in particular, `PreferUnlocked` could reuse an acknowledged in-flight locked input despite an unlocked alternative.

The lock tier is now the primary sort key and chain age the secondary, matching the accumulation path's window order. Because the single-covering tail orders over the CTE (where the notes-table alias is out of scope), the tier expression is materialized as a CTE column and the sort direction applied at the ordering site: `locked_tier_expr` replaces `locked_tier_order_key`, returning the expression and direction separately, with the former composition inlined at the callers that still order on the expression directly.

The new scenario, `single_note_selection_honors_lock_tier_preference` (registered for both shielded pools), locks the older of two covering notes and asserts that single-note selection returns the unlocked note under `PreferUnlocked`, the locked note under `PreferLocked`, and the unlocked note under `Exclude`. Without the fix it fails exactly as the review describes: `PreferUnlocked` reaches for the older locked note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)