### PR TITLE
zcash_client_sqlite: report transparent outputs at their transparent receiver in v_tx_outputs

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -48,6 +48,13 @@ workspace.
   commitment tree position (chain order). Previously notes were drawn in
   scan-discovery order, which for a restored wallet prefers its most recently
   discovered — typically newest — notes.
+- The `to_address` column of the `v_tx_outputs` view now reports transparent
+  outputs received by the wallet at the transparent receiver address itself,
+  rather than at a unified address containing that receiver, and for outputs
+  the wallet created, the recipient address recorded at transaction
+  construction time now takes precedence over the receiving address.
+  Previously, a payment to one of the wallet's own transparent addresses was
+  reported with the receiving account's unified address as its `to_address`.
 
 ## [0.22.0-rc.5] - 2026-07-28
 

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -1527,8 +1527,11 @@ GROUP BY notes.account_id, notes.transaction_id";
 ///   output of this view, one for each such account.
 /// - `to_account_uuid`: The UUID of the wallet account that received the output, if any; for
 ///   outgoing transaction outputs this will be `NULL`.
-/// - `address`: The address to which the output was sent; for received outputs, this is the
-///   address at which the output was received, or `NULL` for wallet-internal outputs.
+/// - `address`: The address to which the output was sent. For outputs created by the wallet,
+///   this is the recipient address recorded when the transaction was created. For other
+///   received outputs it is the address at which the output was received — for transparent
+///   outputs, the transparent receiver itself rather than a unified address containing it —
+///   or `NULL` for wallet-internal outputs.
 /// - `diversifier_index_be`: The big-endian representation of the diversifier index (or, for
 ///   transparent addresses, the BIP 44 change-level index of the derivation path) of the receiving
 ///   address. This will be `NULL` for outgoing transaction outputs.
@@ -1557,7 +1560,13 @@ WITH unioned AS (
            ro.output_index              AS output_index,
            from_account.uuid            AS from_account_uuid,
            to_account.uuid              AS to_account_uuid,
-           a.address                    AS to_address,
+           -- for a transparent output, the address at which it was received is
+           -- the transparent receiver itself, not a unified address containing it
+           CASE ro.pool
+                WHEN 0 THEN a.cached_transparent_receiver_address
+                ELSE a.address
+           END                          AS to_address,
+           0                            AS is_sent_row,
            a.diversifier_index_be       AS diversifier_index_be,
            ro.value                     AS value,
            ro.is_change                 AS is_change,
@@ -1573,7 +1582,7 @@ WITH unioned AS (
     LEFT JOIN accounts from_account ON from_account.id = sent_notes.from_account_id
     LEFT JOIN accounts to_account ON to_account.id = ro.account_id
     UNION ALL
-    -- select all outputs sent from the wallet to external recipients
+    -- select all outputs sent by the wallet
     SELECT t.id_tx                      AS transaction_id,
            t.txid                       AS txid,
            t.mined_height               AS mined_height,
@@ -1583,6 +1592,7 @@ WITH unioned AS (
            from_account.uuid            AS from_account_uuid,
            NULL                         AS to_account_uuid,
            sent_notes.to_address        AS to_address,
+           1                            AS is_sent_row,
            NULL                         AS diversifier_index_be,
            sent_notes.value             AS value,
            0                            AS is_change,
@@ -1605,7 +1615,13 @@ SELECT
     output_index,
     MAX(from_account_uuid)      AS from_account_uuid,
     MAX(to_account_uuid)        AS to_account_uuid,
-    MAX(to_address)             AS to_address,
+    -- the recipient address recorded when the wallet created the output is
+    -- authoritative; the receiving address is reported only for outputs the
+    -- wallet did not create
+    COALESCE(
+        MAX(CASE WHEN is_sent_row THEN to_address END),
+        MAX(CASE WHEN NOT is_sent_row THEN to_address END)
+    )                           AS to_address,
     MAX(value)                  AS value,
     MAX(is_change)              AS is_change,
     MAX(memo)                   AS memo,

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -66,6 +66,7 @@ mod v_transactions_shielding_balance;
 mod v_transactions_transparent_history;
 mod v_tx_outputs_key_scopes;
 mod v_tx_outputs_return_addrs;
+mod v_tx_outputs_transparent_addresses;
 mod v_tx_outputs_use_legacy_false;
 mod wallet_summaries;
 mod witness_stabilized_notes;
@@ -164,6 +165,7 @@ pub mod ids {
     pub use super::v_transactions_transparent_history::MIGRATION_ID as V_TRANSACTIONS_TRANSPARENT_HISTORY;
     pub use super::v_tx_outputs_key_scopes::MIGRATION_ID as V_TX_OUTPUTS_KEY_SCOPES;
     pub use super::v_tx_outputs_return_addrs::MIGRATION_ID as V_TX_OUTPUTS_RETURN_ADDRS;
+    pub use super::v_tx_outputs_transparent_addresses::MIGRATION_ID as V_TX_OUTPUTS_TRANSPARENT_ADDRESSES;
     pub use super::v_tx_outputs_use_legacy_false::MIGRATION_ID as V_TX_OUTPUTS_USE_LEGACY_FALSE;
     pub use super::wallet_summaries::MIGRATION_ID as WALLET_SUMMARIES;
     pub use super::witness_stabilized_notes::MIGRATION_ID as WITNESS_STABILIZED_NOTES;
@@ -237,18 +239,19 @@ pub(super) fn all_migrations<
     //                       `------------------- account_delete_cascade ---------------------------------'
     //                              /               /                  |              \
     //     add_transparent_value_index  v_tx_outputs_key_scopes  standalone_p2sh    witness_stabilized_notes
-    //                                     /                      /            \
-    //                               ivk_item_cache              /           orchard_note_version
-    //                                                          /                  \
-    //                                add_transparent_receiver_address_index        \
-    //                                                                               \
-    //                                                                      ironwood_received_notes ----------------
-    //                                                                      /         |          \                  \
-    //                                                   ironwood_pool_code_views     |      note_locking  fix_bad_ironwood_change_flagging
-    //                                                           |                    |
-    //                                                           |             v_address_uses_ironwood
-    //                                                           |
-    //                                                v_transactions_pool_crossing
+    //                                     /        |             /            \
+    //                               ivk_item_cache |            /           orchard_note_version
+    //                             .----------------'           /                  \
+    //                             |  add_transparent_receiver_address_index        \
+    //                             |                                                 \
+    //                             |                                        ironwood_received_notes ----------------
+    //                             |                                        /         |          \                  \
+    //                             |                     ironwood_pool_code_views     |      note_locking  fix_bad_ironwood_change_flagging
+    //                             |                             |          \         |
+    //                             |                             |           \ v_address_uses_ironwood
+    //                             |                             |            \
+    //                             |              v_transactions_pool_crossing \
+    //                             `------------------------------------------- v_tx_outputs_transparent_addresses
     //
     let rng = Rc::new(Mutex::new(rng));
     vec![
@@ -360,6 +363,7 @@ pub(super) fn all_migrations<
         Box::new(note_locking::Migration),
         Box::new(tx_status_observation_intent::Migration),
         Box::new(orchard_ironwood_migration_anchor_interval::Migration),
+        Box::new(v_tx_outputs_transparent_addresses::Migration),
     ]
 }
 
@@ -551,7 +555,7 @@ pub const V_0_22_0_RC2: &[Uuid] = &[
 
 /// Leaf migrations as of the current repository state.
 pub const CURRENT_LEAF_MIGRATIONS: &[Uuid] = &[
-    v_tx_outputs_key_scopes::MIGRATION_ID,
+    v_tx_outputs_transparent_addresses::MIGRATION_ID,
     ivk_item_cache::MIGRATION_ID,
     add_transparent_receiver_address_index::MIGRATION_ID,
     add_transparent_value_index::MIGRATION_ID,
@@ -719,6 +723,7 @@ pub(crate) mod tests {
             ids::V_TRANSACTIONS_TRANSPARENT_HISTORY,
             ids::V_TX_OUTPUTS_KEY_SCOPES,
             ids::V_TX_OUTPUTS_RETURN_ADDRS,
+            ids::V_TX_OUTPUTS_TRANSPARENT_ADDRESSES,
             ids::V_TX_OUTPUTS_USE_LEGACY_FALSE,
             ids::WALLET_SUMMARIES,
             ids::WITNESS_STABILIZED_NOTES,

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_tx_outputs_transparent_addresses.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_tx_outputs_transparent_addresses.rs
@@ -1,0 +1,162 @@
+//! Reports transparent outputs in `v_tx_outputs` at their transparent receiver address.
+//!
+//! The received-output arm of `v_tx_outputs` resolved every receiving address through
+//! `addresses.address`, which for an external-scope entry holds the unified encoding; the
+//! transparent receiver lives only in `addresses.cached_transparent_receiver_address`. Every
+//! transparent output received by the wallet at such an address was therefore reported with
+//! the enclosing unified address as its `to_address`, misrepresenting what was observably
+//! paid on chain.
+//!
+//! For a payment the wallet made to one of its own transparent addresses the effect was
+//! compounded: the transaction produces both a `sent_notes` row carrying the transparent
+//! address that was actually paid and a received-output row carrying the unified address,
+//! and the view merged the two with `MAX(to_address)` — under SQLite's BINARY collation
+//! `'u' > 't'`, so the unified address deterministically shadowed the recorded recipient.
+//!
+//! This migration recreates `v_tx_outputs` so that the received-output arm reports the
+//! transparent receiver itself for transparent outputs, and so that the merge prefers the
+//! recipient address recorded when the wallet created the output over the receiving address,
+//! rather than choosing between them by byte order. See zcash/librustzcash#2845.
+use std::collections::HashSet;
+
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+
+use crate::wallet::init::WalletMigrationError;
+
+use super::{ironwood_pool_code_views, v_tx_outputs_key_scopes};
+
+/// This migration reports transparent outputs in `v_tx_outputs` at their transparent
+/// receiver address, and makes the recorded sent-to address authoritative for outputs the
+/// wallet created.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x856ecde7_c670_47c1_9345_b80ba5b12c4f);
+
+/// `v_tx_outputs_key_scopes` is the prior owner of the `v_tx_outputs` definition this
+/// migration recreates; `ironwood_pool_code_views` supplies the current `v_received_outputs`
+/// definition whose pool codes the transparent-receiver case discriminates on.
+const DEPENDENCIES: &[Uuid] = &[
+    v_tx_outputs_key_scopes::MIGRATION_ID,
+    ironwood_pool_code_views::MIGRATION_ID,
+];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Reports transparent outputs in v_tx_outputs at their transparent receiver address."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        transaction.execute_batch(
+            "DROP VIEW v_tx_outputs;
+            CREATE VIEW v_tx_outputs AS
+            WITH unioned AS (
+                -- select all outputs received by the wallet
+                SELECT t.id_tx                      AS transaction_id,
+                       t.txid                       AS txid,
+                       t.mined_height               AS mined_height,
+                       IFNULL(t.trust_status, 0)    AS trust_status,
+                       ro.pool                      AS output_pool,
+                       ro.output_index              AS output_index,
+                       from_account.uuid            AS from_account_uuid,
+                       to_account.uuid              AS to_account_uuid,
+                       -- for a transparent output, the address at which it was received is
+                       -- the transparent receiver itself, not a unified address containing it
+                       CASE ro.pool
+                            WHEN 0 THEN a.cached_transparent_receiver_address
+                            ELSE a.address
+                       END                          AS to_address,
+                       0                            AS is_sent_row,
+                       a.diversifier_index_be       AS diversifier_index_be,
+                       ro.value                     AS value,
+                       ro.is_change                 AS is_change,
+                       ro.memo                      AS memo,
+                       a.key_scope                  AS recipient_key_scope
+                FROM v_received_outputs ro
+                JOIN transactions t
+                    ON t.id_tx = ro.transaction_id
+                LEFT JOIN addresses a ON a.id = ro.address_id
+                -- join to the sent_notes table to obtain `from_account_id`
+                LEFT JOIN sent_notes ON sent_notes.id = ro.sent_note_id
+                -- join on the accounts table to obtain account UUIDs
+                LEFT JOIN accounts from_account ON from_account.id = sent_notes.from_account_id
+                LEFT JOIN accounts to_account ON to_account.id = ro.account_id
+                UNION ALL
+                -- select all outputs sent by the wallet
+                SELECT t.id_tx                      AS transaction_id,
+                       t.txid                       AS txid,
+                       t.mined_height               AS mined_height,
+                       IFNULL(t.trust_status, 0)    AS trust_status,
+                       sent_notes.output_pool       AS output_pool,
+                       sent_notes.output_index      AS output_index,
+                       from_account.uuid            AS from_account_uuid,
+                       NULL                         AS to_account_uuid,
+                       sent_notes.to_address        AS to_address,
+                       1                            AS is_sent_row,
+                       NULL                         AS diversifier_index_be,
+                       sent_notes.value             AS value,
+                       0                            AS is_change,
+                       sent_notes.memo              AS memo,
+                       NULL                         AS recipient_key_scope
+                FROM sent_notes
+                JOIN transactions t
+                    ON t.id_tx = sent_notes.transaction_id
+                LEFT JOIN v_received_outputs ro ON ro.sent_note_id = sent_notes.id
+                -- join on the accounts table to obtain account UUIDs
+                LEFT JOIN accounts from_account ON from_account.id = sent_notes.from_account_id
+            )
+            -- merge duplicate rows while retaining maximum information
+            SELECT
+                transaction_id,
+                MAX(txid)                   AS txid,
+                MAX(mined_height)           AS tx_mined_height,
+                MIN(trust_status)           AS tx_trust_status,
+                output_pool,
+                output_index,
+                MAX(from_account_uuid)      AS from_account_uuid,
+                MAX(to_account_uuid)        AS to_account_uuid,
+                -- the recipient address recorded when the wallet created the output is
+                -- authoritative; the receiving address is reported only for outputs the
+                -- wallet did not create
+                COALESCE(
+                    MAX(CASE WHEN is_sent_row THEN to_address END),
+                    MAX(CASE WHEN NOT is_sent_row THEN to_address END)
+                )                           AS to_address,
+                MAX(value)                  AS value,
+                MAX(is_change)              AS is_change,
+                MAX(memo)                   AS memo,
+                MAX(recipient_key_scope)    AS recipient_key_scope
+            FROM unioned
+            GROUP BY transaction_id, output_pool, output_index;
+            ",
+        )?;
+
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+}

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -3004,6 +3004,122 @@ mod tests {
         assert_eq!(mined_height, Some(u32::from(mined_at)));
     }
 
+    /// `v_tx_outputs.to_address` must report the transparent receiver at which a transparent
+    /// output was received — not the unified address that contains that receiver — and for an
+    /// output the wallet itself created, the recipient address recorded at transaction
+    /// construction time is authoritative.
+    ///
+    /// Both properties regressed when the view began resolving received outputs through
+    /// `addresses.address`, which holds the unified encoding for external-scope rows: a
+    /// payment to one of the wallet's own transparent addresses was reported with the
+    /// receiving account's unified address as its recipient, because the received-output row
+    /// carried the unified encoding and the `MAX(to_address)` merge preferred it to the
+    /// transparent encoding recorded in `sent_notes` (`'u' > 't'` in byte order). See
+    /// zcash/librustzcash#2845.
+    #[test]
+    fn v_tx_outputs_reports_transparent_receiver_for_transparent_outputs() {
+        use transparent::bundle::{OutPoint, TxOut};
+        use zcash_client_backend::{
+            data_api::WalletRead as _,
+            wallet::{Recipient, WalletTransparentOutput},
+        };
+        use zcash_keys::{encoding::AddressCodec as _, keys::UnifiedAddressRequest};
+        use zcash_protocol::value::Zatoshis;
+
+        use crate::{TxRef, wallet::put_sent_output};
+
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let account_id = st.test_account().unwrap().id();
+        let birthday = st.test_account().unwrap().birthday().height();
+        let params = st.wallet().db().params;
+        let taddr = *st
+            .wallet()
+            .get_last_generated_address_matching(
+                account_id,
+                UnifiedAddressRequest::AllAvailableKeys,
+            )
+            .unwrap()
+            .unwrap()
+            .transparent()
+            .unwrap();
+        let taddr_str = taddr.encode(&params);
+
+        let mined_at = birthday + 100;
+        st.wallet_mut().update_chain_tip(mined_at + 10).unwrap();
+
+        // Receive an output at the transparent receiver of the account's unified address.
+        let outpoint = OutPoint::fake();
+        let value = Zatoshis::const_from_u64(100_000);
+        let utxo = WalletTransparentOutput::from_parts(
+            outpoint.clone(),
+            TxOut::new(value, taddr.script().into()),
+            Some(mined_at),
+            Some(account_id),
+            Some(TransparentKeyScope::EXTERNAL),
+            None,
+        )
+        .unwrap();
+        st.wallet_mut()
+            .put_received_transparent_utxo(&utxo)
+            .unwrap();
+
+        let to_address = |conn: &rusqlite::Connection| -> Option<String> {
+            conn.query_row(
+                "SELECT to_address FROM v_tx_outputs WHERE txid = :txid",
+                rusqlite::named_params! { ":txid": outpoint.hash().to_vec() },
+                |row| row.get(0),
+            )
+            .unwrap()
+        };
+
+        assert_eq!(
+            to_address(st.wallet().conn()).as_deref(),
+            Some(taddr_str.as_str()),
+            "a received transparent output must be reported at its transparent receiver, \
+             not at the unified address containing it",
+        );
+
+        // Record the send side of the same output, as transaction-data processing does when
+        // the wallet discovers that it funded a transaction paying its own transparent
+        // address.
+        let id_tx: i64 = st
+            .wallet()
+            .conn()
+            .query_row(
+                "SELECT id_tx FROM transactions WHERE txid = :txid",
+                rusqlite::named_params! { ":txid": outpoint.hash().to_vec() },
+                |row| row.get(0),
+            )
+            .unwrap();
+        let conn_tx = st.wallet_mut().conn_mut().transaction().unwrap();
+        put_sent_output(
+            &conn_tx,
+            &params,
+            account_id,
+            TxRef(id_tx),
+            outpoint.n() as usize,
+            &Recipient::InternalTransparent {
+                receiving_account: account_id,
+                recipient_address: taddr,
+            },
+            value,
+            None,
+        )
+        .unwrap();
+        conn_tx.commit().unwrap();
+
+        assert_eq!(
+            to_address(st.wallet().conn()).as_deref(),
+            Some(taddr_str.as_str()),
+            "the transparent address the wallet paid must not be shadowed by the unified \
+             address of the receiving account",
+        );
+    }
+
     #[test]
     fn transparent_balance_across_shielding() {
         zcash_client_backend::data_api::testing::transparent::transparent_balance_across_shielding(


### PR DESCRIPTION
The received-output arm of `v_tx_outputs` resolved every receiving address through `addresses.address`, which for an external-scope entry holds the unified encoding; the transparent receiver lives only in `addresses.cached_transparent_receiver_address`. Every transparent output received by the wallet at such an address was therefore reported with the enclosing unified address as its `to_address`.

For a payment the wallet made to one of its own transparent addresses the effect was compounded: the transaction produces both a `sent_notes` row carrying the transparent address that was actually paid and a received-output row carrying the unified address, and the view merged the two with `MAX(to_address)` — under SQLite's BINARY collation `'u' > 't'`, so the unified address deterministically shadowed the recorded recipient.

The new `v_tx_outputs_transparent_addresses` migration recreates the view so that:
- the received-output arm reports the pool-appropriate receiver (`cached_transparent_receiver_address` for transparent outputs, `address` otherwise), and
- the sent/received merge prefers the recipient address recorded when the wallet created the output over the receiving address — via an `is_sent_row` discriminator and `COALESCE` — rather than choosing between the two encodings by byte order.

A regression test receives a UTXO at the account's own external-scope transparent receiver and asserts `to_address` both before and after the send side is recorded as `Recipient::InternalTransparent`; it fails against the previous view definition in both positions and passes with the migration applied.

Fixes #2845.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
