### PR TITLE
ci: reduce test suite runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,36 @@ on:
   push:
     branches: main
   merge_group:
+  schedule:
+    - cron: '23 8 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: >-
+    ${{
+      format(
+        'ci-{0}-{1}-{2}',
+        github.workflow,
+        github.event_name,
+        github.event.pull_request.number || github.ref
+      )
+    }}
+  cancel-in-progress: >-
+    ${{
+      github.event_name == 'pull_request'
+      || (
+        github.event_name == 'push'
+        && github.ref == 'refs/heads/main'
+      )
+    }}
+
+env:
+  # Full debug information substantially increases optimized test linking time and
+  # cache size, particularly on Windows. Line tables retain useful CI backtraces.
+  CARGO_PROFILE_TEST_DEBUG: 1
+  # Proving code uses Rayon internally. Capping both layers prevents each
+  # concurrent libtest case from trying to occupy the whole runner.
+  RAYON_NUM_THREADS: 2
 
 jobs:
   required-test:
@@ -19,40 +49,26 @@ jobs:
       matrix:
         target:
           - Linux
-        state:
-          - transparent
-          - transparent-inputs-only
-          - transparent-key-encoding-only
-          - Sapling-only
-          - Orchard
-          - all-pools
-          - all-features
-          - NU6.3
-          - NU7
+        state: >-
+          ${{
+            fromJSON(
+              github.event_name == 'schedule'
+              && '["transparent", "transparent-inputs-only", "transparent-key-encoding-only", "Sapling-only", "Orchard", "all-pools", "all-features", "NU7"]'
+              || (
+                github.event_name == 'pull_request'
+                && '["all-features"]'
+                || '["transparent", "transparent-inputs-only", "transparent-key-encoding-only", "Sapling-only", "Orchard", "all-pools", "all-features"]'
+              )
+            )
+          }}
 
         include:
           - target: Linux
             os: ${{ vars.UBUNTU_LARGE_RUNNER || 'ubuntu-latest' }}
 
-          - state: transparent
-            transparent-pool: true
-          - state: transparent-inputs-only
-            extra_flags: transparent-inputs
-          - state: transparent-key-encoding-only
-            extra_flags: transparent-key-encoding
-          - state: Orchard
-            orchard-pool: true
-          - state: all-pools
-            all-pools: true
-          - state: all-features
-            all-features: true
-          - state: NU7
-            all-features: true
-            rustflags: '--cfg zcash_unstable="nu7"'
-
     env:
-      RUSTFLAGS: ${{ matrix.rustflags }}
-      RUSTDOCFLAGS: ${{ matrix.rustflags }}
+      RUSTFLAGS: ${{ matrix.state == 'NU7' && '--cfg zcash_unstable="nu7"' || '' }}
+      RUSTDOCFLAGS: ${{ matrix.state == 'NU7' && '--cfg zcash_unstable="nu7"' || '' }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -61,15 +77,25 @@ jobs:
       - id: prepare
         uses: ./.github/actions/prepare
         with:
-          transparent-pool: ${{ matrix.transparent-pool || false }}
-          orchard-pool: ${{ matrix.orchard-pool || false }}
-          all-pools: ${{ matrix.all-pools || false }}
-          all-features: ${{ matrix.all-features || false }}
-          extra-features: ${{ matrix.extra_flags || '' }}
+          transparent-pool: ${{ matrix.state == 'transparent' }}
+          orchard-pool: ${{ matrix.state == 'Orchard' }}
+          all-pools: ${{ matrix.state == 'all-pools' }}
+          all-features: ${{ matrix.state == 'all-features' || matrix.state == 'NU7' }}
+          extra-features: >-
+            ${{
+              matrix.state == 'transparent-inputs-only'
+              && 'transparent-inputs'
+              || (
+                matrix.state == 'transparent-key-encoding-only'
+                && 'transparent-key-encoding'
+                || ''
+              )
+            }}
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: msrv
-          save-if: ${{ matrix.state == 'all-features' }}
+          # NU7 has a distinct RUSTFLAGS-derived cache key.
+          save-if: ${{ matrix.state == 'all-features' || matrix.state == 'NU7' }}
       - name: Run tests
         shell: bash
         env:
@@ -82,12 +108,70 @@ jobs:
           elif [[ -n "$FEATURES" ]]; then
             feature_flags+=(--features "$FEATURES")
           fi
-          cargo test --workspace "${feature_flags[@]}"
+          cargo test --workspace "${feature_flags[@]}" -- --test-threads=2
       - name: Verify working directory is clean
         run: git diff --exit-code
 
+  feature-check:
+    name: Check ${{ matrix.state }} test targets
+    runs-on: ${{ vars.UBUNTU_LARGE_RUNNER || 'ubuntu-latest' }}
+    strategy:
+      matrix:
+        state: >-
+          ${{
+            fromJSON(
+              github.event_name == 'pull_request'
+              && '["transparent", "transparent-inputs-only", "transparent-key-encoding-only", "Sapling-only", "Orchard", "all-pools"]'
+              || '["covered-by-runtime-matrix"]'
+            )
+          }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - id: prepare
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: ./.github/actions/prepare
+        with:
+          transparent-pool: ${{ matrix.state == 'transparent' }}
+          orchard-pool: ${{ matrix.state == 'Orchard' }}
+          all-pools: ${{ matrix.state == 'all-pools' }}
+          extra-features: >-
+            ${{
+              matrix.state == 'transparent-inputs-only'
+              && 'transparent-inputs'
+              || (
+                matrix.state == 'transparent-key-encoding-only'
+                && 'transparent-key-encoding'
+                || ''
+              )
+            }}
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          shared-key: msrv
+          save-if: "false"
+      - name: Check all test targets
+        if: ${{ github.event_name == 'pull_request' }}
+        shell: bash
+        env:
+          ALL_FEATURES: ${{ steps.prepare.outputs.all-features }}
+          FEATURES: ${{ steps.prepare.outputs.feature-list }}
+        run: |
+          feature_flags=()
+          if [[ "$ALL_FEATURES" == true ]]; then
+            feature_flags+=(--all-features)
+          elif [[ -n "$FEATURES" ]]; then
+            feature_flags+=(--features "$FEATURES")
+          fi
+          cargo check --workspace --all-targets "${feature_flags[@]}"
+      - name: Feature configuration runtime coverage
+        if: ${{ github.event_name != 'pull_request' }}
+        run: echo "The full feature matrix runs tests for this event."
+
   test:
     name: Test ${{ matrix.state }} on ${{ matrix.target }}
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     strategy:
@@ -95,14 +179,14 @@ jobs:
         target:
           - macOS
           - Windows
-        state:
-          - transparent
-          - Sapling-only
-          - Orchard
-          - all-pools
-          - all-features
-          - NU6.3
-          - NU7
+        state: >-
+          ${{
+            fromJSON(
+              github.event_name == 'schedule'
+              && '["all-features", "NU7"]'
+              || '["all-features"]'
+            )
+          }}
 
         include:
           - target: macOS
@@ -110,29 +194,13 @@ jobs:
           - target: Windows
             os: ${{ vars.WINDOWS_LARGE_RUNNER || 'windows-latest' }}
 
-          - state: transparent
-            transparent-pool: true
-          - state: Orchard
-            orchard-pool: true
-          - state: all-pools
-            all-pools: true
-          - state: all-features
-            all-features: true
-          - state: NU7
-            all-features: true
-            rustflags: '--cfg zcash_unstable="nu7"'
-
         exclude:
-          - target: macOS
-            state: all-features
-          - target: macOS
-            state: NU6.3
           - target: macOS
             state: NU7
 
     env:
-      RUSTFLAGS: ${{ matrix.rustflags }}
-      RUSTDOCFLAGS: ${{ matrix.rustflags }}
+      RUSTFLAGS: ${{ matrix.state == 'NU7' && '--cfg zcash_unstable="nu7"' || '' }}
+      RUSTDOCFLAGS: ${{ matrix.state == 'NU7' && '--cfg zcash_unstable="nu7"' || '' }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -141,15 +209,11 @@ jobs:
       - id: prepare
         uses: ./.github/actions/prepare
         with:
-          transparent-pool: ${{ matrix.transparent-pool || false }}
-          orchard-pool: ${{ matrix.orchard-pool || false }}
-          all-pools: ${{ matrix.all-pools || false }}
-          all-features: ${{ matrix.all-features || false }}
-          extra-features: ${{ matrix.extra_flags || '' }}
+          all-features: true
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: msrv
-          save-if: ${{ matrix.state == 'all-features' && matrix.target != 'Windows' }}
+          save-if: ${{ matrix.state == 'all-features' || matrix.state == 'NU7' }}
       - name: Run tests
         shell: bash
         env:
@@ -162,38 +226,32 @@ jobs:
           elif [[ -n "$FEATURES" ]]; then
             feature_flags+=(--features "$FEATURES")
           fi
-          cargo test --workspace "${feature_flags[@]}"
+          cargo test --workspace "${feature_flags[@]}" -- --test-threads=2
       - name: Verify working directory is clean
         run: git diff --exit-code
 
   test-slow:
-    name: Slow Test ${{ matrix.state }} on ${{ matrix.target }}
+    name: Expensive Test ${{ matrix.state }} on ${{ matrix.target }}
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: true
     strategy:
       matrix:
         target:
           - Linux
-        state: # all-pools intentionally omitted
-          - transparent
-          - Sapling-only
-          - Orchard
-          - all-features
-          - NU6.3
-          - NU7
+        state: >-
+          ${{
+            fromJSON(
+              github.event_name == 'schedule'
+              && '["all-pools", "NU7"]'
+              || '["all-pools"]'
+            )
+          }}
 
         include:
           - target: Linux
             os: ${{ vars.UBUNTU_LARGE_RUNNER || 'ubuntu-latest' }}
 
-          - state: transparent
-            transparent-pool: true
-          - state: Orchard
-            orchard-pool: true
-          - state: all-features
-            all-features: true
           - state: NU7
-            all-features: true
             rustflags: '--cfg zcash_unstable="nu7"'
 
     env:
@@ -207,11 +265,8 @@ jobs:
       - id: prepare
         uses: ./.github/actions/prepare
         with:
-          transparent-pool: ${{ matrix.transparent-pool || false }}
-          orchard-pool: ${{ matrix.orchard-pool || false }}
-          all-pools: false
-          all-features: ${{ matrix.all-features || false }}
-          extra-features: ${{ matrix.extra_flags || '' }}
+          all-pools: true
+          extra-features: pczt-tests
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: msrv
@@ -228,9 +283,35 @@ jobs:
           elif [[ -n "$FEATURES" ]]; then
             feature_flags+=(--features "$FEATURES")
           fi
-          cargo test --workspace "${feature_flags[@]}" --features expensive-tests
+          cargo test \
+            --workspace \
+            "${feature_flags[@]}" \
+            --features expensive-tests \
+            -- \
+            --test-threads=2
       - name: Verify working directory is clean
         run: git diff --exit-code
+
+  notify-nightly-failure:
+    name: Notify Slack of nightly test failure
+    needs: test-slow
+    if: ${{ always() && github.event_name == 'schedule' && needs.test-slow.result != 'success' }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    env:
+      RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      TEST_RESULT: ${{ needs.test-slow.result }}
+    steps:
+      - name: Notify Slack
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          errors: true
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: >-
+              librustzcash nightly expensive tests ended with
+              ${{ env.TEST_RESULT }}: ${{ env.RUN_URL }}
 
   build-latest:
     name: Latest build on ${{ matrix.os }}
@@ -600,6 +681,7 @@ jobs:
     name: Required status checks have passed
     needs:
       - required-test
+      - feature-check
       - build-latest
       - build-nodefault
       - build-nostd

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -57,6 +57,9 @@ workspace.
 - `zcash_client_backend::tor::http::HttpError::Timeout`
 
 ### Changed
+- Transaction-construction helpers exposed by `test-dependencies` use the
+  Sapling mock provers. Tests that need cryptographically valid proofs must call
+  the production transaction-construction APIs with a real prover.
 - `zcash_client_backend::data_api::OutputLockStore::get_locked_outputs` is no longer
   gated behind `test-dependencies`; every implementor must now provide it
   unconditionally.

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -20,6 +20,7 @@ use subtle::ConditionallySelectable;
 
 use ::sapling::{
     note_encryption::{SaplingDomain, sapling_note_encryption},
+    prover::mock::{MockOutputProver, MockSpendProver},
     util::generate_random_rseed,
     zip32::DiversifiableFullViewingKey,
 };
@@ -64,6 +65,13 @@ use super::{
         propose_send_max_transfer, propose_standard_transfer_to_address, propose_transfer,
     },
 };
+
+fn real_test_prover() -> &'static LocalTxProver {
+    use std::sync::OnceLock;
+
+    static PROVER: OnceLock<LocalTxProver> = OnceLock::new();
+    PROVER.get_or_init(LocalTxProver::bundled)
+}
 use crate::{
     data_api::{
         MaxSpendMode, OutputLockStore, TargetValue,
@@ -1078,7 +1086,6 @@ where
         InputsT: InputSelector<InputSource = DbT>,
         ChangeT: ChangeStrategy<MetaSource = DbT>,
     {
-        let prover = LocalTxProver::bundled();
         let network = self.network().clone();
 
         let account = self
@@ -1103,8 +1110,8 @@ where
         create_proposed_transactions(
             self.wallet_mut(),
             &network,
-            &prover,
-            &prover,
+            &MockSpendProver,
+            &MockOutputProver,
             &SpendingKeys::from_unified_spending_key(usk.clone()),
             ovk_policy,
             &proposal,
@@ -1354,13 +1361,12 @@ where
     where
         FeeRuleT: FeeRule,
     {
-        let prover = LocalTxProver::bundled();
         let network = self.network().clone();
         create_proposed_transactions(
             self.wallet_mut(),
             &network,
-            &prover,
-            &prover,
+            &MockSpendProver,
+            &MockOutputProver,
             &SpendingKeys::from_unified_spending_key(usk.clone()),
             ovk_policy,
             proposal,
@@ -1416,7 +1422,7 @@ where
     {
         use super::wallet::extract_and_store_transaction_from_pczt;
 
-        let prover = LocalTxProver::bundled();
+        let prover = real_test_prover();
         let (spend_vk, output_vk) = prover.verifying_keys();
 
         extract_and_store_transaction_from_pczt(
@@ -1449,13 +1455,12 @@ where
     {
         use crate::data_api::wallet::shield_transparent_funds;
 
-        let prover = LocalTxProver::bundled();
         let network = self.network().clone();
         shield_transparent_funds(
             self.wallet_mut(),
             &network,
-            &prover,
-            &prover,
+            &MockSpendProver,
+            &MockOutputProver,
             input_selector,
             change_strategy,
             shielding_threshold,

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -11,6 +11,10 @@ workspace.
 ## [Unreleased]
 
 ### Added
+- The additive `ignore-expensive-tests` feature, which compiles expensive tests
+  but marks them as ignored for broad `--all-features` test runs.
+- `zcash_client_sqlite::testing::db::TestDbFactory::file_backed`, for tests
+  that require database reopening or multiple connections.
 - The `v_transactions` view has a new `pool_crossing_value` column, which
   classifies wallet-internal transfers that move an account's own funds between
   shielded pools (for example, ZIP 318 Orchard -> Ironwood migration transfers)
@@ -33,6 +37,11 @@ workspace.
   classified once the wallet has observed the returned output (which the
   scanner marks as change); while such a transaction is unmined it is treated
   as an ordinary payment.
+
+### Changed
+- `zcash_client_sqlite::testing::db::TestDbFactory::default` and
+  `zcash_client_sqlite::testing::BlockCache::default` now use isolated
+  in-memory SQLite databases.
 
 ### Fixed
 - Note selection now draws the oldest eligible notes first, ordering by note

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -220,6 +220,9 @@ unstable = ["zcash_client_backend/unstable"]
 ## A feature used to isolate tests that are expensive to run. Test-only.
 expensive-tests = []
 
+## Marks expensive tests as ignored without removing them from compilation. Test-only.
+ignore-expensive-tests = []
+
 ## A feature used to enable PCZT-specific tests without interfering with the
 ## protocol-specific flags. Test-only.
 pczt-tests = ["serde", "zcash_client_backend/pczt"]

--- a/zcash_client_sqlite/src/chain.rs
+++ b/zcash_client_sqlite/src/chain.rs
@@ -457,23 +457,41 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "expensive-tests")]
+    #[cfg_attr(
+        feature = "ignore-expensive-tests",
+        ignore = "covered by the expensive-test CI matrix"
+    )]
     fn stabilized_note_spendable_after_deep_rewind_sapling() {
         testing::pool::stabilized_note_spendable_after_deep_rewind::<SaplingPoolTester>()
     }
 
     #[test]
-    #[cfg(feature = "orchard")]
+    #[cfg(all(feature = "orchard", feature = "expensive-tests"))]
+    #[cfg_attr(
+        feature = "ignore-expensive-tests",
+        ignore = "covered by the expensive-test CI matrix"
+    )]
     fn stabilized_note_spendable_after_deep_rewind_orchard() {
         testing::pool::stabilized_note_spendable_after_deep_rewind::<OrchardPoolTester>()
     }
 
     #[test]
+    #[cfg(feature = "expensive-tests")]
+    #[cfg_attr(
+        feature = "ignore-expensive-tests",
+        ignore = "covered by the expensive-test CI matrix"
+    )]
     fn newly_discovered_notes_become_stabilized_sapling() {
         testing::pool::newly_discovered_notes_become_stabilized::<SaplingPoolTester>()
     }
 
     #[test]
-    #[cfg(feature = "orchard")]
+    #[cfg(all(feature = "orchard", feature = "expensive-tests"))]
+    #[cfg_attr(
+        feature = "ignore-expensive-tests",
+        ignore = "covered by the expensive-test CI matrix"
+    )]
     fn newly_discovered_notes_become_stabilized_orchard() {
         testing::pool::newly_discovered_notes_become_stabilized::<OrchardPoolTester>()
     }

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -3543,6 +3543,11 @@ impl BlockDb {
     pub fn for_path<P: AsRef<Path>>(path: P) -> Result<Self, rusqlite::Error> {
         rusqlite::Connection::open(path).map(BlockDb)
     }
+
+    #[cfg(any(test, feature = "test-dependencies"))]
+    pub(crate) fn from_connection(conn: rusqlite::Connection) -> Self {
+        Self(conn)
+    }
 }
 
 impl BlockSource for BlockDb {

--- a/zcash_client_sqlite/src/testing.rs
+++ b/zcash_client_sqlite/src/testing.rs
@@ -5,7 +5,6 @@
 
 use prost::Message;
 use rusqlite::params;
-use tempfile::NamedTempFile;
 
 use zcash_client_backend::{
     data_api::testing::{CacheInsertionResult, NoteCommitments, TestCache},
@@ -39,21 +38,16 @@ pub(crate) mod pool;
 /// An in-memory compact-block cache backed by a temporary [`BlockDb`], implementing the
 /// `zcash_client_backend` testing framework's [`TestCache`].
 pub struct BlockCache {
-    _cache_file: NamedTempFile,
     db_cache: BlockDb,
 }
 
 impl BlockCache {
-    /// Creates an empty cache over a fresh temporary block database.
+    /// Creates an empty cache over a fresh in-memory block database.
     pub fn new() -> Self {
-        let cache_file = NamedTempFile::new().unwrap();
-        let db_cache = BlockDb::for_path(cache_file.path()).unwrap();
+        let db_cache = BlockDb::from_connection(rusqlite::Connection::open_in_memory().unwrap());
         init_cache_database(&db_cache).unwrap();
 
-        BlockCache {
-            _cache_file: cache_file,
-            db_cache,
-        }
+        BlockCache { db_cache }
     }
 }
 

--- a/zcash_client_sqlite/src/testing/db.rs
+++ b/zcash_client_sqlite/src/testing/db.rs
@@ -83,13 +83,13 @@ pub(crate) fn test_rng() -> ChaChaRng {
 #[delegate(WalletCommitmentTrees, target = "wallet_db")]
 pub struct TestDb {
     wallet_db: WalletDb<Connection, LocalNetwork, FixedClock, ChaChaRng>,
-    data_file: NamedTempFile,
+    data_file: Option<NamedTempFile>,
 }
 
 impl TestDb {
     fn from_parts(
         wallet_db: WalletDb<Connection, LocalNetwork, FixedClock, ChaChaRng>,
-        data_file: NamedTempFile,
+        data_file: Option<NamedTempFile>,
     ) -> Self {
         Self {
             wallet_db,
@@ -119,13 +119,16 @@ impl TestDb {
         &mut self.wallet_db.conn
     }
 
-    pub(crate) fn take_data_file(self) -> NamedTempFile {
+    pub(crate) fn take_data_file(self) -> Option<NamedTempFile> {
         self.data_file
     }
 
     #[allow(dead_code)]
     pub(crate) fn data_file_path(&self) -> &std::path::Path {
-        self.data_file.path()
+        self.data_file
+            .as_ref()
+            .expect("this test requires a file-backed TestDbFactory")
+            .path()
     }
 
     /// Dump the schema and contents of the given database table, in
@@ -141,7 +144,7 @@ impl TestDb {
     pub(crate) fn dump_table(&self, name: &'static str) {
         assert!(name.chars().all(|c| c.is_ascii_alphabetic() || c == '_'));
         unsafe {
-            run_sqlite3(self.data_file.path(), &format!(r#".dump "{name}""#));
+            run_sqlite3(self.data_file_path(), &format!(r#".dump "{name}""#));
         }
     }
 
@@ -155,7 +158,7 @@ impl TestDb {
     #[allow(dead_code)]
     #[cfg(feature = "unstable")]
     pub(crate) unsafe fn run_sqlite3(&self, command: &str) {
-        unsafe { run_sqlite3(self.data_file.path(), command) }
+        unsafe { run_sqlite3(self.data_file_path(), command) }
     }
 }
 
@@ -193,9 +196,23 @@ unsafe fn run_sqlite3<S: AsRef<OsStr>>(db_path: S, command: &str) {
 
 /// A [`DataStoreFactory`] that builds fresh in-memory [`TestDb`] wallets, optionally migrated only
 /// to a given set of migrations rather than all of them.
+///
+/// Tests that exercise reopening or multiple independent connections can opt into file-backed
+/// storage with [`Self::file_backed`].
 #[derive(Default)]
 pub struct TestDbFactory {
     target_migrations: Option<Vec<Uuid>>,
+    file_backed: bool,
+}
+
+impl TestDbFactory {
+    /// Constructs a factory for tests that require a database file.
+    pub fn file_backed() -> Self {
+        Self {
+            target_migrations: None,
+            file_backed: true,
+        }
+    }
 }
 
 impl DataStoreFactory for TestDbFactory {
@@ -211,9 +228,19 @@ impl DataStoreFactory for TestDbFactory {
         anchor_retention_interval: Option<AnchorRetentionInterval>,
         #[cfg(feature = "transparent-inputs")] gap_limits: Option<GapLimits>,
     ) -> Result<Self::DataStore, Self::Error> {
-        let data_file = NamedTempFile::new().unwrap();
-        let mut db_data =
-            WalletDb::for_path(data_file.path(), network, test_clock(), test_rng()).unwrap();
+        let (mut db_data, data_file) = if self.file_backed {
+            let data_file = NamedTempFile::new().unwrap();
+            let db_data =
+                WalletDb::for_path(data_file.path(), network, test_clock(), test_rng()).unwrap();
+            (db_data, Some(data_file))
+        } else {
+            let conn = Connection::open_in_memory().unwrap();
+            rusqlite::vtab::array::load_module(&conn).unwrap();
+            (
+                WalletDb::from_connection(conn, network, test_clock(), test_rng()),
+                None,
+            )
+        };
         if let Some(interval) = anchor_retention_interval {
             db_data = db_data.with_anchor_retention_interval(interval);
         }
@@ -237,9 +264,9 @@ impl DataStoreFactory for TestDbFactory {
 }
 
 impl Reset for TestDb {
-    type Handle = NamedTempFile;
+    type Handle = Option<NamedTempFile>;
 
-    fn reset<C>(st: &mut TestState<C, Self, LocalNetwork>) -> NamedTempFile {
+    fn reset<C>(st: &mut TestState<C, Self, LocalNetwork>) -> Self::Handle {
         let network = *st.network();
         let anchor_retention_interval = st.wallet().db().anchor_retention_interval;
         #[cfg(feature = "transparent-inputs")]

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -774,6 +774,7 @@ pub(crate) fn rewind_after_non_contiguous_scan<T: ShieldedPoolTester>() {
     )
 }
 
+#[cfg(feature = "expensive-tests")]
 pub(crate) fn stabilized_note_spendable_after_deep_rewind<T: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::stabilized_note_spendable_after_deep_rewind::<T, _>(
         TestDbFactory::default(),
@@ -781,6 +782,7 @@ pub(crate) fn stabilized_note_spendable_after_deep_rewind<T: ShieldedPoolTester>
     )
 }
 
+#[cfg(feature = "expensive-tests")]
 pub(crate) fn newly_discovered_notes_become_stabilized<T: ShieldedPoolTester>() {
     zcash_client_backend::data_api::testing::pool::newly_discovered_notes_become_stabilized::<T, _>(
         TestDbFactory::default(),

--- a/zcash_client_sqlite/src/wallet/locking.rs
+++ b/zcash_client_sqlite/src/wallet/locking.rs
@@ -959,7 +959,7 @@ mod tests {
         fn concurrent_handles_resolve_lock_conflict() {
             let mut st = TestBuilder::new()
                 .with_block_cache(BlockCache::new())
-                .with_data_store_factory(TestDbFactory::default())
+                .with_data_store_factory(TestDbFactory::file_backed())
                 .with_account_from_sapling_activation(BlockHash([0; 32]))
                 .build();
 

--- a/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
+++ b/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
@@ -24,7 +24,8 @@
 #![cfg(all(
     feature = "orchard",
     feature = "pczt-tests",
-    feature = "test-dependencies"
+    feature = "test-dependencies",
+    feature = "expensive-tests"
 ))]
 
 use std::convert::Infallible;
@@ -556,6 +557,10 @@ fn scenarios() -> Vec<Scenario> {
 }
 
 #[test]
+#[cfg_attr(
+    feature = "ignore-expensive-tests",
+    ignore = "covered by the expensive-test CI matrix"
+)]
 fn migration_proves_end_to_end_against_a_funded_wallet() {
     // Proving dominates this test's cost: each preparation proves an Orchard bundle, and each
     // transfer proves both an Orchard AND an Ironwood bundle, so proving every scenario in
@@ -581,6 +586,10 @@ fn migration_proves_end_to_end_against_a_funded_wallet() {
 /// configured on the migration side, so a wallet configured with a non-default retention interval
 /// automatically schedules its migration against the boundaries it actually retains.
 #[test]
+#[cfg_attr(
+    feature = "ignore-expensive-tests",
+    ignore = "covered by the expensive-test CI matrix"
+)]
 fn migration_anchors_to_the_wallets_configured_retention_grid() {
     use core::num::NonZeroU32;
     use zcash_client_backend::data_api::anchor_retention::AnchorRetentionInterval;


### PR DESCRIPTION
## Summary

- stacked on #2854, which resolves the repository's existing zizmor findings and provides safe structured feature outputs
- tier CI so pull requests execute the broad `all-features` configuration while compiling every other active Linux feature configuration across all targets
- retain the complete active Linux runtime matrix, representative cross-platform coverage, and full-workspace expensive `all-pools` suites outside pull requests
- run all currently inactive NU7 runtime coverage only on the nightly schedule, including regular Linux, Windows, and expensive suites
- cancel superseded runs, improve cache reuse, reduce test debug information, and cap nested test/prover concurrency
- use in-memory SQLite databases and Sapling mock provers for routine tests
- add the additive `ignore-expensive-tests` feature, which keeps expensive tests compiled and visible but ignored in broad `--all-features` runs
- report failed scheduled expensive-test runs to Slack through the `SLACK_WEBHOOK_URL` repository secret

## Motivation

Recent CI behavior showed the SQLite all-feature unit suite taking 777.77 seconds on Linux and over 3000 seconds on an uncached Windows NU7 job. The overall observed workflow consumed roughly 704 runner-minutes, with repeated feature/platform configurations paying substantially overlapping setup and execution costs.

With these changes, the all-feature SQLite library suite completes locally with CI-like thread limits in 187.32 seconds, a roughly 76% reduction for the primary bottleneck.

The pruned pull-request matrix preserves runtime coverage for the broad active configuration most likely to expose behavioral differences. The remaining partial configurations still compile all test targets on every pull request. Merge groups, `main`, scheduled, and manual runs retain the broader active runtime coverage. NU7 runtime coverage is scheduled nightly while NU7 is not under active development. Expensive tests run as complete workspace suites rather than fragile name-filtered subsets.

## Slack setup

Create a Slack incoming webhook for the desired channel and save its URL as the `SLACK_WEBHOOK_URL` Actions repository secret. Only a failed or cancelled scheduled expensive-test matrix sends a message; pull-request, push, merge-group, and manual runs do not.

## Validation

- `cargo test -p zcash_client_sqlite --all-features --lib -- --test-threads=2` (480 passed, 2 ignored)
- `cargo test -p zcash_client_backend --all-features --lib` (132 passed)
- `cargo check -p zcash_client_sqlite --all-features --all-targets`
- verified `--all-features` reports the isolated chain and proving tests as ignored with an explicit reason
- verified the nightly-like `expensive-tests` feature set contains no ignored copies of those tests
- file-backed concurrent-lock test passed
- `cargo fmt --all -- --check`
- workflow YAML parse and `git diff --check`
- `uvx zizmor==1.28.0 .github` on the combined stacked tree — no findings

The current GitHub Actions run provides the end-to-end hosted-runner validation.
