### PR TITLE
Release zcash_client_sqlite version 0.22.0-rc.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7332,7 +7332,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_pool_migration"
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 dependencies = [
  "corez",
  "getset",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7186,7 +7186,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.5"
+version = "0.22.0-rc.6"
 dependencies = [
  "ambassador",
  "assert_matches",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7428,7 +7428,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "corez",
  "document-features",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.5"
+version = "0.24.0-rc.6"
 dependencies = [
  "ambassador",
  "arti-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ categories = ["cryptography::cryptocurrencies"]
 # Intra-workspace dependencies
 equihash = { version = "0.3", path = "components/equihash", default-features = false }
 zcash_address = { version = "0.13.0", path = "components/zcash_address", default-features = false }
-zcash_client_backend = { version = "0.24.0-rc.5", path = "zcash_client_backend" }
+zcash_client_backend = { version = "0.24.0-rc.6", path = "zcash_client_backend" }
 # zcash_encoding 0.5.0 is a breaking release (MSRV bump + `CompactSize::write` now
 # rejects values above `MAX_COMPACT_SIZE`). To avoid forcing every dependent to
 # migrate at once, the workspace default stays pinned to the published 0.4; only

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ zcash_client_backend = { version = "0.24.0-rc.5", path = "zcash_client_backend" 
 zcash_encoding = { version = "0.4", default-features = false }
 zcash_keys = { version = "0.16.1", path = "zcash_keys", default-features = false  }
 zcash_pool_migration = { version = "0.1.0-rc.4", path = "zcash_pool_migration" }
-zcash_protocol = { version = "0.10.2", path = "components/zcash_protocol", default-features = false }
+zcash_protocol = { version = "0.10.3", path = "components/zcash_protocol", default-features = false }
 zip321 = { version = "0.9.0-rc.1", path = "components/zip321" }
 
 zcash_note_encryption = "0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ zcash_client_backend = { version = "0.24.0-rc.6", path = "zcash_client_backend" 
 # time, then flip this back to `path = "components/zcash_encoding"` at "0.5".
 zcash_encoding = { version = "0.4", default-features = false }
 zcash_keys = { version = "0.16.1", path = "zcash_keys", default-features = false  }
-zcash_pool_migration = { version = "0.1.0-rc.4", path = "zcash_pool_migration" }
+zcash_pool_migration = { version = "0.1.0-rc.5", path = "zcash_pool_migration" }
 zcash_protocol = { version = "0.10.3", path = "components/zcash_protocol", default-features = false }
 zip321 = { version = "0.9.0-rc.1", path = "components/zip321" }
 

--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -10,6 +10,8 @@ workspace.
 
 ## [Unreleased]
 
+## [0.10.3] - 2026-07-29
+
 ### Added
 - `zcash_protocol::zip318::{PREP_DELAY_MEAN, PREP_DELAY_CAP}`, the ZIP 318
   preparation inter-arrival delay distribution.

--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -20,7 +20,7 @@ workspace.
   144) and `zcash_protocol::zip318::ANCHOR_AGE_CAP` is now 4 boundaries
   (previously 16), adopting the revised ZIP 318 migration timing.
 
-### Removed
+### Deprecated
 - `zcash_protocol::zip318::DELAY_CAP_RATIO`. ZIP 318 no longer relates each
   delay cap to its mean by a shared ratio; use `TRANSFER_DELAY_CAP` and
   `PREP_DELAY_CAP` directly.

--- a/components/zcash_protocol/Cargo.toml
+++ b/components/zcash_protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_protocol"
 description = "Zcash protocol network constants and value types."
-version = "0.10.2"
+version = "0.10.3"
 authors = [
     "Jack Grigg <jack@electriccoin.co>",
     "Kris Nuttycombe <kris@nutty.land>",

--- a/components/zcash_protocol/src/zip318.rs
+++ b/components/zcash_protocol/src/zip318.rs
@@ -66,6 +66,17 @@ pub const PREP_DELAY_MEAN: NonZeroU32 = NonZeroU32::new(16).expect("16 is nonzer
 /// [ZIP 318]: https://zips.z.cash/zip-0318
 pub const PREP_DELAY_CAP: NonZeroU32 = NonZeroU32::new(96).expect("96 is nonzero");
 
+/// The ratio a [ZIP 318] delay distribution's cap bears to its mean: a draw more than four times the
+/// mean is discarded and redrawn, truncating the exponential's heavy tail so that nothing is starved
+/// for an unbounded time.
+///
+/// [ZIP 318]: https://zips.z.cash/zip-0318
+#[deprecated(note = "DO NOT USE; 
+`zcash_protocol::zip318::DELAY_CAP_RATIO`. ZIP 318 no longer relates each
+delay cap to its mean by a shared ratio; use `TRANSFER_DELAY_CAP` and
+`PREP_DELAY_CAP` directly.")]
+pub const DELAY_CAP_RATIO: NonZeroU32 = NonZeroU32::new(4).expect("4 is nonzero");
+
 /// The mean of the [ZIP 318] transfer inter-arrival delay distribution, in blocks: 66, about ninety
 /// minutes at the 75-second target block spacing.
 ///

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,6 +1,10 @@
 
 # cargo-vet imports lock
 
+[[unpublished.zcash_client_backend]]
+version = "0.24.0-rc.6"
+audited_as = "0.24.0-rc.5"
+
 [[unpublished.zcash_protocol]]
 version = "0.10.3"
 audited_as = "0.10.2"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -5,6 +5,10 @@
 version = "0.24.0-rc.6"
 audited_as = "0.24.0-rc.5"
 
+[[unpublished.zcash_pool_migration]]
+version = "0.1.0-rc.5"
+audited_as = "0.1.0-rc.4"
+
 [[unpublished.zcash_protocol]]
 version = "0.10.3"
 audited_as = "0.10.2"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -5,6 +5,10 @@
 version = "0.24.0-rc.6"
 audited_as = "0.24.0-rc.5"
 
+[[unpublished.zcash_client_sqlite]]
+version = "0.22.0-rc.6"
+audited_as = "0.22.0-rc.5"
+
 [[unpublished.zcash_pool_migration]]
 version = "0.1.0-rc.5"
 audited_as = "0.1.0-rc.4"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,25 +1,9 @@
 
 # cargo-vet imports lock
 
-[[unpublished.zcash_client_backend]]
-version = "0.24.0-rc.5"
-audited_as = "0.24.0-rc.4"
-
-[[unpublished.zcash_client_sqlite]]
-version = "0.22.0-rc.5"
-audited_as = "0.22.0-rc.4"
-
-[[unpublished.zcash_keys]]
-version = "0.16.1"
-audited_as = "0.16.0"
-
-[[unpublished.zcash_pool_migration]]
-version = "0.1.0-rc.4"
-audited_as = "0.1.0-rc.3"
-
 [[unpublished.zcash_protocol]]
-version = "0.10.2"
-audited_as = "0.10.1"
+version = "0.10.3"
+audited_as = "0.10.2"
 
 [[publisher.bumpalo]]
 version = "3.16.0"
@@ -469,15 +453,15 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_client_backend]]
-version = "0.24.0-rc.4"
-when = "2026-07-27"
+version = "0.24.0-rc.5"
+when = "2026-07-29"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_client_sqlite]]
-version = "0.22.0-rc.4"
-when = "2026-07-27"
+version = "0.22.0-rc.5"
+when = "2026-07-29"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -504,15 +488,15 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_keys]]
-version = "0.16.0"
-when = "2026-07-25"
+version = "0.16.1"
+when = "2026-07-29"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_pool_migration]]
-version = "0.1.0-rc.3"
-when = "2026-07-27"
+version = "0.1.0-rc.4"
+when = "2026-07-29"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -532,8 +516,8 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_protocol]]
-version = "0.10.1"
-when = "2026-07-24"
+version = "0.10.2"
+when = "2026-07-29"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -17,7 +17,6 @@ workspace.
 - `zcash_client_backend::data_api::InputSource::select_single_spendable_note`, with a
   best-effort default implementation
 - `zcash_client_backend::data_api::ReceivedNotes::{is_empty, into_single_covering}`
-- `zcash_client_backend::data_api::InputSource::anchor_computable`
 
 ### Changed
 - `zcash_client_backend::data_api::wallet::propose_transfer` now funds a canonical
@@ -30,6 +29,7 @@ workspace.
   height (per `InputSource::anchor_computable`), proposing an ordinary crossing
   instead of a canonical proposal whose build would fail with
   `ProposalError::AnchorNotFound`.
+- `zcash_client_backend::data_api::InputSource` has added method `anchor_computable`
 
 ### Fixed
 - `zcash_client_backend::data_api::ll::wallet::put_blocks` now creates (and retains) a

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -10,6 +10,8 @@ workspace.
 
 ## [Unreleased]
 
+## [0.24.0-rc.6] - 2026-07-29
+
 ### Added
 - `zcash_client_backend::data_api::anchor_retention::AnchorRetention::retained_in_range`
 - `zcash_client_backend::data_api::wallet::input_selection::NoteSelection`
@@ -17,6 +19,12 @@ workspace.
 - `zcash_client_backend::data_api::InputSource::select_single_spendable_note`, with a
   best-effort default implementation
 - `zcash_client_backend::data_api::ReceivedNotes::{is_empty, into_single_covering}`
+- `zcash_client_backend::fees::DummyOutputCounts`, the number of dummy outputs in
+  each shielded value pool.
+- `zcash_client_backend::fees::TransactionBalance::{with_dummy_outputs, dummy_outputs}`
+- `zcash_client_backend::proto::proposal::DummyOutputs`, so that the dummy-output
+  counts a fee was computed against survive serialization. A proposal serialized
+  before this field existed parses back with no counts recorded.
 
 ### Changed
 - `zcash_client_backend::data_api::wallet::propose_transfer` now funds a canonical
@@ -30,6 +38,13 @@ workspace.
   instead of a canonical proposal whose build would fail with
   `ProposalError::AnchorNotFound`.
 - `zcash_client_backend::data_api::InputSource` has added method `anchor_computable`
+
+### Removed
+- `zcash_client_backend::fees::TransactionBalance::{with_ironwood_bundle_padding, ironwood_bundle_padding}`.
+  A `ChangeStrategy` records the exact dummy-output count of every shielded bundle it
+  costed, via `with_dummy_outputs`, instead of an Ironwood-specific padding policy;
+  `zcash_client_backend::proposal::Step::ironwood_bundle_padding` derives the builder's
+  padding from those counts and the step's transaction shape.
 
 ### Fixed
 - `zcash_client_backend::data_api::ll::wallet::put_blocks` now creates (and retains) a

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_backend"
 description = "APIs for creating shielded Zcash light clients"
-version = "0.24.0-rc.5"
+version = "0.24.0-rc.6"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -39,6 +39,7 @@ workspace.
   as an ordinary payment.
 
 ### Changed
+- Migrated to `zcash_client_backend 0.24.0-rc.6`.
 - `zcash_client_sqlite::testing::db::TestDbFactory::default` and
   `zcash_client_sqlite::testing::BlockCache::default` now use isolated
   in-memory SQLite databases.

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -10,6 +10,8 @@ workspace.
 
 ## [Unreleased]
 
+## [0.22.0-rc.6] - 2026-07-29
+
 ### Added
 - The additive `ignore-expensive-tests` feature, which compiles expensive tests
   but marks them as ignored for broad `--all-features` test runs.
@@ -40,11 +42,27 @@ workspace.
 
 ### Changed
 - Migrated to `zcash_client_backend 0.24.0-rc.6`, `zcash_pool_migration 0.1.0-rc.5`.
+- The `pczt-tests` feature flag now also enables this crate's `orchard` and
+  `transparent-inputs` features, which `zcash_client_backend/pczt` forces on in the
+  backend; enabling `pczt-tests` alone no longer fails to compile.
 - `zcash_client_sqlite::testing::db::TestDbFactory::default` and
   `zcash_client_sqlite::testing::BlockCache::default` now use isolated
   in-memory SQLite databases.
 
 ### Fixed
+- A wallet created by a build that predates the addition of the
+  `anchor_bucket_interval` column to `orchard_ironwood_migrations` no longer
+  fails every scan. The column was added to the `orchard_ironwood_migration_tables`
+  DDL in place; a wallet that had already applied that migration never acquired
+  the column, and the committed-grid query issued by `put_blocks` then failed at
+  prepare time with `no such column: anchor_bucket_interval`, regardless of
+  whether a pool migration was in progress. Because that query runs on every
+  scan, no block could be written and no transaction acquired a mined height. A
+  new `orchard_ironwood_migration_anchor_interval` migration adds the column
+  where it is missing. An existing row is backfilled with the ZIP 318 grid,
+  which is exact on the production network but a reconstruction on a test
+  network, where a migration planned under a custom grid will be reported as
+  `AnchorIntervalMismatch` and must be re-planned.
 - Note selection now draws the oldest eligible notes first, ordering by note
   commitment tree position (chain order). Previously notes were drawn in
   scan-discovery order, which for a restored wallet prefers its most recently
@@ -95,19 +113,6 @@ workspace.
   `zewif::ZewifImportError`.
 
 ### Fixed
-- A wallet created by a build that predates the addition of the
-  `anchor_bucket_interval` column to `orchard_ironwood_migrations` no longer
-  fails every scan. The column was added to the `orchard_ironwood_migration_tables`
-  DDL in place; a wallet that had already applied that migration never acquired
-  the column, and the committed-grid query issued by `put_blocks` then failed at
-  prepare time with `no such column: anchor_bucket_interval`, regardless of
-  whether a pool migration was in progress. Because that query runs on every
-  scan, no block could be written and no transaction acquired a mined height. A
-  new `orchard_ironwood_migration_anchor_interval` migration adds the column
-  where it is missing. An existing row is backfilled with the ZIP 318 grid,
-  which is exact on the production network but a reconstruction on a test
-  network, where a migration planned under a custom grid will be reported as
-  `AnchorIntervalMismatch` and must be re-planned.
 - Transaction status requests are now generated from explicit, durable
   observation intent. A sent transaction is queried by txid when this wallet
   cannot observe one of its shielded spends or outputs, including transactions

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -39,7 +39,7 @@ workspace.
   as an ordinary payment.
 
 ### Changed
-- Migrated to `zcash_client_backend 0.24.0-rc.6`.
+- Migrated to `zcash_client_backend 0.24.0-rc.6`, `zcash_pool_migration 0.1.0-rc.5`.
 - `zcash_client_sqlite::testing::db::TestDbFactory::default` and
   `zcash_client_sqlite::testing::BlockCache::default` now use isolated
   in-memory SQLite databases.

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_sqlite"
 description = "An SQLite-based Zcash light client"
-version = "0.22.0-rc.5"
+version = "0.22.0-rc.6"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -7,6 +7,8 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.1.0-rc.5] - 2026-07-29
+
 ### Changed
 - Migrated to `zcash_client_backend 0.24.0-rc.6`.
 - `scheduling::SchedulingParams::ZIP_318` adopts the revised ZIP 318 timing:

--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -8,6 +8,7 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Changed
+- Migrated to `zcash_client_backend 0.24.0-rc.6`.
 - `scheduling::SchedulingParams::ZIP_318` adopts the revised ZIP 318 timing:
   transfer delays now have a mean of 66 blocks (previously 144) and
   preparation delays a mean of 16 blocks (previously a provisional 24), with

--- a/zcash_pool_migration/Cargo.toml
+++ b/zcash_pool_migration/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_pool_migration"
 description = "Backend-agnostic value-pool migration engine for Zcash wallets"
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 authors = [
     "Danny Willems <be.danny.willems@gmail.com>",
     "John Boyd <john@coldnoise.net>",


### PR DESCRIPTION
Release round for the ZIP 318 timing revision and the pool-crossing wallet work merged since
`zcash_client_sqlite 0.22.0-rc.5`.

| Crate | Version |
| --- | --- |
| `zcash_protocol` | 0.10.2 → 0.10.3 |
| `zcash_client_backend` | 0.24.0-rc.5 → 0.24.0-rc.6 |
| `zcash_pool_migration` | 0.1.0-rc.4 → 0.1.0-rc.5 |
| `zcash_client_sqlite` | 0.22.0-rc.5 → 0.22.0-rc.6 |

## What this ships

- **Revised ZIP 318 migration timing** (zcash/zips#1343): `TRANSFER_DELAY_MEAN` is now 66 blocks
  (was 144), `ANCHOR_AGE_CAP` is 4 boundaries (was 16), and the preparation delay is specified
  rather than provisional (`PREP_DELAY_MEAN`/`PREP_DELAY_CAP`). #2855 also makes
  `SchedulingParams::new_with_default_distributions` scale every delay parameter by the interval
  ratio instead of deriving delays from fixed cap/mean ratios.
- **Migration-shaped note selection** (#2850, #2856): `propose_transfer` funds a canonical
  crossing from the single oldest covering Orchard note, via the new
  `SpendPolicy::with_note_selection` / `NoteSelection::PreferSingle`.
- **Transaction shape recorded as dummy-output counts** (#2851): a `ChangeStrategy` now records
  the exact per-pool dummy-output count it costed (`fees::DummyOutputCounts`), replacing the
  Ironwood-specific `TransactionBalance::with_ironwood_bundle_padding`. The counts serialize into
  the proposal wire format, so every construction path reproduces the shape the fee was charged
  against without re-running the fee model.
- **Anchor availability fixes** (#2849, #2852): `put_blocks` checkpoints every anchor-retention
  grid height in a scanned range, including boundaries whose blocks carry no note commitments, and
  `propose_transfer` abandons a canonical crossing when no anchor is computable at the bucketed
  boundary rather than proposing one whose build fails with `ProposalError::AnchorNotFound`.
- **Pool-crossing transaction history** (#2822): `v_transactions` gains a `pool_crossing_value`
  column classifying wallet-internal shielded pool crossings and reporting the amount that crossed.
- **`v_tx_outputs` transparent addresses** (#2857): transparent outputs are reported at the
  transparent receiver itself rather than at a unified address containing it.
- **Stuck-scan repair** (#2836): a wallet built from a revision that predates the
  `anchor_bucket_interval` column never acquired it, and the committed-grid query in `put_blocks`
  then failed at prepare time on *every* scan, so no block was written and every transaction stayed
  pending. A new migration installs the column where it is missing.

## Notes for review

- `zcash_protocol` is a **patch** bump. `DELAY_CAP_RATIO` is deprecated rather than removed
  (7bf6378), which keeps the release semver-compatible and confines this round to four crates —
  a breaking `zcash_protocol` release would have forced `zcash_address`, `zcash_primitives`,
  `zcash_transparent`, `zcash_keys`, `pczt`, `zip321`, and `zcash_proofs` into it as well.
  `cargo semver-checks` against 0.10.2 passes 196 checks with no violations.
- The changelog audit moved the #2836 fix entry out of the already-published `0.22.0-rc.5`
  section, where it had originally landed, into this release's `Fixed` section, and added the
  previously-unlogged `fees`/`proto` dummy-output API changes and the `pczt-tests` feature change.
- `cargo semver-checks` reports nothing for the three prerelease crates: with a prerelease
  baseline it assumes a major bump and skips all 253 lints, so their audit rests on the diff sweep.
- Publish bottom-up: `zcash_protocol`, then `zcash_client_backend`, then `zcash_pool_migration`,
  then `zcash_client_sqlite`.
- Tags are added after merge, one per crate on that crate's own release commit.

Prepared with Claude Code assistance.
