### PR TITLE
zcash_client_sqlite: emit the documented diversifier_index_be column from v_tx_outputs

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -10,6 +10,14 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- The `v_tx_outputs` view now emits the `diversifier_index_be` column that its
+  documentation has described since the receiving-address columns were added:
+  the big-endian diversifier index of the receiving address, `NULL` for outputs
+  not received at one of the wallet's diversified addresses. The column was
+  previously computed internally but omitted from the view's output, so any
+  query naming it failed with "no such column".
+
 ## [0.22.0-rc.6] - 2026-07-29
 
 ### Added

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -1534,7 +1534,8 @@ GROUP BY notes.account_id, notes.transaction_id";
 ///   or `NULL` for wallet-internal outputs.
 /// - `diversifier_index_be`: The big-endian representation of the diversifier index (or, for
 ///   transparent addresses, the BIP 44 change-level index of the derivation path) of the receiving
-///   address. This will be `NULL` for outgoing transaction outputs.
+///   address. This will be `NULL` for outputs that were not received at one of the wallet's
+///   diversified addresses (in particular, for outputs sent to external recipients).
 /// - `value`: The value of the output, in zatoshis.
 /// - `is_change`: `0` for outgoing outputs and outputs received at external-facing addresses, `1`
 ///   for outputs received at wallet-internal addresses. This represents a best-effort judgement
@@ -1622,6 +1623,7 @@ SELECT
         MAX(CASE WHEN is_sent_row THEN to_address END),
         MAX(CASE WHEN NOT is_sent_row THEN to_address END)
     )                           AS to_address,
+    MAX(diversifier_index_be)   AS diversifier_index_be,
     MAX(value)                  AS value,
     MAX(is_change)              AS is_change,
     MAX(memo)                   AS memo,

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -64,6 +64,7 @@ mod v_transactions_note_uniqueness;
 mod v_transactions_pool_crossing;
 mod v_transactions_shielding_balance;
 mod v_transactions_transparent_history;
+mod v_tx_outputs_diversifier_index;
 mod v_tx_outputs_key_scopes;
 mod v_tx_outputs_return_addrs;
 mod v_tx_outputs_transparent_addresses;
@@ -163,6 +164,7 @@ pub mod ids {
     pub use super::v_transactions_pool_crossing::MIGRATION_ID as V_TRANSACTIONS_POOL_CROSSING;
     pub use super::v_transactions_shielding_balance::MIGRATION_ID as V_TRANSACTIONS_SHIELDING_BALANCE;
     pub use super::v_transactions_transparent_history::MIGRATION_ID as V_TRANSACTIONS_TRANSPARENT_HISTORY;
+    pub use super::v_tx_outputs_diversifier_index::MIGRATION_ID as V_TX_OUTPUTS_DIVERSIFIER_INDEX;
     pub use super::v_tx_outputs_key_scopes::MIGRATION_ID as V_TX_OUTPUTS_KEY_SCOPES;
     pub use super::v_tx_outputs_return_addrs::MIGRATION_ID as V_TX_OUTPUTS_RETURN_ADDRS;
     pub use super::v_tx_outputs_transparent_addresses::MIGRATION_ID as V_TX_OUTPUTS_TRANSPARENT_ADDRESSES;
@@ -252,6 +254,8 @@ pub(super) fn all_migrations<
     //                             |                             |            \
     //                             |              v_transactions_pool_crossing \
     //                             `------------------------------------------- v_tx_outputs_transparent_addresses
+    //                                                                                          |
+    //                                                                          v_tx_outputs_diversifier_index
     //
     let rng = Rc::new(Mutex::new(rng));
     vec![
@@ -364,6 +368,7 @@ pub(super) fn all_migrations<
         Box::new(tx_status_observation_intent::Migration),
         Box::new(orchard_ironwood_migration_anchor_interval::Migration),
         Box::new(v_tx_outputs_transparent_addresses::Migration),
+        Box::new(v_tx_outputs_diversifier_index::Migration),
     ]
 }
 
@@ -555,7 +560,7 @@ pub const V_0_22_0_RC2: &[Uuid] = &[
 
 /// Leaf migrations as of the current repository state.
 pub const CURRENT_LEAF_MIGRATIONS: &[Uuid] = &[
-    v_tx_outputs_transparent_addresses::MIGRATION_ID,
+    v_tx_outputs_diversifier_index::MIGRATION_ID,
     ivk_item_cache::MIGRATION_ID,
     add_transparent_receiver_address_index::MIGRATION_ID,
     add_transparent_value_index::MIGRATION_ID,
@@ -721,6 +726,7 @@ pub(crate) mod tests {
             ids::V_TRANSACTIONS_POOL_CROSSING,
             ids::V_TRANSACTIONS_SHIELDING_BALANCE,
             ids::V_TRANSACTIONS_TRANSPARENT_HISTORY,
+            ids::V_TX_OUTPUTS_DIVERSIFIER_INDEX,
             ids::V_TX_OUTPUTS_KEY_SCOPES,
             ids::V_TX_OUTPUTS_RETURN_ADDRS,
             ids::V_TX_OUTPUTS_TRANSPARENT_ADDRESSES,

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_tx_outputs_diversifier_index.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_tx_outputs_diversifier_index.rs
@@ -1,0 +1,148 @@
+//! Emits the documented `diversifier_index_be` column from `v_tx_outputs`.
+//!
+//! The column was selected into the view's `unioned` CTE — and documented as part of the
+//! view's output — when receiving-address information was added to `v_tx_outputs`, but the
+//! outer merge projection never carried it through, so `SELECT diversifier_index_be FROM
+//! v_tx_outputs` has always failed with "no such column". This migration recreates the view
+//! with the column projected through the merge: for an output the wallet both sent and
+//! received, the received arm's non-`NULL` index survives, and rows for outputs sent to
+//! external recipients remain `NULL`. See zcash/librustzcash#2863.
+use std::collections::HashSet;
+
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+
+use crate::wallet::init::WalletMigrationError;
+
+use super::v_tx_outputs_transparent_addresses;
+
+/// This migration projects the previously-dropped `diversifier_index_be` column through
+/// the outer merge of `v_tx_outputs`.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xb61cb2a9_5662_4998_8622_e62f1942cb74);
+
+/// `v_tx_outputs_transparent_addresses` is the prior owner of the `v_tx_outputs` definition
+/// this migration recreates.
+const DEPENDENCIES: &[Uuid] = &[v_tx_outputs_transparent_addresses::MIGRATION_ID];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Emits the documented diversifier_index_be column from v_tx_outputs."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        transaction.execute_batch(
+            "DROP VIEW v_tx_outputs;
+            CREATE VIEW v_tx_outputs AS
+            WITH unioned AS (
+                -- select all outputs received by the wallet
+                SELECT t.id_tx                      AS transaction_id,
+                       t.txid                       AS txid,
+                       t.mined_height               AS mined_height,
+                       IFNULL(t.trust_status, 0)    AS trust_status,
+                       ro.pool                      AS output_pool,
+                       ro.output_index              AS output_index,
+                       from_account.uuid            AS from_account_uuid,
+                       to_account.uuid              AS to_account_uuid,
+                       -- for a transparent output, the address at which it was received is
+                       -- the transparent receiver itself, not a unified address containing it
+                       CASE ro.pool
+                            WHEN 0 THEN a.cached_transparent_receiver_address
+                            ELSE a.address
+                       END                          AS to_address,
+                       0                            AS is_sent_row,
+                       a.diversifier_index_be       AS diversifier_index_be,
+                       ro.value                     AS value,
+                       ro.is_change                 AS is_change,
+                       ro.memo                      AS memo,
+                       a.key_scope                  AS recipient_key_scope
+                FROM v_received_outputs ro
+                JOIN transactions t
+                    ON t.id_tx = ro.transaction_id
+                LEFT JOIN addresses a ON a.id = ro.address_id
+                -- join to the sent_notes table to obtain `from_account_id`
+                LEFT JOIN sent_notes ON sent_notes.id = ro.sent_note_id
+                -- join on the accounts table to obtain account UUIDs
+                LEFT JOIN accounts from_account ON from_account.id = sent_notes.from_account_id
+                LEFT JOIN accounts to_account ON to_account.id = ro.account_id
+                UNION ALL
+                -- select all outputs sent by the wallet
+                SELECT t.id_tx                      AS transaction_id,
+                       t.txid                       AS txid,
+                       t.mined_height               AS mined_height,
+                       IFNULL(t.trust_status, 0)    AS trust_status,
+                       sent_notes.output_pool       AS output_pool,
+                       sent_notes.output_index      AS output_index,
+                       from_account.uuid            AS from_account_uuid,
+                       NULL                         AS to_account_uuid,
+                       sent_notes.to_address        AS to_address,
+                       1                            AS is_sent_row,
+                       NULL                         AS diversifier_index_be,
+                       sent_notes.value             AS value,
+                       0                            AS is_change,
+                       sent_notes.memo              AS memo,
+                       NULL                         AS recipient_key_scope
+                FROM sent_notes
+                JOIN transactions t
+                    ON t.id_tx = sent_notes.transaction_id
+                LEFT JOIN v_received_outputs ro ON ro.sent_note_id = sent_notes.id
+                -- join on the accounts table to obtain account UUIDs
+                LEFT JOIN accounts from_account ON from_account.id = sent_notes.from_account_id
+            )
+            -- merge duplicate rows while retaining maximum information
+            SELECT
+                transaction_id,
+                MAX(txid)                   AS txid,
+                MAX(mined_height)           AS tx_mined_height,
+                MIN(trust_status)           AS tx_trust_status,
+                output_pool,
+                output_index,
+                MAX(from_account_uuid)      AS from_account_uuid,
+                MAX(to_account_uuid)        AS to_account_uuid,
+                -- the recipient address recorded when the wallet created the output is
+                -- authoritative; the receiving address is reported only for outputs the
+                -- wallet did not create
+                COALESCE(
+                    MAX(CASE WHEN is_sent_row THEN to_address END),
+                    MAX(CASE WHEN NOT is_sent_row THEN to_address END)
+                )                           AS to_address,
+                MAX(diversifier_index_be)   AS diversifier_index_be,
+                MAX(value)                  AS value,
+                MAX(is_change)              AS is_change,
+                MAX(memo)                   AS memo,
+                MAX(recipient_key_scope)    AS recipient_key_scope
+            FROM unioned
+            GROUP BY transaction_id, output_pool, output_index;
+            ",
+        )?;
+
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+}

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -3120,6 +3120,121 @@ mod tests {
         );
     }
 
+    /// `v_tx_outputs` must emit the `diversifier_index_be` of the receiving address for
+    /// outputs received by the wallet, as its documentation has promised since the column
+    /// was introduced. The outer merge projection previously dropped it, so the documented
+    /// column did not exist in the view's output at all. See zcash/librustzcash#2863.
+    #[test]
+    fn v_tx_outputs_exposes_diversifier_index() {
+        use transparent::bundle::{OutPoint, TxOut};
+        use zcash_client_backend::{
+            data_api::WalletRead as _,
+            wallet::{Recipient, WalletTransparentOutput},
+        };
+        use zcash_keys::{encoding::AddressCodec as _, keys::UnifiedAddressRequest};
+        use zcash_protocol::value::Zatoshis;
+
+        use crate::{TxRef, wallet::put_sent_output};
+
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let account_id = st.test_account().unwrap().id();
+        let birthday = st.test_account().unwrap().birthday().height();
+        let params = st.wallet().db().params;
+        let taddr = *st
+            .wallet()
+            .get_last_generated_address_matching(
+                account_id,
+                UnifiedAddressRequest::AllAvailableKeys,
+            )
+            .unwrap()
+            .unwrap()
+            .transparent()
+            .unwrap();
+        let taddr_str = taddr.encode(&params);
+
+        let mined_at = birthday + 100;
+        st.wallet_mut().update_chain_tip(mined_at + 10).unwrap();
+
+        let outpoint = OutPoint::fake();
+        let value = Zatoshis::const_from_u64(100_000);
+        let utxo = WalletTransparentOutput::from_parts(
+            outpoint.clone(),
+            TxOut::new(value, taddr.script().into()),
+            Some(mined_at),
+            Some(account_id),
+            Some(TransparentKeyScope::EXTERNAL),
+            None,
+        )
+        .unwrap();
+        st.wallet_mut()
+            .put_received_transparent_utxo(&utxo)
+            .unwrap();
+
+        let expected: Vec<u8> = st
+            .wallet()
+            .conn()
+            .query_row(
+                "SELECT diversifier_index_be FROM addresses
+                 WHERE cached_transparent_receiver_address = :addr",
+                rusqlite::named_params! { ":addr": taddr_str },
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        let div_idx = |conn: &rusqlite::Connection| -> Option<Vec<u8>> {
+            conn.query_row(
+                "SELECT diversifier_index_be FROM v_tx_outputs WHERE txid = :txid",
+                rusqlite::named_params! { ":txid": outpoint.hash().to_vec() },
+                |row| row.get(0),
+            )
+            .unwrap()
+        };
+
+        assert_eq!(
+            div_idx(st.wallet().conn()),
+            Some(expected.clone()),
+            "a received output must carry the diversifier index of its receiving address",
+        );
+
+        // Recording the send side of the same output must not displace the index: the
+        // received arm's non-NULL value survives the merge.
+        let id_tx: i64 = st
+            .wallet()
+            .conn()
+            .query_row(
+                "SELECT id_tx FROM transactions WHERE txid = :txid",
+                rusqlite::named_params! { ":txid": outpoint.hash().to_vec() },
+                |row| row.get(0),
+            )
+            .unwrap();
+        let conn_tx = st.wallet_mut().conn_mut().transaction().unwrap();
+        put_sent_output(
+            &conn_tx,
+            &params,
+            account_id,
+            TxRef(id_tx),
+            outpoint.n() as usize,
+            &Recipient::InternalTransparent {
+                receiving_account: account_id,
+                recipient_address: taddr,
+            },
+            value,
+            None,
+        )
+        .unwrap();
+        conn_tx.commit().unwrap();
+
+        assert_eq!(
+            div_idx(st.wallet().conn()),
+            Some(expected),
+            "the receiving address's diversifier index must survive the sent/received merge",
+        );
+    }
+
     #[test]
     fn transparent_balance_across_shielding() {
         zcash_client_backend::data_api::testing::transparent::transparent_balance_across_shielding(


### PR DESCRIPTION
The `diversifier_index_be` column has been selected into the `unioned` CTE of `v_tx_outputs` — and documented as part of the view's output — since the receiving-address columns were added in the implementation of #1951, but the outer merge projection never carried it through: `SELECT diversifier_index_be FROM v_tx_outputs` has always failed with "no such column", and the CTE selection was dead code. Since every query naming the column failed immediately, no consumer can depend on its absence; projecting it is purely additive.

The new `v_tx_outputs_diversifier_index` migration (depending on `v_tx_outputs_transparent_addresses` from #2857) recreates the view with `MAX(diversifier_index_be)` projected through the merge. For an output the wallet both sent and received, the received arm's non-`NULL` index survives; rows for outputs sent to external recipients remain `NULL`. The column documentation's `NULL` condition is restated accordingly ("not received at one of the wallet's diversified addresses" rather than "outgoing"), since a wallet-internal send now carries the receiving address's index.

A regression test receives a UTXO at the account's own external-scope transparent receiver and asserts that the view's `diversifier_index_be` matches the `addresses` table's value for the receiving address, both before and after the send side of the output is recorded; it fails with "no such column" against the previous view definition.

Fixes #2863.

Closes #1073, which asked for this column so that a wallet could recover the diversifier index used to generate a receiving address. That issue's alternative suggestion — populating `to_address` for inbound notes rather than exposing the index — is already satisfied by the received arm's address projection, so this change answers it on both readings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

