### PR TITLE
zcash_client_sqlite: Optimize in-order scan progress queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7197,6 +7197,7 @@ dependencies = [
  "bls12_381",
  "bs58",
  "byteorder",
+ "criterion 0.5.1",
  "document-features",
  "group",
  "hex",

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -10,6 +10,11 @@ workspace.
 
 ## [Unreleased]
 
+### Changed
+- Improved `WalletRead::get_wallet_summary` performance during in-order scans
+  by avoiding per-block scan-queue lookups when pending ranges do not overlap
+  stored blocks.
+
 ## [0.22.0-rc.6] - 2026-07-29
 
 ### Added

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -12,8 +12,8 @@ workspace.
 
 ### Changed
 - Improved `WalletRead::get_wallet_summary` performance during in-order scans
-  by avoiding per-block scan-queue lookups when pending ranges do not overlap
-  stored blocks.
+  by deriving scanned-output totals from stored commitment-tree sizes instead
+  of scanning every stored block.
 
 ## [0.22.0-rc.6] - 2026-07-29
 

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -103,6 +103,7 @@ tempfile = { version = "3.5.0", optional = true }
 ambassador.workspace = true
 assert_matches.workspace = true
 bls12_381.workspace = true
+criterion.workspace = true
 incrementalmerkletree = { workspace = true, features = ["test-dependencies"] }
 incrementalmerkletree-testing.workspace = true
 pasta_curves.workspace = true
@@ -127,6 +128,10 @@ zcash_address = { workspace = true, features = ["test-dependencies"] }
 # feature below enables; see the note there for why it may not be enabled from here.
 zcash_pool_migration = { workspace = true, features = ["test-dependencies"] }
 zip321 = { workspace = true }
+
+[[bench]]
+name = "subtree_scan_progress"
+harness = false
 
 [features]
 default = ["multicore"]

--- a/zcash_client_sqlite/benches/subtree_scan_progress.rs
+++ b/zcash_client_sqlite/benches/subtree_scan_progress.rs
@@ -1,0 +1,139 @@
+use std::time::Duration;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use rusqlite::{Connection, named_params};
+
+/// Models a restored wallet with a substantial scanned history.
+const SCANNED_BLOCK_COUNT: u32 = 500_000;
+/// The first height in the synthetic wallet's scanned range.
+const FIRST_SCANNED_HEIGHT: u32 = 1;
+/// Models the stored priority code for a range that has been scanned.
+const SCANNED_PRIORITY: i64 = 10;
+/// Models a pending range whose priority is greater than `Scanned`.
+const PENDING_PRIORITY: i64 = 20;
+/// Keeps the slower legacy query's benchmark runtime practical.
+const SAMPLE_SIZE: usize = 10;
+/// Provides stable measurements without making the benchmark onerous.
+const MEASUREMENT_TIME: Duration = Duration::from_secs(5);
+
+fn in_order_scan_database() -> Connection {
+    let mut conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "CREATE TABLE blocks (
+             height INTEGER PRIMARY KEY,
+             sapling_output_count INTEGER NOT NULL
+         );
+         CREATE TABLE scan_queue (
+             block_range_start INTEGER NOT NULL UNIQUE,
+             block_range_end INTEGER NOT NULL UNIQUE,
+             priority INTEGER NOT NULL
+         );",
+    )
+    .unwrap();
+
+    let last_scanned_height = FIRST_SCANNED_HEIGHT + SCANNED_BLOCK_COUNT - 1;
+    let tx = conn.transaction().unwrap();
+    tx.execute(
+        "WITH RECURSIVE scanned_blocks(height) AS (
+             SELECT :first_height
+             UNION ALL
+             SELECT height + 1
+             FROM scanned_blocks
+             WHERE height < :last_height
+         )
+         INSERT INTO blocks (height, sapling_output_count)
+         SELECT height, height % 4
+         FROM scanned_blocks",
+        named_params! {
+            ":first_height": FIRST_SCANNED_HEIGHT,
+            ":last_height": last_scanned_height,
+        },
+    )
+    .unwrap();
+    tx.execute(
+        "INSERT INTO scan_queue (
+             block_range_start,
+             block_range_end,
+             priority
+         ) VALUES (:start_height, :end_height, :priority)",
+        named_params! {
+            ":start_height": last_scanned_height + 1,
+            ":end_height": last_scanned_height + SCANNED_BLOCK_COUNT,
+            ":priority": PENDING_PRIORITY,
+        },
+    )
+    .unwrap();
+    tx.commit().unwrap();
+
+    conn
+}
+
+fn bench_in_order_scanned_output_count(c: &mut Criterion) {
+    let conn = in_order_scan_database();
+    let mut group = c.benchmark_group("in_order_scanned_output_count");
+
+    group.bench_function("legacy_correlated_filter", |b| {
+        b.iter(|| {
+            conn.query_row(
+                "SELECT SUM(sapling_output_count)
+                 FROM blocks
+                 WHERE :start_height <= height
+                   AND NOT EXISTS (
+                       SELECT 1 FROM scan_queue
+                       WHERE block_range_start <= blocks.height
+                         AND blocks.height < block_range_end
+                         AND priority > :scanned_priority
+                   )",
+                named_params! {
+                    ":start_height": FIRST_SCANNED_HEIGHT,
+                    ":scanned_priority": SCANNED_PRIORITY,
+                },
+                |row| row.get::<_, Option<u64>>(0),
+            )
+            .unwrap()
+        })
+    });
+
+    group.bench_function("overlap_aware_fast_path", |b| {
+        b.iter(|| {
+            let pending_ranges_overlap = conn
+                .query_row(
+                    "SELECT EXISTS (
+                         SELECT 1 FROM scan_queue
+                         WHERE priority > :scanned_priority
+                           AND :start_height < block_range_end
+                           AND block_range_start <= (SELECT MAX(height) FROM blocks)
+                     )",
+                    named_params! {
+                        ":start_height": FIRST_SCANNED_HEIGHT,
+                        ":scanned_priority": SCANNED_PRIORITY,
+                    },
+                    |row| row.get::<_, bool>(0),
+                )
+                .unwrap();
+            assert!(!pending_ranges_overlap);
+
+            conn.query_row(
+                "SELECT SUM(sapling_output_count)
+                 FROM blocks
+                 WHERE :start_height <= height",
+                named_params! {
+                    ":start_height": FIRST_SCANNED_HEIGHT,
+                },
+                |row| row.get::<_, Option<u64>>(0),
+            )
+            .unwrap()
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(SAMPLE_SIZE)
+        .measurement_time(MEASUREMENT_TIME);
+    targets = bench_in_order_scanned_output_count
+}
+criterion_main!(benches);

--- a/zcash_client_sqlite/benches/subtree_scan_progress.rs
+++ b/zcash_client_sqlite/benches/subtree_scan_progress.rs
@@ -2,26 +2,46 @@ use std::time::Duration;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use rusqlite::{Connection, named_params};
+use tempfile::TempDir;
+use zcash_protocol::consensus::BlockHeight;
+
+#[path = "../src/wallet/scan_progress.rs"]
+mod scan_progress;
 
 /// Models a restored wallet with a substantial scanned history.
-const SCANNED_BLOCK_COUNT: u32 = 500_000;
+const SCANNED_BLOCK_COUNT: u32 = 600_000;
 /// The first height in the synthetic wallet's scanned range.
 const FIRST_SCANNED_HEIGHT: u32 = 1;
 /// Models the stored priority code for a range that has been scanned.
 const SCANNED_PRIORITY: i64 = 10;
 /// Models a pending range whose priority is greater than `Scanned`.
 const PENDING_PRIORITY: i64 = 20;
+/// Produces a small repeating distribution of Sapling outputs across blocks.
+const SAPLING_OUTPUT_COUNT_CYCLE: u32 = 4;
+/// Produces a distinct distribution of Orchard actions across blocks.
+const ORCHARD_ACTION_COUNT_CYCLE: u32 = 7;
+/// Names the temporary, file-backed SQLite database.
+const DATABASE_FILE_NAME: &str = "wallet.db";
 /// Keeps the slower legacy query's benchmark runtime practical.
 const SAMPLE_SIZE: usize = 10;
 /// Provides stable measurements without making the benchmark onerous.
 const MEASUREMENT_TIME: Duration = Duration::from_secs(5);
 
-fn in_order_scan_database() -> Connection {
-    let mut conn = Connection::open_in_memory().unwrap();
+struct InOrderScanDatabase {
+    _directory: TempDir,
+    conn: Connection,
+}
+
+fn in_order_scan_database() -> InOrderScanDatabase {
+    let directory = TempDir::new().unwrap();
+    let mut conn = Connection::open(directory.path().join(DATABASE_FILE_NAME)).unwrap();
     conn.execute_batch(
         "CREATE TABLE blocks (
              height INTEGER PRIMARY KEY,
-             sapling_output_count INTEGER NOT NULL
+             sapling_commitment_tree_size INTEGER NOT NULL,
+             sapling_output_count INTEGER NOT NULL,
+             orchard_commitment_tree_size INTEGER NOT NULL,
+             orchard_action_count INTEGER NOT NULL
          );
          CREATE TABLE scan_queue (
              block_range_start INTEGER NOT NULL UNIQUE,
@@ -34,19 +54,41 @@ fn in_order_scan_database() -> Connection {
     let last_scanned_height = FIRST_SCANNED_HEIGHT + SCANNED_BLOCK_COUNT - 1;
     let tx = conn.transaction().unwrap();
     tx.execute(
-        "WITH RECURSIVE scanned_blocks(height) AS (
-             SELECT :first_height
+        "WITH RECURSIVE scanned_blocks(
+             height,
+             sapling_tree_size,
+             orchard_tree_size
+         ) AS (
+             SELECT :first_height,
+                    :first_height % :sapling_output_count_cycle,
+                    :first_height % :orchard_action_count_cycle
              UNION ALL
-             SELECT height + 1
+             SELECT height + 1,
+                    sapling_tree_size
+                        + ((height + 1) % :sapling_output_count_cycle),
+                    orchard_tree_size
+                        + ((height + 1) % :orchard_action_count_cycle)
              FROM scanned_blocks
              WHERE height < :last_height
          )
-         INSERT INTO blocks (height, sapling_output_count)
-         SELECT height, height % 4
+         INSERT INTO blocks (
+             height,
+             sapling_commitment_tree_size,
+             sapling_output_count,
+             orchard_commitment_tree_size,
+             orchard_action_count
+         )
+         SELECT height,
+                sapling_tree_size,
+                height % :sapling_output_count_cycle,
+                orchard_tree_size,
+                height % :orchard_action_count_cycle
          FROM scanned_blocks",
         named_params! {
             ":first_height": FIRST_SCANNED_HEIGHT,
             ":last_height": last_scanned_height,
+            ":sapling_output_count_cycle": SAPLING_OUTPUT_COUNT_CYCLE,
+            ":orchard_action_count_cycle": ORCHARD_ACTION_COUNT_CYCLE,
         },
     )
     .unwrap();
@@ -55,74 +97,106 @@ fn in_order_scan_database() -> Connection {
              block_range_start,
              block_range_end,
              priority
-         ) VALUES (:start_height, :end_height, :priority)",
+         ) VALUES (
+             :start_height,
+             :pending_start,
+             :scanned_priority
+         ), (
+             :pending_start,
+             :pending_end,
+             :pending_priority
+        )",
         named_params! {
-            ":start_height": last_scanned_height + 1,
-            ":end_height": last_scanned_height + SCANNED_BLOCK_COUNT,
-            ":priority": PENDING_PRIORITY,
+            ":start_height": FIRST_SCANNED_HEIGHT,
+            ":pending_start": last_scanned_height + 1,
+            ":pending_end": last_scanned_height + SCANNED_BLOCK_COUNT,
+            ":scanned_priority": SCANNED_PRIORITY,
+            ":pending_priority": PENDING_PRIORITY,
         },
     )
     .unwrap();
     tx.commit().unwrap();
 
-    conn
+    InOrderScanDatabase {
+        _directory: directory,
+        conn,
+    }
+}
+
+fn unfiltered_output_count(conn: &Connection, output_count_col: &str) -> Option<u64> {
+    conn.query_row(
+        &format!(
+            "SELECT SUM({output_count_col})
+             FROM blocks
+             WHERE :start_height <= height"
+        ),
+        named_params! {
+            ":start_height": FIRST_SCANNED_HEIGHT,
+        },
+        |row| row.get(0),
+    )
+    .unwrap()
 }
 
 fn bench_in_order_scanned_output_count(c: &mut Criterion) {
-    let conn = in_order_scan_database();
-    let mut group = c.benchmark_group("in_order_scanned_output_count");
+    let database = in_order_scan_database();
+    let conn = &database.conn;
+    let mut group = c.benchmark_group("file_backed_in_order_scan_progress");
 
-    group.bench_function("legacy_correlated_filter", |b| {
+    group.bench_function("legacy_correlated_filter_both_pools", |b| {
         b.iter(|| {
-            conn.query_row(
-                "SELECT SUM(sapling_output_count)
-                 FROM blocks
-                 WHERE :start_height <= height
-                   AND NOT EXISTS (
-                       SELECT 1 FROM scan_queue
-                       WHERE block_range_start <= blocks.height
-                         AND blocks.height < block_range_end
-                         AND priority > :scanned_priority
-                   )",
-                named_params! {
-                    ":start_height": FIRST_SCANNED_HEIGHT,
-                    ":scanned_priority": SCANNED_PRIORITY,
-                },
-                |row| row.get::<_, Option<u64>>(0),
+            (
+                scan_progress::row_wise_scanned_output_count(
+                    conn,
+                    "sapling_output_count",
+                    BlockHeight::from(FIRST_SCANNED_HEIGHT),
+                    None,
+                    SCANNED_PRIORITY,
+                )
+                .unwrap(),
+                scan_progress::row_wise_scanned_output_count(
+                    conn,
+                    "orchard_action_count",
+                    BlockHeight::from(FIRST_SCANNED_HEIGHT),
+                    None,
+                    SCANNED_PRIORITY,
+                )
+                .unwrap(),
             )
-            .unwrap()
         })
     });
 
-    group.bench_function("overlap_aware_fast_path", |b| {
+    group.bench_function("unfiltered_sum_both_pools", |b| {
         b.iter(|| {
-            let pending_ranges_overlap = conn
-                .query_row(
-                    "SELECT EXISTS (
-                         SELECT 1 FROM scan_queue
-                         WHERE priority > :scanned_priority
-                           AND :start_height < block_range_end
-                           AND block_range_start <= (SELECT MAX(height) FROM blocks)
-                     )",
-                    named_params! {
-                        ":start_height": FIRST_SCANNED_HEIGHT,
-                        ":scanned_priority": SCANNED_PRIORITY,
-                    },
-                    |row| row.get::<_, bool>(0),
-                )
-                .unwrap();
-            assert!(!pending_ranges_overlap);
-
-            conn.query_row(
-                "SELECT SUM(sapling_output_count)
-                 FROM blocks
-                 WHERE :start_height <= height",
-                named_params! {
-                    ":start_height": FIRST_SCANNED_HEIGHT,
-                },
-                |row| row.get::<_, Option<u64>>(0),
+            (
+                unfiltered_output_count(conn, "sapling_output_count"),
+                unfiltered_output_count(conn, "orchard_action_count"),
             )
-            .unwrap()
+        })
+    });
+
+    group.bench_function("optimized_production_query_both_pools", |b| {
+        b.iter(|| {
+            (
+                scan_progress::scanned_output_count(
+                    conn,
+                    "sapling_commitment_tree_size",
+                    "sapling_output_count",
+                    BlockHeight::from(FIRST_SCANNED_HEIGHT),
+                    None,
+                    SCANNED_PRIORITY,
+                )
+                .unwrap(),
+                scan_progress::scanned_output_count(
+                    conn,
+                    "orchard_commitment_tree_size",
+                    "orchard_action_count",
+                    BlockHeight::from(FIRST_SCANNED_HEIGHT),
+                    None,
+                    SCANNED_PRIORITY,
+                )
+                .unwrap(),
+            )
         })
     });
 

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -2201,6 +2201,82 @@ fn estimate_tree_size<P: consensus::Parameters>(
     Ok(result)
 }
 
+fn pending_range_overlaps_scanned_blocks(
+    conn: &rusqlite::Connection,
+    start_height: BlockHeight,
+    end_height: Option<BlockHeight>,
+    scanned_priority: i64,
+) -> Result<bool, SqliteClientError> {
+    conn.query_row(
+        "SELECT EXISTS (
+             SELECT 1 FROM scan_queue
+             WHERE priority > :scanned_priority
+               AND :start_height < block_range_end
+               AND (:end_height IS NULL OR block_range_start < :end_height)
+               AND block_range_start <= (SELECT MAX(height) FROM blocks)
+         )",
+        named_params! {
+            ":start_height": u32::from(start_height),
+            ":end_height": end_height.map(u32::from),
+            ":scanned_priority": scanned_priority,
+        },
+        |row| row.get(0),
+    )
+    .map_err(SqliteClientError::from)
+}
+
+fn scanned_output_count(
+    conn: &rusqlite::Connection,
+    output_count_col: &str,
+    start_height: BlockHeight,
+    end_height: Option<BlockHeight>,
+    scanned_priority: i64,
+) -> Result<Option<u64>, SqliteClientError> {
+    // A normal in-order scan has pending work above the greatest height in
+    // `blocks`. In that case, checking every stored block for overlap with
+    // `scan_queue` cannot exclude any rows. Only retain the correlated
+    // exclusion when pending work overlaps the queried stored-block span.
+    let pending_ranges_overlap =
+        pending_range_overlaps_scanned_blocks(conn, start_height, end_height, scanned_priority)?;
+    if pending_ranges_overlap {
+        conn.query_row(
+            &format!(
+                "SELECT SUM({output_count_col})
+                 FROM blocks
+                 WHERE :start_height <= height
+                   AND (:end_height IS NULL OR height < :end_height)
+                   AND NOT EXISTS (
+                       SELECT 1 FROM scan_queue
+                       WHERE block_range_start <= blocks.height
+                         AND blocks.height < block_range_end
+                         AND priority > :scanned_priority
+                   )",
+            ),
+            named_params! {
+                ":start_height": u32::from(start_height),
+                ":end_height": end_height.map(u32::from),
+                ":scanned_priority": scanned_priority,
+            },
+            |row| row.get::<_, Option<u64>>(0),
+        )
+    } else {
+        conn.query_row(
+            &format!(
+                "SELECT SUM({output_count_col})
+                 FROM blocks
+                 WHERE :start_height <= height
+                   AND (:end_height IS NULL OR height < :end_height)",
+            ),
+            named_params! {
+                ":start_height": u32::from(start_height),
+                ":end_height": end_height.map(u32::from),
+            },
+            |row| row.get::<_, Option<u64>>(0),
+        )
+    }
+    .map_err(SqliteClientError::from)
+}
+
 #[allow(clippy::too_many_arguments)]
 fn subtree_scan_progress<P: consensus::Parameters>(
     conn: &rusqlite::Connection,
@@ -2233,18 +2309,6 @@ fn subtree_scan_progress<P: consensus::Parameters>(
               AND priority > :scanned_priority
         )";
 
-    let mut stmt_scanned_count_until = conn.prepare_cached(&format!(
-        "SELECT SUM({output_count_col})
-        FROM blocks
-        WHERE :start_height <= height AND height < :end_height
-        {unscanned_filter}",
-    ))?;
-    let mut stmt_scanned_count_from = conn.prepare_cached(&format!(
-        "SELECT SUM({output_count_col})
-        FROM blocks
-        WHERE :start_height <= height
-        {unscanned_filter}",
-    ))?;
     let mut stmt_start_tree_size = conn.prepare_cached(&format!(
         "SELECT MAX({table_prefix}_commitment_tree_size - {output_count_col})
         FROM blocks
@@ -2406,13 +2470,12 @@ fn subtree_scan_progress<P: consensus::Parameters>(
     // Count the total outputs scanned so far on the birthday side of the recover-until height.
     let recovered_count = recover_until_height
         .map(|end_height| {
-            stmt_scanned_count_until.query_row(
-                named_params! {
-                    ":start_height": u32::from(min_birthday_height),
-                    ":end_height": u32::from(end_height),
-                    ":scanned_priority": scanned_priority,
-                },
-                |row| row.get::<_, Option<u64>>(0),
+            scanned_output_count(
+                conn,
+                output_count_col,
+                min_birthday_height,
+                Some(end_height),
+                scanned_priority,
             )
         })
         .transpose()?;
@@ -2432,12 +2495,12 @@ fn subtree_scan_progress<P: consensus::Parameters>(
     let scan = {
         // Count the total outputs scanned so far on the chain tip side of the
         // recover-until height.
-        let scanned_count = stmt_scanned_count_from.query_row(
-            named_params![
-                ":start_height": u32::from(recover_until_height.unwrap_or(min_birthday_height)),
-                ":scanned_priority": scanned_priority,
-            ],
-            |row| row.get::<_, Option<u64>>(0),
+        let scanned_count = scanned_output_count(
+            conn,
+            output_count_col,
+            recover_until_height.unwrap_or(min_birthday_height),
+            None,
+            scanned_priority,
         )?;
 
         recover_until_size
@@ -5901,6 +5964,7 @@ mod tests {
     use zcash_client_backend::data_api::{
         Account as _, AccountSource, TransactionDataRequest, TransactionStatus, WalletRead,
         WalletWrite,
+        scanning::ScanPriority,
         testing::{AddressType, DataStoreFactory, FakeCompactOutput, TestBuilder, TestState},
         wallet::ConfirmationsPolicy,
     };
@@ -5916,12 +5980,124 @@ mod tests {
 
     use super::{
         KeyScope, ShieldedPool, TxQueryType, TxRef, account_birthday,
-        flag_previously_received_change, min_shared_checkpoint_height, queue_tx_retrieval,
-        select_truncation_height,
+        flag_previously_received_change, min_shared_checkpoint_height,
+        pending_range_overlaps_scanned_blocks, priority_code, queue_tx_retrieval,
+        scanned_output_count, select_truncation_height,
     };
 
     #[cfg(feature = "orchard")]
     use {crate::testing::db::TestDb, zcash_protocol::local_consensus::LocalNetwork};
+
+    #[test]
+    fn scanned_output_count_uses_pending_ranges_only_when_they_overlap() {
+        /// Keeps the fixture heights distinct from protocol activation heights.
+        const FIRST_SCANNED_HEIGHT: u32 = 100;
+        /// Provides several rows whose aggregate can detect incorrect filtering.
+        const SCANNED_BLOCK_COUNT: u32 = 3;
+        /// Makes the pending range extend beyond the scanned prefix.
+        const PENDING_BLOCK_COUNT: u32 = 10;
+        /// Gives every fixture row a distinct, nonzero output count.
+        const FIRST_OUTPUT_COUNT: u32 = 1;
+
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE blocks (
+                 height INTEGER PRIMARY KEY,
+                 sapling_output_count INTEGER NOT NULL
+             );
+             CREATE TABLE scan_queue (
+                 block_range_start INTEGER NOT NULL UNIQUE,
+                 block_range_end INTEGER NOT NULL UNIQUE,
+                 priority INTEGER NOT NULL
+             );",
+        )
+        .unwrap();
+
+        let first_scanned_height = BlockHeight::from_u32(FIRST_SCANNED_HEIGHT);
+        let last_scanned_height = first_scanned_height + SCANNED_BLOCK_COUNT.saturating_sub(1);
+        for (height, output_count) in (u32::from(first_scanned_height)
+            ..=u32::from(last_scanned_height))
+            .zip(FIRST_OUTPUT_COUNT..)
+        {
+            conn.execute(
+                "INSERT INTO blocks (height, sapling_output_count) VALUES (?1, ?2)",
+                (height, output_count),
+            )
+            .unwrap();
+        }
+
+        let scanned_priority = priority_code(&ScanPriority::Scanned);
+        let historic_priority = priority_code(&ScanPriority::Historic);
+        let pending_start = u32::from(last_scanned_height) + 1;
+        let pending_end = pending_start + PENDING_BLOCK_COUNT;
+        conn.execute(
+            "INSERT INTO scan_queue (
+                 block_range_start,
+                 block_range_end,
+                 priority
+             ) VALUES (?1, ?2, ?3)",
+            (pending_start, pending_end, historic_priority),
+        )
+        .unwrap();
+
+        assert!(
+            !pending_range_overlaps_scanned_blocks(
+                &conn,
+                first_scanned_height,
+                None,
+                scanned_priority,
+            )
+            .unwrap()
+        );
+        assert_eq!(
+            scanned_output_count(
+                &conn,
+                "sapling_output_count",
+                first_scanned_height,
+                None,
+                scanned_priority,
+            )
+            .unwrap(),
+            Some(
+                (FIRST_OUTPUT_COUNT..FIRST_OUTPUT_COUNT + SCANNED_BLOCK_COUNT)
+                    .map(u64::from)
+                    .sum(),
+            ),
+        );
+
+        conn.execute("DELETE FROM scan_queue", []).unwrap();
+        let overlapping_start = u32::from(first_scanned_height) + 1;
+        conn.execute(
+            "INSERT INTO scan_queue (
+                 block_range_start,
+                 block_range_end,
+                 priority
+             ) VALUES (?1, ?2, ?3)",
+            (overlapping_start, pending_end, historic_priority),
+        )
+        .unwrap();
+
+        assert!(
+            pending_range_overlaps_scanned_blocks(
+                &conn,
+                first_scanned_height,
+                None,
+                scanned_priority,
+            )
+            .unwrap()
+        );
+        assert_eq!(
+            scanned_output_count(
+                &conn,
+                "sapling_output_count",
+                first_scanned_height,
+                None,
+                scanned_priority,
+            )
+            .unwrap(),
+            Some(u64::from(FIRST_OUTPUT_COUNT)),
+        );
+    }
 
     fn connection_with_checkpoint_tables() -> Connection {
         let conn = Connection::open_in_memory().unwrap();

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -180,6 +180,9 @@ pub(crate) mod locking;
 #[cfg(feature = "orchard")]
 pub(crate) mod orchard;
 pub(crate) mod sapling;
+mod scan_progress;
+#[cfg(test)]
+mod scan_progress_tests;
 pub(crate) mod scanning;
 #[cfg(feature = "transparent-inputs")]
 pub(crate) mod transparent;
@@ -2201,82 +2204,6 @@ fn estimate_tree_size<P: consensus::Parameters>(
     Ok(result)
 }
 
-fn pending_range_overlaps_scanned_blocks(
-    conn: &rusqlite::Connection,
-    start_height: BlockHeight,
-    end_height: Option<BlockHeight>,
-    scanned_priority: i64,
-) -> Result<bool, SqliteClientError> {
-    conn.query_row(
-        "SELECT EXISTS (
-             SELECT 1 FROM scan_queue
-             WHERE priority > :scanned_priority
-               AND :start_height < block_range_end
-               AND (:end_height IS NULL OR block_range_start < :end_height)
-               AND block_range_start <= (SELECT MAX(height) FROM blocks)
-         )",
-        named_params! {
-            ":start_height": u32::from(start_height),
-            ":end_height": end_height.map(u32::from),
-            ":scanned_priority": scanned_priority,
-        },
-        |row| row.get(0),
-    )
-    .map_err(SqliteClientError::from)
-}
-
-fn scanned_output_count(
-    conn: &rusqlite::Connection,
-    output_count_col: &str,
-    start_height: BlockHeight,
-    end_height: Option<BlockHeight>,
-    scanned_priority: i64,
-) -> Result<Option<u64>, SqliteClientError> {
-    // A normal in-order scan has pending work above the greatest height in
-    // `blocks`. In that case, checking every stored block for overlap with
-    // `scan_queue` cannot exclude any rows. Only retain the correlated
-    // exclusion when pending work overlaps the queried stored-block span.
-    let pending_ranges_overlap =
-        pending_range_overlaps_scanned_blocks(conn, start_height, end_height, scanned_priority)?;
-    if pending_ranges_overlap {
-        conn.query_row(
-            &format!(
-                "SELECT SUM({output_count_col})
-                 FROM blocks
-                 WHERE :start_height <= height
-                   AND (:end_height IS NULL OR height < :end_height)
-                   AND NOT EXISTS (
-                       SELECT 1 FROM scan_queue
-                       WHERE block_range_start <= blocks.height
-                         AND blocks.height < block_range_end
-                         AND priority > :scanned_priority
-                   )",
-            ),
-            named_params! {
-                ":start_height": u32::from(start_height),
-                ":end_height": end_height.map(u32::from),
-                ":scanned_priority": scanned_priority,
-            },
-            |row| row.get::<_, Option<u64>>(0),
-        )
-    } else {
-        conn.query_row(
-            &format!(
-                "SELECT SUM({output_count_col})
-                 FROM blocks
-                 WHERE :start_height <= height
-                   AND (:end_height IS NULL OR height < :end_height)",
-            ),
-            named_params! {
-                ":start_height": u32::from(start_height),
-                ":end_height": end_height.map(u32::from),
-            },
-            |row| row.get::<_, Option<u64>>(0),
-        )
-    }
-    .map_err(SqliteClientError::from)
-}
-
 #[allow(clippy::too_many_arguments)]
 fn subtree_scan_progress<P: consensus::Parameters>(
     conn: &rusqlite::Connection,
@@ -2293,6 +2220,7 @@ fn subtree_scan_progress<P: consensus::Parameters>(
         shard_height,
         ..
     } = table_constants::<SqliteClientError>(shielded_protocol)?;
+    let tree_size_col = format!("{table_prefix}_commitment_tree_size");
 
     // Each query against the `blocks` table that contributes to scan-progress accounting
     // must exclude heights that fall within a `scan_queue` range whose priority indicates
@@ -2470,8 +2398,9 @@ fn subtree_scan_progress<P: consensus::Parameters>(
     // Count the total outputs scanned so far on the birthday side of the recover-until height.
     let recovered_count = recover_until_height
         .map(|end_height| {
-            scanned_output_count(
+            scan_progress::scanned_output_count(
                 conn,
+                &tree_size_col,
                 output_count_col,
                 min_birthday_height,
                 Some(end_height),
@@ -2495,8 +2424,9 @@ fn subtree_scan_progress<P: consensus::Parameters>(
     let scan = {
         // Count the total outputs scanned so far on the chain tip side of the
         // recover-until height.
-        let scanned_count = scanned_output_count(
+        let scanned_count = scan_progress::scanned_output_count(
             conn,
+            &tree_size_col,
             output_count_col,
             recover_until_height.unwrap_or(min_birthday_height),
             None,
@@ -5980,30 +5910,45 @@ mod tests {
 
     use super::{
         KeyScope, ShieldedPool, TxQueryType, TxRef, account_birthday,
-        flag_previously_received_change, min_shared_checkpoint_height,
-        pending_range_overlaps_scanned_blocks, priority_code, queue_tx_retrieval,
-        scanned_output_count, select_truncation_height,
+        flag_previously_received_change, min_shared_checkpoint_height, priority_code,
+        queue_tx_retrieval,
+        scan_progress::{
+            row_wise_scanned_output_count, scanned_output_count,
+            scanned_output_count_from_tree_sizes,
+        },
+        select_truncation_height,
     };
 
     #[cfg(feature = "orchard")]
     use {crate::testing::db::TestDb, zcash_protocol::local_consensus::LocalNetwork};
 
     #[test]
-    fn scanned_output_count_uses_pending_ranges_only_when_they_overlap() {
+    fn scanned_output_count_uses_tree_size_boundaries() {
         /// Keeps the fixture heights distinct from protocol activation heights.
         const FIRST_SCANNED_HEIGHT: u32 = 100;
-        /// Provides several rows whose aggregate can detect incorrect filtering.
-        const SCANNED_BLOCK_COUNT: u32 = 3;
+        /// Provides enough rows to exercise range clamping and overlap handling.
+        const SCANNED_BLOCK_COUNT: u32 = 6;
         /// Makes the pending range extend beyond the scanned prefix.
         const PENDING_BLOCK_COUNT: u32 = 10;
+        /// Gives each malformed pending range enough blocks to overlap.
+        const OVERLAPPING_RANGE_WIDTH: u32 = 3;
+        /// Makes malformed pending ranges overlap at exactly one block.
+        const PENDING_RANGE_OVERLAP: u32 = 1;
         /// Gives every fixture row a distinct, nonzero output count.
         const FIRST_OUTPUT_COUNT: u32 = 1;
+        /// Ensures that the calculation uses deltas rather than absolute sizes.
+        const INITIAL_TREE_SIZE: u32 = 50;
+        /// The cumulative tree-size column used by the fixture.
+        const TREE_SIZE_COL: &str = "sapling_commitment_tree_size";
+        /// The per-block output-count column used by the fixture.
+        const OUTPUT_COUNT_COL: &str = "sapling_output_count";
 
         let conn = Connection::open_in_memory().unwrap();
         conn.execute_batch(
             "CREATE TABLE blocks (
                  height INTEGER PRIMARY KEY,
-                 sapling_output_count INTEGER NOT NULL
+                 sapling_commitment_tree_size INTEGER,
+                 sapling_output_count INTEGER
              );
              CREATE TABLE scan_queue (
                  block_range_start INTEGER NOT NULL UNIQUE,
@@ -6015,13 +5960,19 @@ mod tests {
 
         let first_scanned_height = BlockHeight::from_u32(FIRST_SCANNED_HEIGHT);
         let last_scanned_height = first_scanned_height + SCANNED_BLOCK_COUNT.saturating_sub(1);
+        let mut tree_size = INITIAL_TREE_SIZE;
         for (height, output_count) in (u32::from(first_scanned_height)
             ..=u32::from(last_scanned_height))
             .zip(FIRST_OUTPUT_COUNT..)
         {
+            tree_size += output_count;
             conn.execute(
-                "INSERT INTO blocks (height, sapling_output_count) VALUES (?1, ?2)",
-                (height, output_count),
+                "INSERT INTO blocks (
+                     height,
+                     sapling_commitment_tree_size,
+                     sapling_output_count
+                 ) VALUES (?1, ?2, ?3)",
+                (height, tree_size, output_count),
             )
             .unwrap();
         }
@@ -6035,67 +5986,206 @@ mod tests {
                  block_range_start,
                  block_range_end,
                  priority
-             ) VALUES (?1, ?2, ?3)",
-            (pending_start, pending_end, historic_priority),
+             ) VALUES (?1, ?2, ?3), (?2, ?4, ?5)",
+            (
+                u32::from(first_scanned_height),
+                pending_start,
+                scanned_priority,
+                pending_end,
+                historic_priority,
+            ),
         )
         .unwrap();
 
-        assert!(
-            !pending_range_overlaps_scanned_blocks(
-                &conn,
-                first_scanned_height,
-                None,
-                scanned_priority,
-            )
-            .unwrap()
-        );
+        let expected_total = (FIRST_OUTPUT_COUNT..FIRST_OUTPUT_COUNT + SCANNED_BLOCK_COUNT)
+            .map(u64::from)
+            .sum();
         assert_eq!(
-            scanned_output_count(
+            scanned_output_count_from_tree_sizes(
                 &conn,
-                "sapling_output_count",
+                TREE_SIZE_COL,
+                OUTPUT_COUNT_COL,
                 first_scanned_height,
                 None,
                 scanned_priority,
             )
             .unwrap(),
-            Some(
-                (FIRST_OUTPUT_COUNT..FIRST_OUTPUT_COUNT + SCANNED_BLOCK_COUNT)
-                    .map(u64::from)
-                    .sum(),
-            ),
+            Some(expected_total),
+        );
+
+        let bounded_start = first_scanned_height + 1;
+        let bounded_end = last_scanned_height;
+        let expected_bounded = (FIRST_OUTPUT_COUNT + 1
+            ..FIRST_OUTPUT_COUNT + SCANNED_BLOCK_COUNT - 1)
+            .map(u64::from)
+            .sum();
+        assert_eq!(
+            scanned_output_count_from_tree_sizes(
+                &conn,
+                TREE_SIZE_COL,
+                OUTPUT_COUNT_COL,
+                bounded_start,
+                Some(bounded_end),
+                scanned_priority,
+            )
+            .unwrap(),
+            Some(expected_bounded),
         );
 
         conn.execute("DELETE FROM scan_queue", []).unwrap();
         let overlapping_start = u32::from(first_scanned_height) + 1;
+        let effective_end = u32::from(last_scanned_height) + 1;
         conn.execute(
             "INSERT INTO scan_queue (
                  block_range_start,
                  block_range_end,
                  priority
-             ) VALUES (?1, ?2, ?3)",
-            (overlapping_start, pending_end, historic_priority),
+             ) VALUES (?1, ?2, ?3), (?2, ?4, ?5)",
+            (
+                u32::from(first_scanned_height),
+                overlapping_start,
+                scanned_priority,
+                effective_end,
+                historic_priority,
+            ),
         )
         .unwrap();
 
-        assert!(
-            pending_range_overlaps_scanned_blocks(
-                &conn,
-                first_scanned_height,
-                None,
-                scanned_priority,
-            )
-            .unwrap()
-        );
+        let expected_after_subtraction = u64::from(FIRST_OUTPUT_COUNT);
         assert_eq!(
-            scanned_output_count(
+            scanned_output_count_from_tree_sizes(
                 &conn,
-                "sapling_output_count",
+                TREE_SIZE_COL,
+                OUTPUT_COUNT_COL,
                 first_scanned_height,
                 None,
                 scanned_priority,
             )
             .unwrap(),
-            Some(u64::from(FIRST_OUTPUT_COUNT)),
+            Some(expected_after_subtraction),
+        );
+        assert_eq!(
+            scanned_output_count_from_tree_sizes(
+                &conn,
+                TREE_SIZE_COL,
+                OUTPUT_COUNT_COL,
+                BlockHeight::from(overlapping_start),
+                Some(BlockHeight::from(effective_end)),
+                scanned_priority,
+            )
+            .unwrap(),
+            Some(0),
+        );
+
+        // A malformed queue partition cannot be evaluated using tree-size
+        // boundaries, so it conservatively uses the row-wise query.
+        conn.execute("DELETE FROM scan_queue", []).unwrap();
+        let first_pending_end = overlapping_start + OVERLAPPING_RANGE_WIDTH;
+        let second_pending_start = first_pending_end - PENDING_RANGE_OVERLAP;
+        let overlapping_end = second_pending_start + OVERLAPPING_RANGE_WIDTH;
+        conn.execute(
+            "INSERT INTO scan_queue (
+                 block_range_start,
+                 block_range_end,
+                 priority
+             ) VALUES (?1, ?2, ?3), (?4, ?5, ?3)",
+            (
+                overlapping_start,
+                first_pending_end,
+                historic_priority,
+                second_pending_start,
+                overlapping_end,
+            ),
+        )
+        .unwrap();
+        assert_eq!(
+            scanned_output_count_from_tree_sizes(
+                &conn,
+                TREE_SIZE_COL,
+                OUTPUT_COUNT_COL,
+                first_scanned_height,
+                None,
+                scanned_priority,
+            )
+            .unwrap(),
+            None,
+        );
+        let row_wise_count = row_wise_scanned_output_count(
+            &conn,
+            OUTPUT_COUNT_COL,
+            first_scanned_height,
+            None,
+            scanned_priority,
+        )
+        .unwrap();
+        assert_eq!(
+            scanned_output_count(
+                &conn,
+                TREE_SIZE_COL,
+                OUTPUT_COUNT_COL,
+                first_scanned_height,
+                None,
+                scanned_priority,
+            )
+            .unwrap(),
+            row_wise_count,
+        );
+
+        // A missing boundary also forces the row-wise fallback.
+        conn.execute("DELETE FROM scan_queue", []).unwrap();
+        conn.execute(
+            "INSERT INTO scan_queue (
+                 block_range_start,
+                 block_range_end,
+                 priority
+             ) VALUES (?1, ?2, ?3), (?2, ?4, ?5)",
+            (
+                u32::from(first_scanned_height),
+                overlapping_start,
+                scanned_priority,
+                effective_end,
+                historic_priority,
+            ),
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE blocks
+             SET sapling_commitment_tree_size = NULL
+             WHERE height = ?1",
+            [u32::from(first_scanned_height)],
+        )
+        .unwrap();
+        assert_eq!(
+            scanned_output_count_from_tree_sizes(
+                &conn,
+                TREE_SIZE_COL,
+                OUTPUT_COUNT_COL,
+                first_scanned_height,
+                None,
+                scanned_priority,
+            )
+            .unwrap(),
+            None,
+        );
+        let row_wise_count = row_wise_scanned_output_count(
+            &conn,
+            OUTPUT_COUNT_COL,
+            first_scanned_height,
+            None,
+            scanned_priority,
+        )
+        .unwrap();
+        assert_eq!(
+            scanned_output_count(
+                &conn,
+                TREE_SIZE_COL,
+                OUTPUT_COUNT_COL,
+                first_scanned_height,
+                None,
+                scanned_priority,
+            )
+            .unwrap(),
+            row_wise_count,
         );
     }
 
@@ -7077,6 +7167,63 @@ mod tests {
         st.scan_cached_blocks(start_height, 5);
 
         (st, start_height)
+    }
+
+    #[cfg(feature = "orchard")]
+    fn assert_scan_progress_matches_row_wise(conn: &Connection, start_height: BlockHeight) {
+        let scanned_priority = priority_code(&ScanPriority::Scanned);
+        for (tree_size_col, output_count_col) in [
+            ("sapling_commitment_tree_size", "sapling_output_count"),
+            ("orchard_commitment_tree_size", "orchard_action_count"),
+        ] {
+            let fast = scanned_output_count_from_tree_sizes(
+                conn,
+                tree_size_col,
+                output_count_col,
+                start_height,
+                None,
+                scanned_priority,
+            )
+            .unwrap();
+            let row_wise = row_wise_scanned_output_count(
+                conn,
+                output_count_col,
+                start_height,
+                None,
+                scanned_priority,
+            )
+            .unwrap();
+            assert!(fast.is_some());
+            assert_eq!(fast.unwrap_or(0), row_wise.unwrap_or(0));
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn scanned_output_count_matches_across_rewind_and_rescan() {
+        use std::collections::HashSet;
+
+        use zcash_client_backend::data_api::chain::ChainState;
+
+        /// Rewinds within the small scanned fixture while retaining a checkpoint.
+        const REWIND_OFFSET: u32 = 2;
+        /// Rescans part of the range queued by the rewind.
+        const RESCAN_BLOCK_COUNT: usize = 2;
+
+        let (mut st, start_height) = wallet_with_scanned_blocks();
+        assert_scan_progress_matches_row_wise(st.wallet().conn(), start_height);
+
+        let rewind_height = start_height + REWIND_OFFSET;
+        st.wallet_mut()
+            .rewind_to_chain_state(
+                ChainState::empty(rewind_height, BlockHash([0; 32])),
+                HashSet::new(),
+            )
+            .unwrap();
+        assert_scan_progress_matches_row_wise(st.wallet().conn(), start_height);
+
+        st.scan_cached_blocks(rewind_height + 1, RESCAN_BLOCK_COUNT);
+        assert_scan_progress_matches_row_wise(st.wallet().conn(), start_height);
     }
 
     #[cfg(feature = "orchard")]

--- a/zcash_client_sqlite/src/wallet/scan_progress.rs
+++ b/zcash_client_sqlite/src/wallet/scan_progress.rs
@@ -1,0 +1,226 @@
+use std::ops::Range;
+
+use rusqlite::{Connection, OptionalExtension, named_params};
+
+use zcash_protocol::consensus::BlockHeight;
+
+fn output_count_for_range(
+    conn: &Connection,
+    tree_size_col: &str,
+    output_count_col: &str,
+    range: &Range<BlockHeight>,
+) -> Result<Option<u64>, rusqlite::Error> {
+    if range.is_empty() {
+        return Ok(Some(0));
+    }
+
+    let boundary_data = conn
+        .query_row(
+            &format!(
+                "SELECT first.{tree_size_col},
+                        first.{output_count_col},
+                        last.{tree_size_col}
+                 FROM blocks AS first
+                 JOIN blocks AS last ON last.height = :last_height
+                 WHERE first.height = :start_height"
+            ),
+            named_params! {
+                ":start_height": u32::from(range.start),
+                ":last_height": u32::from(range.end - 1),
+            },
+            |row| {
+                Ok((
+                    row.get::<_, Option<u64>>(0)?,
+                    row.get::<_, Option<u64>>(1)?,
+                    row.get::<_, Option<u64>>(2)?,
+                ))
+            },
+        )
+        .optional()?;
+
+    Ok(
+        boundary_data.and_then(|(start_tree_size, start_output_count, end_tree_size)| {
+            start_tree_size
+                .zip(start_output_count)
+                .and_then(|(tree_size, output_count)| tree_size.checked_sub(output_count))
+                .zip(end_tree_size)
+                .and_then(|(size_before_start, size_at_end)| {
+                    size_at_end.checked_sub(size_before_start)
+                })
+        }),
+    )
+}
+
+/// Returns whether this database was populated with per-block output counts.
+///
+/// The migration that introduced the output-count columns could only backfill
+/// rows that had an immediately preceding block, so its first stored row is
+/// always `NULL`. Treating that row as a migration marker keeps potentially
+/// sparse historical data on the exact row-wise path. Databases populated by
+/// the current scan code store the count on every inserted block.
+fn has_output_count_for_first_stored_block(
+    conn: &Connection,
+    output_count_col: &str,
+) -> Result<bool, rusqlite::Error> {
+    conn.query_row(
+        &format!(
+            "SELECT {output_count_col} IS NOT NULL
+             FROM blocks
+             ORDER BY height
+             LIMIT 1"
+        ),
+        [],
+        |row| row.get(0),
+    )
+    .optional()
+    .map(Option::unwrap_or_default)
+}
+
+/// Returns the portions of `range` that the row-wise query counts.
+///
+/// The scan queue is maintained as a contiguous, non-overlapping partition.
+/// Requiring that partition here lets tree-size deltas skip pending segments
+/// without assuming that unrepresented interior blocks were scanned. Any
+/// malformed or incomplete partition makes the fast path unavailable.
+fn counted_ranges(
+    conn: &Connection,
+    range: &Range<BlockHeight>,
+    scanned_priority: i64,
+) -> Result<Option<Vec<Range<BlockHeight>>>, rusqlite::Error> {
+    let mut stmt = conn.prepare_cached(
+        "SELECT MAX(block_range_start, :start_height),
+                MIN(block_range_end, :end_height),
+                priority
+         FROM scan_queue
+         WHERE :start_height < block_range_end
+           AND block_range_start < :end_height
+         ORDER BY block_range_start, block_range_end",
+    )?;
+    let mut rows = stmt.query(named_params! {
+        ":start_height": u32::from(range.start),
+        ":end_height": u32::from(range.end),
+    })?;
+    let mut cursor = range.start;
+    let mut counted = vec![];
+    while let Some(row) = rows.next()? {
+        let next =
+            BlockHeight::from(row.get::<_, u32>(0)?)..BlockHeight::from(row.get::<_, u32>(1)?);
+        let priority = row.get::<_, i64>(2)?;
+        if next.is_empty() || next.start != cursor {
+            return Ok(None);
+        }
+        if priority <= scanned_priority {
+            counted.push(next.clone());
+        }
+        cursor = next.end;
+    }
+
+    Ok((cursor == range.end).then_some(counted))
+}
+
+pub(super) fn scanned_output_count_from_tree_sizes(
+    conn: &Connection,
+    tree_size_col: &str,
+    output_count_col: &str,
+    start_height: BlockHeight,
+    end_height: Option<BlockHeight>,
+    scanned_priority: i64,
+) -> Result<Option<u64>, rusqlite::Error> {
+    if !has_output_count_for_first_stored_block(conn, output_count_col)? {
+        return Ok(None);
+    }
+
+    let last_height = conn.query_row(
+        "SELECT MAX(height)
+         FROM blocks
+         WHERE :start_height <= height
+           AND (:end_height IS NULL OR height < :end_height)",
+        named_params! {
+            ":start_height": u32::from(start_height),
+            ":end_height": end_height.map(u32::from),
+        },
+        |row| row.get::<_, Option<u32>>(0),
+    )?;
+    let Some(last_height) = last_height else {
+        return Ok(None);
+    };
+    let Some(end_height) = last_height.checked_add(1).map(BlockHeight::from) else {
+        return Ok(None);
+    };
+    let range = start_height..end_height;
+    let Some(counted_ranges) = counted_ranges(conn, &range, scanned_priority)? else {
+        return Ok(None);
+    };
+
+    let mut total_count: u64 = 0;
+    for counted_range in counted_ranges {
+        let Some(count) =
+            output_count_for_range(conn, tree_size_col, output_count_col, &counted_range)?
+        else {
+            return Ok(None);
+        };
+        let Some(new_total_count) = total_count.checked_add(count) else {
+            return Ok(None);
+        };
+        total_count = new_total_count;
+    }
+
+    Ok(Some(total_count))
+}
+
+pub(super) fn row_wise_scanned_output_count(
+    conn: &Connection,
+    output_count_col: &str,
+    start_height: BlockHeight,
+    end_height: Option<BlockHeight>,
+    scanned_priority: i64,
+) -> Result<Option<u64>, rusqlite::Error> {
+    conn.query_row(
+        &format!(
+            "SELECT SUM({output_count_col})
+             FROM blocks
+             WHERE :start_height <= height
+               AND (:end_height IS NULL OR height < :end_height)
+               AND NOT EXISTS (
+                   SELECT 1 FROM scan_queue
+                   WHERE block_range_start <= blocks.height
+                     AND blocks.height < block_range_end
+                     AND priority > :scanned_priority
+               )"
+        ),
+        named_params! {
+            ":start_height": u32::from(start_height),
+            ":end_height": end_height.map(u32::from),
+            ":scanned_priority": scanned_priority,
+        },
+        |row| row.get(0),
+    )
+}
+
+pub(super) fn scanned_output_count(
+    conn: &Connection,
+    tree_size_col: &str,
+    output_count_col: &str,
+    start_height: BlockHeight,
+    end_height: Option<BlockHeight>,
+    scanned_priority: i64,
+) -> Result<Option<u64>, rusqlite::Error> {
+    if let Some(count) = scanned_output_count_from_tree_sizes(
+        conn,
+        tree_size_col,
+        output_count_col,
+        start_height,
+        end_height,
+        scanned_priority,
+    )? {
+        return Ok(Some(count));
+    }
+
+    row_wise_scanned_output_count(
+        conn,
+        output_count_col,
+        start_height,
+        end_height,
+        scanned_priority,
+    )
+}

--- a/zcash_client_sqlite/src/wallet/scan_progress_tests.rs
+++ b/zcash_client_sqlite/src/wallet/scan_progress_tests.rs
@@ -1,0 +1,254 @@
+use proptest::prelude::*;
+use rusqlite::Connection;
+use zcash_protocol::consensus::BlockHeight;
+
+use super::scan_progress::{
+    row_wise_scanned_output_count, scanned_output_count, scanned_output_count_from_tree_sizes,
+};
+
+/// Keeps generated heights away from protocol activation boundaries.
+const FIRST_HEIGHT: u32 = 100;
+/// Seeds the Sapling tree with a nonzero size.
+const INITIAL_SAPLING_TREE_SIZE: u64 = 50;
+/// Seeds the Orchard tree with a distinct nonzero size.
+const INITIAL_ORCHARD_TREE_SIZE: u64 = 75;
+/// Models the stored priority code for scanned queue entries.
+const SCANNED_PRIORITY: i64 = 10;
+/// Models a priority that causes a queue range to be rescanned.
+const HISTORIC_PRIORITY: i64 = 20;
+/// Keeps each generated database nonempty.
+const MIN_GENERATED_BLOCK_COUNT: usize = 1;
+/// Keeps generated cases small while exercising many queue partitions.
+const MAX_GENERATED_BLOCK_COUNT_EXCLUSIVE: usize = 25;
+/// Bounds per-block output counts to small fixture values.
+const OUTPUT_COUNT_EXCLUSIVE_LIMIT: u8 = 8;
+/// Provides broad differential coverage without slowing the focused test.
+const GENERATED_CASE_COUNT: u32 = 64;
+
+fn empty_progress_database() -> Connection {
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "CREATE TABLE blocks (
+             height INTEGER PRIMARY KEY,
+             sapling_commitment_tree_size INTEGER,
+             sapling_output_count INTEGER,
+             orchard_commitment_tree_size INTEGER,
+             orchard_action_count INTEGER
+         );
+         CREATE TABLE scan_queue (
+             block_range_start INTEGER NOT NULL UNIQUE,
+             block_range_end INTEGER NOT NULL UNIQUE,
+             priority INTEGER NOT NULL
+         );",
+    )
+    .unwrap();
+    conn
+}
+
+fn assert_matches_row_wise(
+    conn: &Connection,
+    tree_size_col: &str,
+    output_count_col: &str,
+    start_height: BlockHeight,
+    end_height: Option<BlockHeight>,
+) {
+    let optimized = scanned_output_count(
+        conn,
+        tree_size_col,
+        output_count_col,
+        start_height,
+        end_height,
+        SCANNED_PRIORITY,
+    )
+    .unwrap()
+    .unwrap_or(0);
+    let row_wise = row_wise_scanned_output_count(
+        conn,
+        output_count_col,
+        start_height,
+        end_height,
+        SCANNED_PRIORITY,
+    )
+    .unwrap()
+    .unwrap_or(0);
+    assert_eq!(optimized, row_wise);
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(GENERATED_CASE_COUNT))]
+
+    #[test]
+    fn generated_queue_partitions_match_row_wise_query(
+        blocks in prop::collection::vec(
+            (
+                0..OUTPUT_COUNT_EXCLUSIVE_LIMIT,
+                0..OUTPUT_COUNT_EXCLUSIVE_LIMIT,
+                any::<bool>(),
+            ),
+            MIN_GENERATED_BLOCK_COUNT..MAX_GENERATED_BLOCK_COUNT_EXCLUSIVE,
+        ),
+        raw_start in any::<u8>(),
+        raw_end in any::<u8>(),
+        bounded in any::<bool>(),
+    ) {
+        let conn = empty_progress_database();
+        let mut sapling_tree_size = INITIAL_SAPLING_TREE_SIZE;
+        let mut orchard_tree_size = INITIAL_ORCHARD_TREE_SIZE;
+        for (offset, (sapling_count, orchard_count, pending)) in
+            blocks.iter().copied().enumerate()
+        {
+            let height = FIRST_HEIGHT + u32::try_from(offset).unwrap();
+            sapling_tree_size += u64::from(sapling_count);
+            orchard_tree_size += u64::from(orchard_count);
+            conn.execute(
+                "INSERT INTO blocks (
+                     height,
+                     sapling_commitment_tree_size,
+                     sapling_output_count,
+                     orchard_commitment_tree_size,
+                     orchard_action_count
+                 ) VALUES (?1, ?2, ?3, ?4, ?5)",
+                (
+                    height,
+                    sapling_tree_size,
+                    sapling_count,
+                    orchard_tree_size,
+                    orchard_count,
+                ),
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO scan_queue (
+                     block_range_start,
+                     block_range_end,
+                     priority
+                 ) VALUES (?1, ?2, ?3)",
+                (
+                    height,
+                    height + 1,
+                    if pending {
+                        HISTORIC_PRIORITY
+                    } else {
+                        SCANNED_PRIORITY
+                    },
+                ),
+            )
+            .unwrap();
+        }
+
+        let start_offset = usize::from(raw_start) % blocks.len();
+        let remaining_block_count = blocks.len() - start_offset;
+        let end_offset = start_offset + 1
+            + usize::from(raw_end) % remaining_block_count;
+        let start_height = BlockHeight::from(
+            FIRST_HEIGHT + u32::try_from(start_offset).unwrap(),
+        );
+        let end_height = bounded.then(|| {
+            BlockHeight::from(FIRST_HEIGHT + u32::try_from(end_offset).unwrap())
+        });
+
+        for (tree_size_col, output_count_col) in [
+            (
+                "sapling_commitment_tree_size",
+                "sapling_output_count",
+            ),
+            (
+                "orchard_commitment_tree_size",
+                "orchard_action_count",
+            ),
+        ] {
+            let fast = scanned_output_count_from_tree_sizes(
+                &conn,
+                tree_size_col,
+                output_count_col,
+                start_height,
+                end_height,
+                SCANNED_PRIORITY,
+            )
+            .unwrap();
+            prop_assert!(fast.is_some());
+
+            let row_wise = row_wise_scanned_output_count(
+                &conn,
+                output_count_col,
+                start_height,
+                end_height,
+                SCANNED_PRIORITY,
+            )
+            .unwrap();
+            prop_assert_eq!(fast.unwrap_or(0), row_wise.unwrap_or(0));
+        }
+    }
+}
+
+#[test]
+fn migrated_output_counts_use_row_wise_fallback() {
+    /// Leaves an interior gap like a non-contiguous historical database.
+    const SECOND_RANGE_START: u32 = FIRST_HEIGHT + 5;
+    /// Models the Sapling delta backfilled for an adjacent row.
+    const FIRST_SAPLING_COUNT: u64 = 2;
+    /// Models the Orchard delta backfilled for an adjacent row.
+    const FIRST_ORCHARD_COUNT: u64 = 3;
+    /// Models a Sapling delta after the historical gap.
+    const SECOND_SAPLING_COUNT: u64 = 5;
+    /// Models an Orchard delta after the historical gap.
+    const SECOND_ORCHARD_COUNT: u64 = 7;
+
+    let conn = empty_progress_database();
+    conn.execute(
+        "INSERT INTO blocks VALUES (?1, ?2, NULL, ?3, NULL)",
+        (
+            FIRST_HEIGHT,
+            INITIAL_SAPLING_TREE_SIZE,
+            INITIAL_ORCHARD_TREE_SIZE,
+        ),
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO blocks VALUES (?1, ?2, ?3, ?4, ?5)",
+        (
+            FIRST_HEIGHT + 1,
+            INITIAL_SAPLING_TREE_SIZE + FIRST_SAPLING_COUNT,
+            FIRST_SAPLING_COUNT,
+            INITIAL_ORCHARD_TREE_SIZE + FIRST_ORCHARD_COUNT,
+            FIRST_ORCHARD_COUNT,
+        ),
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO blocks VALUES (?1, ?2, ?3, ?4, ?5)",
+        (
+            SECOND_RANGE_START,
+            INITIAL_SAPLING_TREE_SIZE + FIRST_SAPLING_COUNT + SECOND_SAPLING_COUNT,
+            SECOND_SAPLING_COUNT,
+            INITIAL_ORCHARD_TREE_SIZE + FIRST_ORCHARD_COUNT + SECOND_ORCHARD_COUNT,
+            SECOND_ORCHARD_COUNT,
+        ),
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO scan_queue VALUES (?1, ?2, ?3)",
+        (FIRST_HEIGHT, SECOND_RANGE_START + 1, SCANNED_PRIORITY),
+    )
+    .unwrap();
+
+    let start_height = BlockHeight::from(FIRST_HEIGHT + 1);
+    for (tree_size_col, output_count_col) in [
+        ("sapling_commitment_tree_size", "sapling_output_count"),
+        ("orchard_commitment_tree_size", "orchard_action_count"),
+    ] {
+        assert_eq!(
+            scanned_output_count_from_tree_sizes(
+                &conn,
+                tree_size_col,
+                output_count_col,
+                start_height,
+                None,
+                SCANNED_PRIORITY,
+            )
+            .unwrap(),
+            None,
+        );
+        assert_matches_row_wise(&conn, tree_size_col, output_count_col, start_height, None);
+    }
+}


### PR DESCRIPTION
## What changed

- Derive scanned-output counts from cumulative Sapling and Orchard
  commitment-tree sizes stored in `blocks`, using indexed lookups at each
  counted `[start, end)` boundary.
- Walk the overlapping `scan_queue` partition and sum only segments whose
  priority is at or below `Scanned`, preserving pending re-scan semantics.
- Keep the former row-wise `SUM ... NOT EXISTS` query as the exact fallback
  and differential-test oracle.
- Add a Criterion benchmark backed by an on-disk SQLite database containing
  600,000 scanned block rows with both Sapling and Orchard counts. The
  optimized benchmark invokes the same private production module as wallet
  summaries.

## Why

The expensive part of the existing scan-progress query is evaluating its
correlated `NOT EXISTS` subquery for every stored block. The database already
stores cumulative commitment-tree sizes, so a complete counted segment is:

```text
outputs[start, end) = tree_size(end - 1) - tree_size(start - 1)
```

For `k` scan-queue segments, the optimized path performs approximately
`O(k log N)` indexed boundary lookups instead of an `O(N)` scan of stored
blocks. The common in-order case has a single scanned segment.

## Equivalence and fallback rules

The optimized path is used only when all of these conditions hold:

- the overlapping scan queue is a complete, contiguous, non-overlapping
  partition of the queried stored-block span;
- every counted segment has exact tree-size and output-count boundary data;
- all boundary subtraction and total addition operations succeed without
  underflow or overflow; and
- the first stored block has a per-block output count, distinguishing databases
  populated by current scan code from historical migration backfills.

If any condition fails, the previous row-wise query runs unchanged. This
covers malformed or incomplete queues, missing boundaries, sparse historical
data, and migration-created `NULL` output counts. Existing wallet-summary
read transactions keep the boundary and queue reads on one SQLite snapshot.

This change issues no database writes and changes no public or crate-visible
API.

## Benchmark

`cargo bench -p zcash_client_sqlite --all-features --bench subtree_scan_progress`

The fixture is a file-backed SQLite database with 600,000 `blocks` rows.
Each iteration computes Sapling and Orchard progress separately, matching the
two pool-specific calculations performed by a wallet summary.

| Query strategy, both pools | Time |
| --- | ---: |
| Legacy correlated filter | 196.20 ms |
| Unfiltered `SUM` | 43.418 ms |
| Optimized production query | 38.768 µs |

The optimized path is approximately 5,060x faster than the legacy correlated
filter and 1,120x faster than two unfiltered sums in this run.

## Equivalence coverage

- 64 generated valid queue partitions, with arbitrary scanned/pending segments,
  bounded and unbounded ranges, zero-output blocks, and independent Sapling and
  Orchard counts, compared against the row-wise oracle.
- Explicit malformed-overlap, missing-boundary, and migration-shaped sparse
  database cases that assert conservative fallback.
- A real wallet lifecycle test that compares both pool calculations after
  initial scan, rewind, and partial rescan.

## Validation

- `cargo test --release -p zcash_client_sqlite --all-features -- scan_progress scanned_output_count_uses_tree_size_boundaries scanned_output_count_matches_across_rewind_and_rescan`
- `cargo bench -p zcash_client_sqlite --all-features --bench subtree_scan_progress`
- `cargo bench -p zcash_client_sqlite --all-features --bench subtree_scan_progress --no-run`
- `cargo check -p zcash_client_sqlite --no-default-features`
- `cargo clippy -p zcash_client_sqlite --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
