### PR TITLE
zcash_client_backend: Gate real_test_prover on the pczt feature

### DIFF
--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -38,6 +38,7 @@ use zcash_primitives::{
     block::BlockHash,
     transaction::{Transaction, TxId, components::sapling::zip212_enforcement, fees::FeeRule},
 };
+#[cfg(feature = "pczt")]
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::{
     ShieldedPool,
@@ -70,6 +71,7 @@ use super::{
     },
 };
 
+#[cfg(feature = "pczt")]
 fn real_test_prover() -> &'static LocalTxProver {
     use std::sync::OnceLock;
 


### PR DESCRIPTION
`real_test_prover`'s only caller (`extract_and_store_transaction_from_pczt`) is gated on the `pczt` feature, but the function and its `LocalTxProver` import are not — so any feature unification that compiles `zcash_client_backend` with `test-dependencies` and without `pczt` (which `zcash_pool_migration --all-features` induces) fails `clippy -D warnings` with a dead-code lint. Two `#[cfg(feature = "pczt")]` attributes align them with the caller.

Verified: the reproducing `cargo clippy -p zcash_pool_migration --all-features --all-targets -- -D warnings` now exits 0, and `zcash_client_backend` builds under both `--all-features` and `--features test-dependencies`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)