### PR TITLE
zcash_pool_migration: Failure states (mark_invalid / AdvanceStep::Attend) and estimate-aware due-ness targets

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -10,6 +10,16 @@ workspace.
 
 ## [Unreleased]
 
+### Changed
+- The pool-migration store persists the new
+  `zcash_pool_migration::engine::MigrationTxState::Invalid` lifecycle state:
+  `orchard_ironwood_migration_transactions` has a new nullable `invalid_reason`
+  column, non-NULL exactly for an `invalid` row (mirroring how `txid` and
+  `mined_height` carry the `broadcast` and `mined` payloads). The
+  `orchard_ironwood_migration_invalid_reason` schema migration adds the column
+  on a wallet whose table predates it; a fresh wallet gets it from the table
+  DDL.
+
 ## [0.22.0-rc.6] - 2026-07-29
 
 ### Added

--- a/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
+++ b/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
@@ -446,6 +446,118 @@ mod tests {
         );
     }
 
+    /// The `Invalid` lifecycle state round-trips through the store's `invalid_reason` column: a
+    /// replace/get preserves the reason exactly, `update_transaction` records a new verdict, and
+    /// moving on from `Invalid` (here to `Mined`, the one transition that may supersede it) clears
+    /// the stored reason rather than leaving it stale beside the new state. This pins the two
+    /// column behaviours the general `put_then_get_round_trips` property (whose generator also
+    /// produces `Invalid` states) does not isolate.
+    #[test]
+    fn invalid_state_round_trips() {
+        use zcash_pool_migration::denomination::DenominationPlan;
+        use zcash_pool_migration::engine::{
+            InvalidReason, MigrationState, MigrationStatus, MigrationTransaction, MigrationTxKind,
+        };
+        use zcash_pool_migration::preparation::PreparationPlan;
+        use zcash_protocol::consensus::BlockHeight;
+        use zcash_protocol::value::Zatoshis;
+
+        let denominations = DenominationPlan::from_stored_parts(
+            Vec::new(),
+            Zatoshis::ZERO,
+            None,
+            Zatoshis::ZERO,
+            Zatoshis::ZERO,
+            Zatoshis::ZERO,
+        )
+        .expect("an empty stored plan reconstructs");
+
+        let dead = MigrationTransaction::from_parts(
+            MigrationTransferId::new(0),
+            MigrationTxKind::Transfer { crossing: 0 },
+            vec![1, 2, 3],
+            Vec::new(),
+            BlockHeight::from_u32(100),
+            BlockHeight::from_u32(200),
+            None,
+            MigrationTxState::Invalid {
+                reason: InvalidReason::FundingSpent,
+            },
+            None,
+        );
+        let state = MigrationState::from_parts(
+            MigrationStatus::Committed,
+            denominations,
+            PreparationPlan::from_parts(Vec::new(), Vec::new()),
+            vec![dead],
+            AnchorBucketInterval::ZIP_318,
+        );
+
+        let mut store = fresh_store();
+        store.replace_migration(&state).expect("write succeeds");
+        assert_eq!(
+            store
+                .get_migration()
+                .expect("read succeeds")
+                .expect("a migration is stored"),
+            state,
+            "the invalid state and its reason must round-trip unchanged"
+        );
+
+        // A newer verdict lands through `update_transaction`...
+        store
+            .update_transaction(
+                MigrationTransferId::new(0),
+                MigrationTxState::Invalid {
+                    reason: InvalidReason::RejectedExpired,
+                },
+            )
+            .expect("update succeeds");
+        assert_eq!(
+            store
+                .get_migration()
+                .expect("read succeeds")
+                .expect("a migration is stored")
+                .transactions()[0]
+                .state()
+                .invalid_reason(),
+            Some(InvalidReason::RejectedExpired)
+        );
+
+        // ...and the mined transition both persists and clears the reason column.
+        store
+            .update_transaction(
+                MigrationTransferId::new(0),
+                MigrationTxState::Mined {
+                    height: BlockHeight::from_u32(150),
+                },
+            )
+            .expect("update succeeds");
+        assert_eq!(
+            store
+                .get_migration()
+                .expect("read succeeds")
+                .expect("a migration is stored")
+                .transactions()[0]
+                .state(),
+            MigrationTxState::Mined {
+                height: BlockHeight::from_u32(150)
+            }
+        );
+        let stored_reason: Option<String> = store
+            .into_inner()
+            .query_row(
+                "SELECT invalid_reason FROM orchard_ironwood_migration_transactions",
+                [],
+                |row| row.get(0),
+            )
+            .expect("the row exists");
+        assert_eq!(
+            stored_reason, None,
+            "a state that is no longer invalid must not keep a stale reason in its row"
+        );
+    }
+
     /// `migration_lock_owners` returns exactly the distinct, non-`None` lock owners across an
     /// account's migration transactions: an account with no migration returns the empty set,
     /// a `None` lock_owner contributes nothing, and repeated owners collapse to one entry.

--- a/zcash_client_sqlite/src/pool_migration/store.rs
+++ b/zcash_client_sqlite/src/pool_migration/store.rs
@@ -32,8 +32,8 @@ use rusqlite::{Connection, OptionalExtension, named_params, params};
 use zcash_client_backend::wallet::LockOwner;
 use zcash_pool_migration::denomination::DenominationPlan;
 use zcash_pool_migration::engine::{
-    MigrationState, MigrationStatus, MigrationTransaction, MigrationTransferId, MigrationTxKind,
-    MigrationTxState,
+    InvalidReason, MigrationState, MigrationStatus, MigrationTransaction, MigrationTransferId,
+    MigrationTxKind, MigrationTxState,
 };
 use zcash_pool_migration::preparation::{PrepInput, PrepOutput, PrepTransaction, PreparationPlan};
 use zcash_pool_migration::scheduling::AnchorBucketInterval;
@@ -162,6 +162,9 @@ fn create_prep_direct_funding_sql(t: &Tables) -> String {
 }
 
 fn create_transactions_sql(t: &Tables) -> String {
+    // `invalid_reason` sits last among the columns so that a table created by this DDL and one
+    // repaired by the `orchard_ironwood_migration_invalid_reason` schema migration's `ADD COLUMN`
+    // (which SQLite appends after the existing columns) share the same stored schema text.
     format!(
         "CREATE TABLE IF NOT EXISTS {} (
             migration_id INTEGER NOT NULL REFERENCES {}(id) ON DELETE CASCADE,
@@ -178,6 +181,7 @@ fn create_transactions_sql(t: &Tables) -> String {
             txid TEXT,
             mined_height INTEGER,
             lock_owner BLOB,
+            invalid_reason TEXT,
             PRIMARY KEY (migration_id, tx_id)
         )",
         t.transactions, t.migrations
@@ -296,10 +300,14 @@ impl<C: BorrowMut<Connection>> Store<C> {
         let conn = self.conn.borrow_mut();
         let migration_id = resolve_migration_id(conn, tables, account_id)?
             .ok_or(Error::Corrupt("update_transaction: no such transaction"))?;
+        // Every payload column is (over)written on every update, so a state change never leaves a
+        // stale payload behind (a row moving `Invalid -> Mined` must not keep its old reason).
+        let invalid_reason = state.invalid_reason();
         let updated = conn.execute(
             &format!(
                 "UPDATE {}
-                    SET state = :state, txid = :txid, mined_height = :mined_height
+                    SET state = :state, txid = :txid, mined_height = :mined_height,
+                        invalid_reason = :invalid_reason
                   WHERE migration_id = :migration_id AND tx_id = :tx_id",
                 tables.transactions
             ),
@@ -307,6 +315,7 @@ impl<C: BorrowMut<Connection>> Store<C> {
                 ":state": state.as_ref(),
                 ":txid": state.broadcast_txid().map(hex::encode),
                 ":mined_height": state.mined_height().map(u32::from),
+                ":invalid_reason": invalid_reason.as_ref().map(|r| r.as_ref()),
                 ":migration_id": migration_id,
                 ":tx_id": u32::from(id),
             },
@@ -600,7 +609,7 @@ fn read_transactions(
         let mut stmt = conn.prepare(&format!(
             "SELECT tx_id, kind, kind_layer, kind_index, kind_crossing, pczt,
                     scheduled_height, expiry_height, anchor_boundary, state, txid, mined_height,
-                    lock_owner
+                    lock_owner, invalid_reason
                FROM {}
               WHERE migration_id = ?
               ORDER BY tx_id",
@@ -621,6 +630,7 @@ fn read_transactions(
                 txid: row.get(10)?,
                 mined_height: row.get(11)?,
                 lock_owner: row.get(12)?,
+                invalid_reason: row.get(13)?,
             })
         })?;
         mapped.collect::<Result<_, _>>()?
@@ -645,10 +655,18 @@ fn read_transactions(
                     .ok_or(Error::Corrupt("state.txid"))
             })
             .transpose()?;
+        let invalid_reason = r
+            .invalid_reason
+            .map(|s| {
+                InvalidReason::try_from(s.as_str())
+                    .map_err(|_| Error::Corrupt("state.invalid_reason"))
+            })
+            .transpose()?;
         let state = MigrationTxState::from_stored(
             &r.state,
             txid,
             r.mined_height.map(BlockHeight::from_u32),
+            invalid_reason,
         )
         .map_err(|_| Error::Corrupt("state"))?;
         let depends_on = read_deps(conn, t, migration_id, r.tx_id)?;
@@ -711,6 +729,7 @@ struct TxRow {
     /// `FromSql` impl errors cleanly (`InvalidBlobSize`) if a non-NULL blob is not exactly 32
     /// bytes, so a corrupt row is rejected rather than silently truncated or panicking.
     lock_owner: Option<[u8; 32]>,
+    invalid_reason: Option<String>,
 }
 
 fn read_deps(
@@ -896,14 +915,15 @@ fn replace_migration(
             .map_or((None, None), |(l, i)| (Some(l as u64), Some(i as u64)));
         let kind_crossing = kind.transfer_crossing().map(|c| c as u64);
         let tx_state = mtx.state();
+        let invalid_reason = tx_state.invalid_reason();
         tx.execute(
             &format!(
                 "INSERT INTO {} (migration_id, tx_id, kind, kind_layer, kind_index, kind_crossing,
                                  pczt, scheduled_height, expiry_height, anchor_boundary, state, txid,
-                                 mined_height, lock_owner)
+                                 mined_height, lock_owner, invalid_reason)
                  VALUES (:migration_id, :tx_id, :kind, :kind_layer, :kind_index, :kind_crossing,
                          :pczt, :scheduled_height, :expiry_height, :anchor_boundary, :state, :txid,
-                         :mined_height, :lock_owner)",
+                         :mined_height, :lock_owner, :invalid_reason)",
                 t.transactions
             ),
             named_params! {
@@ -921,6 +941,7 @@ fn replace_migration(
                 ":txid": tx_state.broadcast_txid().map(hex::encode),
                 ":mined_height": tx_state.mined_height().map(u32::from),
                 ":lock_owner": mtx.lock_owner(),
+                ":invalid_reason": invalid_reason.as_ref().map(|r| r.as_ref()),
             },
         )?;
         for (ordinal, dep) in mtx.depends_on().iter().enumerate() {

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -678,9 +678,12 @@ CREATE TABLE orchard_ironwood_migration_prep_direct_funding (
 )";
 /// One row per migration transaction. `kind` is `preparation` or `transfer`; `pczt` is the pre-signed
 /// transaction (an opaque, already-versioned `BLOB`); `state` is the lifecycle discriminant, with the
-/// hex broadcast `txid` and `mined_height`. `lock_owner` records the `LockOwner` under which this
+/// hex broadcast `txid`, `mined_height`, and `invalid_reason` payload columns (the last non-NULL
+/// exactly for an `invalid` row). `lock_owner` records the `LockOwner` under which this
 /// transaction's notes are locked, if any. Dependencies are edges in
-/// `orchard_ironwood_migration_transaction_deps`.
+/// `orchard_ironwood_migration_transaction_deps`. `invalid_reason` sits last so that a table
+/// created by the `orchard_ironwood_migration_tables` DDL and one repaired by the
+/// `orchard_ironwood_migration_invalid_reason` `ADD COLUMN` share this schema text.
 pub(super) const TABLE_ORCHARD_IRONWOOD_MIGRATION_TRANSACTIONS: &str = "
 CREATE TABLE orchard_ironwood_migration_transactions (
     migration_id INTEGER NOT NULL REFERENCES orchard_ironwood_migrations(id) ON DELETE CASCADE,
@@ -697,6 +700,7 @@ CREATE TABLE orchard_ironwood_migration_transactions (
     txid TEXT,
     mined_height INTEGER,
     lock_owner BLOB,
+    invalid_reason TEXT,
     PRIMARY KEY (migration_id, tx_id)
 )";
 /// The dependency edges between migration transactions.

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -33,6 +33,7 @@ mod ivk_item_cache;
 mod note_locking;
 mod nullifier_map;
 mod orchard_ironwood_migration_anchor_interval;
+mod orchard_ironwood_migration_invalid_reason;
 mod orchard_ironwood_migration_tables;
 mod orchard_note_version;
 mod orchard_received_notes;
@@ -132,6 +133,7 @@ pub mod ids {
     pub use super::note_locking::MIGRATION_ID as NOTE_LOCKING;
     pub use super::nullifier_map::MIGRATION_ID as NULLIFIER_MAP;
     pub use super::orchard_ironwood_migration_anchor_interval::MIGRATION_ID as ORCHARD_IRONWOOD_MIGRATION_ANCHOR_INTERVAL;
+    pub use super::orchard_ironwood_migration_invalid_reason::MIGRATION_ID as ORCHARD_IRONWOOD_MIGRATION_INVALID_REASON;
     pub use super::orchard_ironwood_migration_tables::MIGRATION_ID as ORCHARD_IRONWOOD_MIGRATION_TABLES;
     pub use super::orchard_note_version::MIGRATION_ID as ORCHARD_NOTE_VERSION;
     pub use super::orchard_received_notes::MIGRATION_ID as ORCHARD_RECEIVED_NOTES;
@@ -364,6 +366,7 @@ pub(super) fn all_migrations<
         Box::new(tx_status_observation_intent::Migration),
         Box::new(orchard_ironwood_migration_anchor_interval::Migration),
         Box::new(v_tx_outputs_transparent_addresses::Migration),
+        Box::new(orchard_ironwood_migration_invalid_reason::Migration),
     ]
 }
 
@@ -563,6 +566,7 @@ pub const CURRENT_LEAF_MIGRATIONS: &[Uuid] = &[
     v_address_uses_ironwood::MIGRATION_ID,
     v_transactions_pool_crossing::MIGRATION_ID,
     orchard_ironwood_migration_anchor_interval::MIGRATION_ID,
+    orchard_ironwood_migration_invalid_reason::MIGRATION_ID,
     tree_retained_checkpoints::MIGRATION_ID,
     tx_status_observation_intent::MIGRATION_ID,
 ];
@@ -690,6 +694,7 @@ pub(crate) mod tests {
             ids::NOTE_LOCKING,
             ids::NULLIFIER_MAP,
             ids::ORCHARD_IRONWOOD_MIGRATION_ANCHOR_INTERVAL,
+            ids::ORCHARD_IRONWOOD_MIGRATION_INVALID_REASON,
             ids::ORCHARD_IRONWOOD_MIGRATION_TABLES,
             ids::ORCHARD_NOTE_VERSION,
             ids::ORCHARD_RECEIVED_NOTES,

--- a/zcash_client_sqlite/src/wallet/init/migrations/orchard_ironwood_migration_invalid_reason.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/orchard_ironwood_migration_invalid_reason.rs
@@ -1,0 +1,185 @@
+//! Adds the `invalid_reason` column to `orchard_ironwood_migration_transactions` where it is
+//! missing.
+//!
+//! The column is the payload of the `invalid` migration-transaction lifecycle state (the
+//! event-based failure state: a funding note spent outside the migration, or a node-rejected
+//! broadcast), non-NULL exactly for a row whose `state` is `invalid`, mirroring how `txid` and
+//! `mined_height` carry the `broadcast` and `mined` payloads.
+//!
+//! The table's DDL in [`orchard_ironwood_migration_tables`] gained the column at the same time, so
+//! a fresh wallet creates it there and this migration is a no-op; a wallet that applied that
+//! migration before the column existed gets it added here (its `CREATE TABLE IF NOT EXISTS` never
+//! runs again). Both paths converge on the schema in
+//! [`crate::wallet::db::TABLE_ORCHARD_IRONWOOD_MIGRATION_TRANSACTIONS`]. No backfill is needed: a
+//! pre-existing row cannot be in the `invalid` state (no released store could write one), and for
+//! every other state the column is NULL — exactly what `ADD COLUMN` leaves behind.
+
+use std::collections::HashSet;
+
+use rusqlite::named_params;
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+
+use super::orchard_ironwood_migration_tables;
+use crate::wallet::init::WalletMigrationError;
+
+/// Adds the `invalid_reason` column to `orchard_ironwood_migration_transactions` where it is
+/// missing.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x091bc432_5f94_4708_9e89_863ee014738f);
+
+const DEPENDENCIES: &[Uuid] = &[orchard_ironwood_migration_tables::MIGRATION_ID];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Adds the invalid_reason column to orchard_ironwood_migration_transactions where missing."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        // A wallet whose table was created from the current DDL already has the column; adding it
+        // again is an error rather than a no-op, so the presence check is load-bearing.
+        let has_column = transaction.query_row(
+            "SELECT EXISTS (
+                SELECT 1 FROM pragma_table_info('orchard_ironwood_migration_transactions')
+                WHERE name = :column_name
+             )",
+            named_params![":column_name": COLUMN_NAME],
+            |row| row.get::<_, bool>(0),
+        )?;
+
+        if !has_column {
+            // Nullable with no default: NULL is the correct value for every pre-existing row (none
+            // can be in the `invalid` state), and SQLite appends the column after the existing
+            // ones, matching its position in the current `CREATE TABLE` so the two paths agree on
+            // the stored schema text.
+            transaction.execute_batch(&format!(
+                "ALTER TABLE orchard_ironwood_migration_transactions
+                 ADD COLUMN {COLUMN_NAME} TEXT"
+            ))?;
+        }
+
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
+    }
+}
+
+const COLUMN_NAME: &str = "invalid_reason";
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    use super::*;
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[MIGRATION_ID]);
+    }
+
+    /// The pre-fix schema: `orchard_ironwood_migration_transactions` without `invalid_reason`,
+    /// which is what a wallet that applied `orchard_ironwood_migration_tables` before the column
+    /// existed has on disk. (The parent `orchard_ironwood_migrations` table is stubbed to satisfy
+    /// the foreign key.)
+    fn create_pre_fix_table(conn: &Connection) {
+        conn.execute_batch(
+            "CREATE TABLE orchard_ironwood_migrations (
+                id INTEGER PRIMARY KEY
+            );
+            CREATE TABLE orchard_ironwood_migration_transactions (
+                migration_id INTEGER NOT NULL REFERENCES orchard_ironwood_migrations(id) ON DELETE CASCADE,
+                tx_id INTEGER NOT NULL,
+                kind TEXT NOT NULL,
+                kind_layer INTEGER,
+                kind_index INTEGER,
+                kind_crossing INTEGER,
+                pczt BLOB NOT NULL,
+                scheduled_height INTEGER NOT NULL,
+                expiry_height INTEGER NOT NULL,
+                anchor_boundary INTEGER,
+                state TEXT NOT NULL,
+                txid TEXT,
+                mined_height INTEGER,
+                lock_owner BLOB,
+                PRIMARY KEY (migration_id, tx_id)
+            );",
+        )
+        .unwrap();
+    }
+
+    fn has_invalid_reason_column(conn: &Connection) -> bool {
+        conn.query_row(
+            "SELECT EXISTS (
+                SELECT 1 FROM pragma_table_info('orchard_ironwood_migration_transactions')
+                WHERE name = 'invalid_reason'
+             )",
+            [],
+            |row| row.get::<_, bool>(0),
+        )
+        .unwrap()
+    }
+
+    /// The upgrade path: the column is added, and an existing row keeps its state with a NULL
+    /// reason (no pre-existing row can be `invalid`, so NULL is correct for all of them).
+    #[test]
+    fn adds_column_and_leaves_existing_rows_null() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        create_pre_fix_table(&conn);
+        conn.execute_batch(
+            "INSERT INTO orchard_ironwood_migrations (id) VALUES (1);
+             INSERT INTO orchard_ironwood_migration_transactions (
+                migration_id, tx_id, kind, kind_crossing, pczt, scheduled_height, expiry_height,
+                state
+             )
+             VALUES (1, 0, 'transfer', 0, x'00', 100, 200, 'signed');",
+        )
+        .unwrap();
+
+        let tx = conn.transaction().unwrap();
+        RusqliteMigration::up(&Migration, &tx).unwrap();
+        tx.commit().unwrap();
+
+        assert!(has_invalid_reason_column(&conn));
+
+        let (state, invalid_reason) = conn
+            .query_row(
+                "SELECT state, invalid_reason FROM orchard_ironwood_migration_transactions",
+                [],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?)),
+            )
+            .unwrap();
+        assert_eq!(state, "signed");
+        assert_eq!(invalid_reason, None);
+    }
+
+    /// The fresh path: the table already carries the column, so `up` must leave it alone rather
+    /// than fail with "duplicate column name".
+    #[test]
+    fn is_a_no_op_when_the_column_is_present() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        crate::pool_migration::orchard_ironwood::init_migration_tables(&conn).unwrap();
+        assert!(has_invalid_reason_column(&conn));
+
+        let tx = conn.transaction().unwrap();
+        RusqliteMigration::up(&Migration, &tx).unwrap();
+        tx.commit().unwrap();
+
+        assert!(has_invalid_reason_column(&conn));
+    }
+}

--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -7,6 +7,46 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- `zcash_pool_migration::engine::MigrationTxState::Invalid` (with its
+  `invalid_reason` accessor) and `zcash_pool_migration::engine::InvalidReason`
+  (plus `ParseInvalidReasonError` and its `AsRef<str>` / `TryFrom<&str>` wire
+  codec): the event-based failure state for a transaction the consumer has
+  observed can never mine — a funding note spent outside the migration, or a
+  network-rejected broadcast. It is a state variant rather than an orthogonal
+  flag so that every state-matched query excludes an invalid transaction
+  automatically, and a run containing one never reaches `Complete`.
+- `zcash_pool_migration::engine::MigrationState::mark_invalid`, recording that
+  evidence. A `Mined` transaction is never marked (it succeeded, so the
+  evidence is stale), `mark_mined` supersedes an invalidity verdict (chain
+  inclusion outranks it), and `mark_broadcast` leaves one standing (a
+  submission is not evidence of validity).
+- `zcash_pool_migration::state::AdvanceStep::Attend`, surfaced by `next_step`
+  ahead of all actionable work whenever any transaction is invalid: no
+  automatic step can advance that part of the migration, and the consumer
+  resolves it out-of-band, typically by cancelling the migration and
+  re-planning the remaining balance.
+- `zcash_pool_migration::state::Blocker::Invalid`, the per-transaction view of
+  the same fact in `transaction_statuses` (reported not-ready with no action;
+  the reason rides in the status's `state`).
+- `zcash_pool_migration::engine::RebuildError::Invalid`: the rebuild entry
+  points reject an invalid transfer — even one whose expiry height has also
+  passed — rather than re-spend a funding note that may be gone or reissue an
+  artifact the network rejected.
+- `zcash_pool_migration::state::DuenessTargets` and the estimate-aware query
+  variants `engine::MigrationState::next_provable_at` /
+  `next_broadcastable_at`, for a consumer whose scanned chain view lags the
+  real chain between syncs: a wall-clock estimate of the real target height
+  may ACCELERATE schedule due-ness (and, in `next_broadcastable_at`, withhold
+  a broadcast the estimate says the node would reject as expired), while
+  expiry, rebuild eligibility, and anchor-boundary settledness evaluate on the
+  scanned target only. The single-target `next_provable` /
+  `next_broadcastable` are now delegating wrappers over these with both
+  targets equal — no behavior change.
+- `zcash_pool_migration::testing::arb_invalid_reason`; the
+  `arb_migration_tx_state` strategy now also generates `Invalid` states, so
+  store conformance suites cover the new state's persistence.
+
 ### Changed
 - `engine::MigrationState::next_step` now returns a due `AdvanceStep::Broadcast`
   in preference to `AdvanceStep::Prove` (previously the reverse), so a wallet
@@ -19,6 +59,13 @@ and this library adheres to Rust's notion of
   schedule, so broadcastable at the same wake-up once proved — or a transfer,
   whose broadcast follows at its own scheduled height. Match with
   `AdvanceStep::Prove { id, kind }`.
+- `engine::MigrationTxState::from_stored` takes the stored invalid reason as a
+  fourth argument (`None` for every row written before the `Invalid` state
+  existed).
+- `engine::MigrationState::expired_transactions` never reports a transaction
+  marked `Invalid` (and no query treats one as expired): its death is already
+  recorded and surfaced through `AdvanceStep::Attend`, not the expiry path's
+  rebuild.
 
 ## [0.1.0-rc.5] - 2026-07-29
 

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -253,6 +253,68 @@ impl fmt::Display for ParseMigrationTxKindError {
     }
 }
 
+/// Why a migration transaction was marked [`Invalid`](MigrationTxState::Invalid): the observed
+/// event that killed it.
+///
+/// Each variant is a piece of EVIDENCE the consumer observed through I/O the engine deliberately
+/// never performs — its own network submissions and its wallet's scan of the chain — and reported
+/// with [`MigrationState::mark_invalid`]. The engine cannot detect any of these itself (it sees
+/// only the persisted state), which is exactly why they are recorded as state rather than
+/// recomputed: once recorded, every state-driven decision accounts for them.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InvalidReason {
+    /// A note funding this transaction was spent OUTSIDE the migration (for example by another
+    /// wallet instance sharing the same spend authority), observed by the consumer's wallet scan.
+    /// The transaction double-spends that note, so no node will ever mine it.
+    FundingSpent,
+    /// The network rejected the transaction as INVALID when the consumer submitted it. Something is
+    /// structurally wrong with the signed artifact (or the chain state it commits to), so
+    /// resubmitting it can only be rejected again.
+    RejectedInvalid,
+    /// The network rejected the transaction as EXPIRED when the consumer submitted it: the node's
+    /// tip is already past the transaction's [`expiry_height`](MigrationTransaction::expiry_height)
+    /// (ZIP 203), even though the consumer's own (staler) chain view had not yet confirmed the
+    /// expiry when it broadcast.
+    RejectedExpired,
+}
+
+impl AsRef<str> for InvalidReason {
+    /// The stable lowercase wire name of the reason, as stored by a backend and parsed back with
+    /// [`TryFrom<&str>`](Self). Borrow-free: it returns a `&'static str`, so encoding a reason
+    /// allocates nothing.
+    fn as_ref(&self) -> &str {
+        match self {
+            InvalidReason::FundingSpent => "funding_spent",
+            InvalidReason::RejectedInvalid => "rejected_invalid",
+            InvalidReason::RejectedExpired => "rejected_expired",
+        }
+    }
+}
+
+/// The error returned when a string does not name an [`InvalidReason`] (its [`TryFrom<&str>`] impl).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ParseInvalidReasonError;
+
+impl fmt::Display for ParseInvalidReasonError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("unrecognized migration transaction invalidity reason")
+    }
+}
+
+impl TryFrom<&str> for InvalidReason {
+    type Error = ParseInvalidReasonError;
+
+    /// Parses the lowercase wire name produced by [`AsRef<str>`](AsRef).
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        Ok(match s {
+            "funding_spent" => InvalidReason::FundingSpent,
+            "rejected_invalid" => InvalidReason::RejectedInvalid,
+            "rejected_expired" => InvalidReason::RejectedExpired,
+            _ => return Err(ParseInvalidReasonError),
+        })
+    }
+}
+
 /// Where a migration transaction is in its lifecycle.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MigrationTxState {
@@ -271,6 +333,23 @@ pub enum MigrationTxState {
     Broadcast { txid: TxId },
     /// Mined at the given height.
     Mined { height: BlockHeight },
+    /// Dead by OBSERVED EVENT: the consumer reported (via [`MigrationState::mark_invalid`]) that
+    /// this transaction can never mine — a funding note was spent outside the migration, or the
+    /// network rejected the submission — for the recorded `reason`.
+    ///
+    /// This is the event-based complement to the height-computable expiry death the crate already
+    /// models: expiry is derived from persisted heights on every query, while invalidity rests on
+    /// evidence from the consumer's network I/O or wallet scan — inputs the engine deliberately
+    /// never sees — so it must be recorded once observed. It is a state variant rather than an
+    /// orthogonal flag so that every state-matched query (`next_provable`, `next_broadcastable`,
+    /// the wake-up schedule, the completion check) excludes an invalid transaction automatically;
+    /// [`next_step`](MigrationState::next_step) surfaces it as
+    /// [`AdvanceStep::Attend`](crate::state::AdvanceStep::Attend) for out-of-band resolution.
+    /// The only evidence that outranks it is chain inclusion itself:
+    /// [`mark_mined`](MigrationState::mark_mined) supersedes a stale invalidity verdict, while
+    /// [`mark_broadcast`](MigrationState::mark_broadcast) does not touch it (a submission is not
+    /// evidence of validity).
+    Invalid { reason: InvalidReason },
 }
 
 /// One transaction of a committed migration: its pre-signed PCZT plus the metadata the consuming
@@ -418,8 +497,8 @@ impl TryFrom<&str> for MigrationStatus {
 
 impl AsRef<str> for MigrationTxState {
     /// The stable lowercase wire name of the lifecycle state, as a store persists it (the queryable
-    /// discriminant); the `Broadcast` txid and `Mined` height are stored alongside and reattached by
-    /// [`from_stored`](Self::from_stored).
+    /// discriminant); the `Broadcast` txid, `Mined` height, and `Invalid` reason are stored
+    /// alongside and reattached by [`from_stored`](Self::from_stored).
     fn as_ref(&self) -> &str {
         match self {
             MigrationTxState::AwaitingSignature => "awaiting_signature",
@@ -427,13 +506,15 @@ impl AsRef<str> for MigrationTxState {
             MigrationTxState::Proved => "proved",
             MigrationTxState::Broadcast { .. } => "broadcast",
             MigrationTxState::Mined { .. } => "mined",
+            MigrationTxState::Invalid { .. } => "invalid",
         }
     }
 }
 
-/// The error returned when a stored `(state, txid, mined_height)` triple does not reconstruct a
-/// [`MigrationTxState`] (its [`from_stored`](MigrationTxState::from_stored) constructor): an
-/// unrecognized discriminant, or a `broadcast`/`mined` row missing its txid/height payload.
+/// The error returned when a stored `(state, txid, mined_height, invalid_reason)` tuple does not
+/// reconstruct a [`MigrationTxState`] (its [`from_stored`](MigrationTxState::from_stored)
+/// constructor): an unrecognized discriminant, or a `broadcast`/`mined`/`invalid` row missing its
+/// txid/height/reason payload.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ParseMigrationTxStateError;
 
@@ -462,14 +543,25 @@ impl MigrationTxState {
         }
     }
 
+    /// The reason of an [`Invalid`](Self::Invalid) state (its stored payload), or `None` for any
+    /// other state.
+    pub fn invalid_reason(&self) -> Option<InvalidReason> {
+        match self {
+            MigrationTxState::Invalid { reason } => Some(*reason),
+            _ => None,
+        }
+    }
+
     /// Reconstruct a state from a store: the lowercase discriminant produced by
-    /// [`AsRef<str>`](AsRef), plus the `broadcast` txid and `mined` height columns (each `None` for a
-    /// state that does not carry it). Errors on an unrecognized discriminant, or a `broadcast`/`mined`
-    /// discriminant whose payload column is absent.
+    /// [`AsRef<str>`](AsRef), plus the `broadcast` txid, `mined` height, and `invalid` reason
+    /// columns (each `None` for a state that does not carry it). Errors on an unrecognized
+    /// discriminant, or a `broadcast`/`mined`/`invalid` discriminant whose payload column is
+    /// absent.
     pub fn from_stored(
         state: &str,
         txid: Option<[u8; 32]>,
         mined_height: Option<BlockHeight>,
+        invalid_reason: Option<InvalidReason>,
     ) -> Result<Self, ParseMigrationTxStateError> {
         Ok(match state {
             "awaiting_signature" => MigrationTxState::AwaitingSignature,
@@ -480,6 +572,9 @@ impl MigrationTxState {
             },
             "mined" => MigrationTxState::Mined {
                 height: mined_height.ok_or(ParseMigrationTxStateError)?,
+            },
+            "invalid" => MigrationTxState::Invalid {
+                reason: invalid_reason.ok_or(ParseMigrationTxStateError)?,
             },
             _ => return Err(ParseMigrationTxStateError),
         })
@@ -1449,7 +1544,9 @@ pub enum ProveError<E> {
     /// are proved against a caller-supplied anchor (a transfer proves against its drawn boundary).
     NotAPreparation(MigrationTransferId),
     /// The transaction is not in the [`Signed`](MigrationTxState::Signed) state, so it is not ready
-    /// to prove (it is unsigned, already proved, or already broadcast).
+    /// to prove (it is unsigned, already proved, already broadcast, or marked
+    /// [`Invalid`](MigrationTxState::Invalid) — a dead transaction is resolved out-of-band, not
+    /// proved).
     NotReady(MigrationTransferId),
     /// A transfer carries no anchor boundary. Every transfer draws one at scheduling time, so this
     /// indicates a corrupt stored state rather than a normal condition.
@@ -1648,6 +1745,15 @@ pub enum RebuildError<E> {
     /// still valid, or it has already mined. Guards against reissuing a live transaction as a second,
     /// double-spending copy.
     NotExpired(MigrationTransferId),
+    /// The transaction is marked [`Invalid`](MigrationTxState::Invalid) for the given reason, and
+    /// an invalid transaction is resolved out-of-band (typically by cancelling the migration and
+    /// re-planning the remaining balance), never rebuilt — even when its expiry height has also
+    /// passed. Its death is event-based: a spent funding note would make any rebuild another
+    /// guaranteed double-spend, and a network rejection means the artifact (or the plan behind it)
+    /// needs investigation, so silently reissuing the part is exactly the wrong remediation. A
+    /// consumer that wants the automatic expired-transfer rebuild path simply does not mark a
+    /// merely-expired transfer invalid: the ordinary expiry detection reschedules it on its own.
+    Invalid(MigrationTransferId, InvalidReason),
     /// The stored migration state is internally inconsistent: the denomination plan carries no crossing or
     /// funding value for this transfer's crossing index, or the transfer's stored PCZT is
     /// malformed.
@@ -1700,6 +1806,13 @@ impl<E: fmt::Display> fmt::Display for RebuildError<E> {
                 f,
                 "transaction {} has not expired; there is nothing to rebuild",
                 u32::from(*id)
+            ),
+            RebuildError::Invalid(id, reason) => write!(
+                f,
+                "transaction {} is marked invalid ({}); an invalid transaction is resolved \
+                 out-of-band, not rebuilt",
+                u32::from(*id),
+                reason.as_ref()
             ),
             RebuildError::InconsistentPlan(m) => {
                 write!(f, "the migration plan is internally inconsistent: {m}")
@@ -1862,6 +1975,13 @@ where
         MigrationTxKind::Transfer { crossing } => crossing,
         MigrationTxKind::Preparation { .. } => return Err(RebuildError::NotATransfer(id)),
     };
+    // A transfer marked invalid is dead by observed event, and its remediation is out-of-band (see
+    // `RebuildError::Invalid`) — checked before the expiry condition because an invalid transfer
+    // may well ALSO be past its expiry, and rebuilding it then would re-spend a funding note that
+    // may be gone or reissue an artifact the network already rejected.
+    if let MigrationTxState::Invalid { reason } = tx.state {
+        return Err(RebuildError::Invalid(id, reason));
+    }
     // Only an expired, not-yet-mined transfer is rebuilt (the same condition the state machine reports
     // as expired): a still-valid or already-mined transfer is a typed error, not a silently reissued
     // double spend.
@@ -3791,8 +3911,9 @@ mod commit_tests {
         assert_eq!(state.transactions[0].state, MigrationTxState::Signed);
     }
 
-    /// Rebuilding rejects a transaction that has not expired, a preparation transaction, and an
-    /// unknown id, so a caller cannot reissue a still-valid transfer as a double-spending copy.
+    /// Rebuilding rejects a transaction that has not expired, one marked invalid, a preparation
+    /// transaction, and an unknown id, so a caller cannot reissue a still-valid transfer as a
+    /// double-spending copy — nor an event-dead one whose remediation is out-of-band.
     #[test]
     fn rebuild_expired_transfer_rejects_ineligible_transactions() {
         let seed = 101u64;
@@ -3825,11 +3946,23 @@ mod commit_tests {
             Err(RebuildError::UnknownTransaction(rejected)) if rejected == unknown
         ));
 
+        // A transfer marked invalid, even one whose expiry has ALSO passed: rejected with its
+        // recorded reason. Its death is event-based and resolved out-of-band (`Attend`, typically
+        // cancel and re-plan); rebuilding it could re-spend a funding note that is already gone.
+        state.transactions[0].state = MigrationTxState::Invalid {
+            reason: InvalidReason::FundingSpent,
+        };
+        backend.tip = state.transactions[0].expiry_height + 1;
+        assert!(matches!(
+            rebuild_expired_transfer(&params, &backend, &mut state, id, &mut rng),
+            Err(RebuildError::Invalid(rejected, InvalidReason::FundingSpent)) if rejected == id
+        ));
+        state.transactions[0].state = MigrationTxState::Signed;
+
         // A preparation transaction, even an expired one: rejected. Only a transfer (a leaf of the
         // dependency graph) is rebuilt this way; an expired preparation invalidates its dependents'
         // pre-signatures and needs its own remediation.
         state.transactions[0].kind = MigrationTxKind::Preparation { layer: 0, index: 0 };
-        backend.tip = state.transactions[0].expiry_height + 1;
         assert!(matches!(
             rebuild_expired_transfer(&params, &backend, &mut state, id, &mut rng),
             Err(RebuildError::NotATransfer(rejected)) if rejected == id
@@ -4559,5 +4692,51 @@ mod commit_tests {
         backend.sched_params = SchedulingParams::ZIP_318;
         prove_transfer(&mut backend, &mut state, transfer_id)
             .expect("the transfer proves once the grid matches again");
+    }
+
+    /// The `Invalid` lifecycle state round-trips through the stored-column codec: every reason
+    /// survives `AsRef<str>` / `TryFrom<&str>` and `from_stored`, and an `invalid` discriminant
+    /// without its reason payload is rejected, exactly like a payload-less `broadcast` or `mined`.
+    #[test]
+    fn invalid_state_round_trips_through_from_stored() {
+        for reason in [
+            InvalidReason::FundingSpent,
+            InvalidReason::RejectedInvalid,
+            InvalidReason::RejectedExpired,
+        ] {
+            let state = MigrationTxState::Invalid { reason };
+            assert_eq!(state.as_ref(), "invalid");
+            assert_eq!(state.invalid_reason(), Some(reason));
+            assert_eq!(
+                InvalidReason::try_from(reason.as_ref()),
+                Ok(reason),
+                "the reason's own wire name round-trips"
+            );
+            assert_eq!(
+                MigrationTxState::from_stored("invalid", None, None, Some(reason)),
+                Ok(state)
+            );
+        }
+        assert_eq!(
+            MigrationTxState::from_stored("invalid", None, None, None),
+            Err(ParseMigrationTxStateError),
+            "an invalid row missing its reason column does not reconstruct"
+        );
+        assert_eq!(
+            InvalidReason::try_from("bogus"),
+            Err(ParseInvalidReasonError)
+        );
+        // The reason column is payload for the `invalid` discriminant alone: any other stored
+        // state reconstructs regardless of what the column holds, so a stale value cannot brick a
+        // row (the store nulls it on update, but a reader must not depend on that).
+        assert_eq!(
+            MigrationTxState::from_stored(
+                "signed",
+                None,
+                None,
+                Some(InvalidReason::RejectedExpired)
+            ),
+            Ok(MigrationTxState::Signed)
+        );
     }
 }

--- a/zcash_pool_migration/src/state.rs
+++ b/zcash_pool_migration/src/state.rs
@@ -6,7 +6,9 @@
 //! or a server like Zallet) makes the SAME decisions from the SAME state. The consumer supplies the
 //! I/O: it detects that a broadcast transaction has mined (via its own chain view) and calls
 //! [`MigrationState::mark_mined`], it broadcasts a transaction and calls
-//! [`MigrationState::mark_broadcast`], and it performs the build/prove/broadcast work that
+//! [`MigrationState::mark_broadcast`], it reports evidence that a transaction can never mine (a
+//! funding note spent outside the migration, a node rejection) with
+//! [`MigrationState::mark_invalid`], and it performs the build/prove/broadcast work that
 //! [`MigrationState::next_step`] tells it to do. The decision of WHAT to do next, and the transaction
 //! status a wallet shows the user, live here.
 //!
@@ -27,8 +29,8 @@ use zcash_protocol::TxId;
 use zcash_protocol::consensus::BlockHeight;
 
 use crate::engine::{
-    MigrationState, MigrationStatus, MigrationTransaction, MigrationTransferId, MigrationTxKind,
-    MigrationTxState,
+    InvalidReason, MigrationState, MigrationStatus, MigrationTransaction, MigrationTransferId,
+    MigrationTxKind, MigrationTxState,
 };
 use crate::scheduling::{self, SyncWakeup, WakeupParams, WakeupScheduleError};
 
@@ -38,6 +40,19 @@ use crate::scheduling::{self, SyncWakeup, WakeupParams, WakeupScheduleError};
 /// [`MigrationState::next_step`] again.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AdvanceStep {
+    /// No automatic step can advance this migration: transaction `id` is marked
+    /// [`Invalid`](MigrationTxState::Invalid) (see its status for the reason), and the consumer
+    /// resolves it out-of-band — typically by cancelling the migration and re-planning the
+    /// remaining balance.
+    ///
+    /// Surfaced ahead of all actionable work: every broadcast of an invalid transaction is a
+    /// guaranteed rejection (and everything depending on it waits forever), so a consumer needs
+    /// the attention signal before it continues to drive the run. Only a terminal migration
+    /// ([`Complete`](Self::Complete)) takes precedence.
+    Attend {
+        /// The invalid transaction needing attention.
+        id: MigrationTransferId,
+    },
     /// Prove this pre-signed transaction (install its deferred Orchard anchor and spend witnesses and
     /// store the proven PCZT), WITHOUT broadcasting: its dependencies are mined and, for a transfer,
     /// its drawn anchor boundary has settled (the boundary block is strictly below the chain tip, so
@@ -140,6 +155,14 @@ pub enum Blocker {
     /// signal that the migration needs a new signing ceremony over the affected subtree. Reported
     /// so a wallet can show the transaction as needing attention rather than as merely waiting.
     Expired,
+    /// Marked [`Invalid`](MigrationTxState::Invalid): the consumer observed evidence that this
+    /// transaction can never mine (its [`state`](TransactionStatus::state) carries the
+    /// [`InvalidReason`]), so no chain condition will ever make it actionable again. Its
+    /// resolution is out-of-band, surfaced to the driver as [`AdvanceStep::Attend`]. Reported as a
+    /// blocker — like [`Signature`](Self::Signature) and [`Expired`](Self::Expired), whose facts
+    /// the state and heights also already imply — so a wallet keyed on blockers shows it as
+    /// needing attention rather than as done.
+    Invalid,
 }
 
 /// The status of one migration transaction, as a wallet renders it and decides the next step. This is
@@ -185,6 +208,66 @@ pub struct TransactionStatus {
     pub(crate) txid: Option<TxId>,
 }
 
+/// The pair of target heights the estimate-aware delivery queries
+/// ([`MigrationState::next_provable_at`], [`MigrationState::next_broadcastable_at`]) evaluate
+/// due-ness against, for a consumer whose SCANNED chain view lags the real chain between syncs (a
+/// mobile wallet waking from the background).
+///
+/// `scanned` is the trustworthy target: `scanned_tip + 1`, the height of the next block a
+/// transaction could mine in as witnessed by the data the wallet has actually scanned. `effective`
+/// is the serving target: a wall-clock ESTIMATE of where the real chain's target has reached,
+/// clamped to never fall below `scanned`, consulted only to decide that a scheduled height has
+/// ARRIVED.
+///
+/// The rule the pair encodes: **the estimate may only ACCELERATE schedule due-ness; expiry,
+/// rebuild eligibility, and every other destructive decision evaluate on the scanned target
+/// only.** An estimate can be wrong in either direction, and the two kinds of decision fail
+/// differently. Serving a broadcast a few blocks before its scheduled height is harmless — the
+/// schedule's jitter dwarfs the estimate's error. Treating a transfer as EXPIRED on an estimate
+/// would trigger its rebuild — an entirely new, freshly signed transaction — while the original
+/// may in fact still mine, making the rebuild a double-spend of it. A transfer's anchor-boundary
+/// settledness is likewise a statement about scanned data (the boundary checkpoint either exists
+/// in the wallet's commitment tree or it does not — an estimate cannot conjure it), so it too is
+/// judged on `scanned` alone.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, CopyGetters)]
+pub struct DuenessTargets {
+    /// The scanned target height (`scanned_tip + 1`): expiry, anchor-boundary settledness, and
+    /// every destructive decision evaluate here.
+    #[getset(get_copy = "pub")]
+    scanned: BlockHeight,
+    /// The serving target: schedule due-ness evaluates here. Never below
+    /// [`scanned`](Self::scanned), by construction.
+    #[getset(get_copy = "pub")]
+    effective: BlockHeight,
+}
+
+impl DuenessTargets {
+    /// The targets for a scanned target height plus an optional wall-clock estimate of the real
+    /// chain's target: `effective` is the larger of the two, or `scanned_target` alone when there
+    /// is no estimate. The clamp is what maintains `effective >= scanned`: an estimate BEHIND the
+    /// scanned tip is simply stale (the scanned data has overtaken it), and must not drag serving
+    /// backwards below what the scanned view already proves due.
+    pub fn new(scanned_target: BlockHeight, estimated_target: Option<BlockHeight>) -> Self {
+        let effective = estimated_target.map_or(scanned_target, |estimated| {
+            core::cmp::max(scanned_target, estimated)
+        });
+        Self {
+            scanned: scanned_target,
+            effective,
+        }
+    }
+
+    /// The degenerate targets of a consumer with no estimate: both heights are `target`. The
+    /// single-target queries delegate through this, making them the `effective == scanned` special
+    /// case of the `_at` variants by construction.
+    pub const fn at(target: BlockHeight) -> Self {
+        Self {
+            scanned: target,
+            effective: target,
+        }
+    }
+}
+
 impl MigrationState {
     /// Whether every transaction in `depends_on` is mined.
     pub fn deps_mined(&self, depends_on: &[MigrationTransferId]) -> bool {
@@ -203,9 +286,15 @@ impl MigrationState {
     /// [`expiry_height`](MigrationTransaction::expiry_height) (ZIP 203), so it is expired once
     /// `expiry_height < target_height`. An `expiry_height` of `0` disables expiry (the transaction
     /// never expires), and an already-`Mined` transaction is never expired: it was included before its
-    /// expiry and is final.
+    /// expiry and is final. An [`Invalid`](MigrationTxState::Invalid) transaction is never expired
+    /// either — its death is already recorded, and its remediation (out-of-band, via
+    /// [`AdvanceStep::Attend`]) is not the expiry path's rebuild — so a dead transaction is never
+    /// reported through both channels at once.
     fn is_expired(t: &MigrationTransaction, target_height: BlockHeight) -> bool {
-        if matches!(t.state, MigrationTxState::Mined { .. }) {
+        if matches!(
+            t.state,
+            MigrationTxState::Mined { .. } | MigrationTxState::Invalid { .. }
+        ) {
             return false;
         }
         let expiry = u32::from(t.expiry_height);
@@ -219,7 +308,10 @@ impl MigrationState {
     /// signed anew with a fresh anchor and expiry while keeping its denomination. A TRANSFER here
     /// is also surfaced as [`AdvanceStep::Rebuild`]; a PREPARATION is not (rebuilding it means
     /// re-signing its whole dependent subtree, a remediation beyond a single advance step), so a
-    /// wallet uses this list to tell the user the migration needs a new signing ceremony.
+    /// wallet uses this list to tell the user the migration needs a new signing ceremony. A
+    /// transaction marked [`Invalid`](MigrationTxState::Invalid) is never listed: its death is
+    /// already recorded, surfaced as [`AdvanceStep::Attend`] and resolved out-of-band rather than
+    /// through the expiry path.
     pub fn expired_transactions(&self, target_height: BlockHeight) -> Vec<MigrationTransferId> {
         self.transactions
             .iter()
@@ -242,9 +334,18 @@ impl MigrationState {
             .map(|t| t.id)
     }
 
-    /// Whether transaction `t` is ready to PROVE at `target_height` (`chain_tip + 1`): its
-    /// dependencies are mined and its Orchard anchor is resolvable from the wallet's commitment tree
-    /// right now.
+    /// The id of the first transaction marked [`Invalid`](MigrationTxState::Invalid), the one
+    /// [`Self::next_step`] surfaces as [`AdvanceStep::Attend`]. Purely state-matched: invalidity
+    /// is recorded evidence, not a height computation, so no target height is involved.
+    fn next_attention(&self) -> Option<MigrationTransferId> {
+        self.transactions
+            .iter()
+            .find(|t| matches!(t.state, MigrationTxState::Invalid { .. }))
+            .map(|t| t.id)
+    }
+
+    /// Whether transaction `t` is ready to PROVE at `targets`: its dependencies are mined and its
+    /// Orchard anchor is resolvable from the wallet's commitment tree right now.
     ///
     /// A TRANSFER anchors to a drawn boundary ([`anchor_boundary`](MigrationTransaction::anchor_boundary)),
     /// which must have SETTLED: the boundary block must be strictly below the chain tip so its
@@ -255,30 +356,38 @@ impl MigrationState {
     /// broadcast (see [`Self::next_step`]). A PREPARATION carries no drawn boundary and anchors to
     /// a fresh checkpoint at the tip when proved, so it is prove-ready once its dependencies are
     /// mined and its scheduled height has arrived.
-    fn prove_ready(&self, t: &MigrationTransaction, target_height: BlockHeight) -> bool {
+    ///
+    /// Under the dual-target rule (see [`DuenessTargets`]) only the preparation's schedule
+    /// comparison consults the EFFECTIVE serving target; expiry and a transfer's boundary
+    /// settledness are statements about scanned chain data, judged on the SCANNED target alone.
+    fn prove_ready_at(&self, t: &MigrationTransaction, targets: DuenessTargets) -> bool {
         // An expired transaction can never be mined, so proving it is wasted work: it must be rebuilt
         // (with a fresh anchor and expiry) first. Guarding here keeps `next_provable` from ever
-        // offering an expired transaction.
-        if Self::is_expired(t, target_height) {
+        // offering an expired transaction. Judged on the SCANNED target: an estimate never decides
+        // an expiry.
+        if Self::is_expired(t, targets.scanned()) {
             return false;
         }
         if !self.deps_mined(&t.depends_on) {
             return false;
         }
         match t.anchor_boundary {
-            // A transfer: the boundary must be strictly below the tip. `target_height` is `tip + 1`,
-            // so `boundary < tip` is `boundary + 1 < target_height`.
-            Some(boundary) => u32::from(boundary) + 1 < u32::from(target_height),
-            // A preparation: prove-ready once its schedule is due.
-            None => t.scheduled_height <= target_height,
+            // A transfer: the boundary must be strictly below the SCANNED tip — its checkpoint
+            // exists in the wallet's tree only once the scanned data proves the boundary settled;
+            // an estimate cannot conjure it. The scanned target is `tip + 1`, so `boundary < tip`
+            // is `boundary + 1 < target`.
+            Some(boundary) => u32::from(boundary) + 1 < u32::from(targets.scanned()),
+            // A preparation: prove-ready once its schedule is due on the SERVING target (the one
+            // comparison the estimate may accelerate).
+            None => t.scheduled_height <= targets.effective(),
         }
     }
 
-    /// The next pre-signed transaction ready to PROVE, as [`Self::next_provable`] selects it, with
-    /// the whole transaction visible so [`Self::next_step`] can also surface its kind.
-    fn next_provable_tx(&self, target_height: BlockHeight) -> Option<&MigrationTransaction> {
+    /// The next pre-signed transaction ready to PROVE, as [`Self::next_provable_at`] selects it,
+    /// with the whole transaction visible so [`Self::next_step`] can also surface its kind.
+    fn next_provable_tx_at(&self, targets: DuenessTargets) -> Option<&MigrationTransaction> {
         self.transactions.iter().find(|t| {
-            matches!(t.state, MigrationTxState::Signed) && self.prove_ready(t, target_height)
+            matches!(t.state, MigrationTxState::Signed) && self.prove_ready_at(t, targets)
         })
     }
 
@@ -286,23 +395,62 @@ impl MigrationState {
     /// is resolvable now. Proving is decoupled from broadcasting so a transfer can be proved at a
     /// sync wake-up well before its scheduled broadcast height, keeping the sync work and the
     /// broadcast in separate waking sessions.
+    ///
+    /// Equivalent to [`Self::next_provable_at`] with both targets at `target_height` (the
+    /// no-estimate case).
     pub fn next_provable(&self, target_height: BlockHeight) -> Option<MigrationTransferId> {
-        self.next_provable_tx(target_height).map(|t| t.id)
+        self.next_provable_at(DuenessTargets::at(target_height))
+    }
+
+    /// The estimate-aware variant of [`Self::next_provable`], for a consumer whose scanned chain
+    /// view lags the real chain (see [`DuenessTargets`]): a preparation transaction's schedule
+    /// due-ness is judged on the EFFECTIVE serving target, so a wall-clock estimate can surface it
+    /// at the wake-up its schedule aimed at rather than one sync later; expiry and a transfer's
+    /// anchor-boundary settledness are judged on the SCANNED target alone.
+    pub fn next_provable_at(&self, targets: DuenessTargets) -> Option<MigrationTransferId> {
+        self.next_provable_tx_at(targets).map(|t| t.id)
     }
 
     /// The id of the next transaction ready to BROADCAST: already `Proved`, its dependencies mined,
     /// and scheduled at or before `target_height` (`chain_tip + 1`).
+    ///
+    /// Equivalent to [`Self::next_broadcastable_at`] with both targets at `target_height` (the
+    /// no-estimate case).
     pub fn next_broadcastable(&self, target_height: BlockHeight) -> Option<MigrationTransferId> {
+        self.next_broadcastable_at(DuenessTargets::at(target_height))
+    }
+
+    /// The estimate-aware variant of [`Self::next_broadcastable`], for a consumer whose scanned
+    /// chain view lags the real chain (see [`DuenessTargets`]): the schedule comparison is judged
+    /// on the EFFECTIVE serving target, so a wall-clock estimate can surface a due broadcast at
+    /// the wake-up its schedule aimed at rather than one sync later.
+    ///
+    /// The expiry handling is deliberately ASYMMETRIC between the two targets. A transaction the
+    /// SCANNED target proves expired is excluded exactly as everywhere else, and the ordinary
+    /// expired -> [`AdvanceStep::Rebuild`] path owns it. A transaction whose
+    /// [`expiry_height`](MigrationTransaction::expiry_height) only the EFFECTIVE target has passed
+    /// is ALSO not served, yet is treated as expired NOWHERE: if the estimate is right, the node's
+    /// tip is past its expiry and broadcasting it is a guaranteed network rejection, so the
+    /// protective refusal wastes nothing; if the estimate is wrong, one broadcast waits until the
+    /// scanned tip either reaches the scheduled height (still unexpired: it is served) or confirms
+    /// the expiry (the rebuild path takes over). The estimate may WITHHOLD a doomed submission
+    /// (protective, reversible) but never trigger a rebuild (destructive — a new signing —
+    /// requiring the scanned tip's proof).
+    pub fn next_broadcastable_at(&self, targets: DuenessTargets) -> Option<MigrationTransferId> {
         self.transactions
             .iter()
             .find(|t| {
                 matches!(t.state, MigrationTxState::Proved)
-                    && t.scheduled_height <= target_height
+                    && t.scheduled_height <= targets.effective()
                     && self.deps_mined(&t.depends_on)
                     // An expired proven transaction would be rejected by the node; it must be rebuilt,
                     // not broadcast. This is what stops a wallet resumed after its broadcast windows
-                    // lapsed from broadcasting a stale, no-longer-includable transaction.
-                    && !Self::is_expired(t, target_height)
+                    // lapsed from broadcasting a stale, no-longer-includable transaction. Judged on
+                    // the EFFECTIVE target: since `effective >= scanned`, the one comparison both
+                    // excludes a scanned-confirmed expiry (like every other query) and refuses the
+                    // merely-estimated one — the doomed-broadcast guard; see the method docs for
+                    // the asymmetry.
+                    && !Self::is_expired(t, targets.effective())
             })
             .map(|t| t.id)
     }
@@ -321,14 +469,14 @@ impl MigrationState {
     ///
     /// Covered are transfers in the `Signed` or `AwaitingSignature` state — proving and signature
     /// application are independent operations, so a transfer whose signed PCZT has not yet been
-    /// returned by the external signer still needs its proof on the same schedule — while `Proved`,
-    /// `Broadcast`, and `Mined` transfers, expired transfers (their rebuild reschedules them), and
-    /// preparations (which anchor at the tip when proved, driven by [`Self::next_step`] at their
-    /// own broadcast wake-ups) are not. A transfer lacking a drawn anchor boundary (impossible for
-    /// a state committed by this crate) likewise contributes no wake-up: like a preparation, it is
-    /// driven by [`Self::next_step`] at its scheduled height. Nothing is persisted: the schedule
-    /// is derived from the migration state, so recompute it — with fresh jitter — after any state
-    /// change (a proof stored, a rebuild, a missed wake-up).
+    /// returned by the external signer still needs its proof on the same schedule — while
+    /// `Proved`, `Broadcast`, `Mined`, and `Invalid` transfers, expired transfers (their rebuild
+    /// reschedules them), and preparations (which anchor at the tip when proved, driven by
+    /// [`Self::next_step`] at their own broadcast wake-ups) are not. A transfer lacking a drawn
+    /// anchor boundary (impossible for a state committed by this crate) likewise contributes no
+    /// wake-up: like a preparation, it is driven by [`Self::next_step`] at its scheduled height.
+    /// Nothing is persisted: the schedule is derived from the migration state, so recompute it —
+    /// with fresh jitter — after any state change (a proof stored, a rebuild, a missed wake-up).
     pub fn sync_wakeup_schedule<R: RngCore + CryptoRng>(
         &self,
         current_tip: BlockHeight,
@@ -357,7 +505,10 @@ impl MigrationState {
     /// Recomputes the overall [`MigrationStatus`]: `Complete` once every transaction is mined,
     /// `InProgress` once any has been broadcast or mined. Leaves the status unchanged otherwise (an
     /// uncommitted or freshly committed migration keeps its `Planning`/`Committed` status until work
-    /// begins).
+    /// begins). A run containing an [`Invalid`](MigrationTxState::Invalid) transaction is by the
+    /// same all-mined test never `Complete`: it stays non-terminal, with [`Self::next_step`]
+    /// reporting [`AdvanceStep::Attend`], until the consumer resolves it (typically by cancelling,
+    /// which IS terminal, and re-planning).
     pub fn recompute_status(&mut self) {
         // A terminal status (Complete or Failed, the latter also used for a cancelled migration) is
         // final: never move out of it. Otherwise a cancelled migration whose transactions were
@@ -395,9 +546,18 @@ impl MigrationState {
 
     /// Records that the transaction `id` was broadcast with the given `txid`, then recomputes the
     /// overall status. The consumer calls this after it broadcasts the transaction the engine handed
-    /// it.
+    /// it. An unknown `id` is a no-op.
+    ///
+    /// An [`Invalid`](MigrationTxState::Invalid) transaction is left unchanged: a submission is
+    /// not evidence of validity (a node accepting a transaction into its mempool does not make it
+    /// minable), so it must not erase a recorded death — if the transaction does mine after all,
+    /// [`Self::mark_mined`] supersedes the verdict then.
     pub fn mark_broadcast(&mut self, id: MigrationTransferId, txid: TxId) {
-        if let Some(tx) = self.transactions.iter_mut().find(|t| t.id == id) {
+        if let Some(tx) = self
+            .transactions
+            .iter_mut()
+            .find(|t| t.id == id && !matches!(t.state, MigrationTxState::Invalid { .. }))
+        {
             tx.state = MigrationTxState::Broadcast { txid };
         }
         self.recompute_status();
@@ -406,9 +566,41 @@ impl MigrationState {
     /// Records that the transaction `id` was mined at `height`, then recomputes the overall status. The
     /// consumer detects mining through its own chain view (matching a broadcast transaction's txid) and
     /// calls this, which is what lets a later preparation layer or the transfers become actionable.
+    /// An unknown `id` is a no-op.
+    ///
+    /// Mining DOES overwrite an [`Invalid`](MigrationTxState::Invalid) transaction: inclusion in a
+    /// block is the one piece of evidence that outranks an invalidity verdict (which rests on a
+    /// single node's rejection or the consumer's own scan inference), so a stale or mistaken
+    /// [`Self::mark_invalid`] is self-healing — the chain's verdict wins whichever report arrives
+    /// last.
     pub fn mark_mined(&mut self, id: MigrationTransferId, height: BlockHeight) {
         if let Some(tx) = self.transactions.iter_mut().find(|t| t.id == id) {
             tx.state = MigrationTxState::Mined { height };
+        }
+        self.recompute_status();
+    }
+
+    /// Records the consumer's observed EVIDENCE that transaction `id` can never mine — a funding
+    /// note spent outside the migration, or a node rejecting the submission — moving it to
+    /// [`Invalid`](MigrationTxState::Invalid) with the given `reason`, then recomputes the overall
+    /// status. The consumer reports this from its own I/O (its wallet scan, its broadcast error
+    /// handling): the engine deliberately performs neither, so an event-based death exists for the
+    /// state machine only once it is recorded here. [`Self::next_step`] thereafter surfaces the
+    /// transaction as [`AdvanceStep::Attend`], and every actionable query excludes it.
+    ///
+    /// An already-[`Mined`](MigrationTxState::Mined) transaction is left unchanged: it was
+    /// included in a block, so it SUCCEEDED, and whatever prompted the call is stale — refusing it
+    /// here is what makes a race between a mining detection and an invalidity report converge on
+    /// the chain's verdict in either arrival order. An unknown `id` is a no-op, matching
+    /// [`Self::mark_broadcast`] / [`Self::mark_mined`]. Every other state is overwritten,
+    /// including an earlier `Invalid` (the newest evidence carries the reason shown to the user).
+    pub fn mark_invalid(&mut self, id: MigrationTransferId, reason: InvalidReason) {
+        if let Some(tx) = self
+            .transactions
+            .iter_mut()
+            .find(|t| t.id == id && !matches!(t.state, MigrationTxState::Mined { .. }))
+        {
+            tx.state = MigrationTxState::Invalid { reason };
         }
         self.recompute_status();
     }
@@ -451,6 +643,10 @@ impl MigrationState {
     /// the step's completion, the same step is returned. The steps map onto the crate's
     /// operations as follows:
     ///
+    /// - [`AdvanceStep::Attend`]: the transaction is marked [`Invalid`](MigrationTxState::Invalid)
+    ///   (its entry in [`Self::transaction_statuses`] carries the reason) and nothing this crate
+    ///   automates can advance it: resolve it out-of-band, typically by cancelling the migration
+    ///   and re-planning the remaining balance. The one step no engine operation discharges.
     /// - [`AdvanceStep::Prove`]: install the transaction's deferred anchor and witnesses and store
     ///   the proven PCZT — [`prove_transfer`](crate::engine::prove_transfer) /
     ///   [`prove_preparation`](crate::engine::prove_preparation), which also record the
@@ -474,8 +670,17 @@ impl MigrationState {
     ///
     /// # Ordering, and what it implies for wallet construction
     ///
-    /// When several actions are available at once the priority is BROADCAST, then PROVE, then
-    /// REBUILD.
+    /// When several actions are available at once the priority is ATTEND, then BROADCAST, then
+    /// PROVE, then REBUILD.
+    ///
+    /// Attend outranks everything but a terminal run: an invalid transaction means part of the
+    /// migration is dead in a way no automatic step remedies — every broadcast of it is a
+    /// guaranteed rejection, and everything depending on it waits forever — so a consumer must
+    /// receive the attention signal before it continues to drive, rather than after it has spent
+    /// its waking sessions working a run whose outcome is already decided. (The signal hides no
+    /// work: the still-valid transactions stay visible through [`Self::transaction_statuses`] and
+    /// served by [`Self::next_provable`] / [`Self::next_broadcastable`], so a consumer that
+    /// deliberately continues past it can.)
     ///
     /// Broadcast precedes prove because the two kinds of work want to be in DIFFERENT WAKING
     /// SESSIONS. ZIP 318 requires that a background wake window be used either to sync the wallet
@@ -514,11 +719,27 @@ impl MigrationState {
     /// slept through a transfer's proving wake-ups and its broadcast height is simply offered
     /// `Prove` and then `Broadcast` for it as soon as it wakes — or `Rebuild`, once the transfer
     /// has expired.
+    ///
+    /// This method is deliberately SINGLE-TARGET: the drive loop is evaluated on the consumer's
+    /// scanned chain view (`target_height` = `scanned_tip + 1`), since everything it decides —
+    /// expiry, boundary settledness, what to rebuild — must rest on data the wallet has actually
+    /// seen. A consumer whose scanned tip lags the real chain between syncs and that keeps a
+    /// wall-clock estimate of the real target serves its delivery lanes through
+    /// [`Self::next_provable_at`] / [`Self::next_broadcastable_at`] instead, where the estimate
+    /// may accelerate schedule due-ness (and only that; see [`DuenessTargets`]).
     pub fn next_step(&self, target_height: BlockHeight) -> AdvanceStep {
         // A terminal migration (complete, or failed/cancelled) has no next action: never build or
         // broadcast for it, so a cancelled migration cannot be driven further.
         if self.is_terminal() {
             return AdvanceStep::Complete;
+        }
+        // An invalid transaction outranks all actionable work: part of the run is dead in a way no
+        // automatic step remedies, and the consumer must see that before it keeps driving (see the
+        // ordering rationale above). The migration itself is NOT terminal — the consumer resolves
+        // the death out-of-band, typically by cancelling and re-planning — which is why this is a
+        // step, not a status.
+        if let Some(id) = self.next_attention() {
+            return AdvanceStep::Attend { id };
         }
         // If the wallet has a transaction available for broadcast, it should immediately
         // do that and *not* initiate any sync operations unless the user specifically needs
@@ -530,7 +751,7 @@ impl MigrationState {
         // At this point we know we're not broadcasting, so we can sync and prove. The kind rides
         // along because it decides the session handling: a preparation is broadcast as soon as it
         // is proved, a transfer's broadcast waits for its own (later) session.
-        if let Some(t) = self.next_provable_tx(target_height) {
+        if let Some(t) = self.next_provable_tx_at(DuenessTargets::at(target_height)) {
             return AdvanceStep::Prove {
                 id: t.id,
                 kind: t.kind,
@@ -562,7 +783,9 @@ impl MigrationState {
     /// transfer's drawn boundary has settled; a preparation is due on its schedule) is ready to
     /// prove; a `Proved` one whose scheduled height has arrived is ready to broadcast. Otherwise a
     /// waiting transaction reports what it is blocked on: its dependencies (a preparation still to
-    /// mine), an anchor boundary yet to settle, the broadcast schedule, or an external signature.
+    /// mine), an anchor boundary yet to settle, the broadcast schedule, an external signature, or
+    /// its own death (expired, or marked invalid — the latter with its reason in
+    /// [`state`](TransactionStatus::state)).
     pub fn transaction_statuses(&self, target_height: BlockHeight) -> Vec<TransactionStatus> {
         self.transactions
             .iter()
@@ -570,7 +793,9 @@ impl MigrationState {
                 let deps_ok = self.deps_mined(&t.depends_on);
                 // An expired transaction (not yet mined, past its expiry height) can never be mined and
                 // must be rebuilt; report that ahead of any other blocker, so a wallet shows it as
-                // needing attention rather than as waiting on a dependency or the schedule.
+                // needing attention rather than as waiting on a dependency or the schedule. (An
+                // `Invalid` transaction is never `is_expired`, so its more specific verdict — which
+                // carries a reason — is what gets reported below.)
                 let (ready, action, blocked_on) = if Self::is_expired(t, target_height) {
                     (false, None, Some(Blocker::Expired))
                 } else {
@@ -589,7 +814,7 @@ impl MigrationState {
                         MigrationTxState::Signed => {
                             if !deps_ok {
                                 (false, None, Some(Blocker::Dependencies))
-                            } else if self.prove_ready(t, target_height) {
+                            } else if self.prove_ready_at(t, DuenessTargets::at(target_height)) {
                                 (true, Some(NextAction::Prove), None)
                             } else {
                                 // Deps mined but not prove-ready: a transfer waiting for its anchor
@@ -614,6 +839,10 @@ impl MigrationState {
                         }
                         MigrationTxState::Broadcast { .. } => (false, None, None),
                         MigrationTxState::Mined { .. } => (false, None, None),
+                        // Dead by observed event: not actionable, and no chain condition will
+                        // change that (`next_step` surfaces the run-level attention signal as
+                        // `Attend`). The reason rides in `state`, which this view carries.
+                        MigrationTxState::Invalid { .. } => (false, None, Some(Blocker::Invalid)),
                     }
                 };
                 let txid = match t.state {
@@ -1355,5 +1584,369 @@ mod tests {
             s.next_step(BlockHeight::from_u32(1_000)),
             AdvanceStep::Complete
         );
+    }
+
+    /// A transaction in the given invalid state, for the failure-state tests.
+    fn invalid(reason: InvalidReason) -> MigrationTxState {
+        MigrationTxState::Invalid { reason }
+    }
+
+    /// The precedence pin for evidence-based death: with an invalid transaction present, `Attend`
+    /// is surfaced ahead of a broadcast that is due right now (and hence ahead of prove and
+    /// rebuild, which rank below broadcast).
+    #[test]
+    fn attend_precedes_broadcast_and_all_other_work() {
+        let due = tx(0, transfer(0), MigrationTxState::Proved); // scheduled at 0: due immediately
+        let dead = tx(1, transfer(1), invalid(InvalidReason::FundingSpent));
+        let s = state_with(vec![due, dead]);
+
+        assert_eq!(
+            s.next_broadcastable(BlockHeight::from_u32(100)),
+            Some(MigrationTransferId(0)),
+            "the broadcast IS due; the precedence, not the query, holds it back"
+        );
+        assert_eq!(
+            s.next_step(BlockHeight::from_u32(100)),
+            AdvanceStep::Attend {
+                id: MigrationTransferId(1)
+            }
+        );
+    }
+
+    /// An invalid transaction is excluded from every actionable query — never provable,
+    /// broadcastable, or wake-up-scheduled — and its death is reported through the invalidity
+    /// channel alone: even past its expiry height it is neither listed as expired nor offered for
+    /// rebuild.
+    #[test]
+    fn invalid_transaction_is_excluded_from_every_query() {
+        let target = BlockHeight::from_u32(100);
+        // A transfer that would be provable (boundary settled, no dependencies, never expires) —
+        // and broadcastable were it proved (scheduled height passed) — except for its state.
+        let s = state_with(vec![scheduled_transfer(
+            0,
+            0,
+            40,
+            60,
+            invalid(InvalidReason::RejectedInvalid),
+        )]);
+        assert_eq!(s.next_provable(target), None);
+        assert_eq!(s.next_broadcastable(target), None);
+        let mut r = ChaCha8Rng::seed_from_u64(1);
+        let wakeups = s
+            .sync_wakeup_schedule(BlockHeight::from_u32(50), &WakeupParams::new(10, 0), &mut r)
+            .expect("feasible");
+        assert!(
+            wakeups.is_empty(),
+            "a dead transfer needs no proving wake-up"
+        );
+
+        // The counterfactual, proving the exclusions are the state's doing and not the fixture's:
+        // merely `Signed`, the same transfer is provable and wake-up-scheduled.
+        let mut alive = s.clone();
+        alive.transactions[0].state = MigrationTxState::Signed;
+        assert_eq!(alive.next_provable(target), Some(MigrationTransferId(0)));
+        let mut r = ChaCha8Rng::seed_from_u64(1);
+        assert!(
+            !alive
+                .sync_wakeup_schedule(BlockHeight::from_u32(50), &WakeupParams::new(10, 0), &mut r)
+                .expect("feasible")
+                .is_empty()
+        );
+
+        // Past its expiry as well: still reported through the invalidity channel alone.
+        let mut dead_and_expired = s;
+        dead_and_expired.transactions[0].expiry_height = BlockHeight::from_u32(80);
+        assert!(
+            dead_and_expired.expired_transactions(target).is_empty(),
+            "an invalid transaction is not reported as expired (its death is already recorded)"
+        );
+        assert_eq!(
+            dead_and_expired.next_step(target),
+            AdvanceStep::Attend {
+                id: MigrationTransferId(0)
+            },
+            "and never offered for rebuild"
+        );
+    }
+
+    /// `mark_invalid` records the death (with its reason) for a not-yet-mined transaction and an
+    /// unknown id is a no-op, matching `mark_broadcast`/`mark_mined`; on an already-invalid row
+    /// the newest evidence wins.
+    #[test]
+    fn mark_invalid_records_the_reason_and_ignores_unknown_ids() {
+        let mut s = state_with(vec![
+            tx(0, prep(0, 0), MigrationTxState::Signed),
+            tx(1, transfer(0), MigrationTxState::Proved),
+        ]);
+
+        s.mark_invalid(MigrationTransferId(9), InvalidReason::FundingSpent);
+        assert!(
+            s.transactions
+                .iter()
+                .all(|t| t.state.invalid_reason().is_none()),
+            "an unknown id changes nothing"
+        );
+
+        s.mark_invalid(MigrationTransferId(1), InvalidReason::FundingSpent);
+        assert_eq!(
+            s.transactions[1].state,
+            invalid(InvalidReason::FundingSpent)
+        );
+        assert_eq!(
+            s.status,
+            MigrationStatus::Committed,
+            "nothing broadcast or mined: recomputing the status changes nothing"
+        );
+
+        s.mark_invalid(MigrationTransferId(1), InvalidReason::RejectedInvalid);
+        assert_eq!(
+            s.transactions[1].state.invalid_reason(),
+            Some(InvalidReason::RejectedInvalid),
+            "the newest evidence carries the reason"
+        );
+    }
+
+    /// Chain inclusion is the one piece of evidence that outranks an invalidity verdict: a mined
+    /// row is never marked invalid, `mark_mined` supersedes an earlier verdict, and a broadcast (a
+    /// mere submission, not evidence of validity) leaves the verdict standing — so a race between
+    /// the mining detection and the invalidity report converges on the chain's answer in either
+    /// arrival order.
+    #[test]
+    fn chain_inclusion_outranks_invalidity_evidence() {
+        // Evidence arriving after the mining detection is stale: rejected.
+        let mut s = state_with(vec![tx(0, transfer(0), mined(10))]);
+        s.mark_invalid(MigrationTransferId(0), InvalidReason::FundingSpent);
+        assert_eq!(s.transactions[0].state, mined(10));
+
+        // The other arrival order: the verdict lands first, then the transaction is seen mined.
+        let mut s = state_with(vec![tx(
+            0,
+            transfer(0),
+            invalid(InvalidReason::RejectedExpired),
+        )]);
+        s.mark_mined(MigrationTransferId(0), BlockHeight::from_u32(20));
+        assert_eq!(s.transactions[0].state, mined(20));
+        assert_eq!(s.status, MigrationStatus::Complete);
+
+        // A broadcast is not inclusion: it must not erase the verdict.
+        let mut s = state_with(vec![tx(
+            0,
+            transfer(0),
+            invalid(InvalidReason::FundingSpent),
+        )]);
+        s.mark_broadcast(MigrationTransferId(0), TxId::from_bytes([7; 32]));
+        assert_eq!(
+            s.transactions[0].state.invalid_reason(),
+            Some(InvalidReason::FundingSpent)
+        );
+    }
+
+    /// A run containing an invalid transaction never reaches `Complete`: the all-mined test fails,
+    /// so the migration stays non-terminal — surfacing `Attend` — even when every OTHER
+    /// transaction has mined.
+    #[test]
+    fn a_run_with_an_invalid_transaction_is_not_complete() {
+        let mut s = state_with(vec![
+            tx(0, prep(0, 0), mined(10)),
+            tx(1, transfer(0), MigrationTxState::Proved),
+        ]);
+        s.mark_invalid(MigrationTransferId(1), InvalidReason::FundingSpent);
+        assert_eq!(
+            s.status,
+            MigrationStatus::InProgress,
+            "started (a transaction mined), but never complete"
+        );
+        assert!(!s.is_terminal());
+        assert_eq!(
+            s.next_step(BlockHeight::from_u32(100)),
+            AdvanceStep::Attend {
+                id: MigrationTransferId(1)
+            }
+        );
+    }
+
+    /// An invalid transaction reports not-ready with no action and the `Invalid` blocker, its
+    /// reason riding in `state` — and that verdict wins over `Expired` when both hold, the
+    /// recorded event (which carries a reason) being the more specific fact.
+    #[test]
+    fn transaction_statuses_report_invalid_with_its_reason() {
+        let reason = InvalidReason::RejectedExpired;
+        let dead = tx_expiring(1, transfer(0), invalid(reason), 50);
+        let s = state_with(vec![tx(0, prep(0, 0), mined(10)), dead]);
+
+        // Target 100 is past the expiry height 50 too: Invalid still wins.
+        let v = s.transaction_statuses(BlockHeight::from_u32(100));
+        assert!(!v[1].ready);
+        assert_eq!(v[1].action, None);
+        assert_eq!(v[1].blocked_on, Some(Blocker::Invalid));
+        assert_eq!(
+            v[1].state.invalid_reason(),
+            Some(reason),
+            "the reason is readable off the status's state"
+        );
+    }
+
+    /// A terminal (cancelled) migration is never asked to attend: `Complete` still wins, so a
+    /// consumer that already cancelled a run with a dead transaction is not re-alerted forever.
+    #[test]
+    fn terminal_migration_is_not_offered_for_attention() {
+        let mut s = state_with(vec![tx(
+            0,
+            transfer(0),
+            invalid(InvalidReason::FundingSpent),
+        )]);
+        s.status = MigrationStatus::Failed;
+        assert_eq!(
+            s.next_step(BlockHeight::from_u32(100)),
+            AdvanceStep::Complete
+        );
+    }
+
+    /// `DuenessTargets::new` clamps: a stale estimate below the scanned target never drags the
+    /// serving target backwards, and no estimate leaves both targets coincident (the
+    /// [`DuenessTargets::at`] case).
+    #[test]
+    fn dueness_targets_clamp_a_stale_estimate() {
+        let scanned = BlockHeight::from_u32(200);
+
+        let stale = DuenessTargets::new(scanned, Some(BlockHeight::from_u32(150)));
+        assert_eq!(stale.scanned(), scanned);
+        assert_eq!(stale.effective(), scanned);
+
+        assert_eq!(
+            DuenessTargets::new(scanned, None),
+            DuenessTargets::at(scanned)
+        );
+
+        let ahead = DuenessTargets::new(scanned, Some(BlockHeight::from_u32(250)));
+        assert_eq!(ahead.scanned(), scanned);
+        assert_eq!(ahead.effective(), BlockHeight::from_u32(250));
+    }
+
+    /// The estimate accelerates SCHEDULE due-ness: work due only under the effective target is
+    /// served by the `_at` lanes — a proved transfer for broadcast, a pre-signed preparation for
+    /// proving (its prove-readiness IS schedule due-ness) — while the single-target queries at the
+    /// scanned tip alone still serve nothing.
+    #[test]
+    fn estimated_target_accelerates_schedule_dueness() {
+        let scanned = BlockHeight::from_u32(100);
+        let targets = DuenessTargets::new(scanned, Some(BlockHeight::from_u32(130)));
+
+        // A proved transfer scheduled between the scanned and effective targets.
+        let mut xfer = tx(0, transfer(0), MigrationTxState::Proved);
+        xfer.scheduled_height = BlockHeight::from_u32(120);
+        let s = state_with(vec![xfer]);
+        assert_eq!(s.next_broadcastable(scanned), None);
+        assert_eq!(
+            s.next_broadcastable_at(targets),
+            Some(MigrationTransferId(0))
+        );
+
+        // A pre-signed preparation scheduled likewise.
+        let mut prep0 = tx(0, prep(0, 0), MigrationTxState::Signed);
+        prep0.scheduled_height = BlockHeight::from_u32(120);
+        let s = state_with(vec![prep0]);
+        assert_eq!(s.next_provable(scanned), None);
+        assert_eq!(s.next_provable_at(targets), Some(MigrationTransferId(0)));
+    }
+
+    /// The estimate never DECIDES an expiry — but it does WITHHOLD a doomed broadcast. A proved,
+    /// due transfer whose expiry only the effective target has passed is refused by the
+    /// estimate-aware lane (if the estimate is right, the node would reject the submission), yet
+    /// treated as expired NOWHERE: not listed, not offered for rebuild. The two outcomes are
+    /// distinct decisions, and only the protective refusal may ride on the estimate; once the
+    /// SCANNED tip confirms the expiry, the ordinary rebuild path takes over.
+    #[test]
+    fn estimated_target_withholds_a_doomed_broadcast_but_never_decides_expiry() {
+        let scanned = BlockHeight::from_u32(100);
+        let targets = DuenessTargets::new(scanned, Some(BlockHeight::from_u32(130)));
+        // Due below the scanned target; expires between the scanned and effective targets.
+        let mut xfer = tx_expiring(0, transfer(0), MigrationTxState::Proved, 110);
+        xfer.scheduled_height = BlockHeight::from_u32(90);
+        let s = state_with(vec![xfer]);
+
+        // The scanned view serves it (still includable as far as scanned data proves)...
+        assert_eq!(s.next_broadcastable(scanned), Some(MigrationTransferId(0)));
+        // ...the estimate-aware lane refuses it...
+        assert_eq!(s.next_broadcastable_at(targets), None);
+        // ...and nothing treats it as expired on the estimate: that verdict needs the scanned tip.
+        assert!(s.expired_transactions(scanned).is_empty());
+        assert_eq!(
+            s.next_step(scanned),
+            AdvanceStep::Broadcast {
+                id: MigrationTransferId(0)
+            }
+        );
+
+        // Once the SCANNED target itself passes the expiry, the ordinary expired path owns it.
+        let confirmed = BlockHeight::from_u32(111);
+        assert_eq!(
+            s.expired_transactions(confirmed),
+            vec![MigrationTransferId(0)]
+        );
+        assert_eq!(
+            s.next_step(confirmed),
+            AdvanceStep::Rebuild {
+                id: MigrationTransferId(0)
+            }
+        );
+        assert_eq!(s.next_broadcastable_at(DuenessTargets::at(confirmed)), None);
+    }
+
+    /// A transfer's anchor-boundary settledness is a statement about SCANNED data — the boundary
+    /// checkpoint either exists in the wallet's tree or it does not, and an estimate cannot
+    /// conjure it — so the effective target never accelerates it.
+    #[test]
+    fn boundary_settledness_is_not_accelerated() {
+        // Boundary at 100, schedule long since due: provable once the boundary settles.
+        let mut xfer = tx(0, transfer(0), MigrationTxState::Signed);
+        xfer.anchor_boundary = Some(BlockHeight::from_u32(100));
+        xfer.scheduled_height = BlockHeight::from_u32(90);
+        let s = state_with(vec![xfer]);
+
+        // Scanned tip 100 (target 101): the boundary is not yet strictly below the tip, and no
+        // estimate — however far ahead — changes that.
+        let unsettled = DuenessTargets::new(
+            BlockHeight::from_u32(101),
+            Some(BlockHeight::from_u32(1_000)),
+        );
+        assert_eq!(s.next_provable_at(unsettled), None);
+
+        // One scanned block later the boundary has genuinely settled.
+        let settled = DuenessTargets::new(
+            BlockHeight::from_u32(102),
+            Some(BlockHeight::from_u32(1_000)),
+        );
+        assert_eq!(s.next_provable_at(settled), Some(MigrationTransferId(0)));
+    }
+
+    /// With no estimate the `_at` lanes and the single-target queries agree everywhere: the
+    /// single-target queries delegate through [`DuenessTargets::at`], pinned here over a mixed
+    /// fixture across a sweep of targets that crosses schedules, a boundary settlement, and an
+    /// expiry.
+    #[test]
+    fn single_target_queries_equal_the_at_variants_with_no_estimate() {
+        let mut expiring = tx_expiring(2, transfer(1), MigrationTxState::Proved, 60);
+        expiring.scheduled_height = BlockHeight::from_u32(40);
+        let mut late_prep = tx(3, prep(1, 0), MigrationTxState::Signed);
+        late_prep.scheduled_height = BlockHeight::from_u32(80);
+        let s = state_with(vec![
+            tx(0, prep(0, 0), mined(10)),
+            scheduled_transfer(1, 0, 44, 70, MigrationTxState::Signed),
+            expiring,
+            late_prep,
+        ]);
+
+        for target in 0..120u32 {
+            let target = BlockHeight::from_u32(target);
+            assert_eq!(
+                s.next_provable(target),
+                s.next_provable_at(DuenessTargets::at(target))
+            );
+            assert_eq!(
+                s.next_broadcastable(target),
+                s.next_broadcastable_at(DuenessTargets::at(target))
+            );
+        }
     }
 }

--- a/zcash_pool_migration/src/testing/strategies.rs
+++ b/zcash_pool_migration/src/testing/strategies.rs
@@ -16,8 +16,8 @@ use zcash_protocol::value::testing::arb_zatoshis;
 
 use crate::denomination::DenominationPlan;
 use crate::engine::{
-    MigrationState, MigrationStatus, MigrationTransaction, MigrationTransferId, MigrationTxKind,
-    MigrationTxState,
+    InvalidReason, MigrationState, MigrationStatus, MigrationTransaction, MigrationTransferId,
+    MigrationTxKind, MigrationTxState,
 };
 use crate::preparation::{PrepInput, PrepOutput, PrepTransaction, PreparationPlan};
 use crate::scheduling::AnchorBucketInterval;
@@ -137,9 +137,18 @@ pub fn arb_migration_tx_kind() -> impl Strategy<Value = MigrationTxKind> {
     ]
 }
 
+/// An arbitrary [`InvalidReason`], covering every variant.
+pub fn arb_invalid_reason() -> impl Strategy<Value = InvalidReason> {
+    prop_oneof![
+        Just(InvalidReason::FundingSpent),
+        Just(InvalidReason::RejectedInvalid),
+        Just(InvalidReason::RejectedExpired),
+    ]
+}
+
 /// An arbitrary [`MigrationTxState`], covering every variant (including the
-/// [`Broadcast`](MigrationTxState::Broadcast) txid and [`Mined`](MigrationTxState::Mined) height
-/// payloads).
+/// [`Broadcast`](MigrationTxState::Broadcast) txid, [`Mined`](MigrationTxState::Mined) height, and
+/// [`Invalid`](MigrationTxState::Invalid) reason payloads).
 pub fn arb_migration_tx_state() -> impl Strategy<Value = MigrationTxState> {
     prop_oneof![
         Just(MigrationTxState::AwaitingSignature),
@@ -147,6 +156,7 @@ pub fn arb_migration_tx_state() -> impl Strategy<Value = MigrationTxState> {
         Just(MigrationTxState::Proved),
         arb_txid().prop_map(|txid| MigrationTxState::Broadcast { txid }),
         arb_block_height().prop_map(|height| MigrationTxState::Mined { height }),
+        arb_invalid_reason().prop_map(|reason| MigrationTxState::Invalid { reason }),
     ]
 }
 


### PR DESCRIPTION
## Motivation

Both mobile wallet SDKs consuming this crate (the Swift and Kotlin lightwallet SDKs) have independently grown the same two pieces of compensating machinery, which this PR moves into the engine where they belong.

**1. Event-based transaction death is unreportable.** A committed migration transaction can die in ways the engine — by design — never observes: the network rejects its broadcast (input spent / expired), or the wallet's scan reveals a funding note spent outside the migration (typically the same seed running in a second wallet instance). The engine's reporting surface (`mark_broadcast`, `mark_mined`, `apply_signature`) has no failure verb, so the row stays `Proved`-and-due and `next_step` surfaces a guaranteed-to-fail `Broadcast` forever. Both SDKs track death in side-tables their drive loops and the engine's queries cannot see — recreating, badly, a precedence invariant this crate is better placed to own. The engine already models the one death it can compute from its own inputs (height-based expiry → `Rebuild`); this adds the event-based one it must be told about.

**2. Estimate-aware due-ness is hand-rolled twice.** Mobile wallets evaluate schedule due-ness against a wall-clock estimate of the chain tip (their scanned tip is stale between rare syncs; ZIP 318's session separation forbids syncing in a broadcast session), under a hard rule: the estimate may only accelerate schedule due-ness, never decide expiry or any destructive outcome. Both SDKs carry duplicated "split twin" copies of `next_provable`/`next_broadcastable` encoding that split, which silently drift from the originals across releases.

## What this adds

- `MigrationTxState::Invalid { reason: InvalidReason }` (`FundingSpent` / `RejectedInvalid` / `RejectedExpired`) + `MigrationState::mark_invalid(id, reason)`. Unknown-id and Mined-row marking are documented no-ops; `mark_mined` overwrites `Invalid` (chain inclusion outranks invalidity evidence, so a stale verdict self-heals), `mark_broadcast` does not.
- `AdvanceStep::Attend { id }`, surfaced ahead of all actionable work (a terminal migration still reports `Complete`); `Blocker::Invalid`; `transaction_statuses` carries the reason via the state. Invalid rows are excluded from `next_provable`, `next_broadcastable`, `sync_wakeup_schedule`, `expired_transactions` (one death channel per row), and rebuild rejects them with the new `RebuildError::Invalid(id, reason)`.
- `DuenessTargets { scanned, effective }` (constructor clamps `effective = max(scanned, estimate)`) and `next_provable_at` / `next_broadcastable_at`: schedule comparisons at the effective target; expiry and transfer-boundary settledness always at the scanned target (an estimate cannot conjure a checkpoint); and a doomed-broadcast withhold — a row whose expiry the effective target has passed is not served (protective and reversible), while expiry itself is only ever decided by scanned data. The existing single-target queries delegate to the `_at` variants at identical targets — zero behavior change.
- `zcash_client_sqlite`: the `orchard_ironwood_migration_invalid_reason` migration (nullable `invalid_reason` column) + store round-trip + conformance coverage; `testing` strategies generate the new state.

## Verification

`cargo test -p zcash_pool_migration --all-features` (180 tests incl. 18 new), `cargo test -p zcash_client_sqlite --all-features` for the init/migrations/pool_migration suites (122), expensive `--include-ignored` proving tests, clippy (`--all-features --all-targets` and `--no-default-features`) with no new warnings, `cargo doc` clean, and the migration-UUID checks — all green.

Follow-up to #2867's drive-loop documentation; part of the #2630 effort. The Swift SDK adopts this via a git pin immediately (deleting its side-table and twins); the Kotlin SDK can do the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)