### PR TITLE
zip318: recognize migration transactions from their shape, and record it

### DIFF
--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -13,8 +13,14 @@ workspace.
 ### Added
 - `zcash_protocol::zip318::{CROSSING_SOURCE_ACTIONS, CROSSING_DESTINATION_ACTIONS}`,
   the action counts of a canonical pool crossing.
-- `zcash_protocol::zip318::PoolMigrationConstants::{canonical_expiry, is_canonical_expiry}`,
-  which generalize the free `expiry_height` to an overridden expiry window.
+- `zcash_protocol::zip318::PoolMigrationConstants::{canonical_expiry, is_canonical_expiry,
+  is_canonical_expiry_value}`. The first two generalize the free `expiry_height` to an
+  overridden expiry window; the third judges an expiry without a reference height,
+  for a caller that has none and must not change its answer once it gets one.
+- `zcash_protocol::zip318::Zip318Classification::{to_code, from_code}`, the stable
+  integer encoding a store persists and an FFI carries. Zero means NOT CLASSIFIED
+  and is meant to be a column's default; it is distinct from the code for
+  `Nonconforming`, which is a decision.
 - `zcash_protocol::zip318::{Zip318TxKind, Zip318Classification, Zip318Evidence,
   DestinationOutput, OutputOwner, classify}`, which recognize the ZIP 318
   transaction shapes from evidence a caller gathers. `classify` names a

--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -10,6 +10,17 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `zcash_protocol::zip318::{CROSSING_SOURCE_ACTIONS, CROSSING_DESTINATION_ACTIONS}`,
+  the action counts of a canonical pool crossing.
+- `zcash_protocol::zip318::PoolMigrationConstants::{canonical_expiry, is_canonical_expiry}`,
+  which generalize the free `expiry_height` to an overridden expiry window.
+- `zcash_protocol::zip318::{Zip318TxKind, Zip318Classification, Zip318Evidence,
+  DestinationOutput, OutputOwner, classify}`, which recognize the ZIP 318
+  transaction shapes from evidence a caller gathers. `classify` names a
+  conformance class and never a provenance, and is monotone in the evidence, so
+  a decision it reaches is never later contradicted.
+
 ## [0.10.3] - 2026-07-29
 
 ### Added

--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -22,10 +22,10 @@ workspace.
   and is meant to be a column's default; it is distinct from the code for
   `Nonconforming`, which is a decision.
 - `zcash_protocol::zip318::{Zip318TxKind, Zip318Classification, Zip318Evidence,
-  DestinationOutput, OutputOwner, classify}`, which recognize the ZIP 318
-  transaction shapes from evidence a caller gathers. `classify` names a
-  conformance class and never a provenance, and is monotone in the evidence, so
-  a decision it reaches is never later contradicted.
+  classify}`, which recognize the ZIP 318 transaction shapes from evidence a
+  caller gathers. `classify` names a conformance class and never a provenance,
+  and is monotone in the evidence, so a decision it reaches is never later
+  contradicted.
 
 ## [0.10.3] - 2026-07-29
 

--- a/components/zcash_protocol/src/zip318.rs
+++ b/components/zcash_protocol/src/zip318.rs
@@ -333,6 +333,270 @@ pub trait PoolMigrationConstants {
     fn is_canonical_denomination(&self, value: Zatoshis) -> bool {
         is_canonical_within(value, self.max_residual_value(), self.denomination_cap())
     }
+
+    /// The canonical rolling expiry height for a transaction targeting `reference`, under these
+    /// parameters. See the free [`expiry_height`], which this generalizes to an overridden
+    /// [`expiry_window`](Self::expiry_window).
+    fn canonical_expiry(&self, reference: BlockHeight) -> BlockHeight {
+        let (modulus, window) = self.expiry_window();
+        let h = u32::from(reference);
+        BlockHeight::from_u32(h - (h % modulus)) + window
+    }
+
+    /// Returns whether `expiry` is the canonical rolling expiry for a transaction targeting
+    /// `reference`.
+    ///
+    /// This is the sharpest single ZIP 318 discriminator. An ordinary transaction expires a fixed
+    /// short delta after its target height, so its expiry is essentially uniform; a ZIP 318
+    /// transaction's expiry is one of the few heights the rolling window admits.
+    fn is_canonical_expiry(&self, expiry: BlockHeight, reference: BlockHeight) -> bool {
+        expiry == self.canonical_expiry(reference)
+    }
+}
+
+/// Source-pool (Orchard) actions in a canonical [ZIP 318] pool crossing: the spend and its change,
+/// or a padding dummy when the note's value exactly covers the crossing and its fee.
+///
+/// [ZIP 318]: https://zips.z.cash/zip-0318
+pub const CROSSING_SOURCE_ACTIONS: usize = 2;
+
+/// Destination-pool (Ironwood) actions in a canonical [ZIP 318] pool crossing: the single
+/// canonical output, unpadded.
+///
+/// [ZIP 318]: https://zips.z.cash/zip-0318
+pub const CROSSING_DESTINATION_ACTIONS: usize = 1;
+
+/// The shape a [ZIP 318]-conforming transaction has.
+///
+/// This names a CONFORMANCE CLASS, never a provenance. ZIP 318's privacy argument is that every
+/// migration transaction looks like every other one, so recognising the shape places a transaction
+/// in the anonymity set and can never establish that it came from any particular wallet's
+/// migration run. Present it to a user as "migration" if that is the useful word, but do not build
+/// anything on the assumption that this identifies a run.
+///
+/// [ZIP 318]: https://zips.z.cash/zip-0318
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Zip318TxKind {
+    /// A note-preparation transaction: an Orchard-only send-to-self, padded to exactly
+    /// [`PoolMigrationConstants::preparation_tx_actions`] actions, restructuring the wallet's
+    /// notes into the self-funding notes a migration spends.
+    Preparation,
+    /// A pool crossing paying the account's OWN internal destination-pool address: a migration
+    /// transfer.
+    Transfer,
+    /// A pool crossing of the same canonical shape paying an EXTERNAL recipient.
+    ///
+    /// The ordinary send path builds these deliberately, so that a payment of a canonical
+    /// denomination across the turnstile joins the migration anonymity set. It is in the set, but
+    /// it is a payment to a third party and MUST NOT be presented as a migration.
+    CanonicalCrossingPayment,
+}
+
+/// Whether a destination-pool output pays the account itself or someone else.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum OutputOwner {
+    /// The account's own internal (change) address.
+    OwnInternal,
+    /// Anything else, including the account's own external address.
+    Other,
+}
+
+/// The single value-carrying output in the destination pool of a pool crossing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DestinationOutput {
+    /// The value crossing the turnstile.
+    pub value: Zatoshis,
+    /// Who the crossing pays, which is what separates a migration transfer from a canonical
+    /// crossing payment.
+    pub owner: OutputOwner,
+}
+
+/// The result of classifying a transaction against [ZIP 318].
+///
+/// [`Unknown`](Self::Unknown) is NOT a third answer alongside the other two: it is the least
+/// element of an information ordering. Evidence about a transaction only ever grows (a compact
+/// scan learns less than an enhanced transaction, which learns less than one whose anchor can also
+/// be resolved), and [`classify`] is monotone with respect to that growth. Because the order on
+/// results is flat, monotonicity says exactly: *once decided, never decided differently*. A
+/// consumer may therefore cache a decision, and must render `Unknown` as "no label yet" rather
+/// than as "not a migration", or rows will visibly relabel themselves as data arrives.
+///
+/// [ZIP 318]: https://zips.z.cash/zip-0318
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Zip318Classification {
+    /// The transaction has this ZIP 318 shape.
+    Conforms(Zip318TxKind),
+    /// The transaction definitely does not have any ZIP 318 shape. Emitted only when the evidence
+    /// needed to refute is actually present.
+    Nonconforming,
+    /// Not enough evidence to decide yet.
+    Unknown,
+}
+
+impl Zip318Classification {
+    /// The kind, if this classification is a conforming one.
+    pub fn kind(&self) -> Option<Zip318TxKind> {
+        match self {
+            Self::Conforms(kind) => Some(*kind),
+            _ => None,
+        }
+    }
+
+    /// Whether this is a transaction of a wallet's own migration: a preparation transaction or a
+    /// transfer, but NOT a canonical crossing payment to a third party.
+    pub fn is_own_migration(&self) -> bool {
+        matches!(
+            self,
+            Self::Conforms(Zip318TxKind::Preparation) | Self::Conforms(Zip318TxKind::Transfer)
+        )
+    }
+}
+
+/// Everything [`classify`] needs to observe about a transaction, gathered by whichever component
+/// can see it.
+///
+/// A `None` field means THIS SOURCE CANNOT ANSWER, which is not the same as an answer of `false`.
+/// The struct is therefore a point in the information ordering described on
+/// [`Zip318Classification`], and [`Default::default`] (everything `None`) is its least element.
+///
+/// Two obligations on whoever fills this in, both of which keep [`classify`] monotone:
+///
+/// - Each field is STABLE for a given transaction: `None` may become a value as wallet data
+///   arrives, but a value must never change to a different value.
+/// - The two CONFIRMATORY fields ([`anchor_on_grid`](Self::anchor_on_grid) and
+///   [`fee_is_canonical`](Self::fee_is_canonical)) must reflect a fixed capability of the source,
+///   not a per-transaction accident. A source that answers them for one transaction and not for
+///   the next can contradict its own earlier decisions.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Zip318Evidence {
+    /// The number of actions in the source-pool (Orchard) bundle, including padding dummies.
+    pub source_actions: Option<usize>,
+    /// The number of actions in the destination-pool (Ironwood) bundle, including padding dummies.
+    /// Zero when there is no destination bundle at all.
+    pub destination_actions: Option<usize>,
+    /// Whether any transparent or Sapling bundle is present. No ZIP 318 transaction carries one.
+    pub other_bundles_present: Option<bool>,
+    /// Whether every value-carrying source-pool output pays the account's own internal address.
+    ///
+    /// Padding dummies carry no value and are excluded; only the outputs the wallet actually
+    /// created are considered.
+    pub source_outputs_all_internal: Option<bool>,
+    /// The single value-carrying destination-pool output, when the transaction has one.
+    pub sole_destination_output: Option<DestinationOutput>,
+    /// Whether the expiry height is the canonical rolling expiry, judged against a height the
+    /// source considers authoritative: the MINED height once mined, or the target height for a
+    /// transaction the wallet is itself building.
+    ///
+    /// A source that has neither must leave this `None`. Judging an unmined transaction against
+    /// the chain tip is a monotonicity violation waiting to happen, because the canonical expiry
+    /// is a step function of the height and the answer would change once the transaction is mined
+    /// in the next period.
+    pub expiry_is_canonical: Option<bool>,
+    /// Whether the shielded anchor lies on the retention grid. CONFIRMATORY: a source that cannot
+    /// resolve the anchor leaves this `None`, which widens the predicate rather than blocking it.
+    pub anchor_on_grid: Option<bool>,
+    /// Whether the fee is the one the canonical shape pays under the standard rule. CONFIRMATORY,
+    /// on the same terms as [`anchor_on_grid`](Self::anchor_on_grid).
+    pub fee_is_canonical: Option<bool>,
+}
+
+/// Classifies a transaction against [ZIP 318] from what `evidence` could observe.
+///
+/// The result is an OVER-APPROXIMATION whenever the evidence omits a confirmatory clause: dropping
+/// a conjunct enlarges a predicate's extension, so every strictly canonical transaction is
+/// recognised (no false negatives) while a transaction matching the shape but, say, anchored off
+/// the grid may also be admitted. That is the right direction for a label, which should err
+/// towards showing rather than hiding, but it means this is not a substitute for the pre-build
+/// check when deciding whether to BUILD a canonical crossing.
+///
+/// [ZIP 318]: https://zips.z.cash/zip-0318
+pub fn classify<C>(evidence: &Zip318Evidence, constants: &C) -> Zip318Classification
+where
+    C: PoolMigrationConstants + ?Sized,
+{
+    // A confirmatory clause refutes when it is answered negatively, and is simply absent
+    // otherwise; see the over-approximation note above.
+    if evidence.anchor_on_grid == Some(false) || evidence.fee_is_canonical == Some(false) {
+        return Zip318Classification::Nonconforming;
+    }
+
+    // The clauses every ZIP 318 shape shares. Any one of them unanswered leaves the whole
+    // classification at the least element, rather than allowing a refutation we could not support.
+    let (
+        Some(source_actions),
+        Some(destination_actions),
+        Some(other_bundles_present),
+        Some(expiry_is_canonical),
+    ) = (
+        evidence.source_actions,
+        evidence.destination_actions,
+        evidence.other_bundles_present,
+        evidence.expiry_is_canonical,
+    )
+    else {
+        return Zip318Classification::Unknown;
+    };
+
+    if other_bundles_present || !expiry_is_canonical {
+        return Zip318Classification::Nonconforming;
+    }
+
+    // The destination bundle decides which shape is even a candidate: a preparation transaction
+    // never crosses, and a crossing carries exactly one destination action.
+    match destination_actions {
+        0 => classify_preparation(evidence, constants, source_actions),
+        CROSSING_DESTINATION_ACTIONS => classify_crossing(evidence, constants, source_actions),
+        _ => Zip318Classification::Nonconforming,
+    }
+}
+
+/// The preparation branch of [`classify`]: an Orchard-only send-to-self padded to the specified
+/// action count.
+fn classify_preparation<C>(
+    evidence: &Zip318Evidence,
+    constants: &C,
+    source_actions: usize,
+) -> Zip318Classification
+where
+    C: PoolMigrationConstants + ?Sized,
+{
+    if source_actions != constants.preparation_tx_actions() {
+        return Zip318Classification::Nonconforming;
+    }
+
+    match evidence.source_outputs_all_internal {
+        None => Zip318Classification::Unknown,
+        Some(false) => Zip318Classification::Nonconforming,
+        Some(true) => Zip318Classification::Conforms(Zip318TxKind::Preparation),
+    }
+}
+
+/// The crossing branch of [`classify`]. This is the ONLY place where a transfer and a canonical
+/// crossing payment part company, and they part on the recipient alone.
+fn classify_crossing<C>(
+    evidence: &Zip318Evidence,
+    constants: &C,
+    source_actions: usize,
+) -> Zip318Classification
+where
+    C: PoolMigrationConstants + ?Sized,
+{
+    if source_actions != CROSSING_SOURCE_ACTIONS {
+        return Zip318Classification::Nonconforming;
+    }
+
+    let Some(output) = evidence.sole_destination_output else {
+        return Zip318Classification::Unknown;
+    };
+
+    if !constants.is_canonical_denomination(output.value) {
+        return Zip318Classification::Nonconforming;
+    }
+
+    Zip318Classification::Conforms(match output.owner {
+        OutputOwner::OwnInternal => Zip318TxKind::Transfer,
+        OutputOwner::Other => Zip318TxKind::CanonicalCrossingPayment,
+    })
 }
 
 #[cfg(test)]
@@ -533,5 +797,297 @@ mod tests {
         assert!(is_canonical_denomination(two_zec));
         assert!(!SmallCap.is_canonical_denomination(two_zec));
         assert!(SmallCap.is_canonical_denomination(Zatoshis::const_from_u64(COIN)));
+    }
+
+    // --- classification ---------------------------------------------------------------------
+
+    /// A wallet on the specified parameters.
+    #[derive(Clone)]
+    struct Zip318Params;
+    impl PoolMigrationConstants for Zip318Params {}
+
+    /// The canonical expiry agrees with the free function on the specified parameters, and an
+    /// ordinary expiry (a short fixed delta past the target) never satisfies it.
+    #[test]
+    fn canonical_expiry_matches_the_specified_window() {
+        for height in [0u32, 1, 144, 34_559, 34_560, 2_000_000] {
+            let h = BlockHeight::from_u32(height);
+            assert_eq!(Zip318Params.canonical_expiry(h), expiry_height(h));
+            assert!(Zip318Params.is_canonical_expiry(expiry_height(h), h));
+            // The `DEFAULT_TX_EXPIRY_DELTA` of an ordinary transaction is 40 blocks.
+            assert!(!Zip318Params.is_canonical_expiry(h + 40, h));
+        }
+    }
+
+    /// An implementor that shortens the expiry window is honoured, where the free function still
+    /// reports the specified answer.
+    #[test]
+    fn canonical_expiry_honours_an_overridden_window() {
+        #[derive(Clone)]
+        struct ShortWindow;
+        impl PoolMigrationConstants for ShortWindow {
+            fn expiry_window(&self) -> (u32, u32) {
+                (100, 200)
+            }
+        }
+
+        let h = BlockHeight::from_u32(250);
+        assert_eq!(ShortWindow.canonical_expiry(h), BlockHeight::from_u32(400));
+        assert!(ShortWindow.is_canonical_expiry(BlockHeight::from_u32(400), h));
+        assert!(!ShortWindow.is_canonical_expiry(expiry_height(h), h));
+    }
+
+    /// Evidence for a well-formed preparation transaction, from a source that can answer every
+    /// clause. Tests below knock out one field at a time.
+    fn prep_evidence() -> Zip318Evidence {
+        Zip318Evidence {
+            source_actions: Some(PREP_TX_ACTIONS),
+            destination_actions: Some(0),
+            other_bundles_present: Some(false),
+            source_outputs_all_internal: Some(true),
+            sole_destination_output: None,
+            expiry_is_canonical: Some(true),
+            anchor_on_grid: Some(true),
+            fee_is_canonical: Some(true),
+        }
+    }
+
+    /// Evidence for a well-formed pool crossing carrying `value` to `owner`.
+    fn crossing_evidence(value: Zatoshis, owner: OutputOwner) -> Zip318Evidence {
+        Zip318Evidence {
+            source_actions: Some(CROSSING_SOURCE_ACTIONS),
+            destination_actions: Some(CROSSING_DESTINATION_ACTIONS),
+            other_bundles_present: Some(false),
+            source_outputs_all_internal: None,
+            sole_destination_output: Some(DestinationOutput { value, owner }),
+            expiry_is_canonical: Some(true),
+            anchor_on_grid: Some(true),
+            fee_is_canonical: Some(true),
+        }
+    }
+
+    /// The least element of the information ordering decides nothing.
+    #[test]
+    fn no_evidence_is_unknown() {
+        assert_eq!(
+            classify(&Zip318Evidence::default(), &Zip318Params),
+            Zip318Classification::Unknown
+        );
+    }
+
+    #[test]
+    fn a_canonical_preparation_conforms() {
+        assert_eq!(
+            classify(&prep_evidence(), &Zip318Params),
+            Zip318Classification::Conforms(Zip318TxKind::Preparation)
+        );
+    }
+
+    /// The two crossing kinds differ ONLY in who the destination output pays.
+    #[test]
+    fn a_crossing_is_a_transfer_only_when_it_pays_the_account_itself() {
+        let value = Zatoshis::const_from_u64(COIN);
+        assert_eq!(
+            classify(
+                &crossing_evidence(value, OutputOwner::OwnInternal),
+                &Zip318Params
+            ),
+            Zip318Classification::Conforms(Zip318TxKind::Transfer)
+        );
+        assert_eq!(
+            classify(&crossing_evidence(value, OutputOwner::Other), &Zip318Params),
+            Zip318Classification::Conforms(Zip318TxKind::CanonicalCrossingPayment)
+        );
+    }
+
+    /// The shape clauses each refute on their own. These are the ordinary transactions that must
+    /// never be labelled: a note split with the wrong action count, one carrying another bundle,
+    /// one with an ordinary expiry, and a crossing of an off-series amount.
+    #[test]
+    fn each_clause_refutes_on_its_own() {
+        let cases: [(&str, Zip318Evidence); 5] = [
+            (
+                "an ordinary split has a different action count",
+                Zip318Evidence {
+                    source_actions: Some(PREP_TX_ACTIONS + 1),
+                    ..prep_evidence()
+                },
+            ),
+            (
+                "no ZIP 318 transaction carries another bundle",
+                Zip318Evidence {
+                    other_bundles_present: Some(true),
+                    ..prep_evidence()
+                },
+            ),
+            (
+                "an ordinary expiry is not the rolling one",
+                Zip318Evidence {
+                    expiry_is_canonical: Some(false),
+                    ..prep_evidence()
+                },
+            ),
+            (
+                "a preparation output paying elsewhere is not a send-to-self",
+                Zip318Evidence {
+                    source_outputs_all_internal: Some(false),
+                    ..prep_evidence()
+                },
+            ),
+            (
+                "a crossing of an off-series amount joins no anonymity set",
+                crossing_evidence(Zatoshis::const_from_u64(3 * COIN), OutputOwner::OwnInternal),
+            ),
+        ];
+
+        for (why, evidence) in cases {
+            assert_eq!(
+                classify(&evidence, &Zip318Params),
+                Zip318Classification::Nonconforming,
+                "{why}"
+            );
+        }
+    }
+
+    /// A 16-action Orchard-only send-to-self that lands on a canonical expiry by coincidence is
+    /// still refused if anything else about it is wrong. The clauses are conjoined precisely
+    /// because no single one of them is rare enough on its own.
+    #[test]
+    fn a_coincidental_expiry_alone_does_not_conform() {
+        let evidence = Zip318Evidence {
+            other_bundles_present: Some(true),
+            expiry_is_canonical: Some(true),
+            ..prep_evidence()
+        };
+        assert_eq!(
+            classify(&evidence, &Zip318Params),
+            Zip318Classification::Nonconforming
+        );
+    }
+
+    /// A confirmatory clause refutes when answered negatively, and is absent otherwise. Absence
+    /// widens the predicate (the over-approximation), it does not block it.
+    #[test]
+    fn confirmatory_clauses_refute_but_do_not_block() {
+        for knock_out in [
+            Zip318Evidence {
+                anchor_on_grid: Some(false),
+                ..prep_evidence()
+            },
+            Zip318Evidence {
+                fee_is_canonical: Some(false),
+                ..prep_evidence()
+            },
+        ] {
+            assert_eq!(
+                classify(&knock_out, &Zip318Params),
+                Zip318Classification::Nonconforming
+            );
+        }
+
+        // A source that cannot answer either one still decides.
+        let unanswerable = Zip318Evidence {
+            anchor_on_grid: None,
+            fee_is_canonical: None,
+            ..prep_evidence()
+        };
+        assert_eq!(
+            classify(&unanswerable, &Zip318Params),
+            Zip318Classification::Conforms(Zip318TxKind::Preparation)
+        );
+    }
+
+    /// A required clause left unanswered yields the least element, never a refutation: we do not
+    /// claim a transaction is not a migration on evidence we do not have.
+    #[test]
+    fn an_unanswered_required_clause_is_unknown_not_a_refutation() {
+        let knock_outs = [
+            Zip318Evidence {
+                source_actions: None,
+                ..prep_evidence()
+            },
+            Zip318Evidence {
+                destination_actions: None,
+                ..prep_evidence()
+            },
+            Zip318Evidence {
+                other_bundles_present: None,
+                ..prep_evidence()
+            },
+            Zip318Evidence {
+                expiry_is_canonical: None,
+                ..prep_evidence()
+            },
+            Zip318Evidence {
+                source_outputs_all_internal: None,
+                ..prep_evidence()
+            },
+        ];
+
+        for evidence in knock_outs {
+            assert_eq!(
+                classify(&evidence, &Zip318Params),
+                Zip318Classification::Unknown
+            );
+        }
+
+        // The same for the crossing branch's own required clause.
+        let no_output = Zip318Evidence {
+            sole_destination_output: None,
+            ..crossing_evidence(Zatoshis::const_from_u64(COIN), OutputOwner::OwnInternal)
+        };
+        assert_eq!(
+            classify(&no_output, &Zip318Params),
+            Zip318Classification::Unknown
+        );
+    }
+
+    /// MONOTONICITY. As evidence grows, the classification only ever moves up the flat
+    /// information order: `Unknown` may become a decision, but a decision never becomes a
+    /// different decision. This is what lets a consumer cache a label, and what stops a history
+    /// row relabelling itself while the wallet catches up.
+    #[test]
+    fn classification_is_monotone_in_the_evidence() {
+        // A chain of evidence values, each learning one more clause than the last, for both a
+        // conforming and a refuted transaction.
+        for full in [
+            prep_evidence(),
+            crossing_evidence(Zatoshis::const_from_u64(COIN), OutputOwner::Other),
+            Zip318Evidence {
+                other_bundles_present: Some(true),
+                ..prep_evidence()
+            },
+        ] {
+            let chain = [
+                Zip318Evidence::default(),
+                Zip318Evidence {
+                    source_actions: full.source_actions,
+                    destination_actions: full.destination_actions,
+                    ..Zip318Evidence::default()
+                },
+                Zip318Evidence {
+                    sole_destination_output: None,
+                    expiry_is_canonical: None,
+                    ..full
+                },
+                full,
+            ];
+
+            let mut decided: Option<Zip318Classification> = None;
+            for evidence in chain {
+                match classify(&evidence, &Zip318Params) {
+                    Zip318Classification::Unknown => assert!(
+                        decided.is_none(),
+                        "evidence grew and a decision reverted to Unknown"
+                    ),
+                    settled => {
+                        if let Some(earlier) = decided {
+                            assert_eq!(earlier, settled, "evidence grew and the decision changed");
+                        }
+                        decided = Some(settled);
+                    }
+                }
+            }
+        }
     }
 }

--- a/components/zcash_protocol/src/zip318.rs
+++ b/components/zcash_protocol/src/zip318.rs
@@ -406,34 +406,16 @@ pub enum Zip318TxKind {
     /// [`PoolMigrationConstants::preparation_tx_actions`] actions, restructuring the wallet's
     /// notes into the self-funding notes a migration spends.
     Preparation,
-    /// A pool crossing paying the account's OWN internal destination-pool address: a migration
-    /// transfer.
-    Transfer,
-    /// A pool crossing of the same canonical shape paying an EXTERNAL recipient.
+    /// A pool crossing: a canonical denomination carried across the turnstile by a transaction of
+    /// the canonical shape.
     ///
-    /// The ordinary send path builds these deliberately, so that a payment of a canonical
-    /// denomination across the turnstile joins the migration anonymity set. It is in the set, but
-    /// it is a payment to a third party and MUST NOT be presented as a migration.
-    CanonicalCrossingPayment,
-}
-
-/// Whether a destination-pool output pays the account itself or someone else.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum OutputOwner {
-    /// The account's own internal (change) address.
-    OwnInternal,
-    /// Anything else, including the account's own external address.
-    Other,
-}
-
-/// The single value-carrying output in the destination pool of a pool crossing.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct DestinationOutput {
-    /// The value crossing the turnstile.
-    pub value: Zatoshis,
-    /// Who the crossing pays, which is what separates a migration transfer from a canonical
-    /// crossing payment.
-    pub owner: OutputOwner,
+    /// This does NOT say who the crossing pays. The ordinary send path deliberately builds
+    /// payments to third parties in this same shape, so that a payment of a canonical denomination
+    /// joins the migration anonymity set, and nothing observable about the transaction separates
+    /// one from a wallet's own migration transfer. That indistinguishability is the point of the
+    /// shape, so this crate does not offer a distinction it cannot make. A wallet that knows the
+    /// recipient of its OWN transaction may of course draw one from its own records.
+    Transfer,
 }
 
 /// The result of classifying a transaction against [ZIP 318].
@@ -478,7 +460,6 @@ impl Zip318Classification {
             Self::Nonconforming => 1,
             Self::Conforms(Zip318TxKind::Preparation) => 2,
             Self::Conforms(Zip318TxKind::Transfer) => 3,
-            Self::Conforms(Zip318TxKind::CanonicalCrossingPayment) => 4,
         }
     }
 
@@ -495,7 +476,6 @@ impl Zip318Classification {
             1 => Self::Nonconforming,
             2 => Self::Conforms(Zip318TxKind::Preparation),
             3 => Self::Conforms(Zip318TxKind::Transfer),
-            4 => Self::Conforms(Zip318TxKind::CanonicalCrossingPayment),
             _ => Self::Unknown,
         }
     }
@@ -504,9 +484,10 @@ impl Zip318Classification {
 /// Everything [`classify`] needs to observe about a transaction, gathered by whichever component
 /// can see it.
 ///
-/// A `None` field means THIS SOURCE CANNOT ANSWER, which is not the same as an answer of `false`.
-/// The struct is therefore a point in the information ordering described on
-/// [`Zip318Classification`], and [`Default::default`] (everything `None`) is its least element.
+/// An unanswered clause means THIS SOURCE CANNOT ANSWER, which is not the same as an answer of
+/// `false`. The struct is therefore a point in the information ordering described on
+/// [`Zip318Classification`], and [`Default::default`] (everything unanswered) is its least element.
+/// A source builds its evidence up from there, one clause at a time, through the `with_` methods.
 ///
 /// Two obligations on whoever fills this in, both of which keep [`classify`] monotone:
 ///
@@ -518,15 +499,87 @@ impl Zip318Classification {
 ///   the next can contradict its own earlier decisions.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct Zip318Evidence {
+    source_actions: Option<usize>,
+    destination_actions: Option<usize>,
+    other_bundles_present: Option<bool>,
+    source_is_send_to_self: Option<bool>,
+    sole_destination_value: Option<Zatoshis>,
+    expiry_is_canonical: Option<bool>,
+    anchor_on_grid: Option<bool>,
+    fee_is_canonical: Option<bool>,
+}
+
+impl Zip318Evidence {
+    /// Records the number of actions in the source-pool (Orchard) bundle.
+    pub fn with_source_actions(mut self, source_actions: Option<usize>) -> Self {
+        self.source_actions = source_actions;
+        self
+    }
+
+    /// Records the number of actions in the destination-pool (Ironwood) bundle.
+    pub fn with_destination_actions(mut self, destination_actions: Option<usize>) -> Self {
+        self.destination_actions = destination_actions;
+        self
+    }
+
+    /// Records whether any transparent or Sapling bundle is present.
+    pub fn with_other_bundles_present(mut self, other_bundles_present: Option<bool>) -> Self {
+        self.other_bundles_present = other_bundles_present;
+        self
+    }
+
+    /// Records whether the source-pool outputs are consistent with a send-to-self. See
+    /// [`source_is_send_to_self`](Self::source_is_send_to_self) for how tightly a given source
+    /// may claim this.
+    pub fn with_source_is_send_to_self(mut self, source_is_send_to_self: Option<bool>) -> Self {
+        self.source_is_send_to_self = source_is_send_to_self;
+        self
+    }
+
+    /// Records the value carried by the single value-carrying destination-pool output.
+    pub fn with_sole_destination_value(mut self, sole_destination_value: Option<Zatoshis>) -> Self {
+        self.sole_destination_value = sole_destination_value;
+        self
+    }
+
+    /// Records whether the expiry height is the canonical rolling expiry. See
+    /// [`expiry_is_canonical`](Self::expiry_is_canonical) for the height it must be judged
+    /// against.
+    pub fn with_expiry_is_canonical(mut self, expiry_is_canonical: Option<bool>) -> Self {
+        self.expiry_is_canonical = expiry_is_canonical;
+        self
+    }
+
+    /// Records whether the shielded anchor lies on the retention grid.
+    pub fn with_anchor_on_grid(mut self, anchor_on_grid: Option<bool>) -> Self {
+        self.anchor_on_grid = anchor_on_grid;
+        self
+    }
+
+    /// Records whether the fee is the one the canonical shape pays.
+    pub fn with_fee_is_canonical(mut self, fee_is_canonical: Option<bool>) -> Self {
+        self.fee_is_canonical = fee_is_canonical;
+        self
+    }
+
     /// The number of actions in the source-pool (Orchard) bundle, including padding dummies.
-    pub source_actions: Option<usize>,
+    pub fn source_actions(&self) -> Option<usize> {
+        self.source_actions
+    }
+
     /// The number of actions in the destination-pool (Ironwood) bundle, including padding dummies.
     /// Zero when there is no destination bundle at all.
-    pub destination_actions: Option<usize>,
+    pub fn destination_actions(&self) -> Option<usize> {
+        self.destination_actions
+    }
+
     /// Whether any transparent or Sapling bundle is present. No ZIP 318 transaction carries one.
-    pub other_bundles_present: Option<bool>,
+    pub fn other_bundles_present(&self) -> Option<bool> {
+        self.other_bundles_present
+    }
+
     /// Whether the source-pool outputs are consistent with a wallet-internal send-to-self, as
-    /// precisely as this source can tell.
+    /// precisely as the source that gathered this could tell.
     ///
     /// The clause names the CLAIM rather than a check, because how tightly it can be established
     /// depends on what the source can see, and no source can do better than its own view:
@@ -543,24 +596,40 @@ pub struct Zip318Evidence {
     ///
     /// The looser reading admits strictly more, so it keeps the over-approximation direction
     /// [`classify`] already has: no false negatives, some admitted look-alikes.
-    pub source_is_send_to_self: Option<bool>,
-    /// The single value-carrying destination-pool output, when the transaction has one.
-    pub sole_destination_output: Option<DestinationOutput>,
+    pub fn source_is_send_to_self(&self) -> Option<bool> {
+        self.source_is_send_to_self
+    }
+
+    /// The value carried by the single value-carrying destination-pool output, when the
+    /// transaction has one.
+    pub fn sole_destination_value(&self) -> Option<Zatoshis> {
+        self.sole_destination_value
+    }
+
     /// Whether the expiry height is the canonical rolling expiry, judged against a height the
     /// source considers authoritative: the MINED height once mined, or the target height for a
     /// transaction the wallet is itself building.
     ///
-    /// A source that has neither must leave this `None`. Judging an unmined transaction against
-    /// the chain tip is a monotonicity violation waiting to happen, because the canonical expiry
-    /// is a step function of the height and the answer would change once the transaction is mined
-    /// in the next period.
-    pub expiry_is_canonical: Option<bool>,
+    /// A source that has neither must leave this unanswered. Judging an unmined transaction
+    /// against the chain tip is a monotonicity violation waiting to happen, because the canonical
+    /// expiry is a step function of the height and the answer would change once the transaction is
+    /// mined in the next period.
+    pub fn expiry_is_canonical(&self) -> Option<bool> {
+        self.expiry_is_canonical
+    }
+
     /// Whether the shielded anchor lies on the retention grid. CONFIRMATORY: a source that cannot
-    /// resolve the anchor leaves this `None`, which widens the predicate rather than blocking it.
-    pub anchor_on_grid: Option<bool>,
+    /// resolve the anchor leaves this unanswered, which widens the predicate rather than blocking
+    /// it.
+    pub fn anchor_on_grid(&self) -> Option<bool> {
+        self.anchor_on_grid
+    }
+
     /// Whether the fee is the one the canonical shape pays under the standard rule. CONFIRMATORY,
     /// on the same terms as [`anchor_on_grid`](Self::anchor_on_grid).
-    pub fee_is_canonical: Option<bool>,
+    pub fn fee_is_canonical(&self) -> Option<bool> {
+        self.fee_is_canonical
+    }
 }
 
 /// Classifies a transaction against [ZIP 318] from what `evidence` could observe.
@@ -634,8 +703,8 @@ where
     }
 }
 
-/// The crossing branch of [`classify`]. This is the ONLY place where a transfer and a canonical
-/// crossing payment part company, and they part on the recipient alone.
+/// The crossing branch of [`classify`]: the canonical two-action source bundle carrying a
+/// canonical denomination across the turnstile.
 fn classify_crossing<C>(
     evidence: &Zip318Evidence,
     constants: &C,
@@ -648,18 +717,15 @@ where
         return Zip318Classification::Nonconforming;
     }
 
-    let Some(output) = evidence.sole_destination_output else {
+    let Some(value) = evidence.sole_destination_value else {
         return Zip318Classification::Unknown;
     };
 
-    if !constants.is_canonical_denomination(output.value) {
+    if !constants.is_canonical_denomination(value) {
         return Zip318Classification::Nonconforming;
     }
 
-    Zip318Classification::Conforms(match output.owner {
-        OutputOwner::OwnInternal => Zip318TxKind::Transfer,
-        OutputOwner::Other => Zip318TxKind::CanonicalCrossingPayment,
-    })
+    Zip318Classification::Conforms(Zip318TxKind::Transfer)
 }
 
 #[cfg(test)]
@@ -934,7 +1000,6 @@ mod tests {
             Zip318Classification::Nonconforming,
             Zip318Classification::Conforms(Zip318TxKind::Preparation),
             Zip318Classification::Conforms(Zip318TxKind::Transfer),
-            Zip318Classification::Conforms(Zip318TxKind::CanonicalCrossingPayment),
         ] {
             assert_eq!(
                 Zip318Classification::from_code(classification.to_code()),
@@ -956,7 +1021,7 @@ mod tests {
         );
 
         // A code from a newer version teaches an older consumer nothing, which is `Unknown`.
-        for unrecognised in [5, 99, -1] {
+        for unrecognised in [4, 99, -1] {
             assert_eq!(
                 Zip318Classification::from_code(unrecognised),
                 Zip318Classification::Unknown
@@ -967,30 +1032,26 @@ mod tests {
     /// Evidence for a well-formed preparation transaction, from a source that can answer every
     /// clause. Tests below knock out one field at a time.
     fn prep_evidence() -> Zip318Evidence {
-        Zip318Evidence {
-            source_actions: Some(PREP_TX_ACTIONS),
-            destination_actions: Some(0),
-            other_bundles_present: Some(false),
-            source_is_send_to_self: Some(true),
-            sole_destination_output: None,
-            expiry_is_canonical: Some(true),
-            anchor_on_grid: Some(true),
-            fee_is_canonical: Some(true),
-        }
+        Zip318Evidence::default()
+            .with_source_actions(Some(PREP_TX_ACTIONS))
+            .with_destination_actions(Some(0))
+            .with_other_bundles_present(Some(false))
+            .with_source_is_send_to_self(Some(true))
+            .with_expiry_is_canonical(Some(true))
+            .with_anchor_on_grid(Some(true))
+            .with_fee_is_canonical(Some(true))
     }
 
-    /// Evidence for a well-formed pool crossing carrying `value` to `owner`.
-    fn crossing_evidence(value: Zatoshis, owner: OutputOwner) -> Zip318Evidence {
-        Zip318Evidence {
-            source_actions: Some(CROSSING_SOURCE_ACTIONS),
-            destination_actions: Some(CROSSING_DESTINATION_ACTIONS),
-            other_bundles_present: Some(false),
-            source_is_send_to_self: None,
-            sole_destination_output: Some(DestinationOutput { value, owner }),
-            expiry_is_canonical: Some(true),
-            anchor_on_grid: Some(true),
-            fee_is_canonical: Some(true),
-        }
+    /// Evidence for a well-formed pool crossing carrying `value`.
+    fn crossing_evidence(value: Zatoshis) -> Zip318Evidence {
+        Zip318Evidence::default()
+            .with_source_actions(Some(CROSSING_SOURCE_ACTIONS))
+            .with_destination_actions(Some(CROSSING_DESTINATION_ACTIONS))
+            .with_other_bundles_present(Some(false))
+            .with_sole_destination_value(Some(value))
+            .with_expiry_is_canonical(Some(true))
+            .with_anchor_on_grid(Some(true))
+            .with_fee_is_canonical(Some(true))
     }
 
     /// The least element of the information ordering decides nothing.
@@ -1010,20 +1071,17 @@ mod tests {
         );
     }
 
-    /// The two crossing kinds differ ONLY in who the destination output pays.
+    /// A crossing conforms on its shape and its denomination alone. Nothing here observes the
+    /// recipient, which is exactly the indistinguishability the canonical shape buys: a payment to
+    /// a third party in this shape is the same transaction as a wallet's own migration transfer.
     #[test]
-    fn a_crossing_is_a_transfer_only_when_it_pays_the_account_itself() {
-        let value = Zatoshis::const_from_u64(COIN);
+    fn a_canonical_crossing_conforms() {
         assert_eq!(
             classify(
-                &crossing_evidence(value, OutputOwner::OwnInternal),
+                &crossing_evidence(Zatoshis::const_from_u64(COIN)),
                 &Zip318Params
             ),
             Zip318Classification::Conforms(Zip318TxKind::Transfer)
-        );
-        assert_eq!(
-            classify(&crossing_evidence(value, OutputOwner::Other), &Zip318Params),
-            Zip318Classification::Conforms(Zip318TxKind::CanonicalCrossingPayment)
         );
     }
 
@@ -1035,35 +1093,23 @@ mod tests {
         let cases: [(&str, Zip318Evidence); 5] = [
             (
                 "an ordinary split has a different action count",
-                Zip318Evidence {
-                    source_actions: Some(PREP_TX_ACTIONS + 1),
-                    ..prep_evidence()
-                },
+                prep_evidence().with_source_actions(Some(PREP_TX_ACTIONS + 1)),
             ),
             (
                 "no ZIP 318 transaction carries another bundle",
-                Zip318Evidence {
-                    other_bundles_present: Some(true),
-                    ..prep_evidence()
-                },
+                prep_evidence().with_other_bundles_present(Some(true)),
             ),
             (
                 "an ordinary expiry is not the rolling one",
-                Zip318Evidence {
-                    expiry_is_canonical: Some(false),
-                    ..prep_evidence()
-                },
+                prep_evidence().with_expiry_is_canonical(Some(false)),
             ),
             (
                 "a preparation output paying elsewhere is not a send-to-self",
-                Zip318Evidence {
-                    source_is_send_to_self: Some(false),
-                    ..prep_evidence()
-                },
+                prep_evidence().with_source_is_send_to_self(Some(false)),
             ),
             (
                 "a crossing of an off-series amount joins no anonymity set",
-                crossing_evidence(Zatoshis::const_from_u64(3 * COIN), OutputOwner::OwnInternal),
+                crossing_evidence(Zatoshis::const_from_u64(3 * COIN)),
             ),
         ];
 
@@ -1081,11 +1127,9 @@ mod tests {
     /// because no single one of them is rare enough on its own.
     #[test]
     fn a_coincidental_expiry_alone_does_not_conform() {
-        let evidence = Zip318Evidence {
-            other_bundles_present: Some(true),
-            expiry_is_canonical: Some(true),
-            ..prep_evidence()
-        };
+        let evidence = prep_evidence()
+            .with_other_bundles_present(Some(true))
+            .with_expiry_is_canonical(Some(true));
         assert_eq!(
             classify(&evidence, &Zip318Params),
             Zip318Classification::Nonconforming
@@ -1097,14 +1141,8 @@ mod tests {
     #[test]
     fn confirmatory_clauses_refute_but_do_not_block() {
         for knock_out in [
-            Zip318Evidence {
-                anchor_on_grid: Some(false),
-                ..prep_evidence()
-            },
-            Zip318Evidence {
-                fee_is_canonical: Some(false),
-                ..prep_evidence()
-            },
+            prep_evidence().with_anchor_on_grid(Some(false)),
+            prep_evidence().with_fee_is_canonical(Some(false)),
         ] {
             assert_eq!(
                 classify(&knock_out, &Zip318Params),
@@ -1113,11 +1151,9 @@ mod tests {
         }
 
         // A source that cannot answer either one still decides.
-        let unanswerable = Zip318Evidence {
-            anchor_on_grid: None,
-            fee_is_canonical: None,
-            ..prep_evidence()
-        };
+        let unanswerable = prep_evidence()
+            .with_anchor_on_grid(None)
+            .with_fee_is_canonical(None);
         assert_eq!(
             classify(&unanswerable, &Zip318Params),
             Zip318Classification::Conforms(Zip318TxKind::Preparation)
@@ -1129,26 +1165,11 @@ mod tests {
     #[test]
     fn an_unanswered_required_clause_is_unknown_not_a_refutation() {
         let knock_outs = [
-            Zip318Evidence {
-                source_actions: None,
-                ..prep_evidence()
-            },
-            Zip318Evidence {
-                destination_actions: None,
-                ..prep_evidence()
-            },
-            Zip318Evidence {
-                other_bundles_present: None,
-                ..prep_evidence()
-            },
-            Zip318Evidence {
-                expiry_is_canonical: None,
-                ..prep_evidence()
-            },
-            Zip318Evidence {
-                source_is_send_to_self: None,
-                ..prep_evidence()
-            },
+            prep_evidence().with_source_actions(None),
+            prep_evidence().with_destination_actions(None),
+            prep_evidence().with_other_bundles_present(None),
+            prep_evidence().with_expiry_is_canonical(None),
+            prep_evidence().with_source_is_send_to_self(None),
         ];
 
         for evidence in knock_outs {
@@ -1159,10 +1180,8 @@ mod tests {
         }
 
         // The same for the crossing branch's own required clause.
-        let no_output = Zip318Evidence {
-            sole_destination_output: None,
-            ..crossing_evidence(Zatoshis::const_from_u64(COIN), OutputOwner::OwnInternal)
-        };
+        let no_output =
+            crossing_evidence(Zatoshis::const_from_u64(COIN)).with_sole_destination_value(None);
         assert_eq!(
             classify(&no_output, &Zip318Params),
             Zip318Classification::Unknown
@@ -1179,24 +1198,16 @@ mod tests {
         // conforming and a refuted transaction.
         for full in [
             prep_evidence(),
-            crossing_evidence(Zatoshis::const_from_u64(COIN), OutputOwner::Other),
-            Zip318Evidence {
-                other_bundles_present: Some(true),
-                ..prep_evidence()
-            },
+            crossing_evidence(Zatoshis::const_from_u64(COIN)),
+            prep_evidence().with_other_bundles_present(Some(true)),
         ] {
             let chain = [
                 Zip318Evidence::default(),
-                Zip318Evidence {
-                    source_actions: full.source_actions,
-                    destination_actions: full.destination_actions,
-                    ..Zip318Evidence::default()
-                },
-                Zip318Evidence {
-                    sole_destination_output: None,
-                    expiry_is_canonical: None,
-                    ..full
-                },
+                Zip318Evidence::default()
+                    .with_source_actions(full.source_actions())
+                    .with_destination_actions(full.destination_actions()),
+                full.with_sole_destination_value(None)
+                    .with_expiry_is_canonical(None),
                 full,
             ];
 

--- a/components/zcash_protocol/src/zip318.rs
+++ b/components/zcash_protocol/src/zip318.rs
@@ -349,8 +349,33 @@ pub trait PoolMigrationConstants {
     /// This is the sharpest single ZIP 318 discriminator. An ordinary transaction expires a fixed
     /// short delta after its target height, so its expiry is essentially uniform; a ZIP 318
     /// transaction's expiry is one of the few heights the rolling window admits.
+    ///
+    /// Use [`is_canonical_expiry_value`](Self::is_canonical_expiry_value) instead when no
+    /// reference height is available, or when the answer must not change as one becomes available.
     fn is_canonical_expiry(&self, expiry: BlockHeight, reference: BlockHeight) -> bool {
         expiry == self.canonical_expiry(reference)
+    }
+
+    /// Returns whether `expiry` could be a canonical rolling expiry for SOME height: whether it is
+    /// a multiple of the expiry modulus and at least one whole window above zero.
+    ///
+    /// This is the height-INDEPENDENT form of
+    /// [`is_canonical_expiry`](Self::is_canonical_expiry), and it exists because the reference
+    /// height a transaction should be judged against is not always available when the judgement
+    /// must be made. A transaction observed before it is mined has no mined height, and judging it
+    /// against the chain tip instead would be unstable: the canonical expiry is a step function of
+    /// the height, so the answer would change once the transaction was mined in a later modulus
+    /// period, contradicting an earlier decision.
+    ///
+    /// It is weaker, deliberately. It admits a canonical expiry belonging to a different period
+    /// than the one the transaction was mined in, which the reference-height form rejects. Nearly
+    /// all of the discriminating power survives: an ordinary expiry is a short fixed delta past an
+    /// arbitrary target height, so it lands on a multiple of the modulus with probability about one
+    /// in the modulus.
+    fn is_canonical_expiry_value(&self, expiry: BlockHeight) -> bool {
+        let (modulus, window) = self.expiry_window();
+        let expiry = u32::from(expiry);
+        expiry >= window && expiry % modulus == 0
     }
 }
 
@@ -434,6 +459,47 @@ pub enum Zip318Classification {
 }
 
 impl Zip318Classification {
+    /// The stable integer encoding of this classification, for a store to persist and a foreign
+    /// function interface to carry.
+    ///
+    /// [`Unknown`](Self::Unknown) is `0`, which is also the value a store should DEFAULT the
+    /// column to. A row holding it has not been classified, and nothing will classify it on its
+    /// own: it needs the transaction rescanned. That is deliberately a real value rather than
+    /// NULL, so a store can find such rows with an ordinary query, and deliberately distinct from
+    /// [`Nonconforming`](Self::Nonconforming), which is a decision that the transaction is not a
+    /// ZIP 318 one. Confusing the two would present "we never looked" as "we looked and it is
+    /// not", which is exactly the claim this type refuses to make without evidence.
+    ///
+    /// The encoding is APPEND-ONLY: existing values never change meaning, and new kinds take new
+    /// codes. See [`from_code`](Self::from_code) for what an older consumer does with a newer one.
+    pub fn to_code(&self) -> i64 {
+        match self {
+            Self::Unknown => 0,
+            Self::Nonconforming => 1,
+            Self::Conforms(Zip318TxKind::Preparation) => 2,
+            Self::Conforms(Zip318TxKind::Transfer) => 3,
+            Self::Conforms(Zip318TxKind::CanonicalCrossingPayment) => 4,
+        }
+    }
+
+    /// Decodes [`to_code`](Self::to_code). An unrecognised code decodes to
+    /// [`Unknown`](Self::Unknown).
+    ///
+    /// Unknown decodes to unknown rather than to a refusal on purpose. A consumer built against an
+    /// older version of this crate meeting a code from a newer one has learned nothing about the
+    /// transaction, and saying so is honest; deciding `Nonconforming` instead would assert a
+    /// judgement it is not entitled to, and would break monotonicity the moment the consumer was
+    /// updated and changed its mind.
+    pub fn from_code(code: i64) -> Self {
+        match code {
+            1 => Self::Nonconforming,
+            2 => Self::Conforms(Zip318TxKind::Preparation),
+            3 => Self::Conforms(Zip318TxKind::Transfer),
+            4 => Self::Conforms(Zip318TxKind::CanonicalCrossingPayment),
+            _ => Self::Unknown,
+        }
+    }
+
     /// The kind, if this classification is a conforming one.
     pub fn kind(&self) -> Option<Zip318TxKind> {
         match self {
@@ -835,6 +901,70 @@ mod tests {
         assert_eq!(ShortWindow.canonical_expiry(h), BlockHeight::from_u32(400));
         assert!(ShortWindow.is_canonical_expiry(BlockHeight::from_u32(400), h));
         assert!(!ShortWindow.is_canonical_expiry(expiry_height(h), h));
+    }
+
+    /// The height-independent expiry test admits every canonical expiry, and rejects the ordinary
+    /// expiry of a transaction targeting any height.
+    #[test]
+    fn the_height_independent_expiry_test_admits_canonical_expiries() {
+        for height in [0u32, 1, 144, 34_559, 34_560, 2_000_000] {
+            let h = BlockHeight::from_u32(height);
+            assert!(
+                Zip318Params.is_canonical_expiry_value(expiry_height(h)),
+                "the canonical expiry for {height} must be admitted without a reference height"
+            );
+            assert!(
+                !Zip318Params.is_canonical_expiry_value(h + 40),
+                "an ordinary expiry for {height} must be rejected"
+            );
+        }
+
+        // Weaker than the reference-height form, and this is the gap: an expiry canonical for one
+        // period is admitted while a transaction mined in another period is being judged.
+        let other_period = expiry_height(BlockHeight::from_u32(0));
+        let mined_much_later = BlockHeight::from_u32(10 * EXPIRY_MODULUS);
+        assert!(Zip318Params.is_canonical_expiry_value(other_period));
+        assert!(!Zip318Params.is_canonical_expiry(other_period, mined_much_later));
+    }
+
+    /// The persisted encoding round-trips, and the two ways of not having a label stay distinct:
+    /// "never classified, needs a rescan" must never be stored or read as "classified, and not a
+    /// ZIP 318 transaction".
+    #[test]
+    fn the_classification_encoding_round_trips() {
+        for classification in [
+            Zip318Classification::Unknown,
+            Zip318Classification::Nonconforming,
+            Zip318Classification::Conforms(Zip318TxKind::Preparation),
+            Zip318Classification::Conforms(Zip318TxKind::Transfer),
+            Zip318Classification::Conforms(Zip318TxKind::CanonicalCrossingPayment),
+        ] {
+            assert_eq!(
+                Zip318Classification::from_code(classification.to_code()),
+                classification
+            );
+        }
+
+        // Zero is `Unknown`, so a column defaulting to zero reads back as unclassified rather
+        // than as a decision. This is what a backfill leaves behind.
+        assert_eq!(Zip318Classification::Unknown.to_code(), 0);
+        assert_eq!(
+            Zip318Classification::from_code(0),
+            Zip318Classification::Unknown
+        );
+        assert_ne!(
+            Zip318Classification::Unknown.to_code(),
+            Zip318Classification::Nonconforming.to_code(),
+            "never classified must not encode as classified-and-refused"
+        );
+
+        // A code from a newer version teaches an older consumer nothing, which is `Unknown`.
+        for unrecognised in [5, 99, -1] {
+            assert_eq!(
+                Zip318Classification::from_code(unrecognised),
+                Zip318Classification::Unknown
+            );
+        }
     }
 
     /// Evidence for a well-formed preparation transaction, from a source that can answer every

--- a/components/zcash_protocol/src/zip318.rs
+++ b/components/zcash_protocol/src/zip318.rs
@@ -542,11 +542,25 @@ pub struct Zip318Evidence {
     pub destination_actions: Option<usize>,
     /// Whether any transparent or Sapling bundle is present. No ZIP 318 transaction carries one.
     pub other_bundles_present: Option<bool>,
-    /// Whether every value-carrying source-pool output pays the account's own internal address.
+    /// Whether the source-pool outputs are consistent with a wallet-internal send-to-self, as
+    /// precisely as this source can tell.
     ///
-    /// Padding dummies carry no value and are excluded; only the outputs the wallet actually
-    /// created are considered.
-    pub source_outputs_all_internal: Option<bool>,
+    /// The clause names the CLAIM rather than a check, because how tightly it can be established
+    /// depends on what the source can see, and no source can do better than its own view:
+    ///
+    /// - From an unproven transaction the wallet is building, exactly: the values and recipients
+    ///   are all present, so "every value-carrying output pays the account's own internal address"
+    ///   is directly checkable, with zero-valued padding dummies excluded.
+    /// - From a MINED transaction, only loosely, and this is not a shortcoming of the
+    ///   implementation. A padding dummy and an unrelated party's output are equally
+    ///   undecryptable, so the two cannot be told apart at all, which is precisely what the
+    ///   padding is for. The strongest sound reading is "at least one output decrypts to the
+    ///   account's own internal address, none decrypts to one of its external addresses, and no
+    ///   external recipient is otherwise known".
+    ///
+    /// The looser reading admits strictly more, so it keeps the over-approximation direction
+    /// [`classify`] already has: no false negatives, some admitted look-alikes.
+    pub source_is_send_to_self: Option<bool>,
     /// The single value-carrying destination-pool output, when the transaction has one.
     pub sole_destination_output: Option<DestinationOutput>,
     /// Whether the expiry height is the canonical rolling expiry, judged against a height the
@@ -630,7 +644,7 @@ where
         return Zip318Classification::Nonconforming;
     }
 
-    match evidence.source_outputs_all_internal {
+    match evidence.source_is_send_to_self {
         None => Zip318Classification::Unknown,
         Some(false) => Zip318Classification::Nonconforming,
         Some(true) => Zip318Classification::Conforms(Zip318TxKind::Preparation),
@@ -974,7 +988,7 @@ mod tests {
             source_actions: Some(PREP_TX_ACTIONS),
             destination_actions: Some(0),
             other_bundles_present: Some(false),
-            source_outputs_all_internal: Some(true),
+            source_is_send_to_self: Some(true),
             sole_destination_output: None,
             expiry_is_canonical: Some(true),
             anchor_on_grid: Some(true),
@@ -988,7 +1002,7 @@ mod tests {
             source_actions: Some(CROSSING_SOURCE_ACTIONS),
             destination_actions: Some(CROSSING_DESTINATION_ACTIONS),
             other_bundles_present: Some(false),
-            source_outputs_all_internal: None,
+            source_is_send_to_self: None,
             sole_destination_output: Some(DestinationOutput { value, owner }),
             expiry_is_canonical: Some(true),
             anchor_on_grid: Some(true),
@@ -1060,7 +1074,7 @@ mod tests {
             (
                 "a preparation output paying elsewhere is not a send-to-self",
                 Zip318Evidence {
-                    source_outputs_all_internal: Some(false),
+                    source_is_send_to_self: Some(false),
                     ..prep_evidence()
                 },
             ),
@@ -1149,7 +1163,7 @@ mod tests {
                 ..prep_evidence()
             },
             Zip318Evidence {
-                source_outputs_all_internal: None,
+                source_is_send_to_self: None,
                 ..prep_evidence()
             },
         ];

--- a/components/zcash_protocol/src/zip318.rs
+++ b/components/zcash_protocol/src/zip318.rs
@@ -499,23 +499,6 @@ impl Zip318Classification {
             _ => Self::Unknown,
         }
     }
-
-    /// The kind, if this classification is a conforming one.
-    pub fn kind(&self) -> Option<Zip318TxKind> {
-        match self {
-            Self::Conforms(kind) => Some(*kind),
-            _ => None,
-        }
-    }
-
-    /// Whether this is a transaction of a wallet's own migration: a preparation transaction or a
-    /// transfer, but NOT a canonical crossing payment to a third party.
-    pub fn is_own_migration(&self) -> bool {
-        matches!(
-            self,
-            Self::Conforms(Zip318TxKind::Preparation) | Self::Conforms(Zip318TxKind::Transfer)
-        )
-    }
 }
 
 /// Everything [`classify`] needs to observe about a transaction, gathered by whichever component

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -13,10 +13,8 @@ workspace.
 ### Added
 - `pczt::Pczt::has_data_in_pool`, which reports whether the always-present
   bundle for a given pool actually holds anything.
-- `pczt::orchard::Bundle::{sole_action, value_carrying_outputs_all_pay}`
-- `pczt::orchard::Output::pays`, which tests the recipient without the caller
-  handling the raw address encoding. It and `value_carrying_outputs_all_pay`
-  return `None` when a field they judge has been redacted from the PCZT.
+- `pczt::orchard::Bundle::{sole_action, value_carrying_outputs_all_pay}`. The
+  latter returns `None` when a field it judges has been redacted from the PCZT.
 
 ## [0.9.1] - 2026-07-26
 

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -11,13 +11,12 @@ workspace.
 ## [Unreleased]
 
 ### Added
-- `pczt::Pczt::{has_transparent_data, has_sapling_data}`, which report whether
-  the always-present transparent and Sapling bundles actually hold anything.
-- `pczt::orchard::Bundle::{outputs, sole_action, value_carrying_outputs_all_pay}`
-- `pczt::orchard::Output::{carries_value, pays}`, which distinguish an output a
-  wallet asked for from a zero-valued padding dummy, and test the recipient
-  without the caller handling the raw address encoding. Both return `None` when
-  the field they judge has been redacted from the PCZT.
+- `pczt::Pczt::has_data_in_pool`, which reports whether the always-present
+  bundle for a given pool actually holds anything.
+- `pczt::orchard::Bundle::{sole_action, value_carrying_outputs_all_pay}`
+- `pczt::orchard::Output::pays`, which tests the recipient without the caller
+  handling the raw address encoding. It and `value_carrying_outputs_all_pay`
+  return `None` when a field they judge has been redacted from the PCZT.
 
 ## [0.9.1] - 2026-07-26
 

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -10,6 +10,15 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `pczt::Pczt::{has_transparent_data, has_sapling_data}`, which report whether
+  the always-present transparent and Sapling bundles actually hold anything.
+- `pczt::orchard::Bundle::{outputs, sole_action, value_carrying_outputs_all_pay}`
+- `pczt::orchard::Output::{carries_value, pays}`, which distinguish an output a
+  wallet asked for from a zero-valued padding dummy, and test the recipient
+  without the caller handling the raw address encoding. Both return `None` when
+  the field they judge has been redacted from the PCZT.
+
 ## [0.9.1] - 2026-07-26
 
 ### Fixed

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -25,6 +25,7 @@ use alloc::vec::Vec;
 
 use getset::Getters;
 
+use zcash_protocol::PoolType;
 #[cfg(any(feature = "io-finalizer", feature = "signer", feature = "tx-extractor"))]
 use zcash_protocol::constants::{V6_TX_VERSION, V6_VERSION_GROUP_ID};
 #[cfg(all(
@@ -408,20 +409,21 @@ pub enum EncodingError {
 }
 
 impl Pczt {
-    /// Whether this PCZT carries any transparent inputs or outputs.
+    /// Whether this PCZT carries any inputs or outputs in the given pool.
     ///
-    /// The transparent bundle is always present as a value, so its mere existence says nothing;
-    /// this asks whether it holds anything.
-    pub fn has_transparent_data(&self) -> bool {
-        !self.transparent.inputs().is_empty() || !self.transparent.outputs().is_empty()
-    }
-
-    /// Whether this PCZT carries any Sapling spends or outputs.
-    ///
-    /// As for [`has_transparent_data`](Self::has_transparent_data), the bundle is always present
-    /// and this asks whether it holds anything.
-    pub fn has_sapling_data(&self) -> bool {
-        !self.sapling.spends().is_empty() || !self.sapling.outputs().is_empty()
+    /// Every bundle is always present as a value, so its existence says nothing; this asks whether
+    /// it holds anything.
+    pub fn has_data_in_pool(&self, pool: PoolType) -> bool {
+        match pool {
+            PoolType::TRANSPARENT => {
+                !self.transparent.inputs().is_empty() || !self.transparent.outputs().is_empty()
+            }
+            PoolType::SAPLING => {
+                !self.sapling.spends().is_empty() || !self.sapling.outputs().is_empty()
+            }
+            PoolType::ORCHARD => !self.orchard.actions().is_empty(),
+            PoolType::IRONWOOD => !self.ironwood.actions().is_empty(),
+        }
     }
 
     /// Parses a PCZT from its encoding.

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -408,6 +408,22 @@ pub enum EncodingError {
 }
 
 impl Pczt {
+    /// Whether this PCZT carries any transparent inputs or outputs.
+    ///
+    /// The transparent bundle is always present as a value, so its mere existence says nothing;
+    /// this asks whether it holds anything.
+    pub fn has_transparent_data(&self) -> bool {
+        !self.transparent.inputs().is_empty() || !self.transparent.outputs().is_empty()
+    }
+
+    /// Whether this PCZT carries any Sapling spends or outputs.
+    ///
+    /// As for [`has_transparent_data`](Self::has_transparent_data), the bundle is always present
+    /// and this asks whether it holds anything.
+    pub fn has_sapling_data(&self) -> bool {
+        !self.sapling.spends().is_empty() || !self.sapling.outputs().is_empty()
+    }
+
     /// Parses a PCZT from its encoding.
     pub fn parse(bytes: &[u8]) -> Result<Self, ParseError> {
         let (version, body) = parse_header(bytes, MAGIC_BYTES).map_err(|e| match e {

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -92,20 +92,7 @@ pub struct Bundle {
 }
 
 impl Bundle {
-    /// The outputs of this bundle's actions, in action order.
-    ///
-    /// Every action carries an output, including the padding dummies a Constructor fabricates to
-    /// bring the bundle up to a required action count; use [`Output::carries_value`] to tell them
-    /// apart from the outputs a wallet actually asked for.
-    pub fn outputs(&self) -> impl Iterator<Item = &Output> {
-        self.actions.iter().map(|action| &action.output)
-    }
-
     /// This bundle's sole action, or `None` if it does not have exactly one.
-    ///
-    /// A one-action bundle is a shape some protocols require (an unpadded single output, for
-    /// example), and asking for it directly avoids a caller indexing into `actions` after a
-    /// separate length check.
     pub fn sole_action(&self) -> Option<&Action> {
         match self.actions.as_slice() {
             [action] => Some(action),
@@ -116,13 +103,15 @@ impl Bundle {
     /// Whether every output of this bundle that carries value pays `recipient`, which is what
     /// makes the bundle a send-to-self.
     ///
-    /// Zero-valued padding dummies are excluded: they pay nobody in particular, so counting them
-    /// would make every padded bundle fail. Returns `None` if any output has had the value or the
-    /// recipient it would be judged on redacted, since the question cannot then be answered rather
-    /// than answered negatively.
+    /// Zero-valued padding dummies are excluded: a Constructor fabricates them to bring the bundle
+    /// up to a required action count and they pay nobody in particular, so counting them would make
+    /// every padded bundle fail. Returns `None` if any output has had the value or the recipient it
+    /// would be judged on redacted, since the question cannot then be answered rather than answered
+    /// negatively.
     pub fn value_carrying_outputs_all_pay(&self, recipient: &[u8; 43]) -> Option<bool> {
-        for output in self.outputs() {
-            if !output.carries_value()? {
+        for action in &self.actions {
+            let output = &action.output;
+            if output.value? == 0 {
                 continue;
             }
             if !output.pays(recipient)? {
@@ -718,14 +707,6 @@ pub struct Output {
 }
 
 impl Output {
-    /// Whether this output carries value, i.e. whether it is one a wallet asked for rather than a
-    /// zero-valued padding dummy a Constructor fabricated.
-    ///
-    /// Returns `None` if the value has been redacted from the PCZT.
-    pub fn carries_value(&self) -> Option<bool> {
-        self.value.map(|value| value > 0)
-    }
-
     /// Whether this output pays `recipient`, given as the [raw encoding] of an Orchard payment
     /// address.
     ///

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -91,6 +91,48 @@ pub struct Bundle {
     pub(crate) bsk: Option<[u8; 32]>,
 }
 
+impl Bundle {
+    /// The outputs of this bundle's actions, in action order.
+    ///
+    /// Every action carries an output, including the padding dummies a Constructor fabricates to
+    /// bring the bundle up to a required action count; use [`Output::carries_value`] to tell them
+    /// apart from the outputs a wallet actually asked for.
+    pub fn outputs(&self) -> impl Iterator<Item = &Output> {
+        self.actions.iter().map(|action| &action.output)
+    }
+
+    /// This bundle's sole action, or `None` if it does not have exactly one.
+    ///
+    /// A one-action bundle is a shape some protocols require (an unpadded single output, for
+    /// example), and asking for it directly avoids a caller indexing into `actions` after a
+    /// separate length check.
+    pub fn sole_action(&self) -> Option<&Action> {
+        match self.actions.as_slice() {
+            [action] => Some(action),
+            _ => None,
+        }
+    }
+
+    /// Whether every output of this bundle that carries value pays `recipient`, which is what
+    /// makes the bundle a send-to-self.
+    ///
+    /// Zero-valued padding dummies are excluded: they pay nobody in particular, so counting them
+    /// would make every padded bundle fail. Returns `None` if any output has had the value or the
+    /// recipient it would be judged on redacted, since the question cannot then be answered rather
+    /// than answered negatively.
+    pub fn value_carrying_outputs_all_pay(&self, recipient: &[u8; 43]) -> Option<bool> {
+        for output in self.outputs() {
+            if !output.carries_value()? {
+                continue;
+            }
+            if !output.pays(recipient)? {
+                return Some(false);
+            }
+        }
+        Some(true)
+    }
+}
+
 /// The default Orchard bundle flags: both spends and outputs enabled (bits 0 and
 /// 1). This is the value the Creator sets on a new bundle, and the flag value of
 /// an empty bundle for serialization purposes.
@@ -673,6 +715,26 @@ pub struct Output {
     /// Proprietary fields related to the note being created.
     #[getset(get = "pub")]
     pub(crate) proprietary: BTreeMap<String, Vec<u8>>,
+}
+
+impl Output {
+    /// Whether this output carries value, i.e. whether it is one a wallet asked for rather than a
+    /// zero-valued padding dummy a Constructor fabricated.
+    ///
+    /// Returns `None` if the value has been redacted from the PCZT.
+    pub fn carries_value(&self) -> Option<bool> {
+        self.value.map(|value| value > 0)
+    }
+
+    /// Whether this output pays `recipient`, given as the [raw encoding] of an Orchard payment
+    /// address.
+    ///
+    /// Returns `None` if the recipient has been redacted from the PCZT.
+    ///
+    /// [raw encoding]: https://zips.z.cash/protocol/protocol.pdf#orchardpaymentaddrencoding
+    pub fn pays(&self, recipient: &[u8; 43]) -> Option<bool> {
+        self.recipient.map(|paid| &paid == recipient)
+    }
 }
 
 /// Types for the v1 Orchard PCZT encoding.

--- a/pczt/src/orchard.rs
+++ b/pczt/src/orchard.rs
@@ -100,21 +100,23 @@ impl Bundle {
         }
     }
 
-    /// Whether every output of this bundle that carries value pays `recipient`, which is what
-    /// makes the bundle a send-to-self.
+    /// Whether every output of this bundle that carries value pays `recipient`, given as the [raw
+    /// encoding] of an Orchard payment address, which is what makes the bundle a send-to-self.
     ///
     /// Zero-valued padding dummies are excluded: a Constructor fabricates them to bring the bundle
     /// up to a required action count and they pay nobody in particular, so counting them would make
     /// every padded bundle fail. Returns `None` if any output has had the value or the recipient it
     /// would be judged on redacted, since the question cannot then be answered rather than answered
     /// negatively.
+    ///
+    /// [raw encoding]: https://zips.z.cash/protocol/protocol.pdf#orchardpaymentaddrencoding
     pub fn value_carrying_outputs_all_pay(&self, recipient: &[u8; 43]) -> Option<bool> {
         for action in &self.actions {
             let output = &action.output;
             if output.value? == 0 {
                 continue;
             }
-            if !output.pays(recipient)? {
+            if &output.recipient? != recipient {
                 return Some(false);
             }
         }
@@ -704,18 +706,6 @@ pub struct Output {
     /// Proprietary fields related to the note being created.
     #[getset(get = "pub")]
     pub(crate) proprietary: BTreeMap<String, Vec<u8>>,
-}
-
-impl Output {
-    /// Whether this output pays `recipient`, given as the [raw encoding] of an Orchard payment
-    /// address.
-    ///
-    /// Returns `None` if the recipient has been redacted from the PCZT.
-    ///
-    /// [raw encoding]: https://zips.z.cash/protocol/protocol.pdf#orchardpaymentaddrencoding
-    pub fn pays(&self, recipient: &[u8; 43]) -> Option<bool> {
-        self.recipient.map(|paid| &paid == recipient)
-    }
 }
 
 /// Types for the v1 Orchard PCZT encoding.

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -10,6 +10,16 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `zcash_client_backend::data_api::zip318`, which assembles ZIP 318 classification
+  evidence from a decrypted transaction and classifies it. What it can observe is
+  weaker than what the same predicate sees on a transaction the wallet is building,
+  because on chain a zero-valued padding dummy and an unrelated party's output are
+  equally undecryptable; the weaker reading admits more, never less.
+- `zcash_client_backend::data_api::ll::LowLevelWalletWrite::put_zip318_classification`,
+  called by `store_decrypted_tx`. A store that has not been given a classification
+  for a transaction must report it as unclassified, never as `Nonconforming`.
+
 ### Fixed
 - `zcash_client_backend::data_api::wallet::extract_and_store_transaction_from_pczt`
   now records the transaction's Ironwood outputs in the stored `SentTransaction`.

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -138,6 +138,8 @@ pub use locking::OutputLockStore;
 pub use locking::ambassador_impl_OutputLockStore;
 pub mod scanning;
 pub mod wallet;
+#[cfg(feature = "orchard")]
+pub mod zip318;
 
 #[cfg(any(test, feature = "test-dependencies"))]
 pub mod testing;

--- a/zcash_client_backend/src/data_api/ll.rs
+++ b/zcash_client_backend/src/data_api/ll.rs
@@ -24,6 +24,7 @@ use zcash_protocol::{
     consensus::{BlockHeight, TxIndex},
     memo::MemoBytes,
     value::{BalanceError, Zatoshis},
+    zip318::Zip318Classification,
 };
 use zip32::Scope;
 
@@ -388,6 +389,28 @@ pub trait LowLevelWalletWrite: LowLevelWalletRead {
         &mut self,
         txid: TxId,
         status: TransactionStatus,
+    ) -> Result<(), Self::Error>;
+
+    /// Records how a transaction classifies against [ZIP 318], so that a wallet can label a
+    /// migration transaction in its history without consulting a migration plan.
+    ///
+    /// A store persists this rather than recomputing it, because the evidence it rests on is only
+    /// all present at once while the transaction is being decrypted. A store that has not been
+    /// given a classification for a transaction MUST report it as
+    /// [`Zip318Classification::Unknown`] rather than as
+    /// [`Nonconforming`](Zip318Classification::Nonconforming): the two mean "we never looked" and
+    /// "we looked and it is not one", and presenting the first as the second asserts a judgement
+    /// the wallet has not made.
+    ///
+    /// This is called at most once per transaction. Every input to the classification is fixed by
+    /// the time a transaction is decrypted, so the value never needs revisiting; in particular it
+    /// does not depend on the mined height, which would otherwise make it change under the store.
+    ///
+    /// [ZIP 318]: https://zips.z.cash/zip-0318
+    fn put_zip318_classification(
+        &mut self,
+        tx_ref: Self::TxRef,
+        classification: Zip318Classification,
     ) -> Result<(), Self::Error>;
 
     /// Adds information about a received Sapling note to the wallet, or updates any existing

--- a/zcash_client_backend/src/data_api/ll/wallet.rs
+++ b/zcash_client_backend/src/data_api/ll/wallet.rs
@@ -34,6 +34,9 @@ use crate::{
 
 use super::{LowLevelWalletRead, LowLevelWalletWrite, TxMeta};
 
+#[cfg(feature = "orchard")]
+use crate::data_api::anchor_retention::{AnchorRetentionInterval, PoolMigrationParams};
+
 #[cfg(feature = "transparent-inputs")]
 use {
     crate::data_api::Account,
@@ -940,6 +943,30 @@ where
     let tx_ref = wallet_db.put_tx_data(d_tx.tx(), fee, None, None, observed_height)?;
     if let Some(height) = d_tx.mined_height() {
         wallet_db.set_transaction_status(d_tx.tx().txid(), TransactionStatus::Mined(height))?;
+    }
+
+    // Record how the transaction classifies against ZIP 318, so that a wallet can label a
+    // migration transaction in its history without a migration plan, which does not survive a
+    // seed restore. This is the one moment at which the parsed transaction and the decrypted
+    // outputs are both in hand; a store recomputing it later would have neither.
+    //
+    // The SPECIFIED parameters are used rather than the store's own. The only value a wallet
+    // overrides is the anchor bucket interval, and this evidence source cannot evaluate the anchor
+    // clause at all (resolving an anchor to a height needs the retained boundary checkpoints), so
+    // the override cannot change the answer. Deliberately not read from the store: `LowLevelWalletRead`
+    // does not expose it, and adding a second accessor for a grid the store is the authority on is
+    // exactly how two call sites come to disagree. Thread the store's parameters in here if a
+    // future clause ever consults the grid.
+    #[cfg(feature = "orchard")]
+    {
+        let params = PoolMigrationParams::from(AnchorRetentionInterval::default());
+        let classification = crate::data_api::zip318::classify_decrypted_tx(
+            d_tx.tx(),
+            d_tx.orchard_outputs(),
+            d_tx.ironwood_outputs(),
+            &params,
+        );
+        wallet_db.put_zip318_classification(tx_ref, classification)?;
     }
 
     let has_wallet_shielded_spend = mark_notes_spent(

--- a/zcash_client_backend/src/data_api/zip318.rs
+++ b/zcash_client_backend/src/data_api/zip318.rs
@@ -19,9 +19,7 @@
 
 use zcash_primitives::transaction::Transaction;
 use zcash_protocol::value::Zatoshis;
-use zcash_protocol::zip318::{
-    DestinationOutput, OutputOwner, PoolMigrationConstants, Zip318Classification, Zip318Evidence,
-};
+use zcash_protocol::zip318::{PoolMigrationConstants, Zip318Classification, Zip318Evidence};
 
 use crate::decrypt::{DecryptedOutput, TransferType};
 
@@ -60,25 +58,28 @@ fn evidence_from_decrypted_tx<AccountId, C>(
 where
     C: PoolMigrationConstants + ?Sized,
 {
-    Zip318Evidence {
-        source_actions: Some(action_count(tx.orchard_bundle().map(|b| b.actions().len()))),
-        destination_actions: Some(action_count(
+    // The expiry clause takes the height-independent form, deliberately. The reference-height form
+    // cannot be evaluated before the transaction is mined, and judging it against the chain tip
+    // instead would let the answer change once the transaction was mined in a later modulus period,
+    // contradicting a decision already recorded.
+    //
+    // Neither confirmatory clause is answerable here, so both are left unanswered. Resolving the
+    // anchor to a height needs the wallet's retained boundary checkpoints, and the fee needs the
+    // value of inputs the wallet may not own; a store that has both may answer them and narrow the
+    // result.
+    Zip318Evidence::default()
+        .with_source_actions(Some(action_count(
+            tx.orchard_bundle().map(|b| b.actions().len()),
+        )))
+        .with_destination_actions(Some(action_count(
             tx.ironwood_bundle().map(|b| b.actions().len()),
-        )),
-        other_bundles_present: Some(other_bundles_present(tx)),
-        source_is_send_to_self: Some(is_send_to_self(orchard_outputs)),
-        sole_destination_output: sole_destination_output(ironwood_outputs),
-        // The height-independent form, deliberately. The reference-height form cannot be evaluated
-        // before the transaction is mined, and judging it against the chain tip instead would let
-        // the answer change once the transaction was mined in a later modulus period, contradicting
-        // a decision already recorded.
-        expiry_is_canonical: Some(constants.is_canonical_expiry_value(tx.expiry_height())),
-        // Neither confirmatory clause is answerable here. Resolving the anchor to a height needs
-        // the wallet's retained boundary checkpoints, and the fee needs the value of inputs the
-        // wallet may not own; a store that has both may answer them and narrow the result.
-        anchor_on_grid: None,
-        fee_is_canonical: None,
-    }
+        )))
+        .with_other_bundles_present(Some(other_bundles_present(tx)))
+        .with_source_is_send_to_self(Some(is_send_to_self(orchard_outputs)))
+        .with_sole_destination_value(sole_destination_value(ironwood_outputs))
+        .with_expiry_is_canonical(Some(
+            constants.is_canonical_expiry_value(tx.expiry_height()),
+        ))
 }
 
 /// An absent bundle contributes no actions, which is what a preparation transaction's destination
@@ -124,26 +125,20 @@ fn is_send_to_self<AccountId>(
     any_internal
 }
 
-/// The sole destination-pool output, when the wallet can attribute exactly one.
+/// The value of the sole destination-pool output, when the wallet can attribute exactly one.
 ///
 /// A crossing the wallet cannot decrypt at all yields `None` (unknown), not a refutation: a
 /// stranger's canonical crossing is invisible here, and claiming otherwise would be a judgement on
 /// evidence we do not have.
 #[cfg(feature = "orchard")]
-fn sole_destination_output<AccountId>(
+fn sole_destination_value<AccountId>(
     ironwood_outputs: &[DecryptedOutput<(orchard::Note, orchard::ValuePool), AccountId>],
-) -> Option<DestinationOutput> {
+) -> Option<Zatoshis> {
     let [output] = ironwood_outputs else {
         return None;
     };
 
     let (note, _pool) = output.note();
 
-    Some(DestinationOutput {
-        value: Zatoshis::from_u64(note.value().inner()).ok()?,
-        owner: match output.transfer_type() {
-            TransferType::AccountInternal => OutputOwner::OwnInternal,
-            _ => OutputOwner::Other,
-        },
-    })
+    Zatoshis::from_u64(note.value().inner()).ok()
 }

--- a/zcash_client_backend/src/data_api/zip318.rs
+++ b/zcash_client_backend/src/data_api/zip318.rs
@@ -14,6 +14,8 @@
 //!
 //! [ZIP 318]: https://zips.z.cash/zip-0318
 //! [`store_decrypted_tx`]: crate::data_api::ll::wallet::store_decrypted_tx
+//! [`classify`]: zcash_protocol::zip318::classify
+//! [`Zip318Evidence::source_is_send_to_self`]: zcash_protocol::zip318::Zip318Evidence::source_is_send_to_self
 
 use zcash_primitives::transaction::Transaction;
 use zcash_protocol::value::Zatoshis;

--- a/zcash_client_backend/src/data_api/zip318.rs
+++ b/zcash_client_backend/src/data_api/zip318.rs
@@ -1,0 +1,148 @@
+//! Assembling [ZIP 318] classification evidence from a decrypted transaction.
+//!
+//! This is the evidence source a wallet uses in production, and the only one that runs against a
+//! transaction the wallet did not build. It lives here, in the backend-generic layer, rather than
+//! in a store, because [`store_decrypted_tx`] is where the parsed transaction and the decrypted
+//! outputs are in hand at the same moment; a store that re-derived the evidence from its own rows
+//! would be a second implementation of the predicate to keep in step with this one.
+//!
+//! What it can observe is weaker than what the same predicate sees on an unproven transaction, for
+//! a reason that is inherent rather than incidental: on chain, a zero-valued padding dummy and an
+//! unrelated party's output are equally undecryptable, so no amount of work distinguishes them.
+//! See [`Zip318Evidence::source_is_send_to_self`] for how the clause weakens, and [`classify`] for
+//! why weakening it is sound: it admits more, never less.
+//!
+//! [ZIP 318]: https://zips.z.cash/zip-0318
+//! [`store_decrypted_tx`]: crate::data_api::ll::wallet::store_decrypted_tx
+
+use zcash_primitives::transaction::Transaction;
+use zcash_protocol::value::Zatoshis;
+use zcash_protocol::zip318::{
+    DestinationOutput, OutputOwner, PoolMigrationConstants, Zip318Classification, Zip318Evidence,
+};
+
+use crate::decrypt::{DecryptedOutput, TransferType};
+
+/// Classifies a decrypted transaction against [ZIP 318].
+///
+/// `orchard_outputs` and `ironwood_outputs` are the outputs the wallet could decrypt, as
+/// [`DecryptedTransaction`] reports them; an output absent from both is one the wallet cannot
+/// attribute, which is not the same as one belonging to somebody else.
+///
+/// [ZIP 318]: https://zips.z.cash/zip-0318
+/// [`DecryptedTransaction`]: crate::data_api::DecryptedTransaction
+#[cfg(feature = "orchard")]
+pub fn classify_decrypted_tx<AccountId, C>(
+    tx: &Transaction,
+    orchard_outputs: &[DecryptedOutput<(orchard::Note, orchard::ValuePool), AccountId>],
+    ironwood_outputs: &[DecryptedOutput<(orchard::Note, orchard::ValuePool), AccountId>],
+    constants: &C,
+) -> Zip318Classification
+where
+    C: PoolMigrationConstants + ?Sized,
+{
+    zcash_protocol::zip318::classify(
+        &evidence_from_decrypted_tx(tx, orchard_outputs, ironwood_outputs, constants),
+        constants,
+    )
+}
+
+/// The evidence behind [`classify_decrypted_tx`], exposed so that a caller can inspect which
+/// clause decided a classification.
+#[cfg(feature = "orchard")]
+pub fn evidence_from_decrypted_tx<AccountId, C>(
+    tx: &Transaction,
+    orchard_outputs: &[DecryptedOutput<(orchard::Note, orchard::ValuePool), AccountId>],
+    ironwood_outputs: &[DecryptedOutput<(orchard::Note, orchard::ValuePool), AccountId>],
+    constants: &C,
+) -> Zip318Evidence
+where
+    C: PoolMigrationConstants + ?Sized,
+{
+    Zip318Evidence {
+        source_actions: Some(action_count(tx.orchard_bundle().map(|b| b.actions().len()))),
+        destination_actions: Some(action_count(
+            tx.ironwood_bundle().map(|b| b.actions().len()),
+        )),
+        other_bundles_present: Some(other_bundles_present(tx)),
+        source_is_send_to_self: Some(is_send_to_self(orchard_outputs)),
+        sole_destination_output: sole_destination_output(ironwood_outputs),
+        // The height-independent form, deliberately. The reference-height form cannot be evaluated
+        // before the transaction is mined, and judging it against the chain tip instead would let
+        // the answer change once the transaction was mined in a later modulus period, contradicting
+        // a decision already recorded.
+        expiry_is_canonical: Some(constants.is_canonical_expiry_value(tx.expiry_height())),
+        // Neither confirmatory clause is answerable here. Resolving the anchor to a height needs
+        // the wallet's retained boundary checkpoints, and the fee needs the value of inputs the
+        // wallet may not own; a store that has both may answer them and narrow the result.
+        anchor_on_grid: None,
+        fee_is_canonical: None,
+    }
+}
+
+/// An absent bundle contributes no actions, which is what a preparation transaction's destination
+/// pool looks like.
+#[cfg(feature = "orchard")]
+fn action_count(bundle_actions: Option<usize>) -> usize {
+    bundle_actions.unwrap_or(0)
+}
+
+/// Whether the transaction carries a transparent or Sapling bundle. No ZIP 318 transaction carries
+/// either, so this is a refutation on its own.
+#[cfg(feature = "orchard")]
+fn other_bundles_present(tx: &Transaction) -> bool {
+    tx.transparent_bundle()
+        .is_some_and(|b| !b.vin.is_empty() || !b.vout.is_empty())
+        || tx
+            .sapling_bundle()
+            .is_some_and(|b| !b.shielded_spends().is_empty() || !b.shielded_outputs().is_empty())
+}
+
+/// Whether the source-pool outputs are consistent with a send-to-self.
+///
+/// This is the weakened clause described in the module documentation. It cannot be "every
+/// value-carrying output is internal", because the outputs the wallet cannot decrypt are exactly
+/// the ones it cannot classify, and a padding dummy is one of those. What it can say is that the
+/// wallet received something on its own internal address here and received nothing on an external
+/// one, which is the strongest sound reading available from chain data.
+#[cfg(feature = "orchard")]
+fn is_send_to_self<AccountId>(
+    orchard_outputs: &[DecryptedOutput<(orchard::Note, orchard::ValuePool), AccountId>],
+) -> bool {
+    let mut any_internal = false;
+    for output in orchard_outputs {
+        match output.transfer_type() {
+            TransferType::AccountInternal => any_internal = true,
+            // An output on one of the account's own external addresses, or one the wallet sent to
+            // somebody else, both mean this is not a send-to-self.
+            TransferType::Incoming | TransferType::Outgoing | TransferType::WalletInternal => {
+                return false;
+            }
+        }
+    }
+    any_internal
+}
+
+/// The sole destination-pool output, when the wallet can attribute exactly one.
+///
+/// A crossing the wallet cannot decrypt at all yields `None` (unknown), not a refutation: a
+/// stranger's canonical crossing is invisible here, and claiming otherwise would be a judgement on
+/// evidence we do not have.
+#[cfg(feature = "orchard")]
+fn sole_destination_output<AccountId>(
+    ironwood_outputs: &[DecryptedOutput<(orchard::Note, orchard::ValuePool), AccountId>],
+) -> Option<DestinationOutput> {
+    let [output] = ironwood_outputs else {
+        return None;
+    };
+
+    let (note, _pool) = output.note();
+
+    Some(DestinationOutput {
+        value: Zatoshis::from_u64(note.value().inner()).ok()?,
+        owner: match output.transfer_type() {
+            TransferType::AccountInternal => OutputOwner::OwnInternal,
+            _ => OutputOwner::Other,
+        },
+    })
+}

--- a/zcash_client_backend/src/data_api/zip318.rs
+++ b/zcash_client_backend/src/data_api/zip318.rs
@@ -49,10 +49,9 @@ where
     )
 }
 
-/// The evidence behind [`classify_decrypted_tx`], exposed so that a caller can inspect which
-/// clause decided a classification.
+/// The evidence behind [`classify_decrypted_tx`].
 #[cfg(feature = "orchard")]
-pub fn evidence_from_decrypted_tx<AccountId, C>(
+fn evidence_from_decrypted_tx<AccountId, C>(
     tx: &Transaction,
     orchard_outputs: &[DecryptedOutput<(orchard::Note, orchard::ValuePool), AccountId>],
     ironwood_outputs: &[DecryptedOutput<(orchard::Note, orchard::ValuePool), AccountId>],

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -10,6 +10,15 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- A `zip318_kind` column on the `transactions` table, recording how each transaction
+  classifies against ZIP 318 so that a wallet can label a pool-migration transaction
+  in its history without a migration plan, which does not survive a seed restore.
+  The column defaults to the code for NOT CLASSIFIED. The migration deliberately
+  does not classify existing rows: those keep the default and need the transaction
+  rescanned. A client must render the default as no label, never as "not a
+  migration".
+
 ## [0.22.0-rc.6] - 2026-07-29
 
 ### Added

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -18,6 +18,10 @@ workspace.
   does not classify existing rows: those keep the default and need the transaction
   rescanned. A client must render the default as no label, never as "not a
   migration".
+- A `zip318_kind` column on `v_transactions`, carrying that value through to the
+  view clients read their transaction history from. The mobile SDKs build their
+  history types from this view with their own SQL, so the column reaches them
+  with no change to any foreign function interface.
 
 ## [0.22.0-rc.6] - 2026-07-29
 

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -2724,6 +2724,14 @@ impl<'a, C: Borrow<rusqlite::Transaction<'a>>, P: consensus::Parameters, CL: Clo
         )
     }
 
+    fn put_zip318_classification(
+        &mut self,
+        tx_ref: Self::TxRef,
+        classification: zcash_protocol::zip318::Zip318Classification,
+    ) -> Result<(), Self::Error> {
+        wallet::put_zip318_classification(self.conn.borrow(), tx_ref, classification)
+    }
+
     fn put_received_sapling_note<T: ReceivedSaplingOutput<AccountId = Self::AccountId>>(
         &mut self,
         output: &T,

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -5137,6 +5137,28 @@ pub(crate) fn put_tx_data(
         .map_err(SqliteClientError::from)
 }
 
+/// Records how a transaction classifies against ZIP 318.
+///
+/// The column defaults to the code for "not classified", so a row this was never called for
+/// reports as unclassified rather than as a decision that the transaction is not a migration
+/// transaction. Rows written before this column existed keep that default, and need the
+/// transaction rescanned before they can be labelled.
+pub(crate) fn put_zip318_classification(
+    conn: &rusqlite::Connection,
+    tx_ref: TxRef,
+    classification: zcash_protocol::zip318::Zip318Classification,
+) -> Result<(), SqliteClientError> {
+    conn.execute(
+        "UPDATE transactions SET zip318_kind = :zip318_kind WHERE id_tx = :id_tx",
+        named_params![
+            ":zip318_kind": classification.to_code(),
+            ":id_tx": tx_ref.0,
+        ],
+    )?;
+
+    Ok(())
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum TxQueryType {
     Status,

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -1486,7 +1486,8 @@ SELECT accounts.uuid                AS account_uuid,
        -- between shielded pools; NULL when it is not such a transfer. A transaction is one
        -- exactly when this column is non-NULL.
        pool_crossings.crossing_value AS pool_crossing_value,
-       transactions.trust_status
+       transactions.trust_status,
+       transactions.zip318_kind
 FROM notes
 JOIN accounts ON accounts.id = notes.account_id
 JOIN transactions ON transactions.id_tx = notes.transaction_id
@@ -1498,7 +1499,8 @@ LEFT JOIN sent_note_counts
 LEFT JOIN pool_crossings
      ON pool_crossings.account_id = notes.account_id
      AND pool_crossings.transaction_id = notes.transaction_id
-GROUP BY notes.account_id, notes.transaction_id";
+GROUP BY notes.account_id, notes.transaction_id
+";
 
 /// Selects all outputs received by the wallet, plus any outputs sent from the wallet to
 /// external recipients.

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -314,6 +314,14 @@ CREATE TABLE blocks (
 /// - `trust_status`: A flag indicating whether the transaction should be considered "trusted".
 ///   When set to `1`, outputs of this transaction will be considered spendable with `trusted`
 ///   confirmations instead of `untrusted` confirmations.
+/// - `zip318_kind`: how the transaction classifies against ZIP 318, encoded by
+///   [`Zip318Classification::to_code`]. The default, `0`, means NOT CLASSIFIED, and is what a row
+///   holds until the wallet has decrypted the transaction; it is deliberately distinct from the
+///   code for "nonconforming", which is a decision that the transaction is not a ZIP 318 one. A
+///   client must render the default as no label, never as "not a migration". Rows written before
+///   this column existed keep the default and need the transaction rescanned.
+///
+/// [`Zip318Classification::to_code`]: zcash_protocol::zip318::Zip318Classification::to_code
 pub(super) const TABLE_TRANSACTIONS: &str = r#"
 CREATE TABLE "transactions" (
     id_tx INTEGER PRIMARY KEY,
@@ -329,6 +337,7 @@ CREATE TABLE "transactions" (
     min_observed_height INTEGER NOT NULL,
     confirmed_unmined_at_height INTEGER,
     trust_status INTEGER,
+    zip318_kind INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (block) REFERENCES blocks(height),
     CONSTRAINT height_consistency CHECK (
         block IS NULL OR mined_height = block

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -70,6 +70,7 @@ mod v_tx_outputs_transparent_addresses;
 mod v_tx_outputs_use_legacy_false;
 mod wallet_summaries;
 mod witness_stabilized_notes;
+mod zip318_classification;
 
 use std::{rc::Rc, sync::Mutex};
 
@@ -168,6 +169,7 @@ pub mod ids {
         v_tx_outputs_use_legacy_false::MIGRATION_ID as V_TX_OUTPUTS_USE_LEGACY_FALSE,
         wallet_summaries::MIGRATION_ID as WALLET_SUMMARIES,
         witness_stabilized_notes::MIGRATION_ID as WITNESS_STABILIZED_NOTES,
+        zip318_classification::MIGRATION_ID as ZIP318_CLASSIFICATION,
     };
 }
 
@@ -358,6 +360,7 @@ pub(super) fn all_migrations<
         Box::new(fix_bad_ironwood_change_flagging::Migration),
         Box::new(v_address_uses_ironwood::Migration),
         Box::new(v_transactions_pool_crossing::Migration),
+        Box::new(zip318_classification::Migration),
         Box::new(orchard_ironwood_migration_tables::Migration),
         Box::new(tree_retained_checkpoints::Migration),
         Box::new(note_locking::Migration),
@@ -561,10 +564,10 @@ pub const CURRENT_LEAF_MIGRATIONS: &[Uuid] = &[
     add_transparent_value_index::MIGRATION_ID,
     fix_bad_ironwood_change_flagging::MIGRATION_ID,
     v_address_uses_ironwood::MIGRATION_ID,
-    v_transactions_pool_crossing::MIGRATION_ID,
     orchard_ironwood_migration_anchor_interval::MIGRATION_ID,
     tree_retained_checkpoints::MIGRATION_ID,
     tx_status_observation_intent::MIGRATION_ID,
+    zip318_classification::MIGRATION_ID,
 ];
 
 pub(super) fn verify_network_compatibility<P: consensus::Parameters>(

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -727,8 +727,10 @@ pub(crate) mod tests {
             ids::V_TX_OUTPUTS_RETURN_ADDRS,
             ids::V_TX_OUTPUTS_TRANSPARENT_ADDRESSES,
             ids::V_TX_OUTPUTS_USE_LEGACY_FALSE,
+            ids::V_TRANSACTIONS_ZIP318_KIND,
             ids::WALLET_SUMMARIES,
             ids::WITNESS_STABILIZED_NOTES,
+            ids::ZIP318_CLASSIFICATION,
         ]);
 
         let migrations =

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -64,6 +64,7 @@ mod v_transactions_note_uniqueness;
 mod v_transactions_pool_crossing;
 mod v_transactions_shielding_balance;
 mod v_transactions_transparent_history;
+mod v_transactions_zip318_kind;
 mod v_tx_outputs_key_scopes;
 mod v_tx_outputs_return_addrs;
 mod v_tx_outputs_transparent_addresses;
@@ -163,6 +164,7 @@ pub mod ids {
         v_transactions_pool_crossing::MIGRATION_ID as V_TRANSACTIONS_POOL_CROSSING,
         v_transactions_shielding_balance::MIGRATION_ID as V_TRANSACTIONS_SHIELDING_BALANCE,
         v_transactions_transparent_history::MIGRATION_ID as V_TRANSACTIONS_TRANSPARENT_HISTORY,
+        v_transactions_zip318_kind::MIGRATION_ID as V_TRANSACTIONS_ZIP318_KIND,
         v_tx_outputs_key_scopes::MIGRATION_ID as V_TX_OUTPUTS_KEY_SCOPES,
         v_tx_outputs_return_addrs::MIGRATION_ID as V_TX_OUTPUTS_RETURN_ADDRS,
         v_tx_outputs_transparent_addresses::MIGRATION_ID as V_TX_OUTPUTS_TRANSPARENT_ADDRESSES,
@@ -361,6 +363,7 @@ pub(super) fn all_migrations<
         Box::new(v_address_uses_ironwood::Migration),
         Box::new(v_transactions_pool_crossing::Migration),
         Box::new(zip318_classification::Migration),
+        Box::new(v_transactions_zip318_kind::Migration),
         Box::new(orchard_ironwood_migration_tables::Migration),
         Box::new(tree_retained_checkpoints::Migration),
         Box::new(note_locking::Migration),
@@ -567,7 +570,7 @@ pub const CURRENT_LEAF_MIGRATIONS: &[Uuid] = &[
     orchard_ironwood_migration_anchor_interval::MIGRATION_ID,
     tree_retained_checkpoints::MIGRATION_ID,
     tx_status_observation_intent::MIGRATION_ID,
-    zip318_classification::MIGRATION_ID,
+    v_transactions_zip318_kind::MIGRATION_ID,
 ];
 
 pub(super) fn verify_network_compatibility<P: consensus::Parameters>(

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_zip318_kind.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_zip318_kind.rs
@@ -1,0 +1,454 @@
+//! Exposes each transaction's ZIP 318 classification through `v_transactions`.
+//!
+//! The classification is written to `transactions.zip318_kind` as a transaction is decrypted, but
+//! nothing could read it from the view a client actually queries for its history. The mobile SDKs
+//! in particular build their history types from `v_transactions` with their own SQL, so a column
+//! there reaches them with no change to any foreign function interface; a Rust-only accessor would
+//! not.
+//!
+//! # Reading the column
+//!
+//! The value is [`Zip318Classification::to_code`]. Zero means NOT CLASSIFIED: either the
+//! transaction predates the column, or the wallet has not decrypted it yet. It is NOT a decision
+//! that the transaction is not a migration transaction, which is a different code. A client must
+//! render zero as no label at all. Rendering it as "not a migration" would present a transaction
+//! the wallet never examined as one it examined and rejected.
+//!
+//! A client showing a "migration" label wants the codes for a preparation transaction and a
+//! transfer. The code for a canonical crossing PAYMENT must not be labelled as a migration: it has
+//! the same shape by design, but it pays a third party.
+//!
+//! [`Zip318Classification::to_code`]: zcash_protocol::zip318::Zip318Classification::to_code
+
+use std::collections::HashSet;
+
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+
+use crate::wallet::init::WalletMigrationError;
+
+use super::zip318_classification;
+
+/// This migration recreates `v_transactions` with a `zip318_kind` column.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x6f2b1c84_9a3d_4e50_b7c6_2d9f1a4e83b7);
+
+/// `zip318_classification` adds the underlying column on the `transactions` table that this view
+/// column reads.
+const DEPENDENCIES: &[Uuid] = &[zip318_classification::MIGRATION_ID];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Exposes each transaction's ZIP 318 classification through v_transactions."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        transaction.execute_batch(
+            "DROP VIEW v_transactions;
+            CREATE VIEW v_transactions AS
+            WITH
+            notes AS (
+                -- Outputs received in this transaction
+                SELECT ro.account_id              AS account_id,
+                       ro.transaction_id          AS transaction_id,
+                       ro.pool                    AS pool,
+                       id_within_pool_table,
+                       ro.value                   AS value,
+                       ro.value                   AS received_value,
+                       0                          AS spent_value,
+                       0                          AS spent_note_count,
+                       CASE
+                            WHEN ro.is_change THEN 1
+                            ELSE 0
+                       END AS change_note_count,
+                       CASE
+                            WHEN ro.is_change THEN 0
+                            ELSE 1
+                       END AS received_count,
+                       CASE
+                         WHEN (ro.memo IS NULL OR ro.memo = X'F6')
+                           THEN 0
+                         ELSE 1
+                       END AS memo_present,
+                       -- The wallet cannot receive transparent outputs in shielding transactions.
+                       CASE
+                         WHEN ro.pool = 0
+                           THEN 1
+                         ELSE 0
+                       END AS does_not_match_shielding
+                FROM v_received_outputs ro
+                UNION
+                -- Outputs spent in this transaction
+                SELECT ro.account_id              AS account_id,
+                       ros.transaction_id         AS transaction_id,
+                       ro.pool                    AS pool,
+                       id_within_pool_table,
+                       -ro.value                  AS value,
+                       0                          AS received_value,
+                       ro.value                   AS spent_value,
+                       1                          AS spent_note_count,
+                       0                          AS change_note_count,
+                       0                          AS received_count,
+                       0                          AS memo_present,
+                       -- The wallet cannot spend shielded outputs in shielding transactions.
+                       CASE
+                         WHEN ro.pool != 0
+                           THEN 1
+                         ELSE 0
+                       END AS does_not_match_shielding
+                FROM v_received_outputs ro
+                JOIN v_received_output_spends ros
+                     ON ros.pool = ro.pool
+                     AND ros.received_output_id = ro.id_within_pool_table
+            ),
+            -- What each account spent and received in each pool, per transaction. A pool the account
+            -- received value in but spent nothing from is a pool that value crossed into from
+            -- elsewhere, which is what `pool_crossings` below is built on.
+            notes_by_pool AS (
+                SELECT account_id, transaction_id, pool,
+                       SUM(spent_note_count)                   AS spent_note_count,
+                       SUM(received_count + change_note_count) AS received_note_count,
+                       SUM(received_value)                     AS received_value
+                FROM notes
+                GROUP BY account_id, transaction_id, pool
+            ),
+            -- Obtain a count of the notes that the wallet created in each transaction,
+            -- not counting change notes.
+            sent_note_counts AS (
+                SELECT sent_notes.from_account_id     AS account_id,
+                       sent_notes.transaction_id      AS transaction_id,
+                       COUNT(DISTINCT sent_notes.id)  AS sent_notes,
+                       SUM(
+                         CASE
+                           WHEN (sent_notes.memo IS NULL OR sent_notes.memo = X'F6' OR ro.transaction_id IS NOT NULL)
+                             THEN 0
+                           ELSE 1
+                         END
+                       ) AS memo_count
+                FROM sent_notes
+                LEFT JOIN v_received_outputs ro ON sent_notes.id = ro.sent_note_id
+                WHERE COALESCE(ro.is_change, 0) = 0
+                GROUP BY account_id, sent_notes.transaction_id
+            ),
+            -- Identifies the transactions that are wallet-internal transfers moving an account's own
+            -- funds between shielded pools, and reports the value that crossed. `crossing_value` is
+            -- non-NULL exactly for such a transaction, so it carries both the classification and the
+            -- amount; see the `pool_crossing_value` column below.
+            pool_crossings AS (
+                SELECT notes_by_pool.account_id     AS account_id,
+                       notes_by_pool.transaction_id AS transaction_id,
+                       CASE WHEN (
+                            -- Every note spent and every output received by the wallet is shielded.
+                            SUM(CASE WHEN notes_by_pool.pool = 0 THEN notes_by_pool.spent_note_count + notes_by_pool.received_note_count ELSE 0 END) = 0
+                            -- The transaction spends at least one of the account's notes.
+                            AND SUM(notes_by_pool.spent_note_count) > 0
+                            -- At least one output was received in a pool the account spent nothing
+                            -- from, so value crossed between pools.
+                            AND SUM(CASE WHEN notes_by_pool.spent_note_count = 0 THEN notes_by_pool.received_note_count ELSE 0 END) > 0
+                            -- We do not know about any external outputs of the transaction.
+                            AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
+                       )
+                       -- The total value received in the pools the account did not spend from. The
+                       -- condition above guarantees at least one such output, so when this branch is
+                       -- taken the sum is never NULL.
+                       THEN SUM(CASE WHEN notes_by_pool.spent_note_count = 0 THEN notes_by_pool.received_value ELSE 0 END)
+                       END AS crossing_value
+                FROM notes_by_pool
+                LEFT JOIN sent_note_counts
+                     ON sent_note_counts.account_id = notes_by_pool.account_id
+                     AND sent_note_counts.transaction_id = notes_by_pool.transaction_id
+                GROUP BY notes_by_pool.account_id, notes_by_pool.transaction_id
+            ),
+            blocks_max_height AS (
+                SELECT MAX(blocks.height) AS max_height FROM blocks
+            )
+            SELECT accounts.uuid                AS account_uuid,
+                   transactions.mined_height    AS mined_height,
+                   transactions.txid            AS txid,
+                   transactions.tx_index        AS tx_index,
+                   transactions.expiry_height   AS expiry_height,
+                   transactions.raw             AS raw,
+                   SUM(notes.value)             AS account_balance_delta,
+                   SUM(notes.spent_value)       AS total_spent,
+                   SUM(notes.received_value)    AS total_received,
+                   transactions.fee             AS fee_paid,
+                   SUM(notes.change_note_count) > 0  AS has_change,
+                   MAX(COALESCE(sent_note_counts.sent_notes, 0))  AS sent_note_count,
+                   SUM(notes.received_count)         AS received_note_count,
+                   SUM(notes.memo_present) + MAX(COALESCE(sent_note_counts.memo_count, 0)) AS memo_count,
+                   blocks.time                       AS block_time,
+                   (
+                        transactions.mined_height IS NULL
+                        AND transactions.expiry_height BETWEEN 1 AND blocks_max_height.max_height
+                   ) AS expired_unmined,
+                   SUM(notes.spent_note_count) AS spent_note_count,
+                   (
+                        -- All of the wallet-spent and wallet-received notes are consistent with a
+                        -- shielding transaction.
+                        SUM(notes.does_not_match_shielding) = 0
+                        -- The transaction contains at least one wallet-spent output.
+                        AND SUM(notes.spent_note_count) > 0
+                        -- The transaction contains at least one wallet-received note.
+                        AND (SUM(notes.received_count) + SUM(notes.change_note_count)) > 0
+                        -- We do not know about any external outputs of the transaction.
+                        AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
+                   ) AS is_shielding,
+                   -- The value that crossed pools, when this transaction is a wallet-internal transfer
+                   -- between shielded pools; NULL when it is not such a transfer. A transaction is one
+                   -- exactly when this column is non-NULL.
+                   pool_crossings.crossing_value AS pool_crossing_value,
+                   transactions.trust_status,
+                   transactions.zip318_kind
+            FROM notes
+            JOIN accounts ON accounts.id = notes.account_id
+            JOIN transactions ON transactions.id_tx = notes.transaction_id
+            LEFT JOIN blocks_max_height
+            LEFT JOIN blocks ON blocks.height = transactions.mined_height
+            LEFT JOIN sent_note_counts
+                 ON sent_note_counts.account_id = notes.account_id
+                 AND sent_note_counts.transaction_id = notes.transaction_id
+            LEFT JOIN pool_crossings
+                 ON pool_crossings.account_id = notes.account_id
+                 AND pool_crossings.transaction_id = notes.transaction_id
+            GROUP BY notes.account_id, notes.transaction_id;",
+        )?;
+
+        Ok(())
+    }
+
+    fn down(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        transaction.execute_batch(
+            "DROP VIEW v_transactions;
+            CREATE VIEW v_transactions AS
+            WITH
+            notes AS (
+                -- Outputs received in this transaction
+                SELECT ro.account_id              AS account_id,
+                       ro.transaction_id          AS transaction_id,
+                       ro.pool                    AS pool,
+                       id_within_pool_table,
+                       ro.value                   AS value,
+                       ro.value                   AS received_value,
+                       0                          AS spent_value,
+                       0                          AS spent_note_count,
+                       CASE
+                            WHEN ro.is_change THEN 1
+                            ELSE 0
+                       END AS change_note_count,
+                       CASE
+                            WHEN ro.is_change THEN 0
+                            ELSE 1
+                       END AS received_count,
+                       CASE
+                         WHEN (ro.memo IS NULL OR ro.memo = X'F6')
+                           THEN 0
+                         ELSE 1
+                       END AS memo_present,
+                       -- The wallet cannot receive transparent outputs in shielding transactions.
+                       CASE
+                         WHEN ro.pool = 0
+                           THEN 1
+                         ELSE 0
+                       END AS does_not_match_shielding
+                FROM v_received_outputs ro
+                UNION
+                -- Outputs spent in this transaction
+                SELECT ro.account_id              AS account_id,
+                       ros.transaction_id         AS transaction_id,
+                       ro.pool                    AS pool,
+                       id_within_pool_table,
+                       -ro.value                  AS value,
+                       0                          AS received_value,
+                       ro.value                   AS spent_value,
+                       1                          AS spent_note_count,
+                       0                          AS change_note_count,
+                       0                          AS received_count,
+                       0                          AS memo_present,
+                       -- The wallet cannot spend shielded outputs in shielding transactions.
+                       CASE
+                         WHEN ro.pool != 0
+                           THEN 1
+                         ELSE 0
+                       END AS does_not_match_shielding
+                FROM v_received_outputs ro
+                JOIN v_received_output_spends ros
+                     ON ros.pool = ro.pool
+                     AND ros.received_output_id = ro.id_within_pool_table
+            ),
+            -- What each account spent and received in each pool, per transaction. A pool the account
+            -- received value in but spent nothing from is a pool that value crossed into from
+            -- elsewhere, which is what `pool_crossings` below is built on.
+            notes_by_pool AS (
+                SELECT account_id, transaction_id, pool,
+                       SUM(spent_note_count)                   AS spent_note_count,
+                       SUM(received_count + change_note_count) AS received_note_count,
+                       SUM(received_value)                     AS received_value
+                FROM notes
+                GROUP BY account_id, transaction_id, pool
+            ),
+            -- Obtain a count of the notes that the wallet created in each transaction,
+            -- not counting change notes.
+            sent_note_counts AS (
+                SELECT sent_notes.from_account_id     AS account_id,
+                       sent_notes.transaction_id      AS transaction_id,
+                       COUNT(DISTINCT sent_notes.id)  AS sent_notes,
+                       SUM(
+                         CASE
+                           WHEN (sent_notes.memo IS NULL OR sent_notes.memo = X'F6' OR ro.transaction_id IS NOT NULL)
+                             THEN 0
+                           ELSE 1
+                         END
+                       ) AS memo_count
+                FROM sent_notes
+                LEFT JOIN v_received_outputs ro ON sent_notes.id = ro.sent_note_id
+                WHERE COALESCE(ro.is_change, 0) = 0
+                GROUP BY account_id, sent_notes.transaction_id
+            ),
+            -- Identifies the transactions that are wallet-internal transfers moving an account's own
+            -- funds between shielded pools, and reports the value that crossed. `crossing_value` is
+            -- non-NULL exactly for such a transaction, so it carries both the classification and the
+            -- amount; see the `pool_crossing_value` column below.
+            pool_crossings AS (
+                SELECT notes_by_pool.account_id     AS account_id,
+                       notes_by_pool.transaction_id AS transaction_id,
+                       CASE WHEN (
+                            -- Every note spent and every output received by the wallet is shielded.
+                            SUM(CASE WHEN notes_by_pool.pool = 0 THEN notes_by_pool.spent_note_count + notes_by_pool.received_note_count ELSE 0 END) = 0
+                            -- The transaction spends at least one of the account's notes.
+                            AND SUM(notes_by_pool.spent_note_count) > 0
+                            -- At least one output was received in a pool the account spent nothing
+                            -- from, so value crossed between pools.
+                            AND SUM(CASE WHEN notes_by_pool.spent_note_count = 0 THEN notes_by_pool.received_note_count ELSE 0 END) > 0
+                            -- We do not know about any external outputs of the transaction.
+                            AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
+                       )
+                       -- The total value received in the pools the account did not spend from. The
+                       -- condition above guarantees at least one such output, so when this branch is
+                       -- taken the sum is never NULL.
+                       THEN SUM(CASE WHEN notes_by_pool.spent_note_count = 0 THEN notes_by_pool.received_value ELSE 0 END)
+                       END AS crossing_value
+                FROM notes_by_pool
+                LEFT JOIN sent_note_counts
+                     ON sent_note_counts.account_id = notes_by_pool.account_id
+                     AND sent_note_counts.transaction_id = notes_by_pool.transaction_id
+                GROUP BY notes_by_pool.account_id, notes_by_pool.transaction_id
+            ),
+            blocks_max_height AS (
+                SELECT MAX(blocks.height) AS max_height FROM blocks
+            )
+            SELECT accounts.uuid                AS account_uuid,
+                   transactions.mined_height    AS mined_height,
+                   transactions.txid            AS txid,
+                   transactions.tx_index        AS tx_index,
+                   transactions.expiry_height   AS expiry_height,
+                   transactions.raw             AS raw,
+                   SUM(notes.value)             AS account_balance_delta,
+                   SUM(notes.spent_value)       AS total_spent,
+                   SUM(notes.received_value)    AS total_received,
+                   transactions.fee             AS fee_paid,
+                   SUM(notes.change_note_count) > 0  AS has_change,
+                   MAX(COALESCE(sent_note_counts.sent_notes, 0))  AS sent_note_count,
+                   SUM(notes.received_count)         AS received_note_count,
+                   SUM(notes.memo_present) + MAX(COALESCE(sent_note_counts.memo_count, 0)) AS memo_count,
+                   blocks.time                       AS block_time,
+                   (
+                        transactions.mined_height IS NULL
+                        AND transactions.expiry_height BETWEEN 1 AND blocks_max_height.max_height
+                   ) AS expired_unmined,
+                   SUM(notes.spent_note_count) AS spent_note_count,
+                   (
+                        -- All of the wallet-spent and wallet-received notes are consistent with a
+                        -- shielding transaction.
+                        SUM(notes.does_not_match_shielding) = 0
+                        -- The transaction contains at least one wallet-spent output.
+                        AND SUM(notes.spent_note_count) > 0
+                        -- The transaction contains at least one wallet-received note.
+                        AND (SUM(notes.received_count) + SUM(notes.change_note_count)) > 0
+                        -- We do not know about any external outputs of the transaction.
+                        AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
+                   ) AS is_shielding,
+                   -- The value that crossed pools, when this transaction is a wallet-internal transfer
+                   -- between shielded pools; NULL when it is not such a transfer. A transaction is one
+                   -- exactly when this column is non-NULL.
+                   pool_crossings.crossing_value AS pool_crossing_value,
+                   transactions.trust_status
+            FROM notes
+            JOIN accounts ON accounts.id = notes.account_id
+            JOIN transactions ON transactions.id_tx = notes.transaction_id
+            LEFT JOIN blocks_max_height
+            LEFT JOIN blocks ON blocks.height = transactions.mined_height
+            LEFT JOIN sent_note_counts
+                 ON sent_note_counts.account_id = notes.account_id
+                 AND sent_note_counts.transaction_id = notes.transaction_id
+            LEFT JOIN pool_crossings
+                 ON pool_crossings.account_id = notes.account_id
+                 AND pool_crossings.transaction_id = notes.transaction_id
+            GROUP BY notes.account_id, notes.transaction_id;",
+        )?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use secrecy::Secret;
+    use tempfile::NamedTempFile;
+    use zcash_protocol::consensus::Network;
+
+    use crate::WalletDb;
+    use crate::testing::db::{test_clock, test_rng};
+    use crate::wallet::init::WalletMigrator;
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+
+    /// The view must be QUERYABLE, not merely creatable. SQLite stores a view's SELECT as text and
+    /// does not resolve its column references until the view is used, so a `CREATE VIEW` naming a
+    /// column that does not exist succeeds and fails only later, at the first query a client makes.
+    /// Migrating cleanly is therefore not evidence that this migration worked.
+    #[test]
+    fn the_view_column_is_queryable() {
+        let data_file = NamedTempFile::new().unwrap();
+        let mut db_data = WalletDb::for_path(
+            data_file.path(),
+            Network::TestNetwork,
+            test_clock(),
+            test_rng(),
+        )
+        .unwrap();
+
+        WalletMigrator::new()
+            .with_seed(Secret::new(vec![0xab; 32]))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, &[super::MIGRATION_ID])
+            .unwrap();
+
+        // The wallet is empty, so this returns zero; preparing and stepping the statement is what
+        // forces SQLite to resolve `transactions.zip318_kind` through the view.
+        let count: i64 = db_data
+            .conn
+            .query_row("SELECT COUNT(zip318_kind) FROM v_transactions", [], |row| {
+                row.get(0)
+            })
+            .expect("the zip318_kind column resolves when v_transactions is queried");
+
+        assert_eq!(count, 0);
+    }
+}

--- a/zcash_client_sqlite/src/wallet/init/migrations/zip318_classification.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/zip318_classification.rs
@@ -1,0 +1,103 @@
+//! Adds a column recording how each transaction classifies against ZIP 318.
+//!
+//! A wallet that wants to label a pool-migration transaction in its history cannot rely on the
+//! migration plan it scheduled the transaction from: that plan does not survive a seed restore, and
+//! it says nothing about a transaction the wallet did not itself schedule. The classification is
+//! instead derived from the transaction's shape, which is recoverable from chain data, and stored
+//! here so that it is available to the same SQL a client already uses to read its history.
+//!
+//! It is stored rather than computed on read because the evidence it rests on is only all present
+//! at once while the transaction is being decrypted: the action counts come from the raw
+//! transaction, and whether the outputs are the account's own comes from decryption. Neither is
+//! available to a view.
+//!
+//! # The default is "not classified", not "not a migration"
+//!
+//! The column defaults to zero, which decodes to
+//! [`Zip318Classification::Unknown`](zcash_protocol::zip318::Zip318Classification::Unknown). This
+//! migration deliberately does NOT classify existing rows. Doing so would mean re-deriving the
+//! classification from stored columns alone, without the decrypted outputs, which is both the
+//! weakest evidence available and a second implementation of the predicate to keep in step with the
+//! real one.
+//!
+//! So every transaction already in the wallet keeps the default, and needs the transaction
+//! rescanned before it can be labelled. That is a real value rather than NULL so those rows can be
+//! found with an ordinary query, and it is distinct from the code for "nonconforming", which is a
+//! decision. A client MUST render the default as no label, never as "not a migration": the two mean
+//! "we never looked" and "we looked and it is not one".
+
+use std::collections::HashSet;
+
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+
+use crate::wallet::init::WalletMigrationError;
+
+use super::v_transactions_pool_crossing;
+
+/// This migration adds the `zip318_kind` column to the `transactions` table.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x0a35a9e4_6c1d_4f7a_9c02_51b8de4f7c33);
+
+/// `v_transactions_pool_crossing` is the most recent migration to touch how transactions are
+/// classified for history purposes; ordering after it keeps the two classifications' migrations in
+/// a single chain rather than letting them race.
+const DEPENDENCIES: &[Uuid] = &[v_transactions_pool_crossing::MIGRATION_ID];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Adds a column recording each transaction's ZIP 318 classification."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, conn: &rusqlite::Transaction) -> Result<(), WalletMigrationError> {
+        // Zero is the code for "not classified"; see the module documentation for why existing
+        // rows keep it rather than being classified here.
+        conn.execute_batch(
+            "ALTER TABLE transactions
+             ADD COLUMN zip318_kind INTEGER NOT NULL DEFAULT 0;",
+        )?;
+
+        Ok(())
+    }
+
+    fn down(&self, conn: &rusqlite::Transaction) -> Result<(), WalletMigrationError> {
+        conn.execute_batch("ALTER TABLE transactions DROP COLUMN zip318_kind;")?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use zcash_protocol::zip318::Zip318Classification;
+
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+
+    /// The column's SQL default must be the code for "not classified", so that a row this
+    /// migration did not classify reads back as unclassified rather than as a decision that the
+    /// transaction is not a migration transaction. The DDL is asserted against the schema constant
+    /// by [`test_migrate`]; this pins the constant the DDL has to carry.
+    #[test]
+    fn the_column_default_means_unclassified() {
+        assert_eq!(Zip318Classification::Unknown.to_code(), 0);
+        assert_ne!(Zip318Classification::Nonconforming.to_code(), 0);
+    }
+}

--- a/zcash_pool_migration/src/lib.rs
+++ b/zcash_pool_migration/src/lib.rs
@@ -32,6 +32,8 @@ pub mod signing_rounds;
 pub mod state;
 #[cfg(feature = "wallet")]
 pub mod wallet;
+#[cfg(feature = "orchard")]
+pub mod zip318_shape;
 
 #[cfg(any(test, feature = "test-dependencies"))]
 pub mod testing;

--- a/zcash_pool_migration/src/zip318_shape.rs
+++ b/zcash_pool_migration/src/zip318_shape.rs
@@ -1,0 +1,296 @@
+//! Reading [ZIP 318] classification evidence off a PCZT.
+//!
+//! This is the evidence source a TEST uses: it observes a transaction the builders have just
+//! produced, before it is proven or mined, which is what lets the conformance suite check that
+//! everything this crate builds is recognised by the classifier a wallet will later apply to the
+//! mined transaction. Proving a PCZT to obtain a `Transaction` costs a prover run; every field the
+//! classifier needs is already in the PCZT, so nothing here requires one.
+//!
+//! The observations themselves belong to the PCZT, not to ZIP 318, so they live on the `pczt`
+//! types ([`Bundle::value_carrying_outputs_all_pay`], [`Output::pays`],
+//! [`Pczt::has_transparent_data`], and friends). This module only maps them onto the ZIP's clauses,
+//! which is why it is as short as it is.
+//!
+//! It deliberately answers neither confirmatory clause. A PCZT built by this crate carries DEFERRED
+//! anchors (ZIP 374), so there is no anchor to place on the retention grid, and the fee is not a
+//! PCZT field. Both are left unanswered rather than guessed, which widens the predicate (see
+//! [`classify`]) instead of blocking or misleading it.
+//!
+//! [ZIP 318]: https://zips.z.cash/zip-0318
+//! [`classify`]: zcash_protocol::zip318::classify
+//! [`Bundle::value_carrying_outputs_all_pay`]: pczt::orchard::Bundle::value_carrying_outputs_all_pay
+//! [`Output::pays`]: pczt::orchard::Output::pays
+//! [`Pczt::has_transparent_data`]: pczt::Pczt::has_transparent_data
+
+use orchard::keys::{FullViewingKey, Scope};
+use zcash_protocol::consensus::BlockHeight;
+use zcash_protocol::value::Zatoshis;
+use zcash_protocol::zip318::{
+    DestinationOutput, OutputOwner, PoolMigrationConstants, Zip318Evidence,
+};
+
+/// The internal-scope diversifier index the builders send the account's own outputs to. Mirrors
+/// `build::prep`'s constant; an output at any other index is not one of ours.
+const INTERNAL_ADDRESS_INDEX: u32 = 0;
+
+/// Gathers the [ZIP 318] evidence a PCZT can supply, for classification by
+/// [`classify`](zcash_protocol::zip318::classify).
+///
+/// `fvk` is the account whose transaction this is, used to recognise the account's own internal
+/// address. `expiry_reference` is the height the canonical rolling expiry is judged against, which
+/// for an unmined PCZT is the target height it was built for; passing anything else (a chain tip,
+/// say) makes the expiry clause unstable, because the canonical expiry is a step function of the
+/// height. See [`Zip318Evidence`] for that obligation and the others.
+///
+/// [ZIP 318]: https://zips.z.cash/zip-0318
+pub fn evidence_from_pczt<C>(
+    pczt: &pczt::Pczt,
+    fvk: &FullViewingKey,
+    expiry_reference: BlockHeight,
+    constants: &C,
+) -> Zip318Evidence
+where
+    C: PoolMigrationConstants + ?Sized,
+{
+    let internal = fvk
+        .address_at(INTERNAL_ADDRESS_INDEX, Scope::Internal)
+        .to_raw_address_bytes();
+    let expiry = BlockHeight::from_u32(*pczt.global().expiry_height());
+
+    Zip318Evidence {
+        source_actions: Some(pczt.orchard().actions().len()),
+        destination_actions: Some(pczt.ironwood().actions().len()),
+        other_bundles_present: Some(pczt.has_transparent_data() || pczt.has_sapling_data()),
+        source_outputs_all_internal: pczt.orchard().value_carrying_outputs_all_pay(&internal),
+        sole_destination_output: sole_destination_output(pczt.ironwood(), &internal),
+        expiry_is_canonical: Some(constants.is_canonical_expiry(expiry, expiry_reference)),
+        // Deferred anchors and an absent fee field; see the module documentation.
+        anchor_on_grid: None,
+        fee_is_canonical: None,
+    }
+}
+
+/// The sole output of a single-action destination bundle, which is the shape a canonical crossing
+/// has.
+///
+/// `None` when the bundle does not have exactly one action (the action count is a separate clause,
+/// so this is not itself a refutation) or when the output's value or recipient has been redacted. A
+/// zero value is reported as such rather than skipped: zero is not a canonical denomination, so the
+/// classifier refuses it, which is the right answer for a destination bundle holding only a dummy.
+fn sole_destination_output(
+    bundle: &pczt::orchard::Bundle,
+    internal: &[u8; 43],
+) -> Option<DestinationOutput> {
+    let output = bundle.sole_action()?.output();
+
+    Some(DestinationOutput {
+        value: Zatoshis::from_u64((*output.value())?).ok()?,
+        owner: if output.pays(internal)? {
+            OutputOwner::OwnInternal
+        } else {
+            OutputOwner::Other
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use rand_chacha::ChaCha8Rng;
+    use rand_core::SeedableRng;
+    use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
+    use zcash_protocol::value::COIN;
+    use zcash_protocol::zip318::{PREP_TX_ACTIONS, Zip318Classification, Zip318TxKind};
+
+    use crate::build::test_util::{TARGET_HEIGHT, account, regtest_network, single_note_witness};
+    use crate::build::{build_prep_tx, build_transfer_pczt};
+    use crate::denomination::{DESTINATION_ACTIONS_PER_TRANSFER, SOURCE_ACTIONS_PER_TRANSFER, zat};
+    use crate::preparation::PrepOutput;
+
+    /// A wallet on the specified ZIP 318 parameters.
+    #[derive(Clone)]
+    struct Zip318Params;
+    impl PoolMigrationConstants for Zip318Params {}
+
+    /// The canonical rolling expiry the engine embeds for a transaction targeting the build
+    /// height. Building with anything else is what the "ordinary expiry" case below exercises.
+    fn canonical_expiry() -> u32 {
+        u32::from(crate::scheduling::expiry_height(BlockHeight::from_u32(
+            TARGET_HEIGHT,
+        )))
+    }
+
+    fn classify_pczt(pczt: &pczt::Pczt, fvk: &FullViewingKey) -> Zip318Classification {
+        zcash_protocol::zip318::classify(
+            &evidence_from_pczt(
+                pczt,
+                fvk,
+                BlockHeight::from_u32(TARGET_HEIGHT),
+                &Zip318Params,
+            ),
+            &Zip318Params,
+        )
+    }
+
+    /// Builds a transfer crossing `crossing_value`, with the given expiry.
+    fn transfer(crossing_value: u64, expiry: u32) -> (pczt::Pczt, FullViewingKey) {
+        let fvk = account(7);
+        let buffer = (SOURCE_ACTIONS_PER_TRANSFER + DESTINATION_ACTIONS_PER_TRANSFER) as u64
+            * MARGINAL_FEE.into_u64();
+        let (note, _path, _anchor) = single_note_witness(&fvk, crossing_value + buffer, 11);
+
+        let pczt = build_transfer_pczt(
+            &regtest_network(true),
+            TARGET_HEIGHT,
+            expiry,
+            &fvk,
+            note,
+            zat(crossing_value),
+            None,
+            ChaCha8Rng::seed_from_u64(3),
+        )
+        .expect("a self-funding note builds a balanced transfer");
+
+        (pczt, fvk)
+    }
+
+    /// Builds a single-output preparation transaction, with the given expiry.
+    fn preparation(expiry: u32) -> (pczt::Pczt, FullViewingKey) {
+        let fvk = account(23);
+        let output_value = 5 * COIN;
+        let fee = PREP_TX_ACTIONS as u64 * MARGINAL_FEE.into_u64();
+        let (note, _path, _anchor) = single_note_witness(&fvk, output_value + fee, 29);
+
+        let (pczt, _placed) = build_prep_tx(
+            &regtest_network(true),
+            TARGET_HEIGHT,
+            expiry,
+            &fvk,
+            vec![note],
+            &[PrepOutput::Funding(zat(output_value))],
+            None,
+            ChaCha8Rng::seed_from_u64(5),
+        )
+        .expect("a funded note builds a balanced preparation transaction");
+
+        (pczt, fvk)
+    }
+
+    /// THE CONFORMANCE LOOP. What this crate builds must be what the classifier recognises: a
+    /// transfer classifies as a transfer, a preparation transaction as a preparation transaction.
+    /// If these ever disagree, either a builder has drifted from ZIP 318 or the classifier has,
+    /// and nothing else in the workspace would notice.
+    #[test]
+    fn the_builders_emit_what_the_classifier_recognises() {
+        let (pczt, fvk) = transfer(COIN, canonical_expiry());
+        assert_eq!(
+            classify_pczt(&pczt, &fvk),
+            Zip318Classification::Conforms(Zip318TxKind::Transfer),
+            "a built transfer must be recognised as one"
+        );
+
+        let (pczt, fvk) = preparation(canonical_expiry());
+        assert_eq!(
+            classify_pczt(&pczt, &fvk),
+            Zip318Classification::Conforms(Zip318TxKind::Preparation),
+            "a built preparation transaction must be recognised as one"
+        );
+    }
+
+    /// The padding is what makes the shapes uniform, so it is also what the evidence must see: a
+    /// preparation transaction is padded to exactly the specified action count and crosses
+    /// nothing, and a transfer carries the two-action source bundle and a single unpadded
+    /// destination action.
+    #[test]
+    fn the_evidence_reports_the_padded_shapes() {
+        let (pczt, fvk) = preparation(canonical_expiry());
+        let evidence = evidence_from_pczt(
+            &pczt,
+            &fvk,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            &Zip318Params,
+        );
+        assert_eq!(evidence.source_actions, Some(PREP_TX_ACTIONS));
+        assert_eq!(evidence.destination_actions, Some(0));
+        assert_eq!(evidence.other_bundles_present, Some(false));
+        assert_eq!(evidence.source_outputs_all_internal, Some(true));
+
+        let (pczt, fvk) = transfer(COIN, canonical_expiry());
+        let evidence = evidence_from_pczt(
+            &pczt,
+            &fvk,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            &Zip318Params,
+        );
+        assert_eq!(evidence.source_actions, Some(SOURCE_ACTIONS_PER_TRANSFER));
+        assert_eq!(
+            evidence.destination_actions,
+            Some(DESTINATION_ACTIONS_PER_TRANSFER)
+        );
+        assert_eq!(
+            evidence.sole_destination_output,
+            Some(DestinationOutput {
+                value: zat(COIN),
+                owner: OutputOwner::OwnInternal,
+            }),
+            "the crossing pays the account's own internal address"
+        );
+    }
+
+    /// A PCZT source answers neither confirmatory clause: it has no anchor to place on the grid
+    /// (ZIP 374 defers them) and no fee field. Unanswered widens the predicate rather than
+    /// blocking it, which is why the classifications above still decide.
+    #[test]
+    fn a_pczt_answers_neither_confirmatory_clause() {
+        let (pczt, fvk) = transfer(COIN, canonical_expiry());
+        let evidence = evidence_from_pczt(
+            &pczt,
+            &fvk,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            &Zip318Params,
+        );
+        assert_eq!(evidence.anchor_on_grid, None);
+        assert_eq!(evidence.fee_is_canonical, None);
+    }
+
+    /// The same transactions built with an ORDINARY expiry are refused. This is the discriminator
+    /// that separates ZIP 318 transactions from ordinary ones with the same bundle shape, so it
+    /// has to bite even on transactions these builders produced.
+    #[test]
+    fn an_ordinary_expiry_is_refused() {
+        let ordinary = TARGET_HEIGHT + 40;
+
+        for (pczt, fvk) in [transfer(COIN, ordinary), preparation(ordinary)] {
+            assert_eq!(
+                classify_pczt(&pczt, &fvk),
+                Zip318Classification::Nonconforming,
+                "an ordinary expiry is not the canonical rolling one"
+            );
+        }
+    }
+
+    /// A crossing of an off-series amount joins no anonymity set, so it is refused even though its
+    /// shape is otherwise exact.
+    #[test]
+    fn an_off_series_crossing_is_refused() {
+        let (pczt, fvk) = transfer(3 * COIN, canonical_expiry());
+        assert_eq!(
+            classify_pczt(&pczt, &fvk),
+            Zip318Classification::Nonconforming
+        );
+    }
+
+    /// A transaction of ANOTHER account's is not this account's migration: the outputs pay an
+    /// internal address that is not the one being asked about. This is the property that keeps a
+    /// wallet from labelling a stranger's look-alike as its own.
+    #[test]
+    fn another_accounts_transaction_is_not_ours() {
+        let (pczt, _fvk) = preparation(canonical_expiry());
+        let stranger = account(99);
+        assert_eq!(
+            classify_pczt(&pczt, &stranger),
+            Zip318Classification::Nonconforming
+        );
+    }
+}

--- a/zcash_pool_migration/src/zip318_shape.rs
+++ b/zcash_pool_migration/src/zip318_shape.rs
@@ -8,8 +8,8 @@
 //!
 //! The observations themselves belong to the PCZT, not to ZIP 318, so they live on the `pczt`
 //! types ([`Bundle::value_carrying_outputs_all_pay`], [`Output::pays`],
-//! [`Pczt::has_transparent_data`], and friends). This module only maps them onto the ZIP's clauses,
-//! which is why it is as short as it is.
+//! [`Pczt::has_data_in_pool`]). This module only maps them onto the ZIP's clauses, which is why it
+//! is as short as it is.
 //!
 //! It deliberately answers neither confirmatory clause. A PCZT built by this crate carries DEFERRED
 //! anchors (ZIP 374), so there is no anchor to place on the retention grid, and the fee is not a
@@ -20,9 +20,10 @@
 //! [`classify`]: zcash_protocol::zip318::classify
 //! [`Bundle::value_carrying_outputs_all_pay`]: pczt::orchard::Bundle::value_carrying_outputs_all_pay
 //! [`Output::pays`]: pczt::orchard::Output::pays
-//! [`Pczt::has_transparent_data`]: pczt::Pczt::has_transparent_data
+//! [`Pczt::has_data_in_pool`]: pczt::Pczt::has_data_in_pool
 
 use orchard::keys::{FullViewingKey, Scope};
+use zcash_protocol::PoolType;
 use zcash_protocol::consensus::BlockHeight;
 use zcash_protocol::value::Zatoshis;
 use zcash_protocol::zip318::{
@@ -60,7 +61,10 @@ where
     Zip318Evidence {
         source_actions: Some(pczt.orchard().actions().len()),
         destination_actions: Some(pczt.ironwood().actions().len()),
-        other_bundles_present: Some(pczt.has_transparent_data() || pczt.has_sapling_data()),
+        other_bundles_present: Some(
+            pczt.has_data_in_pool(PoolType::TRANSPARENT)
+                || pczt.has_data_in_pool(PoolType::SAPLING),
+        ),
         source_is_send_to_self: pczt.orchard().value_carrying_outputs_all_pay(&internal),
         sole_destination_output: sole_destination_output(pczt.ironwood(), &internal),
         expiry_is_canonical: Some(constants.is_canonical_expiry(expiry, expiry_reference)),

--- a/zcash_pool_migration/src/zip318_shape.rs
+++ b/zcash_pool_migration/src/zip318_shape.rs
@@ -7,7 +7,7 @@
 //! classifier needs is already in the PCZT, so nothing here requires one.
 //!
 //! The observations themselves belong to the PCZT, not to ZIP 318, so they live on the `pczt`
-//! types ([`Bundle::value_carrying_outputs_all_pay`], [`Output::pays`],
+//! types ([`Bundle::value_carrying_outputs_all_pay`], [`Bundle::sole_action`],
 //! [`Pczt::has_data_in_pool`]). This module only maps them onto the ZIP's clauses, which is why it
 //! is as short as it is.
 //!
@@ -19,16 +19,14 @@
 //! [ZIP 318]: https://zips.z.cash/zip-0318
 //! [`classify`]: zcash_protocol::zip318::classify
 //! [`Bundle::value_carrying_outputs_all_pay`]: pczt::orchard::Bundle::value_carrying_outputs_all_pay
-//! [`Output::pays`]: pczt::orchard::Output::pays
+//! [`Bundle::sole_action`]: pczt::orchard::Bundle::sole_action
 //! [`Pczt::has_data_in_pool`]: pczt::Pczt::has_data_in_pool
 
 use orchard::keys::{FullViewingKey, Scope};
 use zcash_protocol::PoolType;
 use zcash_protocol::consensus::BlockHeight;
 use zcash_protocol::value::Zatoshis;
-use zcash_protocol::zip318::{
-    DestinationOutput, OutputOwner, PoolMigrationConstants, Zip318Evidence,
-};
+use zcash_protocol::zip318::{PoolMigrationConstants, Zip318Evidence};
 
 /// The internal-scope diversifier index the builders send the account's own outputs to. Mirrors
 /// `build::prep`'s constant; an output at any other index is not one of ours.
@@ -58,43 +56,33 @@ where
         .to_raw_address_bytes();
     let expiry = BlockHeight::from_u32(*pczt.global().expiry_height());
 
-    Zip318Evidence {
-        source_actions: Some(pczt.orchard().actions().len()),
-        destination_actions: Some(pczt.ironwood().actions().len()),
-        other_bundles_present: Some(
+    // Neither confirmatory clause is answered: deferred anchors and an absent fee field, see the
+    // module documentation.
+    Zip318Evidence::default()
+        .with_source_actions(Some(pczt.orchard().actions().len()))
+        .with_destination_actions(Some(pczt.ironwood().actions().len()))
+        .with_other_bundles_present(Some(
             pczt.has_data_in_pool(PoolType::TRANSPARENT)
                 || pczt.has_data_in_pool(PoolType::SAPLING),
-        ),
-        source_is_send_to_self: pczt.orchard().value_carrying_outputs_all_pay(&internal),
-        sole_destination_output: sole_destination_output(pczt.ironwood(), &internal),
-        expiry_is_canonical: Some(constants.is_canonical_expiry(expiry, expiry_reference)),
-        // Deferred anchors and an absent fee field; see the module documentation.
-        anchor_on_grid: None,
-        fee_is_canonical: None,
-    }
+        ))
+        .with_source_is_send_to_self(pczt.orchard().value_carrying_outputs_all_pay(&internal))
+        .with_sole_destination_value(sole_destination_value(pczt.ironwood()))
+        .with_expiry_is_canonical(Some(
+            constants.is_canonical_expiry(expiry, expiry_reference),
+        ))
 }
 
-/// The sole output of a single-action destination bundle, which is the shape a canonical crossing
-/// has.
+/// The value of the sole output of a single-action destination bundle, which is the shape a
+/// canonical crossing has.
 ///
 /// `None` when the bundle does not have exactly one action (the action count is a separate clause,
-/// so this is not itself a refutation) or when the output's value or recipient has been redacted. A
-/// zero value is reported as such rather than skipped: zero is not a canonical denomination, so the
-/// classifier refuses it, which is the right answer for a destination bundle holding only a dummy.
-fn sole_destination_output(
-    bundle: &pczt::orchard::Bundle,
-    internal: &[u8; 43],
-) -> Option<DestinationOutput> {
+/// so this is not itself a refutation) or when the output's value has been redacted. A zero value
+/// is reported as such rather than skipped: zero is not a canonical denomination, so the classifier
+/// refuses it, which is the right answer for a destination bundle holding only a dummy.
+fn sole_destination_value(bundle: &pczt::orchard::Bundle) -> Option<Zatoshis> {
     let output = bundle.sole_action()?.output();
 
-    Some(DestinationOutput {
-        value: Zatoshis::from_u64((*output.value())?).ok()?,
-        owner: if output.pays(internal)? {
-            OutputOwner::OwnInternal
-        } else {
-            OutputOwner::Other
-        },
-    })
+    Zatoshis::from_u64((*output.value())?).ok()
 }
 
 #[cfg(test)]
@@ -215,10 +203,10 @@ mod tests {
             BlockHeight::from_u32(TARGET_HEIGHT),
             &Zip318Params,
         );
-        assert_eq!(evidence.source_actions, Some(PREP_TX_ACTIONS));
-        assert_eq!(evidence.destination_actions, Some(0));
-        assert_eq!(evidence.other_bundles_present, Some(false));
-        assert_eq!(evidence.source_is_send_to_self, Some(true));
+        assert_eq!(evidence.source_actions(), Some(PREP_TX_ACTIONS));
+        assert_eq!(evidence.destination_actions(), Some(0));
+        assert_eq!(evidence.other_bundles_present(), Some(false));
+        assert_eq!(evidence.source_is_send_to_self(), Some(true));
 
         let (pczt, fvk) = transfer(COIN, canonical_expiry());
         let evidence = evidence_from_pczt(
@@ -227,18 +215,15 @@ mod tests {
             BlockHeight::from_u32(TARGET_HEIGHT),
             &Zip318Params,
         );
-        assert_eq!(evidence.source_actions, Some(SOURCE_ACTIONS_PER_TRANSFER));
+        assert_eq!(evidence.source_actions(), Some(SOURCE_ACTIONS_PER_TRANSFER));
         assert_eq!(
-            evidence.destination_actions,
+            evidence.destination_actions(),
             Some(DESTINATION_ACTIONS_PER_TRANSFER)
         );
         assert_eq!(
-            evidence.sole_destination_output,
-            Some(DestinationOutput {
-                value: zat(COIN),
-                owner: OutputOwner::OwnInternal,
-            }),
-            "the crossing pays the account's own internal address"
+            evidence.sole_destination_value(),
+            Some(zat(COIN)),
+            "the crossing carries the canonical denomination"
         );
     }
 
@@ -254,8 +239,8 @@ mod tests {
             BlockHeight::from_u32(TARGET_HEIGHT),
             &Zip318Params,
         );
-        assert_eq!(evidence.anchor_on_grid, None);
-        assert_eq!(evidence.fee_is_canonical, None);
+        assert_eq!(evidence.anchor_on_grid(), None);
+        assert_eq!(evidence.fee_is_canonical(), None);
     }
 
     /// The same transactions built with an ORDINARY expiry are refused. This is the discriminator

--- a/zcash_pool_migration/src/zip318_shape.rs
+++ b/zcash_pool_migration/src/zip318_shape.rs
@@ -61,7 +61,7 @@ where
         source_actions: Some(pczt.orchard().actions().len()),
         destination_actions: Some(pczt.ironwood().actions().len()),
         other_bundles_present: Some(pczt.has_transparent_data() || pczt.has_sapling_data()),
-        source_outputs_all_internal: pczt.orchard().value_carrying_outputs_all_pay(&internal),
+        source_is_send_to_self: pczt.orchard().value_carrying_outputs_all_pay(&internal),
         sole_destination_output: sole_destination_output(pczt.ironwood(), &internal),
         expiry_is_canonical: Some(constants.is_canonical_expiry(expiry, expiry_reference)),
         // Deferred anchors and an absent fee field; see the module documentation.
@@ -214,7 +214,7 @@ mod tests {
         assert_eq!(evidence.source_actions, Some(PREP_TX_ACTIONS));
         assert_eq!(evidence.destination_actions, Some(0));
         assert_eq!(evidence.other_bundles_present, Some(false));
-        assert_eq!(evidence.source_outputs_all_internal, Some(true));
+        assert_eq!(evidence.source_is_send_to_self, Some(true));
 
         let (pczt, fvk) = transfer(COIN, canonical_expiry());
         let evidence = evidence_from_pczt(


### PR DESCRIPTION
## Motivation

A wallet can label a transaction in its history as a ZIP 318 pool-migration
transaction only if it can recognize one. The migration plan table answers that
today, but it does not survive a seed restore, and it cannot answer for a
transaction the wallet did not itself schedule. Mobile wallets want a
"Migration" label (with preparation vs transfer as a second label) that keeps
working after a restore.

This adds the predicate, the two evidence sources that feed it, and the storage
and view column a client reads it from.

## The predicate

`zcash_protocol::zip318::classify` decides the question from the transaction's
shape alone. The discriminators are the ones an ordinary transaction does not
have:

| property | ordinary split | prep | transfer |
| --- | --- | --- | --- |
| Orchard actions | spends + outputs, min 2 | exactly 16 | 2, padded |
| Ironwood actions | n/a | none | exactly 1, unpadded |
| `expiry_height` | `target + 40` | mult. of 34 560 | mult. of 34 560 |
| external outputs | usually present | never | never |
| output values | arbitrary | denom + fee buffer | `{1,2,5}*10^k` |

Neither is rare enough alone, so they are conjoined. The canonical rolling
expiry carries most of the weight: an accidental multiple of 34 560 is about 1
in 34 560, and it must coincide with an exactly-16-action, Orchard-only, fully
internal transaction to produce a false positive.

## Three things the API deliberately commits to

**It names a conformance class, never a provenance.** ZIP 318's privacy
argument is that every migration transaction looks like every other one, so
recognizing the shape places a transaction in the anonymity set and can never
establish which wallet's run produced it. Anything we can compute, a chain
observer can compute too. Hence `Zip318TxKind` rather than an `is_migration`
predicate, and hence sharpening the classifier past the class would be a
privacy regression rather than an improvement.

**There are three shapes, not two.** The ordinary send path already builds
canonical crossings that pay a third party (`Step::is_canonical_crossing`), so
`CanonicalCrossingPayment` is distinguished from `Transfer` by the recipient
alone. A client must not present it as a migration.

**`Unknown` is the least element of an information ordering, not a third
answer.** Evidence only grows, and `classify` is monotone in it, so a decision
is never later contradicted; that is what lets a store persist a label. It also
forces the expiry clause to be judged height-independently, because the
canonical expiry is a step function: judging an unmined transaction against the
chain tip would flip the answer once it was mined in the next modulus period.
That in turn is what collapses the storage to a single write point, since every
input is then fixed by the time a transaction is decrypted.

## Two evidence sources

The conditions are written once, over a struct of `Option` fields that is
literally a point in the information ordering above (`Default` is its least
element, and the monotonicity property test builds a chain by nulling fields).

- **From a PCZT** (`zcash_pool_migration::zip318_shape`), which is what lets
  the conformance suite assert that everything the migration builders emit is
  recognized, with no prover run: proving a PCZT to obtain a `Transaction` is
  expensive, and every field the predicate needs is already in the PCZT.
- **From a decrypted transaction** (`zcash_client_backend::data_api::zip318`),
  the production path, called from `store_decrypted_tx`. It lives in the
  backend-generic layer because that is the one moment the parsed transaction
  and the decrypted outputs are in hand together.

The second is necessarily weaker, for a reason that is inherent rather than
incidental: **on chain, a zero-valued padding dummy and an unrelated party's
output are equally undecryptable**, which is exactly what the padding is for. So
"every value-carrying output pays my internal address" is not checkable, and the
clause becomes "the wallet received on its own internal address here and
received nothing on an external one". It is named for the claim rather than for
a check, since how tightly it can be established depends on the source. The
looser reading admits strictly more, preserving the direction the classifier
already has: no false negatives, some admitted look-alikes.

## Storage

`transactions.zip318_kind`, written once as a transaction is decrypted, and
exposed through `v_transactions`. The mobile SDKs build their history types from
that view with their own SQL, so the column reaches them with no FFI change.

The column defaults to the code for **not classified**, and the migration
deliberately does not classify existing rows: doing so would mean re-deriving
from stored columns without the decrypted outputs, which is both the weakest
evidence available and a second implementation of the predicate to keep in step
with the real one. Those rows keep the default and need the transaction
rescanned.

That default is a real value rather than NULL so the rows can be found with an
ordinary query, and it is distinct from the code for `Nonconforming`, which is a
decision. **A client must render it as no label, never as "not a migration"**:
the two mean "we never looked" and "we looked and it is not one". For the same
reason an unrecognized code decodes to `Unknown` rather than to a refusal.

## Tests

The one that matters is the conformance loop: what `build_prep_tx` and
`build_transfer_pczt` emit must be what `classify` recognizes. If those ever
disagree, either a builder has drifted from ZIP 318 or the classifier has, and
nothing else in the workspace would notice today.

Also covered: monotonicity in the evidence, each clause refuting on its own, an
ordinary expiry refused even on a transaction these builders produced, an
off-series crossing refused, another account's transaction not being ours, a
required clause left unanswered yielding `Unknown` rather than a refutation, and
the encoding round-trip with an explicit assertion that "never classified" and
"nonconforming" do not collide.

The view test asserts the view is QUERYABLE, not merely that the migration
applies. SQLite stores a view's SELECT as text and does not resolve its column
references until the view is used, so a `CREATE VIEW` naming a column that does
not exist succeeds and fails only later, at the first query a client makes.
Migrating cleanly would not have caught a bad reference; the first mobile client
to open its history would have.

Green: `zcash_client_sqlite` 240, `zcash_pool_migration` 170, `zcash_protocol`
36, `pczt` 19. `cargo fmt` applied. `zcash_client_backend` still builds with
`orchard` off. The three pre-existing `pczt` dead-code clippy warnings are
unchanged from `main`.

## Added API surface (for review)

Everything this PR adds. Four public items in the two low-level crates, after
dropping what had no callers.

**`zcash_protocol::zip318`** (the predicate; `no_std`, no I/O)

| item | kind | note |
| --- | --- | --- |
| `Zip318TxKind` | enum | `Preparation`, `Transfer`, `CanonicalCrossingPayment` |
| `Zip318Classification` | enum | `Conforms(kind)`, `Nonconforming`, `Unknown` |
| `Zip318Classification::{to_code, from_code}` | fn | the persisted/FFI integer; 0 = not classified |
| `Zip318Evidence` | struct | 8 `Option` fields; `Default` is the least element |
| `DestinationOutput`, `OutputOwner` | struct, enum | the sole crossing output and who it pays |
| `classify` | fn | the predicate; two private helpers behind it |
| `CROSSING_SOURCE_ACTIONS`, `CROSSING_DESTINATION_ACTIONS` | const | 2 and 1 |
| `PoolMigrationConstants::{canonical_expiry, is_canonical_expiry, is_canonical_expiry_value}` | trait fn | the third is the height-independent form |

**`pczt`** (observations about a PCZT, not about ZIP 318)

| item | kind | note |
| --- | --- | --- |
| `Pczt::has_data_in_pool(PoolType)` | fn | follows the `Step::*_in_pool` idiom |
| `orchard::Bundle::sole_action` | fn | |
| `orchard::Bundle::value_carrying_outputs_all_pay` | fn | `None` when a judged field is redacted |
| `orchard::Output::pays` | fn | |

**`zcash_pool_migration`**

| item | kind | note |
| --- | --- | --- |
| `zip318_shape::evidence_from_pczt` | fn | the test-oracle evidence source |

**`zcash_client_backend`**

| item | kind | note |
| --- | --- | --- |
| `data_api::zip318::classify_decrypted_tx` | fn | the production evidence source |
| `LowLevelWalletWrite::put_zip318_classification` | trait fn | new required method |

**`zcash_client_sqlite`** (no new public Rust API)

| item | kind | note |
| --- | --- | --- |
| `transactions.zip318_kind` | column | `NOT NULL DEFAULT 0` |
| `v_transactions.zip318_kind` | view column | what the mobile SDKs read |
| 2 migrations | | add the column; recreate the view |

Removed before review as having no callers: `Zip318Classification::{kind,
is_own_migration}`, `pczt::orchard::Bundle::outputs`,
`pczt::orchard::Output::carries_value`. `evidence_from_decrypted_tx` is private.

## Known gaps, deliberately not in this PR

- **No end-to-end test** that scans a real migration transaction into a wallet
  DB and asserts the column comes out as `Transfer`. The write path is verified
  by construction and by type-level tests, and the predicate by the PCZT
  conformance loop; the seam between them is untested.
- **No rescan method** for rows sitting at the default. Needed: a way to
  enumerate them, a way to re-classify (likely re-derivable without a full chain
  rescan, but that needs confirming before it is promised), a decision on who
  triggers it, and progress reporting.
- **Evidence from `Step`**, which would let `Step::is_canonical_crossing` become
  a wrapper over `classify` so the workspace holds one definition of the
  conditions. It touches shipping proposal behavior, so it deserves its own PR
  with a temporary old-vs-new equality assertion before the old body is deleted.
  Note it needs a decision first: a `Step` has no expiry height (the canonical
  expiry is applied later, at build time), so its evidence must assert the
  clause from the surrounding code's invariant rather than observe it.

Note that the post-scan predicate is a sound over-approximation: it cannot
evaluate the anchor-on-the-grid clause, and dropping a conjunct enlarges a
predicate's extension. Every strictly canonical transaction is recognized (no
false negatives) while a shape-exact transaction anchored off the grid may also
be admitted. That is the right direction for a label, and a store that resolves
the bundle anchor against its retained boundary roots can close it later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

