### PR TITLE
Move clippy-each-feature.sh to a top-level scripts directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -597,7 +597,7 @@ jobs:
       # `--all-features` and `--no-default-features` endpoints both miss. The script carries the
       # full rationale and can be run locally against one crate or the whole workspace.
       - name: Clippy each feature
-        run: .github/helpers/clippy-each-feature.sh "$CRATE"
+        run: scripts/clippy-each-feature.sh "$CRATE"
         env:
           CRATE: ${{ matrix.crate }}
 

--- a/scripts/clippy-each-feature.sh
+++ b/scripts/clippy-each-feature.sh
@@ -17,14 +17,14 @@
 # runner.
 #
 # Usage:
-#   .github/helpers/clippy-each-feature.sh                       # every workspace crate
-#   .github/helpers/clippy-each-feature.sh zcash_client_backend  # one crate
+#   scripts/clippy-each-feature.sh                       # every workspace crate
+#   scripts/clippy-each-feature.sh zcash_client_backend  # one crate
 #
 # Exits non-zero if any configuration fails to lint.
 
 set -uo pipefail
 
-repo_root=$(cd "$(dirname "$0")/../.." && pwd)
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
 
 # GitHub's log-annotation commands are noise outside Actions, so emit them only there.
 if [ -n "${GITHUB_ACTIONS:-}" ]; then


### PR DESCRIPTION
`clippy-each-feature.sh` is useful outside CI: it lints one crate's features, or
the whole workspace's, from a local checkout. Living under `.github/helpers`
implied it was CI-only plumbing.

Moves it to `scripts/clippy-each-feature.sh`, adjusts the repo-root resolution
(`../..` -> `..`) and the usage lines in the header, and updates the `Clippy
each feature` step in `ci.yml`.

Verified by running the moved script from outside the repo against
`zcash_encoding`: it resolved the repo root and linted each feature as before.
`shellcheck` is clean.

`check-dep-graph.py` stays in `.github/helpers` since it is genuinely CI-only.

Closes #2875

🤖 Generated with [Claude Code](https://claude.com/claude-code)