### PR TITLE
Enable the mainstream wallet feature set by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ categories = ["cryptography::cryptocurrencies"]
 # Intra-workspace dependencies
 equihash = { version = "0.3", path = "components/equihash", default-features = false }
 zcash_address = { version = "0.13.0", path = "components/zcash_address", default-features = false }
-zcash_client_backend = { version = "0.24.0-rc.7", path = "zcash_client_backend" }
+zcash_client_backend = { version = "0.24.0-rc.7", path = "zcash_client_backend", default-features = false }
 # zcash_encoding 0.5.0 is a breaking release (MSRV bump + `CompactSize::write` now
 # rejects values above `MAX_COMPACT_SIZE`). To avoid forcing every dependent to
 # migrate at once, the workspace default stays pinned to the published 0.4; only
@@ -54,7 +54,7 @@ zcash_note_encryption = "0.4.1"
 zcash_primitives = { version = "0.30.0", path = "zcash_primitives", default-features = false }
 zcash_proofs = { version = "0.30.0", path = "zcash_proofs", default-features = false }
 
-pczt = { version = "0.9.2", path = "pczt" }
+pczt = { version = "0.9.2", path = "pczt", default-features = false }
 
 # Shielded protocols
 bellman = { version = "0.14", default-features = false, features = ["groth16"] }

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -10,6 +10,11 @@ workspace.
 
 ## [Unreleased]
 
+### Changed
+- The `orchard` and `sapling` features are now enabled by default. Consumers
+  that require a smaller feature set (such as `no_std` signers) should disable
+  default features and enable only the features they need.
+
 ## [0.9.2] - 2026-08-03
 
 ### Added

--- a/pczt/Cargo.toml
+++ b/pczt/Cargo.toml
@@ -70,7 +70,7 @@ zcash_protocol = { workspace = true, features = ["local-consensus"] }
 zip32.workspace = true
 
 [features]
-default = ["std"]
+default = ["std", "orchard", "sapling"]
 std = ["document-features"]
 zip-233 = ["zcash_primitives/zip-233"]
 

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -10,6 +10,11 @@ workspace.
 
 ## [Unreleased]
 
+### Changed
+- The `orchard` feature is now enabled by default. Consumers that require a
+  smaller feature set should disable default features and enable only the
+  features they need.
+
 ## [0.24.0-rc.7] - 2026-08-03
 
 ### Added

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -165,7 +165,7 @@ zcash_proofs = { workspace = true, features = ["bundled-prover"] }
 zcash_protocol = { workspace = true, features = ["local-consensus", "test-dependencies"] }
 
 [features]
-default = ["time/default"]
+default = ["time/default", "orchard"]
 zip-233 = ["zcash_primitives/zip-233"]
 
 ## Enables the `tonic` gRPC client bindings for connecting to a `lightwalletd` server.

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -10,6 +10,11 @@ workspace.
 
 ## [Unreleased]
 
+### Changed
+- The `orchard` feature is now enabled by default. Consumers that require a
+  smaller feature set should disable default features and enable only the
+  features they need.
+
 ## [0.22.0-rc.7] - 2026-08-03
 
 ### Added

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -131,7 +131,7 @@ zcash_pool_migration = { workspace = true, features = ["test-dependencies"] }
 zip321 = { workspace = true }
 
 [features]
-default = ["multicore"]
+default = ["multicore", "orchard"]
 zip-233 = ["zcash_primitives/zip-233", "zcash_client_backend/zip-233"]
 
 ## Enables multithreading support for creating proofs and building subtrees.

--- a/zcash_keys/CHANGELOG.md
+++ b/zcash_keys/CHANGELOG.md
@@ -9,6 +9,11 @@ workspace.
 
 ## [Unreleased]
 
+### Changed
+- The `orchard` and `sapling` features are now enabled by default. Consumers
+  that require a smaller feature set should disable default features and enable
+  only the features they need.
+
 ## [0.16.1] - 2026-07-28
 
 ### Added

--- a/zcash_keys/Cargo.toml
+++ b/zcash_keys/Cargo.toml
@@ -89,7 +89,7 @@ zcash_address = { workspace = true, features = ["test-dependencies"] }
 zcash_script.workspace = true
 
 [features]
-default = ["std"]
+default = ["std", "orchard", "sapling"]
 std = [
     "dep:document-features",
     "orchard?/std",


### PR DESCRIPTION
Closes #2853.

A pass over the workspace's default features, aligning them with the modern default use-case: a shielded wallet. Every known consumer (zallet, zcash-devtool, the mobile SDK backends) currently has to enable the same features by hand.

## Changes

| Crate | Old defaults | Added |
| --- | --- | --- |
| `zcash_keys` | `std` | `orchard`, `sapling` |
| `zcash_client_backend` | `time/default` | `orchard` |
| `zcash_client_sqlite` | `multicore` | `orchard` |
| `pczt` | `std` | `orchard`, `sapling` (pools only, roles stay opt-in) |

Transparent handling (`transparent-inputs` and the features that build on it) deliberately stays opt-in everywhere, per review: a wallet that handles transparent funds must explicitly say so. Earlier revisions of this PR also touched `zcash_primitives`, `zcash_transparent`, and the `zcash` crate; those changes are gone.

So that the new defaults don't leak into dependents' minimal builds, the `pczt` and `zcash_client_backend` entries in `[workspace.dependencies]` now disable default features, matching the convention every other local crate already follows. (Without this, `zcash_client_sqlite --no-default-features` fails to compile: the backend's default `orchard` forces the backend traits' Orchard methods on while the sqlite crate's own `orchard`-gated impls stay off.) No dependent re-enables `pczt`'s `std` feature: it only gates feature-flag documentation generation — the crate is unconditionally `no_std` — so nothing relied on it. Renaming that feature to something honest (e.g. `document-features`) is left to a follow-up, since removing a published feature forces a `pczt` major bump.

Left off by default, deliberately:
- Transparent handling (`transparent-inputs`, `transparent-key-import`, `spend-index`), per above.
- Networking (`sync`, `lightwalletd-tonic*`): heavy tonic/tokio dependency tree, and not universal (zallet does not use the tonic sync path).
- `zcash_client_backend/pczt`: all three surveyed consumers enable it, so it is a plausible candidate — but it drags in the prover role and `postcard`/`serde`. Opinions welcome.
- Legacy migration (`zcashd-compat`, `zewif`), `unstable*`, `test-dependencies`, `zcash_proofs/bundled-prover` and `download-params`.

## Open questions

- The CI feature matrix's sparse states (`Sapling-only`, …) pass `--features` without `--no-default-features`, so after this change they partially degenerate toward supersets of the defaults and exercise fewer sparse combinations. They still pass (verified locally), but keeping that coverage would need the matrix reworked around per-crate `--no-default-features` runs — left out of scope here.
- Whether `zcash_client_backend/pczt` (and with it the pczt roles) belongs in the defaults, per above.

## Testing

- `cargo check --workspace`, `cargo check --workspace --all-targets`, and per-crate `cargo check` with the new defaults pass locally.
- `--no-default-features` builds of every touched crate (and `zcash_client_sqlite`, which the workspace wiring fix exists for) pass locally.
- `--all-features` and `--no-default-features` dependency graphs are unchanged by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpuFThaAVXvGz3Z5dt4Lw5
https://claude.ai/code/session_01RFJUSRmxCMbcDmsVzbXk31
