### PR TITLE
zcash_client_sqlite: compute CURRENT_LEAF_MIGRATIONS at compile time

### DIFF
--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -553,19 +553,142 @@ pub const V_0_22_0_RC2: &[Uuid] = &[
     note_locking::MIGRATION_ID,
 ];
 
-/// Leaf migrations as of the current repository state.
-pub const CURRENT_LEAF_MIGRATIONS: &[Uuid] = &[
-    v_tx_outputs_transparent_addresses::MIGRATION_ID,
-    ivk_item_cache::MIGRATION_ID,
-    add_transparent_receiver_address_index::MIGRATION_ID,
-    add_transparent_value_index::MIGRATION_ID,
-    fix_bad_ironwood_change_flagging::MIGRATION_ID,
-    v_address_uses_ironwood::MIGRATION_ID,
-    v_transactions_pool_crossing::MIGRATION_ID,
-    orchard_ironwood_migration_anchor_interval::MIGRATION_ID,
-    tree_retained_checkpoints::MIGRATION_ID,
-    tx_status_observation_intent::MIGRATION_ID,
-];
+/// Returns whether `id` appears in any of the given dependency lists.
+const fn is_depended_on(id: Uuid, dependencies: &[&[Uuid]]) -> bool {
+    let mut i = 0;
+    while i < dependencies.len() {
+        let deps = dependencies[i];
+        let mut j = 0;
+        while j < deps.len() {
+            if deps[j].as_u128() == id.as_u128() {
+                return true;
+            }
+            j += 1;
+        }
+        i += 1;
+    }
+    false
+}
+
+/// Counts the identifiers in `ids` that appear in none of the given dependency lists.
+const fn count_leaves(ids: &[Uuid], dependencies: &[&[Uuid]]) -> usize {
+    let mut count = 0;
+    let mut i = 0;
+    while i < ids.len() {
+        if !is_depended_on(ids[i], dependencies) {
+            count += 1;
+        }
+        i += 1;
+    }
+    count
+}
+
+/// Collects the identifiers in `ids` that appear in none of the given dependency lists,
+/// preserving their order in `ids`.
+///
+/// `N` must equal [`count_leaves`] for the same arguments; const evaluation fails otherwise.
+const fn collect_leaves<const N: usize>(ids: &[Uuid], dependencies: &[&[Uuid]]) -> [Uuid; N] {
+    let mut leaves = [Uuid::nil(); N];
+    let mut count = 0;
+    let mut i = 0;
+    while i < ids.len() {
+        if !is_depended_on(ids[i], dependencies) {
+            leaves[count] = ids[i];
+            count += 1;
+        }
+        i += 1;
+    }
+    assert!(count == N);
+    leaves
+}
+
+/// Defines [`CURRENT_LEAF_MIGRATIONS`] as the leaves of the migration dependency graph,
+/// computed at compile time from the listed migration modules.
+///
+/// Every migration module must be listed here. Each contributes its `MIGRATION_ID` and
+/// `DEPENDENCIES` to the graph; the leaves are the migrations on which no listed
+/// migration depends.
+macro_rules! migration_graph_leaves {
+    ($($migration:ident),+ $(,)?) => {
+        /// The identifiers of all migrations in the dependency graph.
+        const ALL_MIGRATION_IDS: &[Uuid] = &[$($migration::MIGRATION_ID),+];
+
+        /// The dependencies of each migration, in the same order as [`ALL_MIGRATION_IDS`].
+        const ALL_DEPENDENCIES: &[&[Uuid]] = &[$($migration::DEPENDENCIES),+];
+
+        const LEAF_MIGRATION_IDS: [Uuid; count_leaves(ALL_MIGRATION_IDS, ALL_DEPENDENCIES)] =
+            collect_leaves(ALL_MIGRATION_IDS, ALL_DEPENDENCIES);
+
+        /// Leaf migrations as of the current repository state.
+        pub const CURRENT_LEAF_MIGRATIONS: &[Uuid] = &LEAF_MIGRATION_IDS;
+    };
+}
+
+migration_graph_leaves!(
+    account_delete_cascade,
+    add_account_birthdays,
+    add_account_uuids,
+    add_transaction_trust_marker,
+    add_transaction_views,
+    add_transparent_receiver_address_index,
+    add_transparent_value_index,
+    add_utxo_account,
+    addresses_table,
+    ensure_default_transparent_address,
+    ensure_orchard_ua_receiver,
+    ephemeral_addresses,
+    fix_bad_change_flagging,
+    fix_bad_ironwood_change_flagging,
+    fix_broken_commitment_trees,
+    fix_transparent_received_outputs,
+    fix_v_transactions_expired_unmined,
+    full_account_ids,
+    initial_setup,
+    ironwood_pool_code_views,
+    ironwood_received_notes,
+    ironwood_shardtree,
+    ivk_item_cache,
+    note_locking,
+    nullifier_map,
+    orchard_ironwood_migration_anchor_interval,
+    orchard_ironwood_migration_tables,
+    orchard_note_version,
+    orchard_received_notes,
+    orchard_shardtree,
+    received_notes_nullable_nf,
+    receiving_key_scopes,
+    sapling_memo_consistency,
+    sent_notes_to_internal,
+    shardtree_support,
+    spend_key_available,
+    standalone_p2sh,
+    support_legacy_sqlite,
+    support_zcashd_wallet_import,
+    transparent_gap_limit_handling,
+    tree_retained_checkpoints,
+    tx_observation_height,
+    tx_retrieval_queue,
+    tx_retrieval_queue_expiry,
+    tx_status_observation_intent,
+    ufvk_support,
+    utxos_table,
+    utxos_to_txos,
+    v_address_uses_ironwood,
+    v_received_output_spends_account,
+    v_sapling_shard_unscanned_ranges,
+    v_transactions_additional_totals,
+    v_transactions_net,
+    v_transactions_note_uniqueness,
+    v_transactions_pool_crossing,
+    v_transactions_shielding_balance,
+    v_transactions_transparent_history,
+    v_tx_outputs_key_scopes,
+    v_tx_outputs_return_addrs,
+    v_tx_outputs_transparent_addresses,
+    v_tx_outputs_use_legacy_false,
+    wallet_summaries,
+    witness_stabilized_notes,
+);
 
 pub(super) fn verify_network_compatibility<P: consensus::Parameters>(
     conn: &rusqlite::Connection,
@@ -637,9 +760,9 @@ pub(crate) mod tests {
 
     /// `CURRENT_LEAF_MIGRATIONS` must list exactly the leaves of the migration dependency graph
     /// (the migrations that no other migration depends on), so that migrating to the current
-    /// state reaches every migration. This recomputes the leaves from the graph and checks them
-    /// against the constant, so a newly added migration that supersedes an existing leaf cannot
-    /// silently leave a stale entry behind.
+    /// state reaches every migration. This recomputes the leaves from the runtime migration
+    /// graph and checks them against the compile-time computation, guarding against divergence
+    /// between the two views of the graph.
     #[test]
     fn current_leaf_migrations_are_the_dag_leaves() {
         let migrations =
@@ -651,6 +774,19 @@ pub(crate) mod tests {
 
         let listed_leaves: HashSet<Uuid> = super::CURRENT_LEAF_MIGRATIONS.iter().copied().collect();
         assert_eq!(computed_leaves, listed_leaves);
+    }
+
+    /// The `migration_graph_leaves!` invocation must list every migration module, or the
+    /// compile-time leaf computation would operate on an incomplete graph. This checks its
+    /// module list against the runtime migration graph.
+    #[test]
+    fn migration_graph_leaves_covers_every_migration() {
+        let migrations =
+            super::all_migrations(&Network::TestNetwork, test_clock(), test_rng(), None);
+
+        let runtime_ids: HashSet<Uuid> = migrations.iter().map(|m| m.id()).collect();
+        let listed_ids: HashSet<Uuid> = super::ALL_MIGRATION_IDS.iter().copied().collect();
+        assert_eq!(runtime_ids, listed_ids);
     }
 
     /// Every migration in the graph must have a publicly-exported identifier, so that an

--- a/zcash_client_sqlite/src/wallet/init/migrations/account_delete_cascade.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/account_delete_cascade.rs
@@ -18,7 +18,7 @@ use crate::wallet::init::{
 /// enable deletion of account records.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x07770bfd_c549_4069_9e05_822458f81cc4);
 
-const DEPENDENCIES: &[Uuid] = &[
+pub(super) const DEPENDENCIES: &[Uuid] = &[
     tx_retrieval_queue_expiry::MIGRATION_ID,
     support_zcashd_wallet_import::MIGRATION_ID,
     v_received_output_spends_account::MIGRATION_ID,

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_account_birthdays.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_account_birthdays.rs
@@ -13,7 +13,7 @@ use super::shardtree_support;
 /// This migration adds a birthday height to each account record.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xeeec0d0d_fee0_4231_8c68_5f3a7c7c2245);
 
-const DEPENDENCIES: &[Uuid] = &[shardtree_support::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[shardtree_support::MIGRATION_ID];
 
 pub(super) struct Migration<P> {
     pub(super) params: P,

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_account_uuids.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_account_uuids.rs
@@ -16,7 +16,7 @@ use super::support_legacy_sqlite;
 /// This migration adds a UUID to each account record, and adds `name` and `key_source` columns.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xcccc623f_3243_43c7_b884_ceef25149e04);
 
-const DEPENDENCIES: &[Uuid] = &[support_legacy_sqlite::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[support_legacy_sqlite::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_transaction_trust_marker.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_transaction_trust_marker.rs
@@ -12,7 +12,7 @@ use crate::wallet::init::WalletMigrationError;
 /// ZIP 315 confirmations policy
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x4e68277f_6269_467e_9437_f3853cc4a41f);
 
-const DEPENDENCIES: &[Uuid] = &[
+pub(super) const DEPENDENCIES: &[Uuid] = &[
     fix_v_transactions_expired_unmined::MIGRATION_ID,
     tx_observation_height::MIGRATION_ID,
 ];

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_transaction_views.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_transaction_views.rs
@@ -17,7 +17,7 @@ use crate::wallet::init::WalletMigrationError;
 /// Migration that adds transaction summary views & add fee information to transactions.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x282fad2e_8372_4ca0_8bed_71821320909f);
 
-const DEPENDENCIES: &[Uuid] = &[
+pub(super) const DEPENDENCIES: &[Uuid] = &[
     add_utxo_account::MIGRATION_ID,
     sent_notes_to_internal::MIGRATION_ID,
 ];

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_transparent_receiver_address_index.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_transparent_receiver_address_index.rs
@@ -44,7 +44,7 @@ pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x3d4f12d6_3da9_4ace_ac65_a0dd0a7
 // depending on it is sufficient to ensure the table is in its final form (including the
 // `cached_transparent_receiver_address` column) before this index is created. No later migration
 // modifies the `addresses` table, so the index will not be dropped by a subsequent table rebuild.
-const DEPENDENCIES: &[Uuid] = &[standalone_p2sh::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[standalone_p2sh::MIGRATION_ID];
 
 pub(super) struct Migration<P> {
     pub(super) params: P,

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_transparent_value_index.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_transparent_value_index.rs
@@ -35,7 +35,7 @@ pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x47c0e9c2_2eda_4b9c_be15_63c636c
 // rebuilds (`fix_transparent_received_outputs`, and `utxos_to_txos` which creates the
 // table initially) do not need to be listed explicitly: `account_delete_cascade`
 // transitively depends on both.
-const DEPENDENCIES: &[Uuid] = &[account_delete_cascade::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[account_delete_cascade::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/add_utxo_account.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/add_utxo_account.rs
@@ -26,7 +26,8 @@ use {
 /// This migration adds an account identifier column to the UTXOs table.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x761884d6_30d8_44ef_b204_0b82551c4ca1);
 
-const DEPENDENCIES: &[Uuid] = &[utxos_table::MIGRATION_ID, addresses_table::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] =
+    &[utxos_table::MIGRATION_ID, addresses_table::MIGRATION_ID];
 
 pub(super) struct Migration<P> {
     pub(super) _params: P,

--- a/zcash_client_sqlite/src/wallet/init/migrations/addresses_table.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/addresses_table.rs
@@ -23,7 +23,7 @@ use super::ufvk_support;
 /// the `accounts` table.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xd956978c_9c87_4d6e_815d_fb8f088d094c);
 
-const DEPENDENCIES: &[Uuid] = &[ufvk_support::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[ufvk_support::MIGRATION_ID];
 
 pub(crate) struct Migration<P: consensus::Parameters> {
     pub(crate) params: P,

--- a/zcash_client_sqlite/src/wallet/init/migrations/ensure_default_transparent_address.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ensure_default_transparent_address.rs
@@ -17,7 +17,7 @@ use crate::wallet::init::WalletMigrationError;
 /// address for the account.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x702cf97b_8395_4edc_b584_5c9f87f0ef35);
 
-const DEPENDENCIES: &[Uuid] = &[transparent_gap_limit_handling::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[transparent_gap_limit_handling::MIGRATION_ID];
 
 pub(super) struct Migration<P> {
     pub(super) _params: P,

--- a/zcash_client_sqlite/src/wallet/init/migrations/ensure_orchard_ua_receiver.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ensure_orchard_ua_receiver.rs
@@ -16,7 +16,7 @@ use crate::{UA_ORCHARD, UA_TRANSPARENT, wallet::init::WalletMigrationError};
 /// This migration ensures that an Orchard receiver exists in the wallet's default Unified address.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x604349c7_5ce5_4768_bea6_12d106ccda93);
 
-const DEPENDENCIES: &[Uuid] = &[orchard_received_notes::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[orchard_received_notes::MIGRATION_ID];
 
 pub(super) struct Migration<P> {
     pub(super) params: P,

--- a/zcash_client_sqlite/src/wallet/init/migrations/ephemeral_addresses.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ephemeral_addresses.rs
@@ -24,7 +24,7 @@ use {
 /// The migration that records ephemeral addresses for each account.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x0e1d4274_1f8e_44e2_909d_689a4bc2967b);
 
-const DEPENDENCIES: &[Uuid] = &[utxos_to_txos::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[utxos_to_txos::MIGRATION_ID];
 
 #[allow(dead_code)]
 pub(super) struct Migration<P> {

--- a/zcash_client_sqlite/src/wallet/init/migrations/fix_bad_change_flagging.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/fix_bad_change_flagging.rs
@@ -21,7 +21,7 @@ use crate::ORCHARD_TABLES_PREFIX;
 /// provided from the account corresponding to that key.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x6d36656d_533b_4b65_ae91_dcb95c4ad289);
 
-const DEPENDENCIES: &[Uuid] = &[fix_broken_commitment_trees::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[fix_broken_commitment_trees::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/fix_bad_ironwood_change_flagging.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/fix_bad_ironwood_change_flagging.rs
@@ -36,7 +36,7 @@ use super::ironwood_received_notes;
 /// was provided from the account corresponding to that key.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xcc104d0d_54d6_4e07_9404_202676561d94);
 
-const DEPENDENCIES: &[Uuid] = &[ironwood_received_notes::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[ironwood_received_notes::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/fix_broken_commitment_trees.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/fix_broken_commitment_trees.rs
@@ -26,7 +26,7 @@ use crate::GapLimits;
 /// reorg handling.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x9fa43ce0_a387_45d1_be03_57a3edc76d01);
 
-const DEPENDENCIES: &[Uuid] = &[support_legacy_sqlite::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[support_legacy_sqlite::MIGRATION_ID];
 
 pub(super) struct Migration<P> {
     pub(super) params: P,

--- a/zcash_client_sqlite/src/wallet/init/migrations/fix_transparent_received_outputs.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/fix_transparent_received_outputs.rs
@@ -13,7 +13,7 @@ use super::{
 /// Fixes the `transparent_received_outputs` table schema to not depend on feature flags.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xb951587c_34fd_4f02_a313_05ff7adb6268);
 
-const DEPENDENCIES: &[Uuid] = &[
+pub(super) const DEPENDENCIES: &[Uuid] = &[
     fix_bad_change_flagging::MIGRATION_ID,
     v_transactions_additional_totals::MIGRATION_ID,
     ensure_default_transparent_address::MIGRATION_ID,

--- a/zcash_client_sqlite/src/wallet/init/migrations/fix_v_transactions_expired_unmined.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/fix_v_transactions_expired_unmined.rs
@@ -12,7 +12,7 @@ use crate::wallet::init::{WalletMigrationError, migrations::fix_transparent_rece
 /// been mined.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x54733173_5f3c_4870_831e_a48a4a93b1d7);
 
-const DEPENDENCIES: &[Uuid] = &[fix_transparent_received_outputs::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[fix_transparent_received_outputs::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/full_account_ids.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/full_account_ids.rs
@@ -24,7 +24,7 @@ pub(crate) struct Migration<P: consensus::Parameters> {
     pub(super) params: P,
 }
 
-const DEPENDENCIES: &[Uuid] = &[
+pub(super) const DEPENDENCIES: &[Uuid] = &[
     receiving_key_scopes::MIGRATION_ID,
     add_account_birthdays::MIGRATION_ID,
     v_transactions_note_uniqueness::MIGRATION_ID,

--- a/zcash_client_sqlite/src/wallet/init/migrations/initial_setup.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/initial_setup.rs
@@ -9,6 +9,8 @@ use crate::wallet::init::WalletMigrationError;
 /// Identifier for the migration that performs the initial setup of the wallet database.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xbc4f5e57_d600_4b6c_990f_b3538f0bfce1);
 
+pub(super) const DEPENDENCIES: &[Uuid] = &[];
+
 pub(super) struct Migration;
 
 impl schemerz::Migration<Uuid> for Migration {
@@ -17,7 +19,7 @@ impl schemerz::Migration<Uuid> for Migration {
     }
 
     fn dependencies(&self) -> HashSet<Uuid> {
-        HashSet::new()
+        DEPENDENCIES.iter().copied().collect()
     }
 
     fn description(&self) -> &'static str {

--- a/zcash_client_sqlite/src/wallet/init/migrations/ironwood_pool_code_views.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ironwood_pool_code_views.rs
@@ -24,7 +24,7 @@ use super::ironwood_received_notes;
 /// Adds Ironwood received notes to the `v_received_outputs` and `v_received_output_spends` views.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xa6ef40c7_050a_43c6_a4e2_2f034168c979);
 
-const DEPENDENCIES: &[Uuid] = &[ironwood_received_notes::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[ironwood_received_notes::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/ironwood_received_notes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ironwood_received_notes.rs
@@ -23,7 +23,7 @@ use super::orchard_note_version;
 /// Adds tables for storage of received Ironwood notes.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xdc0d6c91_b3db_429e_9a7b_d671cc19656e);
 
-const DEPENDENCIES: &[Uuid] = &[orchard_note_version::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[orchard_note_version::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/ironwood_shardtree.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ironwood_shardtree.rs
@@ -20,7 +20,7 @@ pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x1f5420e3_f8a0_4afd_a9e5_e20fc6f
 // Depends on `orchard_shardtree` (the Ironwood tree tables mirror the Orchard ones) and on
 // `wallet_summaries` (which adds the `blocks` output/action-count columns), so the Ironwood
 // block-metadata columns append after all existing `blocks` columns.
-const DEPENDENCIES: &[Uuid] = &[
+pub(super) const DEPENDENCIES: &[Uuid] = &[
     orchard_shardtree::MIGRATION_ID,
     wallet_summaries::MIGRATION_ID,
 ];

--- a/zcash_client_sqlite/src/wallet/init/migrations/ivk_item_cache.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ivk_item_cache.rs
@@ -22,7 +22,7 @@ use super::standalone_p2sh;
 /// Replaces FVK item cache columns with IVK item cache columns in the `accounts` table.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x93278b0f_77fe_473c_b88e_7f285da38dd3);
 
-const DEPENDENCIES: &[Uuid] = &[standalone_p2sh::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[standalone_p2sh::MIGRATION_ID];
 
 pub(crate) struct Migration<P: consensus::Parameters> {
     pub(super) params: P,

--- a/zcash_client_sqlite/src/wallet/init/migrations/note_locking.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/note_locking.rs
@@ -19,7 +19,7 @@ pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xa1d4a28c_7582_4457_b0f4_d3f297b
 // migration that creates or rebuilds any of the four tables (the sapling/orchard/transparent
 // rebuilds all precede it via `orchard_note_version` -> `witness_stabilized_notes` ->
 // `account_delete_cascade`), and it creates the `ironwood_received_notes` table itself.
-const DEPENDENCIES: &[Uuid] = &[ironwood_received_notes::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[ironwood_received_notes::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/nullifier_map.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/nullifier_map.rs
@@ -15,7 +15,7 @@ use super::received_notes_nullable_nf;
 /// revealed in.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xe2d71ac5_6a44_4c6b_a9a0_6d0a79d355f1);
 
-const DEPENDENCIES: &[Uuid] = &[received_notes_nullable_nf::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[received_notes_nullable_nf::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/orchard_ironwood_migration_anchor_interval.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/orchard_ironwood_migration_anchor_interval.rs
@@ -32,7 +32,7 @@ use crate::wallet::init::WalletMigrationError;
 /// Adds the `anchor_bucket_interval` column to `orchard_ironwood_migrations` where it is missing.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x1ab3caf9_ef1e_482c_93a3_a3f1080038df);
 
-const DEPENDENCIES: &[Uuid] = &[orchard_ironwood_migration_tables::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[orchard_ironwood_migration_tables::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/orchard_ironwood_migration_tables.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/orchard_ironwood_migration_tables.rs
@@ -34,7 +34,7 @@ pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x7b2f6a41_9c3d_4e58_8a17_2f6b9d0
 // under the codebase's minimal-frontier convention. If a future migration reshuffles the DAG such that
 // `ironwood_received_notes` no longer pulls in the Orchard source infrastructure, add the Orchard
 // dependencies here explicitly.
-const DEPENDENCIES: &[Uuid] = &[ironwood_received_notes::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[ironwood_received_notes::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/orchard_note_version.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/orchard_note_version.rs
@@ -22,7 +22,7 @@ use super::witness_stabilized_notes;
 /// Adds a `note_version` column to the `orchard_received_notes` table.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x2aa44e8e_e8a7_4760_8de4_501956c969ac);
 
-const DEPENDENCIES: &[Uuid] = &[witness_stabilized_notes::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[witness_stabilized_notes::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/orchard_received_notes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/orchard_received_notes.rs
@@ -15,7 +15,7 @@ use crate::wallet::{init::WalletMigrationError, pool_code};
 /// notes.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x51d7a273_aa19_4109_9325_80e4a5545048);
 
-const DEPENDENCIES: &[Uuid] = &[full_account_ids::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[full_account_ids::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/orchard_shardtree.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/orchard_shardtree.rs
@@ -17,7 +17,7 @@ use crate::wallet::{chain_tip_height, init::WalletMigrationError, scanning::prio
 /// commitment tree data using the `shardtree` crate.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x3a6487f7_e068_42bb_9d12_6bb8dbe6da00);
 
-const DEPENDENCIES: &[Uuid] = &[shardtree_support::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[shardtree_support::MIGRATION_ID];
 
 pub(super) struct Migration<P> {
     pub(super) params: P,

--- a/zcash_client_sqlite/src/wallet/init/migrations/received_notes_nullable_nf.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/received_notes_nullable_nf.rs
@@ -13,7 +13,7 @@ use crate::wallet::init::WalletMigrationError;
 /// `nf` column nullable.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xbdcdcedc_7b29_4f1c_8307_35f937f0d32a);
 
-const DEPENDENCIES: &[Uuid] = &[v_transactions_net::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[v_transactions_net::MIGRATION_ID];
 
 pub(crate) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/receiving_key_scopes.rs
@@ -36,7 +36,7 @@ use crate::{
 /// This migration adds decryption key scope to persisted information about received notes.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xee89ed2b_c1c2_421e_9e98_c1e3e54a7fc2);
 
-const DEPENDENCIES: &[Uuid] = &[shardtree_support::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[shardtree_support::MIGRATION_ID];
 
 pub(super) struct Migration<P> {
     pub(super) params: P,

--- a/zcash_client_sqlite/src/wallet/init/migrations/sapling_memo_consistency.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/sapling_memo_consistency.rs
@@ -28,7 +28,7 @@ use super::received_notes_nullable_nf;
 /// ensure that memo entries are consistent with the decrypted transaction's outputs.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x7029b904_6557_4aa1_9da5_6904b65d2ba5);
 
-const DEPENDENCIES: &[Uuid] = &[received_notes_nullable_nf::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[received_notes_nullable_nf::MIGRATION_ID];
 
 pub(super) struct Migration<P> {
     pub(super) params: P,

--- a/zcash_client_sqlite/src/wallet/init/migrations/sent_notes_to_internal.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/sent_notes_to_internal.rs
@@ -11,7 +11,7 @@ use crate::wallet::init::WalletMigrationError;
 /// This migration adds the `to_account` field to the `sent_notes` table.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x0ddbe561_8259_4212_9ab7_66fdc4a74e1d);
 
-const DEPENDENCIES: &[Uuid] = &[ufvk_support::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[ufvk_support::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/shardtree_support.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/shardtree_support.rs
@@ -33,7 +33,7 @@ use crate::{
 /// data structures.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x7da6489d_e835_4657_8be5_f512bcce6cbf);
 
-const DEPENDENCIES: &[Uuid] = &[received_notes_nullable_nf::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[received_notes_nullable_nf::MIGRATION_ID];
 
 pub(super) struct Migration<P> {
     pub(super) params: P,

--- a/zcash_client_sqlite/src/wallet/init/migrations/spend_key_available.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/spend_key_available.rs
@@ -11,7 +11,7 @@ use super::full_account_ids;
 /// The migration that records ephemeral addresses for each account.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x07610aac_b0e3_4ba8_aaa6_cda606f0fd7b);
 
-const DEPENDENCIES: &[Uuid] = &[full_account_ids::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[full_account_ids::MIGRATION_ID];
 
 #[allow(dead_code)]
 pub(super) struct Migration;

--- a/zcash_client_sqlite/src/wallet/init/migrations/standalone_p2sh.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/standalone_p2sh.rs
@@ -16,7 +16,7 @@ use super::account_delete_cascade;
 /// index.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x944f8a1e_bdfa_4d52_90ca_663dee8efc62);
 
-const DEPENDENCIES: &[Uuid] = &[account_delete_cascade::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[account_delete_cascade::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/support_legacy_sqlite.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/support_legacy_sqlite.rs
@@ -9,7 +9,7 @@ use crate::wallet::init::{WalletMigrationError, migrations::tx_retrieval_queue};
 /// Modifies definitions to avoid keywords that may not be available in older SQLite versions.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x156d8c8f_2173_4b59_89b6_75697d5a2103);
 
-const DEPENDENCIES: &[Uuid] = &[tx_retrieval_queue::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[tx_retrieval_queue::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/support_zcashd_wallet_import.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/support_zcashd_wallet_import.rs
@@ -14,7 +14,7 @@ use super::fix_transparent_received_outputs;
 /// Adds support for storing key material required for zcashd wallet import.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x254d4f20_f0f6_4635_80ed_9d52c536d5df);
 
-const DEPENDENCIES: &[Uuid] = &[fix_transparent_received_outputs::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[fix_transparent_received_outputs::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/transparent_gap_limit_handling.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/transparent_gap_limit_handling.rs
@@ -44,7 +44,7 @@ use {
 /// `ephemeral_addresses` tables.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xc41dfc0e_e870_4859_be47_d2f572f5ca73);
 
-const DEPENDENCIES: &[Uuid] = &[add_account_uuids::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[add_account_uuids::MIGRATION_ID];
 
 pub(super) struct Migration<P, C, R> {
     pub(super) params: P,

--- a/zcash_client_sqlite/src/wallet/init/migrations/tree_retained_checkpoints.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/tree_retained_checkpoints.rs
@@ -15,7 +15,7 @@ use crate::wallet::init::WalletMigrationError;
 /// Migration that adds tables for tracking explicitly-retained shardtree checkpoints ("anchors").
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x62032f4a_88b5_454d_a591_10f3d4c4d2b7);
 
-const DEPENDENCIES: &[Uuid] = &[witness_stabilized_notes::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[witness_stabilized_notes::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/tx_observation_height.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/tx_observation_height.rs
@@ -14,7 +14,7 @@ use crate::wallet::{
 /// Adds minimum observation height to transaction records.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xab1be47e_dbfd_439a_876a_55a7e4a0ea0b);
 
-const DEPENDENCIES: &[Uuid] = &[fix_transparent_received_outputs::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[fix_transparent_received_outputs::MIGRATION_ID];
 
 pub(super) struct Migration<P> {
     pub(super) params: P,

--- a/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue.rs
@@ -38,7 +38,7 @@ use {
     },
 };
 
-const DEPENDENCIES: &[Uuid] = &[
+pub(super) const DEPENDENCIES: &[Uuid] = &[
     orchard_shardtree::MIGRATION_ID,
     ensure_orchard_ua_receiver::MIGRATION_ID,
     ephemeral_addresses::MIGRATION_ID,

--- a/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue_expiry.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/tx_retrieval_queue_expiry.rs
@@ -13,7 +13,7 @@ use super::tx_retrieval_queue;
 /// Adds expiration to transaction enhancement requests.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x9ffe82d4_3bf5_459a_9a21_7affd9e88e95);
 
-const DEPENDENCIES: &[Uuid] = &[tx_retrieval_queue::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[tx_retrieval_queue::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/tx_status_observation_intent.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/tx_status_observation_intent.rs
@@ -20,7 +20,8 @@ use crate::wallet::{
 /// removes status requests whose transactions have wallet-observable shielded spends or outputs.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xd7ab0ab2_1487_4cb7_ba74_72ece5fdba2f);
 
-const DEPENDENCIES: &[Uuid] = &[note_locking::MIGRATION_ID, tx_retrieval_queue::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] =
+    &[note_locking::MIGRATION_ID, tx_retrieval_queue::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/ufvk_support.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/ufvk_support.rs
@@ -30,7 +30,7 @@ use crate::{
 /// Migration that adds support for unified full viewing keys.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xbe57ef3b_388e_42ea_97e2_678dafcf9754);
 
-const DEPENDENCIES: &[Uuid] = &[initial_setup::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[initial_setup::MIGRATION_ID];
 
 pub(super) struct Migration<P> {
     pub(super) params: P,

--- a/zcash_client_sqlite/src/wallet/init/migrations/utxos_table.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/utxos_table.rs
@@ -9,7 +9,7 @@ use crate::wallet::init::{WalletMigrationError, migrations::initial_setup};
 /// The migration that adds initial support for transparent UTXOs to the wallet.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xa2e0ed2e_8852_475e_b0a4_f154b15b9dbe);
 
-const DEPENDENCIES: &[Uuid] = &[initial_setup::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[initial_setup::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/utxos_to_txos.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/utxos_to_txos.rs
@@ -11,7 +11,7 @@ use crate::wallet::init::{WalletMigrationError, migrations::orchard_received_not
 /// adds `spent_note_count` and `is_shielding` to `v_transactions`.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x3a2562b3_f174_46a1_aa8c_1d122ca2e884);
 
-const DEPENDENCIES: &[Uuid] = &[orchard_received_notes::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[orchard_received_notes::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_address_uses_ironwood.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_address_uses_ironwood.rs
@@ -38,7 +38,7 @@ use super::ironwood_received_notes;
 /// Adds Ironwood received notes to the `v_address_uses` view.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xdab89587_cd05_43b0_a5b5_8cb64a702791);
 
-const DEPENDENCIES: &[Uuid] = &[ironwood_received_notes::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[ironwood_received_notes::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_received_output_spends_account.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_received_output_spends_account.rs
@@ -12,7 +12,7 @@ use crate::wallet::init::{WalletMigrationError, migrations::fix_v_transactions_e
 /// fields.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x50fd092d_97b9_44cf_ade9_86b526e4cd50);
 
-const DEPENDENCIES: &[Uuid] = &[fix_v_transactions_expired_unmined::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[fix_v_transactions_expired_unmined::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_sapling_shard_unscanned_ranges.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_sapling_shard_unscanned_ranges.rs
@@ -17,7 +17,7 @@ use super::add_account_birthdays;
 /// commitment tree shard.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xfa934bdc_97b6_4980_8a83_b2cb1ac465fd);
 
-const DEPENDENCIES: &[Uuid] = &[add_account_birthdays::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[add_account_birthdays::MIGRATION_ID];
 
 pub(super) struct Migration<P> {
     pub(super) params: P,

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_additional_totals.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_additional_totals.rs
@@ -14,7 +14,7 @@ use super::add_account_uuids;
 /// aid wallets in distinguishing shielding transactions.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x7f2fd1b3_1872_4b90_88ba_7d02b470090f);
 
-const DEPENDENCIES: &[Uuid] = &[add_account_uuids::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[add_account_uuids::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_net.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_net.rs
@@ -15,7 +15,7 @@ use crate::wallet::{init::WalletMigrationError, pool_code};
 /// received value.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x2aa4d24f_51aa_4a4c_8d9b_e5b8a762865f);
 
-const DEPENDENCIES: &[Uuid] = &[add_transaction_views::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[add_transaction_views::MIGRATION_ID];
 
 pub(crate) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_note_uniqueness.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_note_uniqueness.rs
@@ -14,7 +14,7 @@ use super::v_transactions_shielding_balance;
 /// being incorrectly deduplicated.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xdba47c86_13b5_4601_94b2_0cde0abe1e45);
 
-const DEPENDENCIES: &[Uuid] = &[v_transactions_shielding_balance::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[v_transactions_shielding_balance::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_pool_crossing.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_pool_crossing.rs
@@ -41,7 +41,7 @@ pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x835d61e1_5b88_4f44_92b3_746fb91
 /// `account_delete_cascade` is the prior owner of the `v_transactions` definition this migration
 /// recreates; `ironwood_pool_code_views` supplies the Ironwood arms of `v_received_outputs` and
 /// `v_received_output_spends` that the crossing classification aggregates over.
-const DEPENDENCIES: &[Uuid] = &[
+pub(super) const DEPENDENCIES: &[Uuid] = &[
     account_delete_cascade::MIGRATION_ID,
     ironwood_pool_code_views::MIGRATION_ID,
 ];

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_shielding_balance.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_shielding_balance.rs
@@ -14,7 +14,7 @@ use super::v_tx_outputs_use_legacy_false;
 /// value.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xb8fe5112_4365_473c_8b42_2b07c0f0adaf);
 
-const DEPENDENCIES: &[Uuid] = &[v_tx_outputs_use_legacy_false::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[v_tx_outputs_use_legacy_false::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_transparent_history.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_transparent_history.rs
@@ -14,7 +14,7 @@ use super::sapling_memo_consistency;
 /// utxos for which we lack complete transaction information.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xaa0a4168_b41b_44c5_a47d_c4c66603cfab);
 
-const DEPENDENCIES: &[Uuid] = &[sapling_memo_consistency::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[sapling_memo_consistency::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_tx_outputs_key_scopes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_tx_outputs_key_scopes.rs
@@ -11,7 +11,7 @@ use crate::wallet::init::{WalletMigrationError, migrations::account_delete_casca
 /// views.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x97ac36a9_196f_4dd9_993d_722bde95bebc);
 
-const DEPENDENCIES: &[Uuid] = &[account_delete_cascade::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[account_delete_cascade::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_tx_outputs_return_addrs.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_tx_outputs_return_addrs.rs
@@ -12,7 +12,7 @@ use crate::wallet::init::{WalletMigrationError, migrations::fix_v_transactions_e
 /// to the returned fields.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x894574e0_663e_401a_8426_820b1f75149a);
 
-const DEPENDENCIES: &[Uuid] = &[fix_v_transactions_expired_unmined::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[fix_v_transactions_expired_unmined::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_tx_outputs_transparent_addresses.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_tx_outputs_transparent_addresses.rs
@@ -34,7 +34,7 @@ pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x856ecde7_c670_47c1_9345_b80ba5b
 /// `v_tx_outputs_key_scopes` is the prior owner of the `v_tx_outputs` definition this
 /// migration recreates; `ironwood_pool_code_views` supplies the current `v_received_outputs`
 /// definition whose pool codes the transparent-receiver case discriminates on.
-const DEPENDENCIES: &[Uuid] = &[
+pub(super) const DEPENDENCIES: &[Uuid] = &[
     v_tx_outputs_key_scopes::MIGRATION_ID,
     ironwood_pool_code_views::MIGRATION_ID,
 ];

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_tx_outputs_use_legacy_false.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_tx_outputs_use_legacy_false.rs
@@ -15,7 +15,7 @@ use super::v_transactions_transparent_history;
 /// `TRUE` and `FALSE` constants.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xb3e21434_286f_41f3_8d71_44cce968ab2b);
 
-const DEPENDENCIES: &[Uuid] = &[v_transactions_transparent_history::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[v_transactions_transparent_history::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/wallet_summaries.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/wallet_summaries.rs
@@ -12,7 +12,7 @@ use super::v_sapling_shard_unscanned_ranges;
 /// This migration adds views and database changes required to provide accurate wallet summaries.
 pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xc5bf7f71_2297_41ff_89e1_75e07c4e8838);
 
-const DEPENDENCIES: &[Uuid] = &[v_sapling_shard_unscanned_ranges::MIGRATION_ID];
+pub(super) const DEPENDENCIES: &[Uuid] = &[v_sapling_shard_unscanned_ranges::MIGRATION_ID];
 
 pub(super) struct Migration;
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/witness_stabilized_notes.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/witness_stabilized_notes.rs
@@ -22,7 +22,7 @@ pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x64925567_65ae_495e_b6cf_d5f56e9
 // column of the `blocks` table; that column is added by `ironwood_shardtree`, so this migration
 // must run after it. (The analogous Orchard column is covered because `orchard_shardtree` is
 // already a transitive dependency.)
-const DEPENDENCIES: &[Uuid] = &[
+pub(super) const DEPENDENCIES: &[Uuid] = &[
     account_delete_cascade::MIGRATION_ID,
     ironwood_shardtree::MIGRATION_ID,
 ];


### PR DESCRIPTION
Closes #2860.

`CURRENT_LEAF_MIGRATIONS` was a manually maintained list of the migration DAG's leaves. This derives it in const evaluation instead: each migration module's `DEPENDENCIES` constant (already the single source for its `dependencies()` impl; `initial_setup` gains an empty one for uniformity) is made visible to the parent module, and a `migration_graph_leaves!` macro invoked with the full module list expands to a const-eval computation of the migrations on which no listed migration depends.

The constant keeps its exact type, visibility, and value, so there is no observable API change (verified during development by asserting set-equality with the old manual list).

On the issue's caveat — a migration could still be defined without being included in the graph, since the macro's module list is separate from `all_migrations`. Two tests close that gap:
- the existing `current_leaf_migrations_are_the_dag_leaves` now cross-checks the compile-time leaves against leaves recomputed from the runtime graph;
- a new `migration_graph_leaves_covers_every_migration` asserts the macro's module list matches the ids in `all_migrations`, catching omissions that would not perturb the leaf set.

No changelog entry since the public API and its value are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PctN7C98GHcmQph1AVKeN3