### PR TITLE
zcash_client_sqlite: add WalletSnapshot without scan progress

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -10,6 +10,13 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `WalletSnapshot` and `WalletDb::get_wallet_snapshot`, which return wallet
+  balances, heights, and subtree indices without computing
+  [`WalletSummary::progress`]. Callers that track sync progress elsewhere can
+  use this to avoid the `subtree_scan_progress` aggregates.
+  `WalletRead::get_wallet_summary` is unchanged and still computes progress.
+
 ## [0.22.0-rc.6] - 2026-07-29
 
 ### Added

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -289,6 +289,112 @@ pub struct WalletDb<C, P, CL, R> {
     gap_limits: GapLimits,
 }
 
+/// Wallet balances, heights, and subtree indices without scan-progress accounting.
+///
+/// This is the portion of [`WalletSummary`] that applications need when they already
+/// track sync progress through their own scan loop. Computing
+/// [`WalletSummary::progress`] requires scanning every stored `blocks` row against
+/// `scan_queue`, which can dominate `get_wallet_summary` for deep or fragmented
+/// wallets. [`WalletDb::get_wallet_snapshot`] returns this type and skips that work.
+///
+/// All fields are read inside a single SQLite transaction so the snapshot is
+/// internally consistent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WalletSnapshot<AccountId: Eq + std::hash::Hash> {
+    account_balances: HashMap<AccountId, zcash_client_backend::data_api::AccountBalance>,
+    chain_tip_height: BlockHeight,
+    fully_scanned_height: BlockHeight,
+    next_sapling_subtree_index: u64,
+    #[cfg(feature = "orchard")]
+    next_orchard_subtree_index: u64,
+    #[cfg(feature = "orchard")]
+    next_ironwood_subtree_index: u64,
+}
+
+impl<AccountId: Eq + std::hash::Hash> WalletSnapshot<AccountId> {
+    /// Constructs a new [`WalletSnapshot`] from its constituent parts.
+    pub fn new(
+        account_balances: HashMap<AccountId, zcash_client_backend::data_api::AccountBalance>,
+        chain_tip_height: BlockHeight,
+        fully_scanned_height: BlockHeight,
+        next_sapling_subtree_index: u64,
+        #[cfg(feature = "orchard")] next_orchard_subtree_index: u64,
+        #[cfg(feature = "orchard")] next_ironwood_subtree_index: u64,
+    ) -> Self {
+        Self {
+            account_balances,
+            chain_tip_height,
+            fully_scanned_height,
+            next_sapling_subtree_index,
+            #[cfg(feature = "orchard")]
+            next_orchard_subtree_index,
+            #[cfg(feature = "orchard")]
+            next_ironwood_subtree_index,
+        }
+    }
+
+    /// Returns the balances of accounts in the wallet, keyed by account ID.
+    pub fn account_balances(
+        &self,
+    ) -> &HashMap<AccountId, zcash_client_backend::data_api::AccountBalance> {
+        &self.account_balances
+    }
+
+    /// Returns the height of the current chain tip.
+    pub fn chain_tip_height(&self) -> BlockHeight {
+        self.chain_tip_height
+    }
+
+    /// Returns the height below which all blocks have been scanned by the wallet, ignoring blocks
+    /// below the wallet birthday.
+    pub fn fully_scanned_height(&self) -> BlockHeight {
+        self.fully_scanned_height
+    }
+
+    /// Returns the Sapling subtree index that should start the next range of subtree roots.
+    pub fn next_sapling_subtree_index(&self) -> u64 {
+        self.next_sapling_subtree_index
+    }
+
+    /// Returns the Orchard subtree index that should start the next range of subtree roots.
+    #[cfg(feature = "orchard")]
+    pub fn next_orchard_subtree_index(&self) -> u64 {
+        self.next_orchard_subtree_index
+    }
+
+    /// Returns the Ironwood subtree index that should start the next range of subtree roots.
+    #[cfg(feature = "orchard")]
+    pub fn next_ironwood_subtree_index(&self) -> u64 {
+        self.next_ironwood_subtree_index
+    }
+
+    /// Returns whether or not wallet scanning is complete.
+    pub fn is_synced(&self) -> bool {
+        self.chain_tip_height == self.fully_scanned_height
+    }
+
+    /// Combines this snapshot with a precomputed [`Progress`] value.
+    ///
+    /// Used by [`WalletRead::get_wallet_summary`] so that balance work is not
+    /// duplicated between the snapshot and full-summary paths.
+    pub fn into_wallet_summary(
+        self,
+        progress: zcash_client_backend::data_api::Progress,
+    ) -> WalletSummary<AccountId> {
+        WalletSummary::new(
+            self.account_balances,
+            self.chain_tip_height,
+            self.fully_scanned_height,
+            progress,
+            self.next_sapling_subtree_index,
+            #[cfg(feature = "orchard")]
+            self.next_orchard_subtree_index,
+            #[cfg(feature = "orchard")]
+            self.next_ironwood_subtree_index,
+        )
+    }
+}
+
 /// A wrapper for a SQLite transaction affecting the wallet database.
 pub struct SqlTransaction<'conn>(&'conn rusqlite::Transaction<'conn>);
 
@@ -538,6 +644,30 @@ impl<C: Borrow<rusqlite::Connection>, P, CL, R> WalletDb<C, P, CL, R> {
             #[cfg(feature = "transparent-inputs")]
             gap_limits: GapLimits::default(),
         }
+    }
+}
+
+impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletDb<C, P, CL, R> {
+    /// Returns wallet balances, heights, and subtree indices without computing scan progress.
+    ///
+    /// This is a Vizor-local extension for callers that already track sync progress
+    /// outside of [`WalletSummary::progress`]. It performs the same balance and
+    /// metadata work as [`WalletRead::get_wallet_summary`] inside one SQLite
+    /// transaction, but skips the `subtree_scan_progress` aggregates.
+    ///
+    /// Returns `Ok(None)` when the wallet has no chain tip or birthday, matching
+    /// the early-exit conditions of [`WalletRead::get_wallet_summary`]. Unlike
+    /// that method, a missing progress estimate does not force `None` — progress
+    /// is simply not computed.
+    pub fn get_wallet_snapshot(
+        &self,
+        confirmations_policy: ConfirmationsPolicy,
+    ) -> Result<Option<WalletSnapshot<AccountUuid>>, SqliteClientError> {
+        wallet::get_wallet_snapshot(
+            &self.conn.borrow().unchecked_transaction()?,
+            &self.params,
+            confirmations_policy,
+        )
     }
 }
 

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -373,7 +373,8 @@ impl<AccountId: Eq + std::hash::Hash> WalletSnapshot<AccountId> {
         self.chain_tip_height == self.fully_scanned_height
     }
 
-    /// Combines this snapshot with a precomputed [`Progress`] value.
+    /// Combines this snapshot with a precomputed
+    /// [`Progress`](zcash_client_backend::data_api::Progress) value.
     ///
     /// Used by [`WalletRead::get_wallet_summary`] so that balance work is not
     /// duplicated between the snapshot and full-summary paths.

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -6114,51 +6114,44 @@ mod tests {
         let (h, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
         st.scan_cached_blocks(h, 1);
 
-        // Compare both APIs whenever the stock summary is available. Some
-        // LocalNetwork fixtures return `None` for progress until tip/subtree
-        // state is richer; the snapshot path must still agree in that case.
-        let summary = st
-            .wallet()
-            .get_wallet_summary(ConfirmationsPolicy::MIN)
-            .unwrap();
+        // A scanned wallet always has tip + birthday, so the snapshot must be
+        // present even when LocalNetwork progress accounting still returns None.
         let snapshot = st
             .wallet()
             .db()
             .get_wallet_snapshot(ConfirmationsPolicy::MIN)
-            .unwrap();
+            .unwrap()
+            .expect("scanned wallet must have a snapshot");
+        assert_eq!(snapshot.account_balances().len(), 1);
 
-        match (summary, snapshot) {
-            (None, None) => {}
-            (Some(summary), Some(snapshot)) => {
-                assert_eq!(snapshot.account_balances(), summary.account_balances());
-                assert_eq!(snapshot.chain_tip_height(), summary.chain_tip_height());
-                assert_eq!(
-                    snapshot.fully_scanned_height(),
-                    summary.fully_scanned_height()
-                );
-                assert_eq!(
-                    snapshot.next_sapling_subtree_index(),
-                    summary.next_sapling_subtree_index()
-                );
-                assert_eq!(
-                    snapshot.next_orchard_subtree_index(),
-                    summary.next_orchard_subtree_index()
-                );
-                assert_eq!(
-                    snapshot.next_ironwood_subtree_index(),
-                    summary.next_ironwood_subtree_index()
-                );
-                assert_eq!(snapshot.is_synced(), summary.is_synced());
-                assert_eq!(
-                    snapshot.clone().into_wallet_summary(summary.progress()),
-                    summary
-                );
-            }
-            (summary, snapshot) => panic!(
-                "summary/snapshot availability diverged: summary_is_some={} snapshot_is_some={}",
-                summary.is_some(),
-                snapshot.is_some()
-            ),
+        if let Some(summary) = st
+            .wallet()
+            .get_wallet_summary(ConfirmationsPolicy::MIN)
+            .unwrap()
+        {
+            assert_eq!(snapshot.account_balances(), summary.account_balances());
+            assert_eq!(snapshot.chain_tip_height(), summary.chain_tip_height());
+            assert_eq!(
+                snapshot.fully_scanned_height(),
+                summary.fully_scanned_height()
+            );
+            assert_eq!(
+                snapshot.next_sapling_subtree_index(),
+                summary.next_sapling_subtree_index()
+            );
+            assert_eq!(
+                snapshot.next_orchard_subtree_index(),
+                summary.next_orchard_subtree_index()
+            );
+            assert_eq!(
+                snapshot.next_ironwood_subtree_index(),
+                summary.next_ironwood_subtree_index()
+            );
+            assert_eq!(snapshot.is_synced(), summary.is_synced());
+            assert_eq!(
+                snapshot.clone().into_wallet_summary(summary.progress()),
+                summary
+            );
         }
 
         // Multi-account: both paths must report every account's balance map.
@@ -6217,6 +6210,65 @@ mod tests {
             snapshot.clone().into_wallet_summary(forced.progress()),
             forced
         );
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn wallet_snapshot_available_when_progress_is_missing() {
+        use zcash_client_backend::data_api::testing::{
+            pool::ShieldedPoolTester, sapling::SaplingPoolTester,
+        };
+
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_block_cache(BlockCache::new())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let dfvk = SaplingPoolTester::test_account_fvk(&st);
+        let value = Zatoshis::const_from_u64(10_000);
+        let (h, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
+        st.scan_cached_blocks(h, 1);
+
+        struct NoProgress;
+        impl super::ProgressEstimator for NoProgress {
+            fn sapling_scan_progress<P: zcash_protocol::consensus::Parameters>(
+                &self,
+                _: &rusqlite::Connection,
+                _: &P,
+                _: BlockHeight,
+                _: Option<BlockHeight>,
+                _: BlockHeight,
+            ) -> Result<Option<zcash_client_backend::data_api::Progress>, SqliteClientError>
+            {
+                Ok(None)
+            }
+
+            fn orchard_scan_progress<P: zcash_protocol::consensus::Parameters>(
+                &self,
+                _: &rusqlite::Connection,
+                _: &P,
+                _: BlockHeight,
+                _: Option<BlockHeight>,
+                _: BlockHeight,
+            ) -> Result<Option<zcash_client_backend::data_api::Progress>, SqliteClientError>
+            {
+                Ok(None)
+            }
+        }
+
+        let tx = st.wallet().conn().unchecked_transaction().unwrap();
+        assert_eq!(
+            super::get_wallet_summary(&tx, st.network(), ConfirmationsPolicy::MIN, &NoProgress)
+                .unwrap(),
+            None,
+            "missing progress must keep get_wallet_summary returning None"
+        );
+        let snapshot = super::get_wallet_snapshot(&tx, st.network(), ConfirmationsPolicy::MIN)
+            .unwrap()
+            .expect("snapshot must still return balances when progress is unavailable");
+        assert_eq!(snapshot.account_balances().len(), 1);
+        assert_eq!(snapshot.chain_tip_height(), h);
     }
 
     #[test]

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -6204,14 +6204,10 @@ mod tests {
         }
 
         let tx = st.wallet().conn().unchecked_transaction().unwrap();
-        let forced = super::get_wallet_summary(
-            &tx,
-            st.network(),
-            ConfirmationsPolicy::MIN,
-            &FixedProgress,
-        )
-        .unwrap()
-        .expect("fixed progress plus snapshot must yield a summary");
+        let forced =
+            super::get_wallet_summary(&tx, st.network(), ConfirmationsPolicy::MIN, &FixedProgress)
+                .unwrap()
+                .expect("fixed progress plus snapshot must yield a summary");
         let snapshot = super::get_wallet_snapshot(&tx, st.network(), ConfirmationsPolicy::MIN)
             .unwrap()
             .expect("scanned wallet has a snapshot");

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -2526,17 +2526,15 @@ fn next_subtree_index<H: HashSer, const SHARD_HEIGHT: u8>(
         .unwrap_or(0))
 }
 
-/// Returns the spendable balance for the account at the specified height.
+/// Returns wallet balances, heights, and subtree indices without scan progress.
 ///
-/// This may be used to obtain a balance that ignores notes that have been detected so recently
-/// that they are not yet spendable, or for which it is not yet possible to construct witnesses.
-#[tracing::instrument(skip(tx, params, progress))]
-pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
+/// See [`crate::WalletDb::get_wallet_snapshot`].
+#[tracing::instrument(skip(tx, params))]
+pub(crate) fn get_wallet_snapshot<P: consensus::Parameters>(
     tx: &rusqlite::Transaction,
     params: &P,
     confirmations_policy: ConfirmationsPolicy,
-    progress: &impl ProgressEstimator,
-) -> Result<Option<WalletSummary<AccountUuid>>, SqliteClientError> {
+) -> Result<Option<crate::WalletSnapshot<AccountUuid>>, SqliteClientError> {
     let chain_tip_height = match chain_tip_height(tx)? {
         Some(h) => h,
         None => {
@@ -2551,59 +2549,9 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
         }
     };
 
-    let recover_until_height = recover_until_height(tx)?;
     let fully_scanned_height = block_fully_scanned(tx, params)?.map(|m| m.block_height());
     let target_height = TargetHeight::from(chain_tip_height + 1);
     let anchor_height = get_anchor_height(tx, target_height, confirmations_policy.trusted())?;
-
-    let sapling_progress = progress.sapling_scan_progress(
-        tx,
-        params,
-        birthday_height,
-        recover_until_height,
-        chain_tip_height,
-    )?;
-
-    #[cfg(feature = "orchard")]
-    let orchard_progress = progress.orchard_scan_progress(
-        tx,
-        params,
-        birthday_height,
-        recover_until_height,
-        chain_tip_height,
-    )?;
-    #[cfg(not(feature = "orchard"))]
-    let orchard_progress: Option<Progress> = None;
-
-    // Treat Sapling and Orchard outputs as having the same cost to scan.
-    let progress = sapling_progress
-        .as_ref()
-        .zip(orchard_progress.as_ref())
-        .map(|(s, o)| {
-            Progress::new(
-                Ratio::new(
-                    s.scan().numerator() + o.scan().numerator(),
-                    s.scan().denominator() + o.scan().denominator(),
-                ),
-                s.recovery()
-                    .zip(o.recovery())
-                    .map(|(s, o)| {
-                        Ratio::new(
-                            s.numerator() + o.numerator(),
-                            s.denominator() + o.denominator(),
-                        )
-                    })
-                    .or_else(|| s.recovery())
-                    .or_else(|| o.recovery()),
-            )
-        })
-        .or(sapling_progress)
-        .or(orchard_progress);
-
-    let progress = match progress {
-        Some(p) => p,
-        None => return Ok(None),
-    };
 
     let mut stmt_accounts = tx.prepare_cached("SELECT uuid FROM accounts")?;
     let mut account_balances = stmt_accounts
@@ -2922,19 +2870,99 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
         ORCHARD_SHARD_HEIGHT,
     >(tx, crate::IRONWOOD_TABLES_PREFIX)?;
 
-    let summary = WalletSummary::new(
+    Ok(Some(crate::WalletSnapshot::new(
         account_balances,
         chain_tip_height,
         fully_scanned_height.unwrap_or(birthday_height - 1),
-        progress,
         next_sapling_subtree_index,
         #[cfg(feature = "orchard")]
         next_orchard_subtree_index,
         #[cfg(feature = "orchard")]
         next_ironwood_subtree_index,
-    );
+    )))
+}
 
-    Ok(Some(summary))
+/// Returns the spendable balance for the account at the specified height.
+///
+/// This may be used to obtain a balance that ignores notes that have been detected so recently
+/// that they are not yet spendable, or for which it is not yet possible to construct witnesses.
+///
+/// Progress is computed before the balance snapshot so a missing progress estimate still
+/// short-circuits with `Ok(None)`, matching historical `get_wallet_summary` behaviour.
+#[tracing::instrument(skip(tx, params, progress))]
+pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
+    tx: &rusqlite::Transaction,
+    params: &P,
+    confirmations_policy: ConfirmationsPolicy,
+    progress: &impl ProgressEstimator,
+) -> Result<Option<WalletSummary<AccountUuid>>, SqliteClientError> {
+    let chain_tip_height = match chain_tip_height(tx)? {
+        Some(h) => h,
+        None => {
+            return Ok(None);
+        }
+    };
+
+    let birthday_height = match wallet_birthday(tx)? {
+        Some(h) => h,
+        None => {
+            return Ok(None);
+        }
+    };
+
+    let recover_until_height = recover_until_height(tx)?;
+
+    let sapling_progress = progress.sapling_scan_progress(
+        tx,
+        params,
+        birthday_height,
+        recover_until_height,
+        chain_tip_height,
+    )?;
+
+    #[cfg(feature = "orchard")]
+    let orchard_progress = progress.orchard_scan_progress(
+        tx,
+        params,
+        birthday_height,
+        recover_until_height,
+        chain_tip_height,
+    )?;
+    #[cfg(not(feature = "orchard"))]
+    let orchard_progress: Option<Progress> = None;
+
+    // Treat Sapling and Orchard outputs as having the same cost to scan.
+    let progress = sapling_progress
+        .as_ref()
+        .zip(orchard_progress.as_ref())
+        .map(|(s, o)| {
+            Progress::new(
+                Ratio::new(
+                    s.scan().numerator() + o.scan().numerator(),
+                    s.scan().denominator() + o.scan().denominator(),
+                ),
+                s.recovery()
+                    .zip(o.recovery())
+                    .map(|(s, o)| {
+                        Ratio::new(
+                            s.numerator() + o.numerator(),
+                            s.denominator() + o.denominator(),
+                        )
+                    })
+                    .or_else(|| s.recovery())
+                    .or_else(|| o.recovery()),
+            )
+        })
+        .or(sapling_progress)
+        .or(orchard_progress);
+
+    let progress = match progress {
+        Some(p) => p,
+        None => return Ok(None),
+    };
+
+    Ok(get_wallet_snapshot(tx, params, confirmations_policy)?
+        .map(|snapshot| snapshot.into_wallet_summary(progress)))
 }
 
 /// Returns the memo for a received note, if the note is known to the wallet.
@@ -6049,6 +6077,150 @@ mod tests {
         .unwrap();
 
         assert_eq!(min_shared_checkpoint_height(&conn).unwrap(), None);
+    }
+
+    #[test]
+    fn wallet_snapshot_matches_summary_on_empty_wallet() {
+        let st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        assert_eq!(
+            st.wallet()
+                .db()
+                .get_wallet_snapshot(ConfirmationsPolicy::MIN)
+                .unwrap(),
+            None
+        );
+        assert_eq!(st.get_wallet_summary(ConfirmationsPolicy::MIN), None);
+    }
+
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn wallet_snapshot_matches_summary_after_scan() {
+        use zcash_client_backend::data_api::testing::{
+            pool::ShieldedPoolTester, sapling::SaplingPoolTester,
+        };
+
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_block_cache(BlockCache::new())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let dfvk = SaplingPoolTester::test_account_fvk(&st);
+        let value = Zatoshis::const_from_u64(10_000);
+        let (h, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, value);
+        st.scan_cached_blocks(h, 1);
+
+        // Compare both APIs whenever the stock summary is available. Some
+        // LocalNetwork fixtures return `None` for progress until tip/subtree
+        // state is richer; the snapshot path must still agree in that case.
+        let summary = st
+            .wallet()
+            .get_wallet_summary(ConfirmationsPolicy::MIN)
+            .unwrap();
+        let snapshot = st
+            .wallet()
+            .db()
+            .get_wallet_snapshot(ConfirmationsPolicy::MIN)
+            .unwrap();
+
+        match (summary, snapshot) {
+            (None, None) => {}
+            (Some(summary), Some(snapshot)) => {
+                assert_eq!(snapshot.account_balances(), summary.account_balances());
+                assert_eq!(snapshot.chain_tip_height(), summary.chain_tip_height());
+                assert_eq!(
+                    snapshot.fully_scanned_height(),
+                    summary.fully_scanned_height()
+                );
+                assert_eq!(
+                    snapshot.next_sapling_subtree_index(),
+                    summary.next_sapling_subtree_index()
+                );
+                assert_eq!(
+                    snapshot.next_orchard_subtree_index(),
+                    summary.next_orchard_subtree_index()
+                );
+                assert_eq!(
+                    snapshot.next_ironwood_subtree_index(),
+                    summary.next_ironwood_subtree_index()
+                );
+                assert_eq!(snapshot.is_synced(), summary.is_synced());
+                assert_eq!(
+                    snapshot.clone().into_wallet_summary(summary.progress()),
+                    summary
+                );
+            }
+            (summary, snapshot) => panic!(
+                "summary/snapshot availability diverged: summary_is_some={} snapshot_is_some={}",
+                summary.is_some(),
+                snapshot.is_some()
+            ),
+        }
+
+        // Multi-account: both paths must report every account's balance map.
+        let seed = SecretVec::new(st.test_seed().unwrap().expose_secret().clone());
+        let birthday = st.test_account().unwrap().birthday().clone();
+        st.wallet_mut()
+            .create_account("", &seed, &birthday, None)
+            .unwrap();
+
+        // Fixed progress estimator: proves the snapshot path produces a full
+        // summary even when real progress accounting would return None.
+        struct FixedProgress;
+        impl super::ProgressEstimator for FixedProgress {
+            fn sapling_scan_progress<P: zcash_protocol::consensus::Parameters>(
+                &self,
+                _: &rusqlite::Connection,
+                _: &P,
+                _: BlockHeight,
+                _: Option<BlockHeight>,
+                _: BlockHeight,
+            ) -> Result<Option<zcash_client_backend::data_api::Progress>, SqliteClientError>
+            {
+                Ok(Some(zcash_client_backend::data_api::Progress::new(
+                    zcash_client_backend::data_api::Ratio::new(1, 1),
+                    None,
+                )))
+            }
+
+            fn orchard_scan_progress<P: zcash_protocol::consensus::Parameters>(
+                &self,
+                _: &rusqlite::Connection,
+                _: &P,
+                _: BlockHeight,
+                _: Option<BlockHeight>,
+                _: BlockHeight,
+            ) -> Result<Option<zcash_client_backend::data_api::Progress>, SqliteClientError>
+            {
+                Ok(Some(zcash_client_backend::data_api::Progress::new(
+                    zcash_client_backend::data_api::Ratio::new(1, 1),
+                    None,
+                )))
+            }
+        }
+
+        let tx = st.wallet().conn().unchecked_transaction().unwrap();
+        let forced = super::get_wallet_summary(
+            &tx,
+            st.network(),
+            ConfirmationsPolicy::MIN,
+            &FixedProgress,
+        )
+        .unwrap()
+        .expect("fixed progress plus snapshot must yield a summary");
+        let snapshot = super::get_wallet_snapshot(&tx, st.network(), ConfirmationsPolicy::MIN)
+            .unwrap()
+            .expect("scanned wallet has a snapshot");
+        assert_eq!(snapshot.account_balances().len(), 2);
+        assert_eq!(snapshot.account_balances(), forced.account_balances());
+        assert_eq!(
+            snapshot.clone().into_wallet_summary(forced.progress()),
+            forced
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Backport `WalletSnapshot` and `WalletDb::get_wallet_snapshot` onto the `0.22.0-rc.6` release line.
- Same semantics as the main-branch PR: balances / heights / subtree indices without `WalletSummary::progress`.
- `WalletRead::get_wallet_summary` remains unchanged.

## Motivation / Why
Downstream wallets pinned to `zcash_client_sqlite 0.22.0-rc.6` / `zcash_client_backend 0.24.0-rc.6` (for example Vizor) need a no-progress snapshot API without waiting for a newer crates.io cut from `main`.

Base: `release/zcash_client_sqlite-0.22.0-rc.6` (= tag `zcash_client_sqlite-0.22.0-rc.6`).

## Tests
- `wallet_snapshot_matches_summary_on_empty_wallet`
- `wallet_snapshot_matches_summary_after_scan`
- `cargo check -p zcash_client_sqlite --features "orchard,transparent-inputs,unstable,serde"`