### PR TITLE
Restore batch signer signature redaction

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -10,6 +10,13 @@ workspace.
 
 ## [Unreleased]
 
+### Fixed
+- `zcash_client_backend::data_api::wallet::redact_pczt_for_batch_signer` now
+  omits existing Orchard and Ironwood spend authorization signatures from the
+  batch signing request. They remain present in the caller's authoritative
+  PCZT, so the response only contains new signatures. This restores
+  compatibility with batch Signers that reject pre-signed requests.
+
 ## [0.24.0-rc.6] - 2026-07-29
 
 ### Added

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -8416,20 +8416,10 @@ where
         assert_eq!(batch_bundle.len(), original_bundle.len());
         for (original, batch) in original_bundle.iter().zip(batch_bundle) {
             assert!(!batch.has_fvk);
-            // A pre-signed protocol padding dummy keeps its signature: the batch view has
-            // already dropped its `dummy_sk` and it carries no derivation, so nothing
-            // downstream could ever reproduce that signature.
-            assert_eq!(batch.has_signature, original.has_signature);
+            assert!(!batch.has_signature);
             assert_eq!(
                 batch.has_alpha,
                 original.has_alpha && !original.has_signature
-            );
-            // The invariant the redaction must preserve: every action is either already
-            // authorized or still authorizable. Neither the Signer nor the wallet can
-            // rescue an action that is left with no signature and no randomizer.
-            assert!(
-                batch.has_signature || batch.has_alpha,
-                "the batch signer view stranded an action: {batch:?}",
             );
 
             if original.has_signature {
@@ -8522,14 +8512,16 @@ where
         .unwrap()
         .finish();
 
-    // Every action is now authorized: the ones the Signer signed, plus the pre-signed
-    // padding dummies whose signatures the batch view retained. Those retained signatures
-    // ride back along with the new ones and re-apply to the authoritative PCZT unchanged.
     let signatures = pczt::roles::signer::extract_orchard_spend_auth_signatures(&signed_view);
-    let expected_signature_positions = (0..original_spend_states.0.len())
+    let expected_signature_positions = orchard_signable
+        .iter()
+        .copied()
         .map(|index| (orchard::ValuePool::Orchard, index))
         .chain(
-            (0..original_spend_states.1.len()).map(|index| (orchard::ValuePool::Ironwood, index)),
+            ironwood_signable
+                .iter()
+                .copied()
+                .map(|index| (orchard::ValuePool::Ironwood, index)),
         )
         .collect::<Vec<_>>();
     let signature_positions = signatures

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -3432,7 +3432,11 @@ pub fn redact_pczt_for_batch_signer(pczt: &pczt::Pczt) -> pczt::Pczt {
         mut redactor: pczt::roles::redactor::orchard::OrchardRedactor<'_>,
         preauthorized_action_indices: &[usize],
     ) {
-        // The batch Signer derives its FVK and returns only new signatures.
+        // The batch Signer derives its FVK and returns only new signatures. Existing
+        // signatures MUST be omitted: deployed batch Signers reject requests that
+        // already carry signatures. Omitting them strands nothing — this view is a
+        // signing request, not the authoritative PCZT, and the caller's authoritative
+        // copy retains them.
         redactor.redact_actions(|mut action| {
             action.clear_spend_fvk();
             action.clear_spend_auth_sig();

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -3404,15 +3404,15 @@ fn compact_signer_view(pczt: &pczt::Pczt) -> pczt::Pczt {
 /// independently and returns only new Orchard and Ironwood signatures.
 ///
 /// In addition to the [`SignerView::Compact`] policy of [`redact_pczt_for_signer`],
-/// this removes spend full viewing keys, and removes the randomizer from actions already
-/// authorized in `pczt`, while unsigned actions such as wallet controlled zero value
-/// spends retain theirs. Existing signatures are retained, so every action in the
-/// returned view is either already authorized or still authorizable. Sapling signatures
-/// require a separate signing path.
+/// this removes spend full viewing keys and existing signatures. It also removes the
+/// randomizer from actions already authorized in `pczt`, while unsigned actions such as
+/// wallet controlled zero value spends retain theirs. Sapling signatures require a
+/// separate signing path.
 ///
 /// The caller must retain the authoritative PCZT and apply the returned signature
-/// contributions to it. This function must run before its existing signatures are
-/// redacted. The returned view cannot be signed with the high level
+/// contributions to it; the returned view is not independently extractable. This
+/// function must run before its existing signatures are redacted. The returned view
+/// cannot be signed with the high level
 /// [`pczt::roles::signer::Signer`] because that role expects full viewing keys.
 #[cfg(feature = "pczt")]
 pub fn redact_pczt_for_batch_signer(pczt: &pczt::Pczt) -> pczt::Pczt {
@@ -3433,12 +3433,10 @@ pub fn redact_pczt_for_batch_signer(pczt: &pczt::Pczt) -> pczt::Pczt {
         preauthorized_action_indices: &[usize],
     ) {
         // The batch Signer derives its FVK and returns only new signatures.
-        redactor.redact_actions(|mut action| action.clear_spend_fvk());
-        // An action that already carries a signature needs nothing further, so it gives up its
-        // randomizer. Its signature is RETAINED: the only pre-signed actions in a wallet PCZT
-        // are the protocol padding dummies, which carry no ZIP 32 derivation and whose
-        // `dummy_sk` the compact view has already cleared, so stripping the signature would
-        // leave an action that neither the Signer nor the wallet could ever authorize.
+        redactor.redact_actions(|mut action| {
+            action.clear_spend_fvk();
+            action.clear_spend_auth_sig();
+        });
         // Unsigned actions keep alpha, including wallet controlled zero value spends.
         for &index in preauthorized_action_indices {
             redactor.redact_action(index, |mut action| action.clear_spend_alpha());


### PR DESCRIPTION
Restore the batch signing transport's new-signatures-only contract by omitting existing Orchard and Ironwood spend authorization signatures from the redacted request. The regression was caused by including the IO Finalizer's existing padding-action signatures in the transport view, which deployed Keystone firmware rejects before signing; the authoritative wallet PCZT already retains those signatures, while unsigned wallet-controlled zero-value spends continue to carry their randomizers and ZIP 32 derivation metadata.
