### PR TITLE
zcash_pool_migration: persist proved migration transactions to the wallet DB

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -13,13 +13,30 @@ workspace.
 ### Added
 - `pool_migration::orchard_ironwood::Error::ChainStateUnavailable`, returned
   when a satisfiability check has no fully-scanned height to observe from.
+- `pool_migration::orchard_ironwood::FinalizeError`, and new
+  `pool_migration::orchard_ironwood::Error` variants `UnknownTransaction`,
+  `NotProved`, `ViewingKeyUnavailable`, `Finalize`, and `Wallet`, reporting
+  failures of the store's new proved-transaction finalization.
 - `zcash_client_sqlite::testing::db::TestDb::conn` and `TestDb::conn_mut`, for
   tests that open a sibling store (a `pool_migration` `PoolMigrations`, say)
   over the wallet database's own connection.
 
 ### Changed
-- The pool-migration transfer ordinal is now named `transfer_id` throughout the
-  database schema. The `orchard_ironwood_migration_unsatisfiability` schema
+- `pool_migration::orchard_ironwood::PoolMigrations` now carries the network
+  parameters and a clock — `PoolMigrations::for_account` takes them ahead of
+  the connection (`for_account(params, clock, conn, account)`; a caller that
+  only reads or writes migration state may pass `()` for both, but the
+  `PoolMigrationWrite` implementation requires
+  `zcash_protocol::consensus::Parameters` and `util::Clock` values) — and
+  implements the new `PoolMigrationWrite::store_proved_transaction` (under the
+  `orchard` feature) by finalizing the proved migration transaction and
+  persisting it to the wallet's own transaction tables, atomically with the
+  migration state, in one database transaction: the raw transaction, its fee,
+  its outputs as sent notes, and its input notes marked spent. From the moment
+  a migration transaction is proved, the wallet therefore reports its inputs
+  spent (its own spends can no longer consume them) and its balance reflects
+  the pending transaction, rather than neither until the transaction is mined
+  and scanned. The `orchard_ironwood_migration_unsatisfiability` schema
   migration renames `orchard_ironwood_migration_transactions.tx_id` to
   `transfer_id`, and `orchard_ironwood_migration_transaction_deps`'s `tx_id`
   and `depends_on_tx_id` to `transfer_id` and `depends_on_transfer_id`;

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -151,6 +151,11 @@ orchard = [
     "zcash_client_backend/orchard",
     "zcash_keys/orchard",
     "zcash_pool_migration/wallet",
+    # The pool-migration store finalizes a proved migration PCZT into a `Transaction` when it
+    # persists it to the wallet's transaction tables (`PoolMigrations::store_proved_transaction`).
+    "pczt/orchard",
+    "pczt/spend-finalizer",
+    "pczt/tx-extractor",
 ]
 
 ## Exposes APIs that are useful for testing, such as `proptest` strategies.

--- a/zcash_client_sqlite/src/pool_migration/error.rs
+++ b/zcash_client_sqlite/src/pool_migration/error.rs
@@ -2,6 +2,8 @@
 
 use std::fmt;
 
+use zcash_pool_migration::engine::MigrationTransferId;
+
 /// A failure reading or writing the pool-migration store.
 #[derive(Debug)]
 #[non_exhaustive]
@@ -27,6 +29,56 @@ pub enum Error {
     /// coordinates silently renumbered; a plan produced by the engine never contains these. The
     /// `&'static str` names the offending structure.
     Unrepresentable(&'static str),
+    /// The migration state handed to `store_proved_transaction` contains no transaction with the
+    /// given id, so there is nothing to finalize.
+    UnknownTransaction(MigrationTransferId),
+    /// The transaction handed to `store_proved_transaction` is not in the `Proved` lifecycle
+    /// state, so its stored bytes are not a proven PCZT and no transaction can be finalized from
+    /// them.
+    NotProved(MigrationTransferId),
+    /// The account holds no unified full viewing key, so a finalized migration transaction's
+    /// outputs cannot be recovered for the wallet's sent-transaction record.
+    ViewingKeyUnavailable,
+    /// Finalizing the proven PCZT into a `Transaction` failed.
+    #[cfg(feature = "orchard")]
+    Finalize(FinalizeError),
+    /// Persisting a finalized migration transaction to the wallet's own transaction tables failed.
+    Wallet(Box<crate::error::SqliteClientError>),
+}
+
+/// Why a proven migration PCZT could not be finalized into the `Transaction` the wallet's
+/// sent-transaction record stores.
+#[cfg(feature = "orchard")]
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum FinalizeError {
+    /// The stored PCZT could not be parsed.
+    Parse(pczt::ParseError),
+    /// Moving the spend authorizations into their final form (the PCZT Spend Finalizer role)
+    /// failed: some spend lacks its signature.
+    Spends(pczt::roles::spend_finalizer::Error),
+    /// Extracting (and verifying) the final transaction failed: a proof or signature is missing
+    /// or invalid, or a bundle is malformed.
+    Extract(pczt::roles::tx_extractor::Error),
+    /// The transaction's balance could not be computed (a value outside the valid `Zatoshis`
+    /// range).
+    Balance(zcash_protocol::value::BalanceError),
+}
+
+#[cfg(feature = "orchard")]
+impl fmt::Display for FinalizeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FinalizeError::Parse(e) => write!(f, "parsing the stored proven PCZT failed: {e:?}"),
+            FinalizeError::Spends(e) => write!(f, "finalizing the PCZT's spends failed: {e:?}"),
+            FinalizeError::Extract(e) => {
+                write!(f, "extracting the finalized transaction failed: {e:?}")
+            }
+            FinalizeError::Balance(e) => {
+                write!(f, "computing the transaction's fee failed: {e:?}")
+            }
+        }
+    }
 }
 
 impl fmt::Display for Error {
@@ -48,6 +100,29 @@ impl fmt::Display for Error {
             Error::Unrepresentable(what) => {
                 write!(f, "pool-migration store: cannot represent {what}")
             }
+            Error::UnknownTransaction(id) => write!(
+                f,
+                "pool-migration store: the migration state holds no transaction {}",
+                u32::from(*id)
+            ),
+            Error::NotProved(id) => write!(
+                f,
+                "pool-migration store: transaction {} is not proved, so it cannot be finalized",
+                u32::from(*id)
+            ),
+            Error::ViewingKeyUnavailable => write!(
+                f,
+                "pool-migration store: the account has no unified full viewing key to recover \
+                 the finalized transaction's outputs with"
+            ),
+            #[cfg(feature = "orchard")]
+            Error::Finalize(e) => {
+                write!(f, "pool-migration store: {e}")
+            }
+            Error::Wallet(e) => write!(
+                f,
+                "pool-migration store: persisting the finalized transaction failed: {e}"
+            ),
         }
     }
 }
@@ -56,10 +131,16 @@ impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Error::Db(e) => Some(e),
+            Error::Wallet(e) => Some(e),
             Error::AccountUnknown
             | Error::Corrupt(_)
             | Error::ChainStateUnavailable
-            | Error::Unrepresentable(_) => None,
+            | Error::Unrepresentable(_)
+            | Error::UnknownTransaction(_)
+            | Error::NotProved(_)
+            | Error::ViewingKeyUnavailable => None,
+            #[cfg(feature = "orchard")]
+            Error::Finalize(_) => None,
         }
     }
 }

--- a/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
+++ b/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
@@ -32,6 +32,9 @@ use super::store::{self, Store, Tables};
 
 /// A failure reading or writing the pool-migration store.
 pub use super::error::Error;
+/// Why a proven migration PCZT could not be finalized into a `Transaction`.
+#[cfg(feature = "orchard")]
+pub use super::error::FinalizeError;
 
 /// The Orchard -> Ironwood table and index names this store operates over.
 static TABLES: Tables = Tables {
@@ -171,18 +174,43 @@ fn lift_store_error(e: Error) -> SqliteClientError {
 /// connection a [`WalletDb`](crate::WalletDb) uses, so the pool-migration tables share the wallet
 /// database.
 ///
+/// Sharing the wallet database is what lets [`store_proved_transaction`] persist a finalized
+/// migration transaction into the wallet's own transaction tables ATOMICALLY with the migration
+/// state that records it proved; the network parameters and clock are what that wallet-side
+/// record needs (output recovery and the sent-transaction timestamp), carried here for the same
+/// reason [`WalletDb`](crate::WalletDb) carries them.
+///
 /// An account's migration is owned by its row in the wallet's `accounts` table through the
 /// `account_id` foreign key, so deleting the account removes its migration automatically (via
 /// `ON DELETE CASCADE`); no explicit cleanup is required.
-pub struct PoolMigrations<C>(Store<C>);
+///
+/// [`store_proved_transaction`]: zcash_pool_migration::engine::PoolMigrationWrite::store_proved_transaction
+pub struct PoolMigrations<C, P, CL> {
+    store: Store<C>,
+    // The wallet context `PoolMigrationWrite::store_proved_transaction` (an `orchard`-gated capability)
+    // finalizes under; carried unconditionally so the store's type does not change with the
+    // feature.
+    #[cfg_attr(not(feature = "orchard"), allow(dead_code))]
+    account: AccountUuid,
+    #[cfg_attr(not(feature = "orchard"), allow(dead_code))]
+    params: P,
+    #[cfg_attr(not(feature = "orchard"), allow(dead_code))]
+    clock: CL,
+}
 
-impl<C: Borrow<Connection>> PoolMigrations<C> {
+impl<C: Borrow<Connection>, P, CL> PoolMigrations<C, P, CL> {
     /// Wrap a connection borrow as the store, scoped to `account`'s migration.
     ///
     /// The account is resolved to its `accounts` row up front, so the store keys its migration by
     /// that row (the foreign key the schema uses) rather than by the external UUID. Returns
     /// [`Error::AccountUnknown`] if no account with this UUID exists in the wallet.
-    pub fn for_account(conn: C, account: AccountUuid) -> Result<Self, Error> {
+    ///
+    /// `params` and `clock` serve only [`store_proved_transaction`]
+    /// (output recovery and the sent-transaction timestamp); a caller that only reads and writes
+    /// migration state may pass `()` for both.
+    ///
+    /// [`store_proved_transaction`]: zcash_pool_migration::engine::PoolMigrationWrite::store_proved_transaction
+    pub fn for_account(params: P, clock: CL, conn: C, account: AccountUuid) -> Result<Self, Error> {
         let account_id = conn
             .borrow()
             .query_row(
@@ -192,18 +220,23 @@ impl<C: Borrow<Connection>> PoolMigrations<C> {
             )
             .optional()?
             .ok_or(Error::AccountUnknown)?;
-        Ok(Self(Store::new(conn, &TABLES, account_id)))
+        Ok(Self {
+            store: Store::new(conn, &TABLES, account_id),
+            account,
+            params,
+            clock,
+        })
     }
 }
 
-impl<C> PoolMigrations<C> {
+impl<C, P, CL> PoolMigrations<C, P, CL> {
     /// Recover the wrapped connection borrow.
     pub fn into_inner(self) -> C {
-        self.0.into_inner()
+        self.store.into_inner()
     }
 }
 
-impl<C: Borrow<Connection>> PoolMigrations<C> {
+impl<C: Borrow<Connection>, P, CL> PoolMigrations<C, P, CL> {
     /// Returns the set of [`LockOwner`]s under which this account's in-progress pool migration
     /// has locked notes (empty if there is no migration, or it holds no locks).
     ///
@@ -213,15 +246,15 @@ impl<C: Borrow<Connection>> PoolMigrations<C> {
     /// trait is shared with the pool-agnostic migration engine, which has no notion of
     /// [`LockOwner`] (a wallet-level concept).
     pub fn migration_lock_owners(&self) -> Result<BTreeSet<LockOwner>, Error> {
-        self.0.migration_lock_owners()
+        self.store.migration_lock_owners()
     }
 }
 
-impl<C: Borrow<Connection>> PoolMigrationRead for PoolMigrations<C> {
+impl<C: Borrow<Connection>, P, CL> PoolMigrationRead for PoolMigrations<C, P, CL> {
     type Error = Error;
 
     fn get_migration(&self) -> Result<Option<MigrationState>, Self::Error> {
-        self.0.get_migration()
+        self.store.get_migration()
     }
 
     fn check_step_satisfiability(
@@ -229,19 +262,25 @@ impl<C: Borrow<Connection>> PoolMigrationRead for PoolMigrations<C> {
         tx: &MigrationTransaction,
         settle: ReorgSettleDepth,
     ) -> Result<StepSatisfiability, Self::Error> {
-        self.0.check_step_satisfiability(tx, settle, SOURCE_ROOT_AT)
+        self.store
+            .check_step_satisfiability(tx, settle, SOURCE_ROOT_AT)
     }
 
     /// Pool-independent: a transaction's inclusion is read off the wallet's own `transactions`
     /// table, so unlike the satisfiability oracle this needs no source-pool tree access.
     fn mined_height(&self, txid: TxId) -> Result<Option<BlockHeight>, Self::Error> {
-        self.0.mined_height(txid)
+        self.store.mined_height(txid)
     }
 }
 
-impl<C: BorrowMut<Connection>> PoolMigrationWrite for PoolMigrations<C> {
+impl<C, P, CL> PoolMigrationWrite for PoolMigrations<C, P, CL>
+where
+    C: BorrowMut<Connection>,
+    P: zcash_protocol::consensus::Parameters,
+    CL: crate::util::Clock,
+{
     fn replace_migration(&mut self, state: &MigrationState) -> Result<(), Self::Error> {
-        self.0.replace_migration(state)
+        self.store.replace_migration(state)
     }
 
     fn update_transaction(
@@ -249,7 +288,204 @@ impl<C: BorrowMut<Connection>> PoolMigrationWrite for PoolMigrations<C> {
         id: MigrationTransferId,
         state: MigrationTxState,
     ) -> Result<(), Self::Error> {
-        self.0.update_transaction(id, state)
+        self.store.update_transaction(id, state)
+    }
+
+    /// The wallet-database form of the contract: apply the proof to `state`, then — in ONE
+    /// database transaction — persist the migration state and, with it, the finalized
+    /// transaction's wallet record (its raw bytes, fee, sent outputs, and input-spend marks, as
+    /// `store_transactions_to_be_sent` writes for the standard spend flows), so a transaction is
+    /// never durably recorded proved without the wallet knowing about it, nor the reverse. The
+    /// outputs are recovered by trial decryption under the account's unified full viewing key
+    /// (every real migration output is internal to the account; dummies decrypt under no key),
+    /// and the sent record's target height is the successor of the row's scheduled broadcast
+    /// height.
+    #[cfg(feature = "orchard")]
+    fn store_proved_transaction(
+        &mut self,
+        state: &mut MigrationState,
+        proven: zcash_pool_migration::engine::ProvedTransaction,
+    ) -> Result<(), Self::Error> {
+        let id = proven.id();
+        proven.apply(state);
+        self.finalize_and_store_proved(state, id)
+    }
+
+    /// Without the `orchard` feature this wallet tracks no Orchard (or Ironwood) notes at all:
+    /// there is nothing the wallet's transaction tables could record about a migration
+    /// transaction, and no wallet-side spend the input marks would protect against. The
+    /// contract's no-wallet-tables form is therefore COMPLETE here, not a degraded stand-in:
+    /// apply the proof and persist the migration state alone.
+    #[cfg(not(feature = "orchard"))]
+    fn store_proved_transaction(
+        &mut self,
+        state: &mut MigrationState,
+        proven: zcash_pool_migration::engine::ProvedTransaction,
+    ) -> Result<(), Self::Error> {
+        proven.apply(state);
+        self.replace_migration(state)
+    }
+}
+
+/// Finalization of a proved migration transaction into the wallet's own transaction record.
+#[cfg(feature = "orchard")]
+impl<C, P, CL> PoolMigrations<C, P, CL>
+where
+    C: BorrowMut<Connection>,
+    P: zcash_protocol::consensus::Parameters,
+    CL: crate::util::Clock,
+{
+    /// The body of [`PoolMigrationWrite::store_proved_transaction`], once the proof has been
+    /// applied to `state`: persist `state` and, atomically with it, finalize the
+    /// fully-constructed (proved and signed) migration transaction `proved` into the wallet's
+    /// own transaction tables.
+    ///
+    /// The transaction named by `proved` must be in the [`Proved`](MigrationTxState::Proved)
+    /// lifecycle state in `state`: its stored bytes are then a PCZT carrying both signatures
+    /// (installed at commit) and proofs (installed by the prove step), from which the final
+    /// `Transaction` is extracted mechanically — the PCZT Spend Finalizer and Transaction
+    /// Extractor roles, the latter of which also verifies the proofs and signatures it
+    /// assembles. The wallet-side record is what
+    /// [`WalletWrite::store_transactions_to_be_sent`] writes for the standard spend flows, made
+    /// at the analogous moment: the transaction's raw bytes, fee, creation time, and target
+    /// height in the `transactions` table; its outputs as sent notes; and its input notes marked
+    /// spent — which is what prevents the wallet's OWN later spends from double-spending a
+    /// migration input during the (deliberately long, for a scheduled transfer) window between
+    /// proving and mining.
+    ///
+    /// The transaction's outputs are recovered by trial decryption under the account's unified
+    /// full viewing key rather than from PCZT metadata: every real output of a migration
+    /// transaction is internal to the migrating account, and the padded dummy outputs fail
+    /// decryption, so decryption separates them exactly. The sent-transaction target height is
+    /// the block the transaction aims to mine in: the successor of its scheduled broadcast
+    /// height.
+    ///
+    /// Both writes — the migration state (as [`replace_migration`]) and the wallet transaction
+    /// record — happen in ONE database transaction, so a transaction is never durably recorded
+    /// proved without the wallet record, nor the reverse.
+    ///
+    /// [`WalletWrite::store_transactions_to_be_sent`]:
+    ///     zcash_client_backend::data_api::WalletWrite::store_transactions_to_be_sent
+    /// [`replace_migration`]: PoolMigrationWrite::replace_migration
+    /// [`PoolMigrationWrite::store_proved_transaction`]:
+    ///     zcash_pool_migration::engine::PoolMigrationWrite::store_proved_transaction
+    fn finalize_and_store_proved(
+        &mut self,
+        state: &MigrationState,
+        proved: MigrationTransferId,
+    ) -> Result<(), Error> {
+        use std::collections::HashMap;
+
+        use zcash_client_backend::data_api::{
+            Account as _, SentTransaction, SentTransactionOutput, wallet::TargetHeight,
+        };
+        use zcash_client_backend::decrypt_transaction;
+        use zcash_client_backend::wallet::{Note, Recipient};
+        use zcash_protocol::value::Zatoshis;
+
+        use super::error::FinalizeError;
+
+        let row = state
+            .transactions()
+            .iter()
+            .find(|t| t.id() == proved)
+            .ok_or(Error::UnknownTransaction(proved))?;
+        if !matches!(row.state(), MigrationTxState::Proved) {
+            return Err(Error::NotProved(proved));
+        }
+
+        // Finalize the spend authorizations and extract the transaction. Extraction re-verifies
+        // the proofs and signatures it assembles, so a PCZT that would not survive broadcast is
+        // rejected here rather than recorded.
+        let pczt = ::pczt::Pczt::parse(row.pczt())
+            .map_err(|e| Error::Finalize(FinalizeError::Parse(e)))?;
+        let finalized = ::pczt::roles::spend_finalizer::SpendFinalizer::new(pczt)
+            .finalize_spends()
+            .map_err(|e| Error::Finalize(FinalizeError::Spends(e)))?;
+        let tx = ::pczt::roles::tx_extractor::TransactionExtractor::new(finalized)
+            .extract()
+            .map_err(|e| Error::Finalize(FinalizeError::Extract(e)))?;
+
+        // The fee is fully determined by the shielded value balances: a migration transaction has
+        // no transparent bundle, so the prevout lookup is never consulted.
+        let fee = tx
+            .fee_paid(|_| Ok::<_, zcash_protocol::value::BalanceError>(None))
+            .map_err(|e| Error::Finalize(FinalizeError::Balance(e)))?
+            .ok_or(Error::Corrupt(
+                "migration transaction has transparent inputs",
+            ))?;
+
+        // Recover the outputs by trial decryption under the account's own viewing key. A
+        // migration transaction's real outputs are all internal to the migrating account (feeder
+        // notes, or the value crossing into Ironwood), and its padded dummy outputs decrypt under
+        // no key, so decryption recovers exactly the outputs the wallet must record.
+        let account =
+            crate::wallet::get_account(self.store.connection(), &self.params, self.account)
+                .map_err(|e| Error::Wallet(Box::new(e)))?
+                .ok_or(Error::AccountUnknown)?;
+        let ufvk = account
+            .ufvk()
+            .cloned()
+            .ok_or(Error::ViewingKeyUnavailable)?;
+        let ufvks = HashMap::from([(self.account, ufvk)]);
+        let decrypted = decrypt_transaction(
+            &self.params,
+            None,
+            Some(row.scheduled_height()),
+            &tx,
+            &ufvks,
+        );
+        let outputs = decrypted
+            .orchard_outputs()
+            .iter()
+            .chain(decrypted.ironwood_outputs())
+            .map(|output| {
+                let (note, pool) = *output.note();
+                Zatoshis::from_u64(note.value().inner())
+                    .map(|value| {
+                        SentTransactionOutput::from_parts(
+                            output.index(),
+                            Recipient::InternalShielded {
+                                receiving_account: *output.account(),
+                                external_address: None,
+                                note: Box::new(Note::Orchard { note, pool }),
+                            },
+                            value,
+                            Some(output.memo().clone()),
+                        )
+                    })
+                    .map_err(|e| Error::Finalize(FinalizeError::Balance(e)))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // The transaction is built to be broadcast at its scheduled height, so the block it aims
+        // to mine in — the standard flow's construction target — is that height's successor.
+        let target_height = TargetHeight::from(u32::from(row.scheduled_height()) + 1);
+        let created = time::OffsetDateTime::from(self.clock.now());
+        let sent = SentTransaction::new(
+            &tx,
+            created,
+            target_height,
+            self.account,
+            &outputs,
+            fee,
+            #[cfg(feature = "transparent-inputs")]
+            &[],
+        );
+
+        let params = &self.params;
+        self.store.replace_migration_with(state, |dbtx| {
+            crate::wallet::store_transaction_to_be_sent(
+                dbtx,
+                params,
+                // A migration transaction has no transparent outputs, so the gap-limit machinery
+                // this parameterizes is unreachable.
+                #[cfg(feature = "transparent-inputs")]
+                &zcash_keys::keys::transparent::gap_limits::GapLimits::default(),
+                &sent,
+            )
+            .map_err(|e| Error::Wallet(Box::new(e)))
+        })
     }
 }
 
@@ -283,6 +519,7 @@ mod retention_follows_the_committed_migration {
 
     use super::PoolMigrations;
     use crate::testing::{BlockCache, db::TestDbFactory};
+    use crate::util::SystemClock;
 
     /// A migration carrying no transactions, recorded as committed under `interval`. Only the
     /// recorded grid matters here; the retention decision does not look at the transfers.
@@ -340,10 +577,15 @@ mod retention_follows_the_committed_migration {
             .expect("the test account exists")
             .account()
             .id();
-        PoolMigrations::for_account(st.wallet_mut().conn_mut(), account_id)
-            .expect("the account exists")
-            .replace_migration(&migration_committed_under(committed))
-            .expect("persists the migration");
+        PoolMigrations::for_account(
+            *st.network(),
+            SystemClock,
+            st.wallet_mut().conn_mut(),
+            account_id,
+        )
+        .expect("the account exists")
+        .replace_migration(&migration_committed_under(committed))
+        .expect("persists the migration");
 
         // Scan enough blocks to cross several boundaries of both grids. The account's birthday is
         // the Sapling activation height, so the first generated block sits just above it.
@@ -405,11 +647,16 @@ mod retention_follows_the_committed_migration {
             "the scan must cross at least one boundary of the committed grid",
         );
         assert!(
-            PoolMigrations::for_account(st.wallet_mut().conn_mut(), account_id)
-                .expect("the account exists")
-                .get_migration()
-                .expect("reads the migration")
-                .is_some(),
+            PoolMigrations::for_account(
+                *st.network(),
+                SystemClock,
+                st.wallet_mut().conn_mut(),
+                account_id
+            )
+            .expect("the account exists")
+            .get_migration()
+            .expect("reads the migration")
+            .is_some(),
             "the migration is still recorded",
         );
     }
@@ -449,6 +696,7 @@ mod check_step_satisfiability {
     use super::{Error, PoolMigrations};
     use crate::AccountUuid;
     use crate::testing::{BlockCache, db::TestDb, db::TestDbFactory};
+    use crate::util::SystemClock;
 
     /// The settle depth the anchor-validity tests hold the oracle to; the input-level tests do not
     /// consult it.
@@ -783,8 +1031,13 @@ mod check_step_satisfiability {
     #[test]
     fn known_unspent_inputs_are_satisfiable() {
         let (mut st, account, nf, as_of_height) = wallet_with_scanned_note();
-        let store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-            .expect("the account exists");
+        let store = PoolMigrations::for_account(
+            *st.network(),
+            SystemClock,
+            st.wallet_mut().conn_mut(),
+            account,
+        )
+        .expect("the account exists");
         assert_eq!(
             store
                 .check_step_satisfiability(&transfer(vec![nf], 0), SETTLE)
@@ -797,8 +1050,13 @@ mod check_step_satisfiability {
     fn a_mined_spend_marks_inputs_spent() {
         let (mut st, account, nf, as_of_height) = wallet_with_scanned_note();
         record_mined_spend(&mut st, nf, as_of_height);
-        let store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-            .expect("the account exists");
+        let store = PoolMigrations::for_account(
+            *st.network(),
+            SystemClock,
+            st.wallet_mut().conn_mut(),
+            account,
+        )
+        .expect("the account exists");
         assert_eq!(
             store
                 .check_step_satisfiability(&transfer(vec![nf], 0), SETTLE)
@@ -825,8 +1083,13 @@ mod check_step_satisfiability {
         // reaches it: the spender sits one block above the fully-scanned height.
         record_mined_spend(&mut st, nf, as_of_height + 1);
         {
-            let store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-                .expect("the account exists");
+            let store = PoolMigrations::for_account(
+                *st.network(),
+                SystemClock,
+                st.wallet_mut().conn_mut(),
+                account,
+            )
+            .expect("the account exists");
             assert_eq!(
                 store
                     .check_step_satisfiability(&transfer(vec![nf], 0), SETTLE)
@@ -843,8 +1106,13 @@ mod check_step_satisfiability {
             as_of_height + 1,
             "the next block is the spender's height"
         );
-        let store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-            .expect("the account exists");
+        let store = PoolMigrations::for_account(
+            *st.network(),
+            SystemClock,
+            st.wallet_mut().conn_mut(),
+            account,
+        )
+        .expect("the account exists");
         assert_eq!(
             store
                 .check_step_satisfiability(&transfer(vec![nf], 0), SETTLE)
@@ -865,8 +1133,13 @@ mod check_step_satisfiability {
     fn an_unmined_spend_does_not_obstruct() {
         let (mut st, account, nf, as_of_height) = wallet_with_scanned_note();
         record_unmined_spend(&mut st, nf);
-        let store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-            .expect("the account exists");
+        let store = PoolMigrations::for_account(
+            *st.network(),
+            SystemClock,
+            st.wallet_mut().conn_mut(),
+            account,
+        )
+        .expect("the account exists");
         assert_eq!(
             store
                 .check_step_satisfiability(&transfer(vec![nf], 0), SETTLE)
@@ -878,8 +1151,13 @@ mod check_step_satisfiability {
     #[test]
     fn an_unknown_nullifier_is_not_yet_satisfiable() {
         let (mut st, account, _nf, as_of_height) = wallet_with_scanned_note();
-        let store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-            .expect("the account exists");
+        let store = PoolMigrations::for_account(
+            *st.network(),
+            SystemClock,
+            st.wallet_mut().conn_mut(),
+            account,
+        )
+        .expect("the account exists");
         assert_eq!(
             store
                 .check_step_satisfiability(&transfer(vec![unknown_nullifier()], 0), SETTLE)
@@ -894,8 +1172,13 @@ mod check_step_satisfiability {
     #[test]
     fn expiry_is_judged_at_the_next_block() {
         let (mut st, account, nf, as_of_height) = wallet_with_scanned_note();
-        let store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-            .expect("the account exists");
+        let store = PoolMigrations::for_account(
+            *st.network(),
+            SystemClock,
+            st.wallet_mut().conn_mut(),
+            account,
+        )
+        .expect("the account exists");
         assert_eq!(
             store
                 .check_step_satisfiability(&transfer(vec![nf], u32::from(as_of_height)), SETTLE)
@@ -927,8 +1210,13 @@ mod check_step_satisfiability {
                 .is_none(),
             "nothing is scanned, so no chain state backs an observation",
         );
-        let store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-            .expect("the account exists");
+        let store = PoolMigrations::for_account(
+            *st.network(),
+            SystemClock,
+            st.wallet_mut().conn_mut(),
+            account,
+        )
+        .expect("the account exists");
         assert!(matches!(
             store.check_step_satisfiability(&transfer(Vec::new(), 0), SETTLE),
             Err(Error::Corrupt("spend_nullifiers")),
@@ -942,8 +1230,13 @@ mod check_step_satisfiability {
     fn a_mined_row_with_an_empty_cache_answers() {
         let (mut st, account, _nf, as_of_height) = wallet_with_scanned_note();
         let mined = mined_transfer_with_empty_cache(as_of_height);
-        let store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-            .expect("the account exists");
+        let store = PoolMigrations::for_account(
+            *st.network(),
+            SystemClock,
+            st.wallet_mut().conn_mut(),
+            account,
+        )
+        .expect("the account exists");
         assert_eq!(
             store
                 .check_step_satisfiability(&mined, SETTLE)
@@ -980,8 +1273,13 @@ mod check_step_satisfiability {
             AnchorBucketInterval::ZIP_318,
             ReplanThreshold::DEFAULT,
         );
-        let mut store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-            .expect("the account exists");
+        let mut store = PoolMigrations::for_account(
+            *st.network(),
+            SystemClock,
+            st.wallet_mut().conn_mut(),
+            account,
+        )
+        .expect("the account exists");
         store
             .replace_migration(&state)
             .expect("persists the mined row");
@@ -1033,8 +1331,13 @@ mod check_step_satisfiability {
             .expect("reads the Orchard commitment tree")
             .expect("the boundary's checkpoint is retained");
 
-        let store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-            .expect("the account exists");
+        let store = PoolMigrations::for_account(
+            *st.network(),
+            SystemClock,
+            st.wallet_mut().conn_mut(),
+            account,
+        )
+        .expect("the account exists");
         assert_eq!(
             store
                 .check_step_satisfiability(&broadcast_transfer(vec![nf], boundary, anchor), SETTLE)
@@ -1052,8 +1355,13 @@ mod check_step_satisfiability {
     fn an_anchor_displacement_marks_exactly_at_the_settle_depth() {
         let (mut st, account, nf, _) = wallet_with_scanned_note();
         let as_of_height = st.generate_and_scan_empty_blocks(12);
-        let store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-            .expect("the account exists");
+        let store = PoolMigrations::for_account(
+            *st.network(),
+            SystemClock,
+            st.wallet_mut().conn_mut(),
+            account,
+        )
+        .expect("the account exists");
 
         assert_eq!(
             store
@@ -1101,8 +1409,13 @@ mod check_step_satisfiability {
             broadcast_transfer(vec![nf], as_of_height - SETTLE.blocks(), no_such_root());
 
         {
-            let store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-                .expect("the account exists");
+            let store = PoolMigrations::for_account(
+                *st.network(),
+                SystemClock,
+                st.wallet_mut().conn_mut(),
+                account,
+            )
+            .expect("the account exists");
             assert_eq!(
                 store
                     .check_step_satisfiability(&displaced, SETTLE)
@@ -1129,8 +1442,13 @@ mod check_step_satisfiability {
             )
             .expect("records a checkpoint the tree cannot root");
 
-        let store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-            .expect("the account exists");
+        let store = PoolMigrations::for_account(
+            *st.network(),
+            SystemClock,
+            st.wallet_mut().conn_mut(),
+            account,
+        )
+        .expect("the account exists");
         assert_eq!(
             store
                 .check_step_satisfiability(&displaced, SETTLE)
@@ -1168,8 +1486,13 @@ mod check_step_satisfiability {
 
         let tx = broadcast_transfer(vec![nf], high, no_such_root());
         {
-            let store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-                .expect("the account exists");
+            let store = PoolMigrations::for_account(
+                *st.network(),
+                SystemClock,
+                st.wallet_mut().conn_mut(),
+                account,
+            )
+            .expect("the account exists");
             assert_eq!(
                 store
                     .check_step_satisfiability(&tx, IMMEDIATE)
@@ -1186,8 +1509,13 @@ mod check_step_satisfiability {
             as_of_height >= high,
             "the scanned region now reaches the boundary at {high:?}",
         );
-        let store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-            .expect("the account exists");
+        let store = PoolMigrations::for_account(
+            *st.network(),
+            SystemClock,
+            st.wallet_mut().conn_mut(),
+            account,
+        )
+        .expect("the account exists");
         assert_eq!(
             store
                 .check_step_satisfiability(&tx, IMMEDIATE)
@@ -1216,8 +1544,13 @@ mod check_step_satisfiability {
             no_such_root(),
         );
 
-        let store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-            .expect("the account exists");
+        let store = PoolMigrations::for_account(
+            *st.network(),
+            SystemClock,
+            st.wallet_mut().conn_mut(),
+            account,
+        )
+        .expect("the account exists");
         assert_eq!(
             store
                 .check_step_satisfiability(&signed, SETTLE)
@@ -1236,8 +1569,13 @@ mod check_step_satisfiability {
         let as_of_height = st.generate_and_scan_empty_blocks(12);
         record_mined_spend(&mut st, nf, as_of_height);
 
-        let store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-            .expect("the account exists");
+        let store = PoolMigrations::for_account(
+            *st.network(),
+            SystemClock,
+            st.wallet_mut().conn_mut(),
+            account,
+        )
+        .expect("the account exists");
         assert_eq!(
             store
                 .check_step_satisfiability(
@@ -1274,8 +1612,13 @@ mod check_step_satisfiability {
             no_such_root(),
         );
 
-        let store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-            .expect("the account exists");
+        let store = PoolMigrations::for_account(
+            *st.network(),
+            SystemClock,
+            st.wallet_mut().conn_mut(),
+            account,
+        )
+        .expect("the account exists");
         assert_eq!(
             store
                 .check_step_satisfiability(&prep, SETTLE)
@@ -1298,8 +1641,13 @@ mod check_step_satisfiability {
             ..
         } = scanned_note_fixture(true);
         let other_account = second_account.expect("the fixture created a second account");
-        let store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), other_account)
-            .expect("the second account exists");
+        let store = PoolMigrations::for_account(
+            *st.network(),
+            SystemClock,
+            st.wallet_mut().conn_mut(),
+            other_account,
+        )
+        .expect("the second account exists");
         assert_eq!(
             store
                 .check_step_satisfiability(&transfer(vec![nf], 0), SETTLE)
@@ -1328,6 +1676,7 @@ mod mined_height {
     use super::PoolMigrations;
     use super::check_step_satisfiability::{unscanned_wallet, wallet_with_scanned_note};
     use crate::testing::{BlockCache, db::TestDb};
+    use crate::util::SystemClock;
 
     /// Insert a transaction the wallet knows of, at `mined_height`, with no spend join: the mining
     /// lookup reads `transactions` alone, so nothing here needs a note or a spender.
@@ -1357,8 +1706,13 @@ mod mined_height {
         let (mut st, account, _nf, as_of_height) = wallet_with_scanned_note();
         let txid = TxId::from_bytes([3; 32]);
         record_transaction(&mut st, txid, Some(as_of_height));
-        let store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-            .expect("the account exists");
+        let store = PoolMigrations::for_account(
+            *st.network(),
+            SystemClock,
+            st.wallet_mut().conn_mut(),
+            account,
+        )
+        .expect("the account exists");
         assert_eq!(
             store.mined_height(txid).expect("the store answers"),
             Some(as_of_height),
@@ -1375,8 +1729,13 @@ mod mined_height {
         let txid = TxId::from_bytes([4; 32]);
         record_transaction(&mut st, txid, Some(as_of_height + 1));
         {
-            let store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-                .expect("the account exists");
+            let store = PoolMigrations::for_account(
+                *st.network(),
+                SystemClock,
+                st.wallet_mut().conn_mut(),
+                account,
+            )
+            .expect("the account exists");
             assert_eq!(
                 store.mined_height(txid).expect("the store answers"),
                 None,
@@ -1387,8 +1746,13 @@ mod mined_height {
         let (h3, _) = st.generate_empty_block();
         st.scan_cached_blocks(h3, 1);
         assert_eq!(h3, as_of_height + 1, "the next block is the mined height");
-        let store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-            .expect("the account exists");
+        let store = PoolMigrations::for_account(
+            *st.network(),
+            SystemClock,
+            st.wallet_mut().conn_mut(),
+            account,
+        )
+        .expect("the account exists");
         assert_eq!(
             store.mined_height(txid).expect("the store answers"),
             Some(h3)
@@ -1402,8 +1766,13 @@ mod mined_height {
         let (mut st, account, _nf, _as_of_height) = wallet_with_scanned_note();
         let unmined = TxId::from_bytes([5; 32]);
         record_transaction(&mut st, unmined, None);
-        let store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-            .expect("the account exists");
+        let store = PoolMigrations::for_account(
+            *st.network(),
+            SystemClock,
+            st.wallet_mut().conn_mut(),
+            account,
+        )
+        .expect("the account exists");
         assert_eq!(
             store.mined_height(unmined).expect("the store answers"),
             None
@@ -1425,8 +1794,13 @@ mod mined_height {
         let (mut st, account) = unscanned_wallet();
         let txid = TxId::from_bytes([7; 32]);
         record_transaction(&mut st, txid, Some(BlockHeight::from_u32(100)));
-        let store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-            .expect("the account exists");
+        let store = PoolMigrations::for_account(
+            *st.network(),
+            SystemClock,
+            st.wallet_mut().conn_mut(),
+            account,
+        )
+        .expect("the account exists");
         assert_eq!(store.mined_height(txid).expect("the store answers"), None);
     }
 }
@@ -1453,6 +1827,7 @@ mod truncation_follows_the_wallet {
 
     use super::PoolMigrations;
     use crate::testing::{BlockCache, db::TestDbFactory};
+    use crate::util::SystemClock;
 
     /// A migration transaction in `state`, marked at `unsatisfiable_at`; the plan-shaped fields are
     /// immaterial to truncation. A mark is a stamp and a kind together, and truncation treats every
@@ -1548,8 +1923,13 @@ mod truncation_follows_the_wallet {
             height,
         };
         {
-            let mut store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-                .expect("the account exists");
+            let mut store = PoolMigrations::for_account(
+                *st.network(),
+                SystemClock,
+                st.wallet_mut().conn_mut(),
+                account,
+            )
+            .expect("the account exists");
             store
                 .replace_migration(&migration(
                     MigrationStatus::Complete,
@@ -1568,11 +1948,16 @@ mod truncation_follows_the_wallet {
             "the truncation moved the chain view back"
         );
 
-        let state = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-            .expect("the account exists")
-            .get_migration()
-            .expect("reads the migration")
-            .expect("the migration is present");
+        let state = PoolMigrations::for_account(
+            *st.network(),
+            SystemClock,
+            st.wallet_mut().conn_mut(),
+            account,
+        )
+        .expect("the account exists")
+        .get_migration()
+        .expect("reads the migration")
+        .expect("the migration is present");
         assert_eq!(
             state.transactions()[0].state(),
             mined(0xA0, low),
@@ -1594,8 +1979,13 @@ mod truncation_follows_the_wallet {
         // And the marks: an in-flight transaction marked on evidence above the next truncation
         // loses that mark, while one marked below keeps it.
         {
-            let mut store = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-                .expect("the account exists");
+            let mut store = PoolMigrations::for_account(
+                *st.network(),
+                SystemClock,
+                st.wallet_mut().conn_mut(),
+                account,
+            )
+            .expect("the account exists");
             store
                 .replace_migration(&migration(
                     MigrationStatus::InProgress,
@@ -1629,11 +2019,16 @@ mod truncation_follows_the_wallet {
             "the surviving mark rests below the truncation"
         );
 
-        let state = PoolMigrations::for_account(st.wallet_mut().conn_mut(), account)
-            .expect("the account exists")
-            .get_migration()
-            .expect("reads the migration")
-            .expect("the migration is present");
+        let state = PoolMigrations::for_account(
+            *st.network(),
+            SystemClock,
+            st.wallet_mut().conn_mut(),
+            account,
+        )
+        .expect("the account exists")
+        .get_migration()
+        .expect("reads the migration")
+        .expect("the migration is present");
         assert_eq!(
             (
                 state.transactions()[0].unsatisfiable_at(),
@@ -1682,10 +2077,17 @@ mod tests {
     };
 
     use crate::AccountUuid;
+    use crate::util::SystemClock;
 
     use std::collections::BTreeSet;
+    use zcash_client_backend::data_api::testing::TestBuilder;
     use zcash_client_backend::wallet::LockOwner;
+    use zcash_protocol::local_consensus::LocalNetwork;
     use zcash_protocol::{consensus::BlockHeight, value::Zatoshis};
+
+    /// Consensus parameters for stores whose wallet context is carried but never consulted: no
+    /// test in this module finalizes a proved transaction.
+    const NET: LocalNetwork = TestBuilder::<(), ()>::DEFAULT_NETWORK;
 
     /// A fresh in-memory database with a minimal `accounts` table (the `account_id` foreign-key
     /// target) and the migration tables created, but not yet wrapped as a store for any particular
@@ -1720,10 +2122,10 @@ mod tests {
     /// A fresh, empty store over a new in-memory database with the migration tables created, scoped
     /// to a fresh account. Each proptest case and test gets its own database and account, so writes
     /// never bleed between cases.
-    fn fresh_store() -> PoolMigrations<Connection> {
+    fn fresh_store() -> PoolMigrations<Connection, LocalNetwork, SystemClock> {
         let conn = fresh_conn();
         let account = insert_account(&conn);
-        PoolMigrations::for_account(conn, account).expect("account exists")
+        PoolMigrations::for_account(NET, SystemClock, conn, account).expect("account exists")
     }
 
     #[test]
@@ -1965,7 +2367,7 @@ mod tests {
     fn a_cached_nullifier_of_the_wrong_width_cannot_be_stored() {
         let mut conn = fresh_conn();
         let account = insert_account(&conn);
-        PoolMigrations::for_account(&mut conn, account)
+        PoolMigrations::for_account(NET, SystemClock, &mut conn, account)
             .expect("account exists")
             .replace_migration(&single_transfer_state())
             .expect("write succeeds");
@@ -1989,7 +2391,7 @@ mod tests {
     fn a_signed_row_whose_cached_nullifiers_are_gone_is_corrupt() {
         let mut conn = fresh_conn();
         let account = insert_account(&conn);
-        PoolMigrations::for_account(&mut conn, account)
+        PoolMigrations::for_account(NET, SystemClock, &mut conn, account)
             .expect("account exists")
             .replace_migration(&single_transfer_state())
             .expect("write succeeds");
@@ -1999,7 +2401,8 @@ mod tests {
         )
         .expect("discards the stored cache");
 
-        let store = PoolMigrations::for_account(&conn, account).expect("account exists");
+        let store =
+            PoolMigrations::for_account(NET, SystemClock, &conn, account).expect("account exists");
         let loaded = store
             .get_migration()
             .expect("read succeeds")
@@ -2174,12 +2577,12 @@ mod tests {
         ] {
             let mut conn = fresh_conn();
             let account = insert_account(&conn);
-            PoolMigrations::for_account(&mut conn, account)
+            PoolMigrations::for_account(NET, SystemClock, &mut conn, account)
                 .expect("account exists")
                 .replace_migration(&single_transfer_state())
                 .expect("write succeeds");
             conn.execute(sql, []).expect("corrupts the stored row");
-            let err = PoolMigrations::for_account(&conn, account)
+            let err = PoolMigrations::for_account(NET, SystemClock, &conn, account)
                 .expect("account exists")
                 .get_migration()
                 .unwrap_err();
@@ -2194,7 +2597,7 @@ mod tests {
 
         let mut conn = fresh_conn();
         let account = insert_account(&conn);
-        PoolMigrations::for_account(&mut conn, account)
+        PoolMigrations::for_account(NET, SystemClock, &mut conn, account)
             .expect("account exists")
             .replace_migration(&single_transfer_state())
             .expect("write succeeds");
@@ -2204,7 +2607,7 @@ mod tests {
             [],
         )
         .expect("stores an unrecognized kind");
-        let err = PoolMigrations::for_account(&conn, account)
+        let err = PoolMigrations::for_account(NET, SystemClock, &conn, account)
             .expect("account exists")
             .get_migration()
             .unwrap_err();
@@ -2217,7 +2620,7 @@ mod tests {
     fn replan_threshold_above_100_is_corrupt() {
         let mut conn = fresh_conn();
         let account = insert_account(&conn);
-        PoolMigrations::for_account(&mut conn, account)
+        PoolMigrations::for_account(NET, SystemClock, &mut conn, account)
             .expect("account exists")
             .replace_migration(&single_transfer_state())
             .expect("write succeeds");
@@ -2226,7 +2629,7 @@ mod tests {
             [],
         )
         .expect("corrupts the stored threshold");
-        let err = PoolMigrations::for_account(&conn, account)
+        let err = PoolMigrations::for_account(NET, SystemClock, &conn, account)
             .expect("account exists")
             .get_migration()
             .expect_err("an out-of-range threshold must not decode");
@@ -2268,11 +2671,11 @@ mod tests {
             ReplanThreshold::DEFAULT,
         );
 
-        PoolMigrations::for_account(&mut conn, account_a)
+        PoolMigrations::for_account(NET, SystemClock, &mut conn, account_a)
             .expect("account A exists")
             .replace_migration(&state)
             .expect("write A's migration");
-        PoolMigrations::for_account(&mut conn, account_b)
+        PoolMigrations::for_account(NET, SystemClock, &mut conn, account_b)
             .expect("account B exists")
             .replace_migration(&state)
             .expect("write B's migration");
@@ -2309,7 +2712,7 @@ mod tests {
             "account A's child rows must cascade away, and only those"
         );
         assert_eq!(
-            PoolMigrations::for_account(&conn, account_b)
+            PoolMigrations::for_account(NET, SystemClock, &conn, account_b)
                 .expect("account B exists")
                 .get_migration()
                 .expect("read B"),
@@ -2370,20 +2773,20 @@ mod tests {
             let account_a = insert_account(&conn);
             let account_b = insert_account(&conn);
 
-            PoolMigrations::for_account(&mut conn, account_a)
+            PoolMigrations::for_account(NET, SystemClock, &mut conn, account_a)
                 .expect("account A exists")
                 .replace_migration(&state)
                 .expect("write for A");
 
             prop_assert_eq!(
-                PoolMigrations::for_account(&conn, account_b)
+                PoolMigrations::for_account(NET, SystemClock, &conn, account_b)
                     .expect("account B exists")
                     .get_migration()
                     .expect("read for B"),
                 None
             );
             prop_assert_eq!(
-                PoolMigrations::for_account(&conn, account_a)
+                PoolMigrations::for_account(NET, SystemClock, &conn, account_a)
                     .expect("account A exists")
                     .get_migration()
                     .expect("read for A"),
@@ -2403,28 +2806,28 @@ mod tests {
             let account_a = insert_account(&conn);
             let account_b = insert_account(&conn);
 
-            PoolMigrations::for_account(&mut conn, account_a)
+            PoolMigrations::for_account(NET, SystemClock, &mut conn, account_a)
                 .expect("account A exists")
                 .replace_migration(&state_a_1)
                 .expect("write A first");
-            PoolMigrations::for_account(&mut conn, account_b)
+            PoolMigrations::for_account(NET, SystemClock, &mut conn, account_b)
                 .expect("account B exists")
                 .replace_migration(&state_b)
                 .expect("write B");
-            PoolMigrations::for_account(&mut conn, account_a)
+            PoolMigrations::for_account(NET, SystemClock, &mut conn, account_a)
                 .expect("account A exists")
                 .replace_migration(&state_a_2)
                 .expect("write A second");
 
             prop_assert_eq!(
-                PoolMigrations::for_account(&conn, account_a)
+                PoolMigrations::for_account(NET, SystemClock, &conn, account_a)
                     .expect("account A exists")
                     .get_migration()
                     .expect("read A"),
                 Some(state_a_2)
             );
             prop_assert_eq!(
-                PoolMigrations::for_account(&conn, account_b)
+                PoolMigrations::for_account(NET, SystemClock, &conn, account_b)
                     .expect("account B exists")
                     .get_migration()
                     .expect("read B"),
@@ -2442,7 +2845,7 @@ mod tests {
         ) {
             let conn = fresh_conn();
             let account = insert_account(&conn);
-            let mut store = PoolMigrations::for_account(conn, account).expect("account exists");
+            let mut store = PoolMigrations::for_account(NET, SystemClock, conn, account).expect("account exists");
             store.replace_migration(&first).expect("write first");
             store.replace_migration(&second).expect("write second");
             prop_assert_eq!(store.get_migration().expect("read"), Some(second));
@@ -2463,22 +2866,22 @@ mod tests {
             let account_a = insert_account(&conn);
             let account_b = insert_account(&conn);
 
-            PoolMigrations::for_account(&mut conn, account_a)
+            PoolMigrations::for_account(NET, SystemClock, &mut conn, account_a)
                 .expect("account A exists")
                 .replace_migration(&state)
                 .expect("write A");
-            PoolMigrations::for_account(&mut conn, account_b)
+            PoolMigrations::for_account(NET, SystemClock, &mut conn, account_b)
                 .expect("account B exists")
                 .replace_migration(&state)
                 .expect("write B");
 
-            PoolMigrations::for_account(&mut conn, account_a)
+            PoolMigrations::for_account(NET, SystemClock, &mut conn, account_a)
                 .expect("account A exists")
                 .update_transaction(id, new)
                 .expect("update A");
 
             prop_assert_eq!(
-                PoolMigrations::for_account(&conn, account_b)
+                PoolMigrations::for_account(NET, SystemClock, &conn, account_b)
                     .expect("account B exists")
                     .get_migration()
                     .expect("read B"),

--- a/zcash_client_sqlite/src/pool_migration/store.rs
+++ b/zcash_client_sqlite/src/pool_migration/store.rs
@@ -376,6 +376,15 @@ impl<C> Store<C> {
 }
 
 impl<C: Borrow<Connection>> Store<C> {
+    /// The wallet database connection this store operates over, for reads a pool facade makes
+    /// outside the store's own tables (for example resolving the account's viewing key when
+    /// finalizing a proved migration transaction — an `orchard`-gated capability, hence the
+    /// feature-conditional dead-code allowance).
+    #[cfg_attr(not(feature = "orchard"), allow(dead_code))]
+    pub(crate) fn connection(&self) -> &Connection {
+        self.conn.borrow()
+    }
+
     pub(crate) fn get_migration(&self) -> Result<Option<MigrationState>, Error> {
         read_migration(self.conn.borrow(), self.tables, self.account_id)
     }
@@ -420,10 +429,27 @@ impl<C: Borrow<Connection>> Store<C> {
 
 impl<C: BorrowMut<Connection>> Store<C> {
     pub(crate) fn replace_migration(&mut self, state: &MigrationState) -> Result<(), Error> {
+        self.replace_migration_with(state, |_| Ok(()))
+    }
+
+    /// Replace the migration as [`replace_migration`](Self::replace_migration) does, then run
+    /// `and_then` inside the SAME database transaction, so the store update and whatever the
+    /// caller must record alongside it commit or roll back as one atomic write. This is the seam a
+    /// pool facade uses to persist a finalized migration transaction into the wallet's own
+    /// transaction tables atomically with the migration state that says it is proved.
+    pub(crate) fn replace_migration_with<F>(
+        &mut self,
+        state: &MigrationState,
+        and_then: F,
+    ) -> Result<(), Error>
+    where
+        F: FnOnce(&rusqlite::Transaction<'_>) -> Result<(), Error>,
+    {
         let tables = self.tables;
         let account_id = self.account_id;
         let tx = self.conn.borrow_mut().transaction()?;
         replace_migration(&tx, tables, account_id, state)?;
+        and_then(&tx)?;
         tx.commit()?;
         Ok(())
     }

--- a/zcash_client_sqlite/src/wallet/init/migrations/orchard_ironwood_migration_unsatisfiability.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/orchard_ironwood_migration_unsatisfiability.rs
@@ -919,7 +919,7 @@ mod tests {
             "the mined row is exempt from the backfill, so it caches nothing",
         );
 
-        let store = PoolMigrations::for_account(&conn, AccountUuid::from_uuid(account))
+        let store = PoolMigrations::for_account((), (), &conn, AccountUuid::from_uuid(account))
             .expect("the account exists");
         let state = store
             .get_migration()

--- a/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
+++ b/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
@@ -45,6 +45,7 @@ use zcash_client_backend::data_api::{Account, WalletRead, WalletTest};
 use zcash_client_sqlite::pool_migration::orchard_ironwood::PoolMigrations;
 use zcash_client_sqlite::testing::db::{TestDb, TestDbFactory};
 use zcash_client_sqlite::testing::{BlockCache, highest_rooted_orchard_checkpoint};
+use zcash_client_sqlite::util::SystemClock;
 use zcash_keys::keys::UnifiedSpendingKey;
 
 use zcash_primitives::block::BlockHash;
@@ -158,6 +159,18 @@ impl PoolMigrationWrite for MigrationTestStore {
         // updates all happen against the SQLite store during the drive.
         Ok(())
     }
+
+    /// The contract's no-wallet-tables form; not exercised, for the same reason as
+    /// `update_transaction` — every prove in this file discharges its proof through the SQLite
+    /// store.
+    fn store_proved_transaction(
+        &mut self,
+        state: &mut MigrationState,
+        proven: engine::ProvedTransaction,
+    ) -> Result<(), Self::Error> {
+        proven.apply(state);
+        self.replace_migration(state)
+    }
 }
 
 /// An end-to-end migration proving scenario, built fluently: [`Scenario::funded`] /
@@ -230,6 +243,19 @@ struct Committed {
     change: u64,
 }
 
+/// [`Run::perform_prove`]'s summary of the engine's `ProveOutcome`, with a successful proof's
+/// `ProvedTransaction` already discharged through the store (the engine's own outcome carries the
+/// proof by value, so it cannot survive the persistence the helper performs).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProveStepOutcome {
+    Proved,
+    NotYetProvable,
+    MarkedUnsatisfiable {
+        #[allow(dead_code)]
+        replan_required: bool,
+    },
+}
+
 impl Run {
     /// Phase 1 (setup): builds an NU6.3 wallet, funds the account with the scenario's source Orchard
     /// notes (one per block), and completes their shards so an anchor is available at the tip.
@@ -279,10 +305,17 @@ impl Run {
     }
 
     /// The account's pool-migration store, over the wallet database's own connection — the same
-    /// borrow an application holding that connection would construct it from.
-    fn store(&mut self) -> PoolMigrations<&mut rusqlite::Connection> {
-        PoolMigrations::for_account(self.st.wallet_mut().conn_mut(), self.account_id)
-            .expect("the account has a pool-migration store")
+    /// borrow an application holding that connection would construct it from, with the wallet
+    /// context (parameters and clock) `store_proved_transaction` finalizes under.
+    fn store(&mut self) -> PoolMigrations<&mut rusqlite::Connection, LocalNetwork, SystemClock> {
+        let params = *self.st.network();
+        PoolMigrations::for_account(
+            params,
+            SystemClock,
+            self.st.wallet_mut().conn_mut(),
+            self.account_id,
+        )
+        .expect("the account has a pool-migration store")
     }
 
     /// Write `state` through to the SQLite store, as a consumer does after performing a step.
@@ -335,7 +368,15 @@ impl Run {
     /// Perform an [`AdvanceStep::Prove`] step: install the transaction's deferred anchor and
     /// witnesses against the wallet's commitment trees, prove it, and persist. A PREPARATION
     /// anchors to a fresh checkpoint at the tip (the caller's choice, as for an ordinary
-    /// transaction); a TRANSFER to the boundary its schedule drew.
+    /// transaction); a TRANSFER to the boundary its schedule drew. Returns [`ProveStepOutcome`]
+    /// rather than the engine's own outcome because a successful proof's `ProvedTransaction` is
+    /// consumed by the persistence this helper performs.
+    ///
+    /// A successful proof is persisted through [`PoolMigrations::store_proved_transaction`]: the
+    /// migration state and the finalized transaction's wallet record (its `transactions` row,
+    /// sent outputs, and input-spend marks) are written as one atomic update, which is the
+    /// moment the wallet's own view starts protecting the migration's inputs from its other
+    /// spends. Any other outcome persists the migration state alone.
     ///
     /// The engine's outcome is returned rather than asserted: a prove attempt whose input the
     /// wallet no longer holds unspent is not an error but a determination, and persisting is
@@ -345,7 +386,7 @@ impl Run {
         state: &mut MigrationState,
         id: MigrationTransferId,
         kind: MigrationTxKind,
-    ) -> engine::ProveOutcome {
+    ) -> ProveStepOutcome {
         let anchor = matches!(kind, MigrationTxKind::Preparation { .. }).then(|| {
             let tip = self.target_height() - 1;
             highest_rooted_orchard_checkpoint(self.st.wallet_mut(), tip)
@@ -374,8 +415,22 @@ impl Run {
                 .expect("the prover answers for the transfer"),
             }
         };
-        self.persist(state);
-        outcome
+        match outcome {
+            engine::ProveOutcome::Proved(proven) => {
+                self.store()
+                    .store_proved_transaction(state, proven)
+                    .expect("finalizes and persists the proved transaction");
+                ProveStepOutcome::Proved
+            }
+            engine::ProveOutcome::NotYetProvable => {
+                self.persist(state);
+                ProveStepOutcome::NotYetProvable
+            }
+            engine::ProveOutcome::MarkedUnsatisfiable { replan_required } => {
+                self.persist(state);
+                ProveStepOutcome::MarkedUnsatisfiable { replan_required }
+            }
+        }
     }
 
     /// Perform an [`AdvanceStep::Broadcast`] step: extract the stored proven transaction and
@@ -440,7 +495,7 @@ impl Run {
                     );
                     assert_eq!(
                         self.perform_prove(&mut committed.state, id, kind),
-                        engine::ProveOutcome::Proved,
+                        ProveStepOutcome::Proved,
                     );
                 }
                 AdvanceStep::Broadcast { id } => {
@@ -504,7 +559,7 @@ impl Run {
                 AdvanceStep::Prove { id, kind } => {
                     assert_eq!(
                         self.perform_prove(&mut committed.state, id, kind),
-                        engine::ProveOutcome::Proved,
+                        ProveStepOutcome::Proved,
                     );
                 }
                 AdvanceStep::Broadcast { id } => {
@@ -615,6 +670,26 @@ impl Run {
         height
     }
 
+    /// Forget the wallet-side spend marks of a proved-but-unbroadcast migration transaction, so
+    /// this wallet's own selection can play the role of a SIBLING wallet on the same seed: the
+    /// sibling shares every note but holds no record of this wallet's unbroadcast crossing, so
+    /// nothing excludes the crossing's inputs from ITS selection. Since
+    /// `store_proved_transaction` records those marks at proving time — which is exactly what
+    /// keeps this wallet's own sweeps off a migration input, the protection under test in
+    /// `proving_persists_the_finalized_transaction_to_the_wallet` — simulating the sibling's
+    /// independent view requires lifting them.
+    fn forget_pending_spend_marks(&mut self, txid: TxId) {
+        self.st
+            .wallet_mut()
+            .conn_mut()
+            .execute(
+                "DELETE FROM orchard_received_note_spends
+                 WHERE transaction_id IN (SELECT id_tx FROM transactions WHERE txid = :txid)",
+                rusqlite::named_params![":txid": txid.as_ref()],
+            )
+            .expect("lifts the pending spend marks");
+    }
+
     /// The wallet's fully-scanned height: the chain state every satisfiability observation the
     /// oracle and the prove seam make rests on.
     fn fully_scanned_height(&self) -> BlockHeight {
@@ -720,7 +795,7 @@ impl Run {
                 AdvanceStep::Prove { id, kind } => {
                     assert_eq!(
                         self.perform_prove(&mut committed.state, id, kind),
-                        engine::ProveOutcome::Proved,
+                        ProveStepOutcome::Proved,
                         "{}: proving {id:?}",
                         scenario.label
                     );
@@ -972,6 +1047,223 @@ fn migration_proves_end_to_end_against_a_funded_wallet() {
     scenario.prove_end_to_end();
 }
 
+/// Proving a migration transaction persists its FINALIZED form to the wallet database, atomically
+/// with the migration state that records it proved.
+///
+/// The wallet-side record is the one `store_transactions_to_be_sent` writes for the standard
+/// spend flows: the raw transaction (queryable for broadcast), its outputs as sent notes — here
+/// the Ironwood crossing output carrying the migrated value — and its input notes marked spent,
+/// which is what stops the wallet's OWN later spends from consuming a migration input during the
+/// deliberately long window between proving and broadcast. Atomicity is exercised from the
+/// failure side: with the wallet-side half made to fail, the migration-store half must roll back
+/// with it, so a transaction is never durably `Proved` without the wallet record.
+#[test]
+#[cfg_attr(
+    feature = "ignore-expensive-tests",
+    ignore = "covered by the expensive-test CI matrix"
+)]
+fn proving_persists_the_finalized_transaction_to_the_wallet() {
+    use zcash_client_backend::data_api::InputSource;
+    use zcash_client_backend::data_api::wallet::TargetHeight;
+    use zcash_client_backend::data_api::wallet::input_selection::LockFilter;
+    use zcash_protocol::ShieldedPool;
+
+    // The cheapest scenario with both a preparation and a crossing: one funding note, one
+    // transfer, so the wallet-side record under test is a single transaction's.
+    const SINGLE: &str = "Gwen, 0.0152 ZEC (a single minimum-denomination note)";
+    let scenario = scenarios()
+        .into_iter()
+        .find(|scenario| scenario.label == SINGLE)
+        .expect("the single-crossing scenario exists");
+
+    let mut run = Run::setup(&scenario);
+    let mut committed = run.plan_and_commit(&scenario);
+    let transfer_id = run.drive_to_first_transfer_step(&mut committed);
+
+    let spendable_values = |run: &mut Run| -> Vec<Zatoshis> {
+        let target = TargetHeight::from(u32::from(run.target_height()));
+        run.st
+            .wallet()
+            .select_unspent_notes(
+                run.account_id,
+                &[ShieldedPool::Orchard],
+                target,
+                &[],
+                LockFilter::Unfiltered,
+            )
+            .expect("selects unspent notes")
+            .orchard()
+            .iter()
+            .map(|note| {
+                Zatoshis::from_u64(note.note().value().inner()).expect("a valid note value")
+            })
+            .collect()
+    };
+    let funding_value = committed.funding_notes[0];
+    assert!(
+        spendable_values(&mut run).contains(&funding_value),
+        "premise: the funding note is spendable before the transfer is proved",
+    );
+
+    // Prove through the engine seam alone, so persistence can be exercised separately below. The
+    // engine returns the proof as a value — nothing has moved the state to `Proved` yet.
+    let outcome = {
+        let params = *run.st.network();
+        let scanned_tip = run.fully_scanned_height();
+        let mut redraw_rng = ChaCha8Rng::seed_from_u64(29);
+        let mut prover =
+            WalletMigrationProver::new(run.st.wallet_mut(), run.account_id, run.fvk.clone());
+        engine::prove_transfer(
+            &params,
+            &mut prover,
+            &mut committed.state,
+            transfer_id,
+            scanned_tip,
+            &mut redraw_rng,
+        )
+        .expect("the prover answers for the transfer")
+    };
+    let engine::ProveOutcome::Proved(proven) = outcome else {
+        panic!("expected a proof, got {outcome:?}");
+    };
+    // The proof is consumed by the failure-side attempt below; keep its parts to retry with.
+    let proven_bytes = proven.pczt().to_vec();
+    let txid = committed
+        .state
+        .transactions()
+        .iter()
+        .find(|t| t.id() == transfer_id)
+        .expect("the transfer is present")
+        .txid();
+
+    // FAILURE SIDE: with the wallet-side half unable to write, the migration-store half must
+    // roll back with it — the store keeps saying `Signed`, and the wallet holds no record.
+    run.st
+        .wallet_mut()
+        .conn_mut()
+        .execute_batch("ALTER TABLE sent_notes RENAME TO sent_notes_hidden")
+        .expect("hides the sent-notes table");
+    assert!(
+        run.store()
+            .store_proved_transaction(&mut committed.state, proven)
+            .is_err(),
+        "the wallet-side write cannot succeed without its table",
+    );
+    assert!(
+        matches!(
+            run.stored_migration()
+                .expect("the store holds the migration")
+                .transactions()
+                .iter()
+                .find(|t| t.id() == transfer_id)
+                .expect("the transfer is present")
+                .state(),
+            MigrationTxState::Signed
+        ),
+        "the migration-store half rolled back with the failed wallet-side half",
+    );
+    assert!(
+        run.st
+            .wallet()
+            .get_transaction(txid)
+            .expect("queries the wallet")
+            .is_none(),
+        "no wallet transaction record survives the rollback",
+    );
+    run.st
+        .wallet_mut()
+        .conn_mut()
+        .execute_batch("ALTER TABLE sent_notes_hidden RENAME TO sent_notes")
+        .expect("restores the sent-notes table");
+
+    // SUCCESS SIDE: one atomic write records both halves. (The failure-side attempt consumed the
+    // engine's proof value; the retry reassembles it from the parts kept above, exactly the
+    // resume-and-reprove a real consumer performs more cheaply here.)
+    run.store()
+        .store_proved_transaction(
+            &mut committed.state,
+            engine::ProvedTransaction::from_parts(transfer_id, proven_bytes),
+        )
+        .expect("finalizes and persists the proved transaction");
+    assert!(
+        matches!(
+            run.stored_migration()
+                .expect("the store holds the migration")
+                .transactions()
+                .iter()
+                .find(|t| t.id() == transfer_id)
+                .expect("the transfer is present")
+                .state(),
+            MigrationTxState::Proved
+        ),
+        "the store records the transfer proved",
+    );
+
+    // The wallet holds the raw finalized transaction under the txid the engine derived at build
+    // time, with its Ironwood crossing bundle intact.
+    let tx = run
+        .st
+        .wallet()
+        .get_transaction(txid)
+        .expect("queries the wallet")
+        .expect("the finalized transaction is stored");
+    assert_eq!(tx.txid(), txid);
+    assert!(
+        tx.ironwood_bundle().is_some(),
+        "the crossing carries an Ironwood bundle",
+    );
+
+    // Its sent-output record is exactly the transfer's REAL outputs: the Ironwood crossing
+    // output carrying the migrated value, plus the Orchard change returning the unspent share of
+    // the funding note's fee buffer — together the funding note minus the fee. The padding
+    // dummies decrypt under no key and are exactly what must NOT be recorded.
+    let sent_values: Vec<Zatoshis> = {
+        let conn = run.st.wallet_mut().conn_mut();
+        let mut stmt = conn
+            .prepare(
+                "SELECT sent_notes.value
+                 FROM sent_notes
+                 JOIN transactions ON transactions.id_tx = sent_notes.transaction_id
+                 WHERE transactions.txid = :txid",
+            )
+            .expect("prepares the sent-outputs query");
+        let values = stmt
+            .query_map(rusqlite::named_params![":txid": txid.as_ref()], |row| {
+                row.get::<_, i64>(0)
+            })
+            .expect("queries the sent outputs")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("reads the sent outputs");
+        values
+            .into_iter()
+            .map(|v| Zatoshis::from_nonnegative_i64(v).expect("a valid recorded value"))
+            .collect()
+    };
+    let fee = tx
+        .fee_paid(|_| Ok::<_, zcash_protocol::value::BalanceError>(None))
+        .expect("computes the fee")
+        .expect("a migration transaction has no transparent inputs");
+    assert!(
+        sent_values.contains(&scenario.expected_migrated),
+        "the Ironwood crossing output is recorded, carrying the migrated value",
+    );
+    assert_eq!(
+        sent_values
+            .iter()
+            .try_fold(Zatoshis::ZERO, |acc, v| acc + *v)
+            .expect("a valid total"),
+        (funding_value - fee).expect("the fee is covered by the funding note"),
+        "the recorded outputs account for the funding note minus the fee",
+    );
+
+    // The funding note is now marked spent, so the wallet's own input selection no longer offers
+    // it: the double-spend window between proving and broadcast is closed.
+    assert!(
+        !spendable_values(&mut run).contains(&funding_value),
+        "the funding note is spent in the wallet's view from the moment the proof is persisted",
+    );
+}
+
 /// The adapter reports the WALLET's anchor retention interval as its anchor bucket interval, and
 /// every anchor a committed migration draws lands on that grid.
 ///
@@ -1088,11 +1380,14 @@ fn migration_anchors_to_the_wallets_configured_retention_grid() {
             .expect("a rooted Orchard checkpoint exists");
         {
             let mut prover = WalletMigrationProver::new(st.wallet_mut(), account_id, fvk.clone());
-            assert_eq!(
-                engine::prove_preparation(&mut prover, &mut state, prep_id, anchor)
-                    .expect("proves the preparation transaction"),
-                engine::ProveOutcome::Proved
-            );
+            match engine::prove_preparation(&mut prover, &mut state, prep_id, anchor)
+                .expect("proves the preparation transaction")
+            {
+                // This test drives raw state with no store; applying the proof directly is the
+                // minimal discharge that puts the proven bytes where the extraction below reads.
+                engine::ProveOutcome::Proved(proven) => proven.apply(&mut state),
+                other => panic!("expected a proof, got {other:?}"),
+            }
         }
         let proven = state
             .transactions()
@@ -1157,7 +1452,10 @@ fn migration_anchors_to_the_wallets_configured_retention_grid() {
                  grid failed: {e}"
             )
         });
-        assert_eq!(outcome, engine::ProveOutcome::Proved);
+        let engine::ProveOutcome::Proved(proven) = outcome else {
+            panic!("expected a proof, got {outcome:?}");
+        };
+        proven.apply(&mut state);
     }
 }
 
@@ -1489,7 +1787,11 @@ fn a_rejected_broadcast_is_withheld_until_the_wallet_can_adjudicate_it() {
 
     // (2) THE REAL REJECTION. Another wallet on the same seed sweeps the account; the spend is
     // mined in a block this wallet has not scanned, so its own tables still show the funding note
-    // unspent — and the node refuses the crossing that spends it.
+    // unspent — and the node refuses the crossing that spends it. The sibling holds no record of
+    // this wallet's proved-but-unbroadcast crossing, so its selection is free to take the funding
+    // note this wallet's own selection would refuse; lifting the pending spend marks is what
+    // lets this wallet's machinery enact the sibling's sweep.
+    run.forget_pending_spend_marks(transfer(&committed.state).txid());
     let sweep_tip = run.sweep_to_external_unscanned();
     assert!(run.fully_scanned_height() < sweep_tip);
     committed
@@ -1636,7 +1938,7 @@ fn a_settled_reorg_below_a_broadcast_crossings_anchor_marks_it() {
                 assert_eq!(id, transfer_id);
                 assert_eq!(
                     run.perform_prove(&mut committed.state, id, kind),
-                    engine::ProveOutcome::Proved,
+                    ProveStepOutcome::Proved,
                 );
                 break;
             }

--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -7,6 +7,30 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- `engine::ProvedTransaction`: the proof carried out of a successful
+  `engine::prove_transfer` / `engine::prove_preparation` call — the proven PCZT
+  bytes and the row id they belong to — consumed only by
+  `engine::PoolMigrationWrite::store_proved_transaction` (via its
+  `ProvedTransaction::apply`).
+- `engine::PoolMigrationWrite::store_proved_transaction` (required): records a
+  successfully proved transaction on the migration state and persists it. An implementation over a wallet database
+  must, atomically with that write, finalize the now fully-constructed
+  transaction and persist it to the wallet's own transaction store (as
+  `store_transactions_to_be_sent` records the standard spend flows), so the
+  wallet's view protects the migration's inputs from its own spends between
+  proving and broadcast. A store with no wallet-level transaction records
+  implements it as `proven.apply(state)` followed by `replace_migration`.
+
+### Changed
+- `engine::ProveOutcome::Proved` now carries the `ProvedTransaction`, and
+  `engine::prove_transfer` / `engine::prove_preparation` no longer write the
+  proof into the migration state themselves: a caller discharges the returned
+  proof through `PoolMigrationWrite::store_proved_transaction` (nothing else
+  moves a transaction to `Proved`), and persists a `MarkedUnsatisfiable`
+  outcome with `replace_migration` as before. `ProveOutcome` no longer
+  implements `Clone`/`Copy`.
+
 ### Fixed
 - `engine::prove_transfer` now re-validates a transfer's persisted anchor boundary
   against its funding preparations' REAL mined heights, and re-draws it (via

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -229,6 +229,38 @@ pub trait PoolMigrationWrite: PoolMigrationRead {
         id: MigrationTransferId,
         state: MigrationTxState,
     ) -> Result<(), Self::Error>;
+
+    /// Record a successfully proved transaction — the [`ProvedTransaction`] carried out of
+    /// [`prove_transfer`] / [`prove_preparation`] — on `state`, and persist.
+    ///
+    /// From the moment the proof exists, the transaction is FULLY CONSTRUCTED: its PCZT carries
+    /// both signatures (installed at commit) and proofs, and extracting the broadcastable
+    /// `Transaction` from it is purely mechanical. This method is where a backend makes the
+    /// wallet aware of that fact. An implementation over a wallet database MUST, atomically with
+    /// recording the proof in the migration store, finalize the transaction and persist it to
+    /// the wallet's own transaction store — the record `store_transactions_to_be_sent` writes
+    /// for the standard spend flows: the raw transaction, its outputs, and its input notes
+    /// marked spent, so the wallet's own later spends cannot consume a migration input during
+    /// the (deliberately long, for a scheduled transfer) window between proving and broadcast.
+    /// A store with no wallet-level transaction records (a mock, or a store deferring the wallet
+    /// side elsewhere) applies the proof and persists the migration state alone:
+    ///
+    /// ```ignore
+    /// proven.apply(state);
+    /// self.replace_migration(state)
+    /// ```
+    ///
+    /// On an error the proof is lost with the value and `state` may or may not carry it (an
+    /// implementation applies it before writing); the caller should re-read the migration from
+    /// the store and retry the prove step, which is cheap relative to the ambiguity of guessing.
+    ///
+    /// [`prove_transfer`]: crate::engine::prove_transfer
+    /// [`prove_preparation`]: crate::engine::prove_preparation
+    fn store_proved_transaction(
+        &mut self,
+        state: &mut MigrationState,
+        proven: ProvedTransaction,
+    ) -> Result<(), Self::Error>;
 }
 
 /// A stable ordinal identifier for a migration transaction within a migration. This is a ROW KEY
@@ -778,11 +810,13 @@ impl MigrationState {
             .and_then(|crossing| self.crossing_values().get(crossing).copied())
     }
 
-    /// Replace transfer `id`'s stored PCZT with its proven bytes and move it to
-    /// [`Proved`](MigrationTxState::Proved). Called after [`prove_transfer`] installs the drawn
-    /// anchor and witnesses and proves the transaction, so the durable artifact becomes the proven,
+    /// Replace transaction `id`'s stored PCZT with its proven bytes and move it to
+    /// [`Proved`](MigrationTxState::Proved), so the artifact becomes the proven,
     /// ready-to-broadcast PCZT.
-    #[cfg(feature = "orchard")]
+    ///
+    /// In the production flow this is reached only through [`ProvedTransaction::apply`], inside
+    /// [`PoolMigrationWrite::store_proved_transaction`]: the proof travels from the prove step to
+    /// the store as a value, and the state records it in the same act that persists it.
     pub fn set_transaction_proved(&mut self, id: MigrationTransferId, proven_pczt: Vec<u8>) {
         for tx in &mut self.transactions {
             if tx.id() == id {
@@ -1550,10 +1584,15 @@ pub enum ProveFailure<E> {
 /// The outcome of a prove attempt the engine HANDLED — an error return would invite blind
 /// retries of conditions that are not errors.
 #[cfg(feature = "orchard")]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ProveOutcome {
-    /// The proof was created; the transaction is `Proved` and the proven PCZT stored.
-    Proved,
+    /// The proof was created. The carried [`ProvedTransaction`] is the proven PCZT awaiting its
+    /// persistence: hand it to [`PoolMigrationWrite::store_proved_transaction`], which records
+    /// the transaction `Proved` and persists — for a wallet-database-backed store, atomically
+    /// with the wallet's own record of the finalized transaction. Neither the in-memory state
+    /// nor the store says `Proved` until that call; there is no other way to discharge the
+    /// value.
+    Proved(ProvedTransaction),
     /// An input was not available, and the wallet has not yet scanned past every dependency's
     /// mined height: nothing can be concluded. No state change; retry after further sync.
     NotYetProvable,
@@ -1565,6 +1604,56 @@ pub enum ProveOutcome {
         /// [`MigrationState::replan_required`] as it stands after the mark.
         replan_required: bool,
     },
+}
+
+/// A successfully proved migration transaction awaiting its persistence: the proven PCZT — now
+/// carrying both signatures (installed at commit) and proofs, ready to broadcast — together with
+/// the id of the row it belongs to.
+///
+/// Only a successful [`prove_transfer`] / [`prove_preparation`] produces one, and only
+/// [`PoolMigrationWrite::store_proved_transaction`] consumes one (through
+/// [`apply`](Self::apply), which a store implementation calls to record the proof on the state it
+/// persists). Carrying the proof OUT of the prove step rather than writing it into the state
+/// there is what makes "proved but never persisted to the wallet" unrepresentable: the state
+/// cannot say [`Proved`](MigrationTxState::Proved) until the store method that also owns the
+/// wallet-side record has run. It also keeps the prove seam free of any store borrow — a
+/// wallet-backed prover and a wallet-database store borrow the same wallet mutably, so they can
+/// only ever be used in sequence, never side by side in one call.
+#[derive(Debug, PartialEq, Eq)]
+#[must_use = "a proved transaction is not durable (and its wallet record does not exist) until \
+              it is handed to `PoolMigrationWrite::store_proved_transaction`"]
+pub struct ProvedTransaction {
+    id: MigrationTransferId,
+    pczt: Vec<u8>,
+}
+
+impl ProvedTransaction {
+    /// The id of the migration transaction this proof belongs to.
+    pub fn id(&self) -> MigrationTransferId {
+        self.id
+    }
+
+    /// The proven PCZT's serialized bytes.
+    pub fn pczt(&self) -> &[u8] {
+        &self.pczt
+    }
+
+    /// Record this proof on `state`: the proven PCZT replaces the stored bytes and the
+    /// transaction becomes [`Proved`](MigrationTxState::Proved). This is the sole consumer of
+    /// the value, called by [`PoolMigrationWrite::store_proved_transaction`] implementations on
+    /// the state they are about to persist.
+    pub fn apply(self, state: &mut MigrationState) {
+        state.set_transaction_proved(self.id, self.pczt);
+    }
+
+    /// Reassemble a proved transaction from its parts, for exercising a store's
+    /// [`store_proved_transaction`](PoolMigrationWrite::store_proved_transaction) without
+    /// driving the whole prove pipeline. Test-only: production code obtains these exclusively
+    /// from [`prove_transfer`] / [`prove_preparation`].
+    #[cfg(any(test, feature = "test-dependencies"))]
+    pub fn from_parts(id: MigrationTransferId, pczt: Vec<u8>) -> Self {
+        Self { id, pczt }
+    }
 }
 
 /// The proving seam for a migration transfer: install a transfer's deferred anchors and witnesses
@@ -1817,16 +1906,19 @@ impl<E: fmt::Display> fmt::Display for ProveError<E> {
 #[cfg(feature = "orchard")]
 impl<E: core::error::Error> core::error::Error for ProveError<E> {}
 
-/// Prove a pre-signed migration transfer against the boundary its schedule drew, moving it
-/// `Signed -> Proved`.
+/// Prove a pre-signed migration transfer against the boundary its schedule drew.
 ///
 /// This is the step that finally consults a transfer's PERSISTED
 /// [`anchor_boundary`](MigrationTransaction::anchor_boundary), drawn at scheduling time: it reads
 /// that boundary and hands the stored PCZT and the boundary to
 /// [`MigrationProver::prove_transfer`], which installs the Orchard source anchor and the funding
 /// note's witness against that boundary and the Ironwood destination anchor (through the PCZT
-/// `Updater` role), then proves both bundles. The proven PCZT replaces the stored one and the
-/// transaction becomes [`Proved`](MigrationTxState::Proved), ready to broadcast.
+/// `Updater` role), then proves both bundles. A successful proof is returned as
+/// [`ProveOutcome::Proved`]'s [`ProvedTransaction`], which the caller hands to
+/// [`PoolMigrationWrite::store_proved_transaction`] — the single step that records the
+/// transaction [`Proved`](MigrationTxState::Proved) and persists it, for a wallet-backed store
+/// atomically with the wallet's own record of the finalized transaction. Neither this function
+/// nor anything else moves the state to `Proved`.
 ///
 /// The CALLER decides WHEN to prove each transfer (once its funding note is mined and its drawn
 /// anchor boundary has settled — [`advance_migration`] surfaces this as [`AdvanceStep::Prove`],
@@ -1871,9 +1963,13 @@ impl<E: core::error::Error> core::error::Error for ProveError<E> {}
 /// strand live value behind an observation only a reorg can clear, so the conservative reading is
 /// always a retry.
 ///
-/// The caller PERSISTS the state afterwards, as for a successful proof — a `MarkedUnsatisfiable`
-/// outcome changed the marks and the closure, and an unpersisted mark would be lost on the next
-/// launch.
+/// The caller PERSISTS the outcome: a [`Proved`](ProveOutcome::Proved) answer through
+/// [`PoolMigrationWrite::store_proved_transaction`] (which consumes the carried proof), and a
+/// [`MarkedUnsatisfiable`](ProveOutcome::MarkedUnsatisfiable) one through
+/// [`PoolMigrationWrite::replace_migration`] — the marks and the closure changed, and an
+/// unpersisted mark would be lost on the next launch. (A boundary re-draw rides along with
+/// whichever of the two follows; a [`NotYetProvable`](ProveOutcome::NotYetProvable) answer after
+/// a re-draw is worth persisting for the same reason, though re-deriving it costs only a retry.)
 ///
 /// [`advance_migration`]: crate::satisfiability::advance_migration
 /// [`AdvanceStep::Prove`]: crate::state::AdvanceStep::Prove
@@ -1970,8 +2066,7 @@ where
     match prover.prove_transfer(pczt, anchor_boundary) {
         Ok(proven) => {
             let bytes = proven.serialize().map_err(ProveError::Serialize)?;
-            state.set_transaction_proved(id, bytes);
-            Ok(ProveOutcome::Proved)
+            Ok(ProveOutcome::Proved(ProvedTransaction { id, pczt: bytes }))
         }
         Err(ProveFailure::InputNotAvailable { nullifier, as_of }) => {
             Ok(interpret_input_not_available(state, id, nullifier, as_of))
@@ -2044,7 +2139,7 @@ fn interpret_input_not_available(
 }
 
 /// Prove a pre-signed migration PREPARATION transaction against a checkpoint at which its spent
-/// notes are witnessable, moving it `Signed -> Proved`.
+/// notes are witnessable.
 ///
 /// A preparation transaction carries no drawn
 /// [`anchor_boundary`](MigrationTransaction::anchor_boundary) (it anchors to its already-mined
@@ -2053,8 +2148,10 @@ fn interpret_input_not_available(
 /// (for example the current chain tip). It hands the stored PCZT and the `anchor` to
 /// [`MigrationProver::prove_preparation`], which installs the Orchard source anchor and every real
 /// spend's witness against that checkpoint (through the PCZT `Updater` role) and proves the single
-/// Orchard bundle. The proven PCZT replaces the stored one and the transaction becomes
-/// [`Proved`](MigrationTxState::Proved), ready to broadcast.
+/// Orchard bundle. As for [`prove_transfer`], a successful proof is returned as
+/// [`ProveOutcome::Proved`]'s [`ProvedTransaction`], which the caller hands to
+/// [`PoolMigrationWrite::store_proved_transaction`]; nothing else moves the state to
+/// [`Proved`](MigrationTxState::Proved).
 ///
 /// A transaction not in [`Signed`](MigrationTxState::Signed) is rejected with
 /// [`ProveError::NotReady`] rather than re-proved; a transfer is rejected with
@@ -2064,7 +2161,7 @@ fn interpret_input_not_available(
 /// ([`ProveFailure::InputNotAvailable`]) is answered with a [`ProveOutcome`] rather than an error,
 /// under the same dependency-coverage rule — which a layer-0 preparation, depending on nothing,
 /// satisfies vacuously: the notes it spends were spendable when the migration was committed, hence
-/// long since scanned. The caller PERSISTS the state afterwards, including after
+/// long since scanned. The caller PERSISTS the outcome as for [`prove_transfer`], including after
 /// [`MarkedUnsatisfiable`](ProveOutcome::MarkedUnsatisfiable), which changed the marks and the
 /// dependency closure.
 #[cfg(feature = "orchard")]
@@ -2093,8 +2190,7 @@ where
     match prover.prove_preparation(pczt, anchor) {
         Ok(proven) => {
             let bytes = proven.serialize().map_err(ProveError::Serialize)?;
-            state.set_transaction_proved(id, bytes);
-            Ok(ProveOutcome::Proved)
+            Ok(ProveOutcome::Proved(ProvedTransaction { id, pczt: bytes }))
         }
         Err(ProveFailure::InputNotAvailable { nullifier, as_of }) => {
             Ok(interpret_input_not_available(state, id, nullifier, as_of))
@@ -3740,6 +3836,16 @@ mod tests {
             }
             Ok(())
         }
+
+        /// The contract's no-wallet-tables form: apply the proof and persist the state alone.
+        fn store_proved_transaction(
+            &mut self,
+            state: &mut MigrationState,
+            proven: ProvedTransaction,
+        ) -> Result<(), Self::Error> {
+            proven.apply(state);
+            self.replace_migration(state)
+        }
     }
 
     #[test]
@@ -4124,6 +4230,16 @@ mod commit_tests {
                 tx.state = state;
             }
             Ok(())
+        }
+
+        /// The contract's no-wallet-tables form: apply the proof and persist the state alone.
+        fn store_proved_transaction(
+            &mut self,
+            state: &mut MigrationState,
+            proven: ProvedTransaction,
+        ) -> Result<(), Self::Error> {
+            proven.apply(state);
+            self.replace_migration(state)
         }
     }
 
@@ -4555,20 +4671,24 @@ mod commit_tests {
         assert_eq!(state.transactions.len(), 1, "one directly funded transfer");
         let id = state.transactions[0].id;
 
-        // Prove the transfer: the PROVEN bytes replace the stored ones, and their real spend now
-        // carries a witness, so it is no longer identifiable from the bytes.
-        assert_eq!(
-            prove_transfer(
-                &params,
-                &mut backend,
-                &mut state,
-                id,
-                BlockHeight::from_u32(TARGET_HEIGHT),
-                &mut rng,
-            )
-            .expect("proves the transfer"),
-            ProveOutcome::Proved
-        );
+        // Prove the transfer and discharge the proof through the store, as a consumer does: the
+        // PROVEN bytes replace the stored ones, and their real spend now carries a witness, so it
+        // is no longer identifiable from the bytes.
+        match prove_transfer(
+            &params,
+            &mut backend,
+            &mut state,
+            id,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            &mut rng,
+        )
+        .expect("proves the transfer")
+        {
+            ProveOutcome::Proved(proven) => backend
+                .store_proved_transaction(&mut state, proven)
+                .expect("stores the proof"),
+            other => panic!("expected a proof, got {other:?}"),
+        }
         let old = state.transactions[0].clone();
         assert!(matches!(old.state, MigrationTxState::Proved));
         let proven = pczt::Pczt::parse(&old.pczt).expect("the proven PCZT parses");
@@ -5571,19 +5691,23 @@ mod commit_tests {
             })
             .expect("a committed migration has transfers");
 
-        // Proving reads the persisted boundary, proves, and advances Signed -> Proved.
-        assert_eq!(
-            prove_transfer(
-                &params,
-                &mut backend,
-                &mut state,
-                transfer_id,
-                BlockHeight::from_u32(TARGET_HEIGHT),
-                &mut rng,
-            )
-            .expect("proves the due transfer"),
-            ProveOutcome::Proved
-        );
+        // Proving reads the persisted boundary and proves; discharging the returned proof through
+        // the store is what advances Signed -> Proved.
+        match prove_transfer(
+            &params,
+            &mut backend,
+            &mut state,
+            transfer_id,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            &mut rng,
+        )
+        .expect("proves the due transfer")
+        {
+            ProveOutcome::Proved(proven) => backend
+                .store_proved_transaction(&mut state, proven)
+                .expect("stores the proof"),
+            other => panic!("expected a proof, got {other:?}"),
+        }
         let proved = state
             .transactions
             .iter()
@@ -5688,7 +5812,7 @@ mod commit_tests {
 
         let params = regtest_network(true);
         let mut rng = ChaCha8Rng::seed_from_u64(24);
-        assert_eq!(
+        assert!(matches!(
             prove_transfer(
                 &params,
                 &mut backend,
@@ -5698,8 +5822,8 @@ mod commit_tests {
                 &mut rng,
             )
             .expect("proves the transfer against the re-drawn boundary"),
-            ProveOutcome::Proved
-        );
+            ProveOutcome::Proved(_)
+        ));
 
         let &[proved_against] = backend.prove_anchors.as_slice() else {
             panic!("exactly one prove call reaches the prover");
@@ -5786,7 +5910,7 @@ mod commit_tests {
 
         let params = regtest_network(true);
         let mut rng = ChaCha8Rng::seed_from_u64(32);
-        assert_eq!(
+        assert!(matches!(
             prove_transfer(
                 &params,
                 &mut backend,
@@ -5796,8 +5920,8 @@ mod commit_tests {
                 &mut rng,
             )
             .expect("proves the transfer against the drawn boundary"),
-            ProveOutcome::Proved
-        );
+            ProveOutcome::Proved(_)
+        ));
         assert_eq!(
             backend.prove_anchors,
             vec![drawn_boundary],
@@ -5888,7 +6012,7 @@ mod commit_tests {
 
         // Restoring the committed grid makes the migration provable again.
         backend.sched_params = SchedulingParams::ZIP_318;
-        assert_eq!(
+        assert!(matches!(
             prove_transfer(
                 &params,
                 &mut backend,
@@ -5898,8 +6022,8 @@ mod commit_tests {
                 &mut prove_rng,
             )
             .expect("the transfer proves once the grid matches again"),
-            ProveOutcome::Proved
-        );
+            ProveOutcome::Proved(_)
+        ));
     }
 
     /// The `FailingProver`'s "anything else went wrong" error, which the engine must pass through

--- a/zcash_pool_migration/src/satisfiability.rs
+++ b/zcash_pool_migration/src/satisfiability.rs
@@ -477,12 +477,14 @@ impl DuenessTargets {
 /// state, persists it, and calls this again; until the state records the step's completion, the
 /// same step is offered again. The steps map onto the crate's operations as follows:
 ///
-/// - [`AdvanceStep::Prove`]: install the transaction's deferred anchor and witnesses and store the
-///   proven PCZT — [`prove_transfer`] / [`prove_preparation`], which also record the
-///   `Signed -> Proved` transition. Proving needs a SYNCED wallet and mutable access to its
-///   commitment trees, but only the account's viewing key. The step carries the transaction's kind
-///   so the consumer can tell, without a lookup, whether the broadcast follows in the same session
-///   (a preparation) or in its own later one (a transfer).
+/// - [`AdvanceStep::Prove`]: install the transaction's deferred anchor and witnesses —
+///   [`prove_transfer`] / [`prove_preparation`] — and hand the returned proof to
+///   [`PoolMigrationWrite::store_proved_transaction`], which records the `Signed -> Proved`
+///   transition and persists it (for a wallet-database store, atomically with the wallet's own
+///   record of the now fully-constructed transaction). Proving needs a SYNCED wallet and mutable
+///   access to its commitment trees, but only the account's viewing key. The step carries the
+///   transaction's kind so the consumer can tell, without a lookup, whether the broadcast follows
+///   in the same session (a preparation) or in its own later one (a transfer).
 /// - [`AdvanceStep::Broadcast`]: submit the stored proven transaction to the network, then record
 ///   it with [`MigrationState::mark_broadcast`]. Its mining is later detected through the
 ///   consumer's own chain view and recorded with [`MigrationState::mark_mined`], which is what
@@ -993,6 +995,16 @@ mod advance_tests {
             Ok(())
         }
 
+        /// The contract's no-wallet-tables form: apply the proof and persist the state alone.
+        fn store_proved_transaction(
+            &mut self,
+            state: &mut MigrationState,
+            proven: crate::engine::ProvedTransaction,
+        ) -> Result<(), Self::Error> {
+            proven.apply(state);
+            self.replace_migration(state)
+        }
+
         fn update_transaction(
             &mut self,
             id: MigrationTransferId,
@@ -1193,6 +1205,17 @@ mod advance_tests {
             }
             self.stored = Some(state.clone());
             Ok(())
+        }
+
+        /// Fails exactly as `replace_migration` does: the proof is applied, and the write is
+        /// subject to the configured failure.
+        fn store_proved_transaction(
+            &mut self,
+            state: &mut MigrationState,
+            proven: crate::engine::ProvedTransaction,
+        ) -> Result<(), Self::Error> {
+            proven.apply(state);
+            self.replace_migration(state)
         }
 
         fn update_transaction(

--- a/zcash_pool_migration/src/state.rs
+++ b/zcash_pool_migration/src/state.rs
@@ -42,12 +42,14 @@ use crate::scheduling::{self, SyncWakeup, WakeupParams, WakeupScheduleError};
 /// step names.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AdvanceStep {
-    /// Prove this pre-signed transaction (install its deferred Orchard anchor and spend witnesses and
-    /// store the proven PCZT), WITHOUT broadcasting: its dependencies are mined and, for a transfer,
-    /// its drawn anchor boundary has settled (the boundary block is strictly below the chain tip, so
-    /// its checkpoint exists in the wallet's commitment tree). Broadcast is a separate later step;
-    /// whether it belongs in the same waking session depends on the transaction's `kind` (see that
-    /// field, and [`advance_migration`](crate::satisfiability::advance_migration)).
+    /// Prove this pre-signed transaction (install its deferred Orchard anchor and spend witnesses
+    /// and store the proof through the store's
+    /// `PoolMigrationWrite::store_proved_transaction`), WITHOUT broadcasting: its dependencies
+    /// are mined and, for a transfer, its drawn anchor boundary has settled (the boundary block
+    /// is strictly below the chain tip, so its checkpoint exists in the wallet's commitment
+    /// tree). Broadcast is a separate later step; whether it belongs in the same waking session
+    /// depends on the transaction's `kind` (see that field, and
+    /// [`advance_migration`](crate::satisfiability::advance_migration)).
     ///
     /// Proving is not time-critical: the wallet durably retains the boundary checkpoints its
     /// committed transfers anchor to (they are exempt from ordinary checkpoint pruning; see

--- a/zcash_pool_migration/src/wallet.rs
+++ b/zcash_pool_migration/src/wallet.rs
@@ -355,6 +355,19 @@ where
             .update_transaction(id, state)
             .map_err(Error::Store)
     }
+
+    /// Delegated to the underlying store, whose implementation owns the wallet-side record (for
+    /// `zcash_client_sqlite`'s store, the atomic finalize-and-persist into the wallet's own
+    /// transaction tables).
+    fn store_proved_transaction(
+        &mut self,
+        state: &mut MigrationState,
+        proven: crate::engine::ProvedTransaction,
+    ) -> Result<(), Self::Error> {
+        self.store
+            .store_proved_transaction(state, proven)
+            .map_err(Error::Store)
+    }
 }
 
 /// Why proving a migration transaction through the wallet-backed prover failed. `TE` is the

--- a/zcash_pool_migration_memory/src/lib.rs
+++ b/zcash_pool_migration_memory/src/lib.rs
@@ -41,7 +41,7 @@ use zcash_protocol::value::Zatoshis;
 use zcash_pool_migration::build::{AccountDerivation, sign_pczt};
 use zcash_pool_migration::engine::{
     MigrationBackend, MigrationCrypto, MigrationState, MigrationTransaction, MigrationTransferId,
-    MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
+    MigrationTxState, PoolMigrationRead, PoolMigrationWrite, ProvedTransaction,
 };
 use zcash_pool_migration::satisfiability::{ReorgSettleDepth, StepSatisfiability};
 use zcash_pool_migration::scheduling::SchedulingParams;
@@ -387,6 +387,17 @@ impl PoolMigrationWrite for MockBackend {
         }
         Ok(())
     }
+
+    /// The contract's no-wallet-tables form: this mock maintains no wallet-level transaction
+    /// records, so it applies the proof to the state and persists that alone.
+    fn store_proved_transaction(
+        &mut self,
+        state: &mut MigrationState,
+        proven: ProvedTransaction,
+    ) -> Result<(), Self::Error> {
+        proven.apply(state);
+        self.replace_migration(state)
+    }
 }
 
 /// The fixed chain-tip height [`CommitMock`] reports (and the height its default
@@ -533,6 +544,17 @@ impl PoolMigrationWrite for CommitMock {
             set_transaction_state(stored, id, state);
         }
         Ok(())
+    }
+
+    /// The contract's no-wallet-tables form: this mock maintains no wallet-level transaction
+    /// records, so it applies the proof to the state and persists that alone.
+    fn store_proved_transaction(
+        &mut self,
+        state: &mut MigrationState,
+        proven: ProvedTransaction,
+    ) -> Result<(), Self::Error> {
+        proven.apply(state);
+        self.replace_migration(state)
     }
 }
 


### PR DESCRIPTION
Closes #2891.

From the moment a migration transaction's proof exists it is fully constructed — its PCZT carries both signatures (installed at commit) and proofs — but nothing recorded it outside the migration store: the wallet first learned of it when it was mined and scanned. For the whole window between proving and broadcast (deliberately long, for a scheduled transfer) the wallet reported the transaction's inputs spendable, and its own spends could double-spend them, manufacturing exactly the unsatisfiability the engine otherwise has to detect after the fact.

### The seam

`PoolMigrationWrite` gains a required `store_proved_transaction(state, proven)` method, and `prove_transfer` / `prove_preparation` now return the proof as a `#[must_use]` `ProvedTransaction` value inside `ProveOutcome::Proved` instead of writing it into the state. Only the store method — through `ProvedTransaction::apply` — moves a transaction to `Proved`, so "proved but never persisted to the wallet" is unrepresentable.

Carrying the proof out as a value rather than handing the prove functions a store borrow is load-bearing: a wallet-backed prover (`WalletMigrationProver`, `&mut W`) and a wallet-database store (`PoolMigrations`, over the same wallet's connection) mutably borrow the same wallet, so they can only ever be used in sequence, never side by side in one call.

The method is deliberately **not** `orchard`-gated even though only orchard-gated code can produce a `ProvedTransaction`: a feature-gated *required* trait method makes the feature non-additive under cargo unification (any store impl compiled in a build where some other crate enables `zcash_pool_migration/orchard` would fail with a missing trait item, with no stable `cfg` by which to react). A store with no wallet-level transaction records implements it as the documented two-line form (`proven.apply(state); self.replace_migration(state)`).

### The `zcash_client_sqlite` implementation

`PoolMigrations` finalizes the PCZT (Spend Finalizer + Transaction Extractor, which re-verifies the proofs and signatures it assembles) and persists the result to the wallet's own transaction tables — the raw transaction, its fee, its sent outputs, and its input notes marked spent — in the SAME database transaction as the migration state, so neither half is ever durable without the other. Outputs are recovered by trial decryption under the account's UFVK (every real migration output is internal to the account; padding dummies decrypt under no key), and the sent record's target height is the successor of the row's scheduled broadcast height. The store now carries the network parameters and a clock: `for_account(params, clock, conn, account)`.

The satisfiability oracle is unaffected by the prove-time spend marks: an unmined recorded spend never obstructs, since the oracle requires spend evidence mined at or below the wallet's fully-scanned height.

### Testing

- New end-to-end chain-sim test `proving_persists_the_finalized_transaction_to_the_wallet`: real proving, then asserts the wallet transaction record, the Ironwood crossing sent output (plus the Orchard change returning the unspent fee buffer), exclusion of the funding note from the wallet's own input selection, and failure-side atomicity (with the wallet-side write made to fail, the migration-store half rolls back).
- One existing test adapted: the rejected-broadcast test simulated a same-seed sibling wallet's sweep through this wallet's own selection, which the new protection now (correctly) blocks; it lifts the pending spend marks first to play the sibling's role.
- Full chain-sim suite, `zcash_pool_migration` unit + integration tests, sqlite all-features lib suite, clippy `-D warnings`, and the feature matrix (including the no-`orchard` and cross-crate feature-unification configurations) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
