### PR TITLE
zcash_client_backend: record Ironwood outputs in PCZT extraction

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -11,6 +11,15 @@ workspace.
 ## [Unreleased]
 
 ### Fixed
+- `zcash_client_backend::data_api::wallet::extract_and_store_transaction_from_pczt`
+  now records the transaction's Ironwood outputs in the stored `SentTransaction`.
+  Previously every Ironwood output was silently omitted: for a post-NU6.3 PCZT
+  delivering a payment through the Ironwood pool, the external recipient's
+  address and decrypted memo were never persisted (and are not otherwise
+  recoverable), and wallet-internal Ironwood outputs were invisible to the
+  wallet until the transaction was mined and scanned. The function also now
+  tags every shielded sent output with its note commitment tree, as the
+  transaction-builder spend path does.
 - `zcash_client_backend::data_api::wallet::redact_pczt_for_batch_signer` now
   omits existing Orchard and Ironwood spend authorization signatures from the
   batch signing request. They remain present in the caller's authoritative

--- a/zcash_client_backend/src/data_api/testing/pool.rs
+++ b/zcash_client_backend/src/data_api/testing/pool.rs
@@ -8132,7 +8132,7 @@ pub fn propose_v5_payment_to_orchard_receiver_is_rejected<Dsf>(
 pub fn create_pczt_supports_ironwood_output<Dsf>(ds_factory: Dsf, cache: impl TestCache)
 where
     Dsf: DataStoreFactory,
-    <Dsf as DataStoreFactory>::AccountId: serde::Serialize,
+    <Dsf as DataStoreFactory>::AccountId: serde::Serialize + serde::de::DeserializeOwned,
 {
     // A network on which NU6.3 — the version 6 transaction format — is active from height 100_000.
     let ironwood_active_network = {
@@ -8583,6 +8583,51 @@ where
             original.output().proprietary()
         );
     }
+
+    // Prove both bundles — a single Orchard proving key governs both pools post-NU6.3, selected
+    // by the circuit version the PCZT's consensus branch implies — then extract the final
+    // transaction and store it. The stored record must carry the IRONWOOD payment output (the
+    // payment itself, which post-NU6.3 travels in the Ironwood bundle) alongside the Orchard
+    // change; the Ironwood outputs were previously dropped from the stored `SentTransaction`
+    // entirely (issue #2890).
+    let pczt_branch_id = consensus::BranchId::try_from(*authorized.global().consensus_branch_id())
+        .expect("the PCZT carries a valid consensus branch ID");
+    let orchard_pk = zcash_primitives::transaction::builder::cached_orchard_proving_key(
+        zcash_primitives::transaction::components::orchard::bundle_version_for_branch(
+            pczt_branch_id,
+            ::orchard::ValuePool::Orchard,
+        )
+        .expect("the PCZT's consensus branch supports the Orchard pool")
+        .circuit_version(),
+    );
+    let proven = Prover::new(authorized)
+        .create_orchard_proof(orchard_pk)
+        .unwrap()
+        .create_ironwood_proof(orchard_pk)
+        .unwrap()
+        .finish();
+
+    let txid = st
+        .extract_and_store_transaction_from_pczt(proven)
+        .expect("extracts, verifies, and stores the finalized transaction");
+
+    // The Ironwood payment output is recorded among the transaction's sent outputs, carrying the
+    // payment value and the external recipient address.
+    let sent_outputs = st.wallet().get_sent_outputs(&txid).unwrap();
+    assert!(
+        sent_outputs.iter().any(|output| {
+            output.value() == Zatoshis::const_from_u64(10_000)
+                && output.external_recipient().is_some()
+        }),
+        "the Ironwood payment output is recorded among the sent outputs: {sent_outputs:?}",
+    );
+    assert!(
+        !st.wallet()
+            .get_sent_note_ids(&txid, ShieldedPool::Ironwood)
+            .unwrap()
+            .is_empty(),
+        "the payment's sent-note record belongs to the Ironwood pool",
+    );
 }
 
 /// The transaction history entry for a payment funded from the Orchard pool and delivered

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -110,7 +110,7 @@ use zcash_script::script::{self as zs_script, Evaluable};
 use {
     crate::data_api::error::PcztError,
     bip32::ChildNumber,
-    orchard::note_encryption::OrchardDomain,
+    orchard::note_encryption::{IronwoodDomain, OrchardDomain},
     pczt::roles::{
         creator::Creator, io_finalizer::IoFinalizer, redactor::Redactor,
         spend_finalizer::SpendFinalizer, tx_extractor::TransactionExtractor, updater::Updater,
@@ -3504,62 +3504,82 @@ where
             })
         })?;
 
-    let orchard_output_info = finalized
-        .orchard()
-        .actions()
-        .iter()
-        .map(|act| {
-            let note = || {
-                let recipient =
-                    act.output().recipient().as_ref().and_then(|b| {
+    // The per-action sent-output recovery shared by the Orchard and Ironwood bundles, which
+    // differ only in the note plaintext version their notes carry (`V2` for Orchard, `V3` —
+    // ZIP 2005 — for Ironwood): the note reconstructed from the PCZT's output fields, zipped
+    // with the recipient metadata `create_pczt_from_proposal` attached to the output.
+    #[allow(clippy::type_complexity)]
+    fn orchard_protocol_output_info<AccountId: serde::de::DeserializeOwned>(
+        actions: &[pczt::orchard::Action],
+        note_version: orchard::note::NoteVersion,
+    ) -> Result<
+        Vec<
+            Option<(
+                (PcztRecipient<AccountId>, Option<ZcashAddress>),
+                orchard::Note,
+            )>,
+        >,
+        PcztError,
+    > {
+        actions
+            .iter()
+            .map(|act| {
+                let note = || {
+                    let recipient = act.output().recipient().as_ref().and_then(|b| {
                         ::orchard::Address::from_raw_address_bytes(b).into_option()
                     })?;
-                let value = act
+                    let value = act
+                        .output()
+                        .value()
+                        .map(orchard::value::NoteValue::from_raw)?;
+                    let rho =
+                        orchard::note::Rho::from_bytes(act.spend().nullifier()).into_option()?;
+                    let rseed = act.output().rseed().as_ref().and_then(|rseed| {
+                        orchard::note::RandomSeed::from_bytes(*rseed, &rho).into_option()
+                    })?;
+
+                    orchard::Note::from_parts(recipient, value, rho, rseed, note_version)
+                        .into_option()
+                };
+
+                let external_address = act
                     .output()
-                    .value()
-                    .map(orchard::value::NoteValue::from_raw)?;
-                let rho = orchard::note::Rho::from_bytes(act.spend().nullifier()).into_option()?;
-                let rseed = act.output().rseed().as_ref().and_then(|rseed| {
-                    orchard::note::RandomSeed::from_bytes(*rseed, &rho).into_option()
-                })?;
+                    .user_address()
+                    .as_deref()
+                    .map(ZcashAddress::try_from_encoded)
+                    .transpose()
+                    .map_err(|e| PcztError::Invalid(format!("Invalid user_address: {e}")))?;
 
-                orchard::Note::from_parts(
-                    recipient,
-                    value,
-                    rho,
-                    rseed,
-                    orchard::note::NoteVersion::V2,
-                )
-                .into_option()
-            };
+                let pczt_recipient = act
+                    .output()
+                    .proprietary()
+                    .get(PROPRIETARY_OUTPUT_INFO)
+                    .map(|v| postcard::from_bytes::<PcztRecipient<AccountId>>(v))
+                    .transpose()
+                    .map_err(|e: postcard::Error| {
+                        PcztError::Invalid(format!(
+                            "Postcard decoding of proprietary output info failed: {e}"
+                        ))
+                    })?
+                    .map(|pczt_recipient| (pczt_recipient, external_address));
 
-            let external_address = act
-                .output()
-                .user_address()
-                .as_deref()
-                .map(ZcashAddress::try_from_encoded)
-                .transpose()
-                .map_err(|e| PcztError::Invalid(format!("Invalid user_address: {e}")))?;
+                // If the pczt recipient is not present, this is a dummy note; if the note is not
+                // present, then the PCZT has been pruned to make this output unrecoverable and so
+                // we also ignore it.
+                Ok(pczt_recipient.zip(note()))
+            })
+            .collect::<Result<Vec<_>, PcztError>>()
+    }
 
-            let pczt_recipient = act
-                .output()
-                .proprietary()
-                .get(PROPRIETARY_OUTPUT_INFO)
-                .map(|v| postcard::from_bytes::<PcztRecipient<<DbT as WalletRead>::AccountId>>(v))
-                .transpose()
-                .map_err(|e: postcard::Error| {
-                    PcztError::Invalid(format!(
-                        "Postcard decoding of proprietary output info failed: {e}"
-                    ))
-                })?
-                .map(|pczt_recipient| (pczt_recipient, external_address));
+    let orchard_output_info = orchard_protocol_output_info::<<DbT as WalletRead>::AccountId>(
+        finalized.orchard().actions(),
+        orchard::note::NoteVersion::V2,
+    )?;
 
-            // If the pczt recipient is not present, this is a dummy note; if the note is not
-            // present, then the PCZT has been pruned to make this output unrecoverable and so we
-            // also ignore it.
-            Ok(pczt_recipient.zip(note()))
-        })
-        .collect::<Result<Vec<_>, PcztError>>()?;
+    let ironwood_output_info = orchard_protocol_output_info::<<DbT as WalletRead>::AccountId>(
+        finalized.ironwood().actions(),
+        orchard::note::NoteVersion::V3,
+    )?;
 
     let sapling_output_info = finalized
         .sapling()
@@ -3684,6 +3704,15 @@ where
             MemoBytes::from_bytes(memo_bytes(&m)).expect("Memo is the correct length.")
         });
 
+        // The note commitment tree an output's note is appended to is fully determined by the
+        // pool the output was created in; recording it mirrors the transaction-builder path
+        // (`create_proposed_transactions`), which tags every shielded sent output with its tree.
+        let note_commitment_tree = match output_pool {
+            ShieldedPool::Sapling => NoteCommitmentTree::Sapling,
+            ShieldedPool::Orchard => NoteCommitmentTree::Orchard,
+            ShieldedPool::Ironwood => NoteCommitmentTree::Ironwood,
+        };
+
         let note_value = Zatoshis::try_from(note_value(&note))?;
         let recipient = match (pczt_recipient, external_address) {
             (PcztRecipient::External, Some(addr)) => Ok(Recipient::External {
@@ -3710,7 +3739,8 @@ where
             }
         }?;
 
-        Ok(SentTransactionOutput::from_parts(
+        Ok(SentTransactionOutput::from_parts_in_tree(
+            Some(note_commitment_tree),
             output_index,
             recipient,
             note_value,
@@ -3744,6 +3774,40 @@ where
                             |note| Note::Orchard {
                                 note,
                                 pool: orchard::ValuePool::Orchard,
+                            },
+                        )
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()?;
+
+    #[cfg(feature = "orchard")]
+    let ironwood_outputs = transaction
+        .ironwood_bundle()
+        .map(|bundle| {
+            assert_eq!(bundle.actions().len(), ironwood_output_info.len());
+            bundle
+                .actions()
+                .iter()
+                .zip(ironwood_output_info)
+                .enumerate()
+                .filter_map(|(output_index, (action, output_info))| {
+                    output_info.map(|((pczt_recipient, external_address), note)| {
+                        let domain = IronwoodDomain::for_action(action);
+                        to_sent_transaction_output::<_, _, _, DbT, _>(
+                            domain,
+                            note,
+                            action,
+                            ShieldedPool::Ironwood,
+                            output_index,
+                            pczt_recipient,
+                            external_address,
+                            |note| note.value().inner(),
+                            |memo| memo,
+                            |note| Note::Orchard {
+                                note,
+                                pool: orchard::ValuePool::Ironwood,
                             },
                         )
                     })
@@ -3859,6 +3923,8 @@ where
     let mut outputs: Vec<SentTransactionOutput<_>> = vec![];
     #[cfg(feature = "orchard")]
     outputs.extend(orchard_outputs.into_iter().flatten());
+    #[cfg(feature = "orchard")]
+    outputs.extend(ironwood_outputs.into_iter().flatten());
     outputs.extend(sapling_outputs.into_iter().flatten());
     outputs.extend(transparent_outputs.into_iter().flatten());
 


### PR DESCRIPTION
Fixes #2890.

`extract_and_store_transaction_from_pczt` reconstructed the sent outputs of the Orchard, Sapling, and transparent bundles, but never consulted `finalized.ironwood().actions()` — even though `create_pczt_from_proposal` populates the Ironwood bundle post-NU6.3 (an Orchard-receiver payment is delivered through the Ironwood pool) and attaches the same `PROPRIETARY_OUTPUT_INFO` recipient metadata to its outputs. Every Ironwood output was silently dropped from the stored `SentTransaction`: the external recipient's address and decrypted memo were never recorded (and are not otherwise recoverable), and wallet-internal Ironwood outputs were invisible to the wallet until the transaction was mined and scanned. The extracted transaction and its fee were unaffected — the `pczt` crate's Spend Finalizer and Transaction Extractor both handle Ironwood — so the transaction broadcast correctly while its wallet record was incomplete.

### The fix

- The per-action recovery is factored into one helper shared by the two Orchard-protocol bundles, which differ only in the note plaintext version their notes carry (`V2` for Orchard, `V3` — ZIP 2005 — for Ironwood).
- An Ironwood arm mirroring the Orchard arm recovers the outputs under the `IronwoodDomain` note-encryption domain into `Note::Orchard` values in the Ironwood value pool, tagged `ShieldedPool::Ironwood`.
- Every shielded sent output is now also tagged with its note commitment tree, as the transaction-builder spend path (`create_proposed_transactions`) already does; the tree is fully determined by the output's pool, so it is derived rather than stored redundantly.

### Testing

The gap went unnoticed because the PCZT round-trip tests run on a pre-NU6.3 fixture where Ironwood is not active. `create_pczt_supports_ironwood_output` — which already built a fully authorized version 6 PCZT with a populated Ironwood bundle — now continues through proving (the single post-NU6.3 Orchard proving key covers both bundles), extraction, and storage, and asserts that the Ironwood payment output is recorded among the sent outputs with its value and external recipient, in the Ironwood pool.

Verified in both directions: the extended test passes with the fix, and with the fix reverted it fails showing exactly the reported symptom — the only recorded sent output is the Orchard change; the Ironwood payment is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
