### PR TITLE
Release zcash_client_sqlite version 0.22.0-rc.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7111,7 +7111,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.6"
+version = "0.24.0-rc.7"
 dependencies = [
  "ambassador",
  "arti-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7332,7 +7332,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_pool_migration"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 dependencies = [
  "corez",
  "getset",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7186,7 +7186,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.6"
+version = "0.22.0-rc.7"
 dependencies = [
  "ambassador",
  "assert_matches",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3182,7 +3182,7 @@ dependencies = [
 
 [[package]]
 name = "pczt"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "blake2b_simd",
  "bls12_381",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7428,7 +7428,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "corez",
  "document-features",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ categories = ["cryptography::cryptocurrencies"]
 # Intra-workspace dependencies
 equihash = { version = "0.3", path = "components/equihash", default-features = false }
 zcash_address = { version = "0.13.0", path = "components/zcash_address", default-features = false }
-zcash_client_backend = { version = "0.24.0-rc.6", path = "zcash_client_backend" }
+zcash_client_backend = { version = "0.24.0-rc.7", path = "zcash_client_backend" }
 # zcash_encoding 0.5.0 is a breaking release (MSRV bump + `CompactSize::write` now
 # rejects values above `MAX_COMPACT_SIZE`). To avoid forcing every dependent to
 # migrate at once, the workspace default stays pinned to the published 0.4; only

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ zcash_note_encryption = "0.4.1"
 zcash_primitives = { version = "0.30.0", path = "zcash_primitives", default-features = false }
 zcash_proofs = { version = "0.30.0", path = "zcash_proofs", default-features = false }
 
-pczt = { version = "0.9.1", path = "pczt" }
+pczt = { version = "0.9.2", path = "pczt" }
 
 # Shielded protocols
 bellman = { version = "0.14", default-features = false, features = ["groth16"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ zcash_client_backend = { version = "0.24.0-rc.7", path = "zcash_client_backend" 
 # time, then flip this back to `path = "components/zcash_encoding"` at "0.5".
 zcash_encoding = { version = "0.4", default-features = false }
 zcash_keys = { version = "0.16.1", path = "zcash_keys", default-features = false  }
-zcash_pool_migration = { version = "0.1.0-rc.5", path = "zcash_pool_migration" }
+zcash_pool_migration = { version = "0.1.0-rc.6", path = "zcash_pool_migration" }
 zcash_protocol = { version = "0.10.4", path = "components/zcash_protocol", default-features = false }
 zip321 = { version = "0.9.0-rc.1", path = "components/zip321" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ zcash_client_backend = { version = "0.24.0-rc.6", path = "zcash_client_backend" 
 zcash_encoding = { version = "0.4", default-features = false }
 zcash_keys = { version = "0.16.1", path = "zcash_keys", default-features = false  }
 zcash_pool_migration = { version = "0.1.0-rc.5", path = "zcash_pool_migration" }
-zcash_protocol = { version = "0.10.3", path = "components/zcash_protocol", default-features = false }
+zcash_protocol = { version = "0.10.4", path = "components/zcash_protocol", default-features = false }
 zip321 = { version = "0.9.0-rc.1", path = "components/zip321" }
 
 zcash_note_encryption = "0.4.1"

--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -10,22 +10,24 @@ workspace.
 
 ## [Unreleased]
 
+## [0.10.4] - 2026-08-03
+
 ### Added
+- `zcash_protocol::zip318::{Zip318TxKind, Zip318Classification, Zip318Evidence,
+  classify}`, which recognize the ZIP 318 transaction shapes from evidence a
+  caller gathers. `classify` names a conformance class and never a provenance,
+  and is monotone in the evidence, so a decision it reaches is never later
+  contradicted.
+- `zcash_protocol::zip318::Zip318Classification::{to_code, from_code}`, the stable
+  integer encoding a store persists and an FFI carries. Zero means NOT CLASSIFIED
+  and is meant to be a column's default; it is distinct from the code for
+  `Nonconforming`, which is a decision.
 - `zcash_protocol::zip318::{CROSSING_SOURCE_ACTIONS, CROSSING_DESTINATION_ACTIONS}`,
   the action counts of a canonical pool crossing.
 - `zcash_protocol::zip318::PoolMigrationConstants::{canonical_expiry, is_canonical_expiry,
   is_canonical_expiry_value}`. The first two generalize the free `expiry_height` to an
   overridden expiry window; the third judges an expiry without a reference height,
   for a caller that has none and must not change its answer once it gets one.
-- `zcash_protocol::zip318::Zip318Classification::{to_code, from_code}`, the stable
-  integer encoding a store persists and an FFI carries. Zero means NOT CLASSIFIED
-  and is meant to be a column's default; it is distinct from the code for
-  `Nonconforming`, which is a decision.
-- `zcash_protocol::zip318::{Zip318TxKind, Zip318Classification, Zip318Evidence,
-  classify}`, which recognize the ZIP 318 transaction shapes from evidence a
-  caller gathers. `classify` names a conformance class and never a provenance,
-  and is monotone in the evidence, so a decision it reaches is never later
-  contradicted.
 
 ## [0.10.3] - 2026-07-29
 

--- a/components/zcash_protocol/Cargo.toml
+++ b/components/zcash_protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_protocol"
 description = "Zcash protocol network constants and value types."
-version = "0.10.3"
+version = "0.10.4"
 authors = [
     "Jack Grigg <jack@electriccoin.co>",
     "Kris Nuttycombe <kris@nutty.land>",

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -10,11 +10,18 @@ workspace.
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-08-03
+
 ### Added
 - `pczt::Pczt::has_data_in_pool`, which reports whether the always-present
   bundle for a given pool actually holds anything.
 - `pczt::orchard::Bundle::{sole_action, value_carrying_outputs_all_pay}`. The
   latter returns `None` when a field it judges has been redacted from the PCZT.
+
+### Fixed
+- The `zcp-builder` feature now also enables the `orchard`, `sapling`, and
+  `transparent` features that its code requires; enabling it alone no longer
+  fails to compile.
 
 ## [0.9.1] - 2026-07-26
 

--- a/pczt/Cargo.toml
+++ b/pczt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pczt"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Jack Grigg <jack@electriccoin.co>"]
 edition.workspace = true
 rust-version.workspace = true

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -5,6 +5,10 @@
 version = "0.9.2"
 audited_as = "0.9.1"
 
+[[unpublished.zcash_client_backend]]
+version = "0.24.0-rc.7"
+audited_as = "0.24.0-rc.6"
+
 [[unpublished.zcash_protocol]]
 version = "0.10.4"
 audited_as = "0.10.3"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,21 +1,9 @@
 
 # cargo-vet imports lock
 
-[[unpublished.zcash_client_backend]]
-version = "0.24.0-rc.6"
-audited_as = "0.24.0-rc.5"
-
-[[unpublished.zcash_client_sqlite]]
-version = "0.22.0-rc.6"
-audited_as = "0.22.0-rc.5"
-
-[[unpublished.zcash_pool_migration]]
-version = "0.1.0-rc.5"
-audited_as = "0.1.0-rc.4"
-
 [[unpublished.zcash_protocol]]
-version = "0.10.3"
-audited_as = "0.10.2"
+version = "0.10.4"
+audited_as = "0.10.3"
 
 [[publisher.bumpalo]]
 version = "3.16.0"
@@ -465,15 +453,15 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_client_backend]]
-version = "0.24.0-rc.5"
-when = "2026-07-29"
+version = "0.24.0-rc.6"
+when = "2026-07-30"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_client_sqlite]]
-version = "0.22.0-rc.5"
-when = "2026-07-29"
+version = "0.22.0-rc.6"
+when = "2026-07-30"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -507,8 +495,8 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_pool_migration]]
-version = "0.1.0-rc.4"
-when = "2026-07-29"
+version = "0.1.0-rc.5"
+when = "2026-07-30"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -528,8 +516,8 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_protocol]]
-version = "0.10.2"
-when = "2026-07-29"
+version = "0.10.3"
+when = "2026-07-30"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -9,6 +9,10 @@ audited_as = "0.9.1"
 version = "0.24.0-rc.7"
 audited_as = "0.24.0-rc.6"
 
+[[unpublished.zcash_pool_migration]]
+version = "0.1.0-rc.6"
+audited_as = "0.1.0-rc.5"
+
 [[unpublished.zcash_protocol]]
 version = "0.10.4"
 audited_as = "0.10.3"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,6 +1,10 @@
 
 # cargo-vet imports lock
 
+[[unpublished.pczt]]
+version = "0.9.2"
+audited_as = "0.9.1"
+
 [[unpublished.zcash_protocol]]
 version = "0.10.4"
 audited_as = "0.10.3"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -9,6 +9,10 @@ audited_as = "0.9.1"
 version = "0.24.0-rc.7"
 audited_as = "0.24.0-rc.6"
 
+[[unpublished.zcash_client_sqlite]]
+version = "0.22.0-rc.7"
+audited_as = "0.22.0-rc.6"
+
 [[unpublished.zcash_pool_migration]]
 version = "0.1.0-rc.6"
 audited_as = "0.1.0-rc.5"

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -10,15 +10,33 @@ workspace.
 
 ## [Unreleased]
 
+## [0.24.0-rc.7] - 2026-08-03
+
 ### Added
-- `zcash_client_backend::data_api::zip318`, which assembles ZIP 318 classification
-  evidence from a decrypted transaction and classifies it. What it can observe is
-  weaker than what the same predicate sees on a transaction the wallet is building,
-  because on chain a zero-valued padding dummy and an unrelated party's output are
-  equally undecryptable; the weaker reading admits more, never less.
+- `zcash_client_backend::data_api::zip318` (requires the `orchard` feature), which
+  assembles ZIP 318 classification evidence from a decrypted transaction and
+  classifies it. What it can observe is weaker than what the same predicate sees on
+  a transaction the wallet is building, because on chain a zero-valued padding dummy
+  and an unrelated party's output are equally undecryptable; the weaker reading
+  admits more, never less.
 - `zcash_client_backend::data_api::ll::LowLevelWalletWrite::put_zip318_classification`,
-  called by `store_decrypted_tx`. A store that has not been given a classification
-  for a transaction must report it as unclassified, never as `Nonconforming`.
+  a required method, called by `store_decrypted_tx` under the `orchard` feature. A
+  store that has not been given a classification for a transaction must report it as
+  unclassified, never as `Nonconforming`.
+- `zcash_client_backend::data_api::testing::TestState::generate_and_scan_empty_blocks`
+- `zcash_client_backend::data_api::testing::TestState::create_account_from_test_seed`
+- `zcash_client_backend::data_api::testing::TestState::orchard_anchor_at` (requires
+  the `orchard` feature)
+- `zcash_client_backend::data_api::ll::wallet::batch_ensure_heights`, the complete set
+  of checkpoint heights a batch of scanned blocks must ensure: cross-pool alignment
+  unioned with the heights an `AnchorRetention` policy retains within the batch's
+  range. `put_blocks` now composes its ensure sets through it; behaviour is unchanged.
+  A consumer maintaining its note commitment trees by other means must compose both
+  obligations. Scanning checkpoints a block only at its last note commitment, so a
+  retention-grid boundary landing on a block with no shielded output in any pool is
+  not checkpointed by cross-pool alignment; marking such a boundary without ensuring
+  it leaves anything pre-signed against that height (for example a ZIP 318
+  pool-migration transfer) permanently unprovable.
 
 ### Fixed
 - `zcash_client_backend::data_api::wallet::extract_and_store_transaction_from_pczt`
@@ -35,25 +53,6 @@ workspace.
   batch signing request. They remain present in the caller's authoritative
   PCZT, so the response only contains new signatures. This restores
   compatibility with batch Signers that reject pre-signed requests.
-
-### Added
-- `zcash_client_backend::data_api::testing::TestState::generate_and_scan_empty_blocks`
-- `zcash_client_backend::data_api::testing::TestState::create_account_from_test_seed`
-- `zcash_client_backend::data_api::testing::TestState::orchard_anchor_at` (requires
-  the `orchard` feature)
-- `zcash_client_backend::data_api::ll::wallet::batch_ensure_heights`, the complete set
-  of checkpoint heights a batch of scanned blocks must ensure: cross-pool alignment
-  unioned with the heights an `AnchorRetention` policy retains within the batch's
-  range. `put_blocks` now composes its ensure sets through it; behaviour is unchanged.
-
-  Both obligations are required, and satisfying only the first is a silent correctness
-  bug. Scanning checkpoints a block only at its last note commitment, so a
-  retention-grid boundary landing on a block with no shielded output in any pool is
-  not checkpointed by cross-pool alignment either — and `AnchorRetention` preserves
-  checkpoints, it never creates them. A consumer maintaining its note commitment trees
-  by other means that composes only the cross-pool set therefore marks boundary heights
-  which never materialize, leaving anything pre-signed against them (e.g. a ZIP 318
-  pool-migration transfer) permanently unprovable.
 
 ## [0.24.0-rc.6] - 2026-07-29
 

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_backend"
 description = "APIs for creating shielded Zcash light clients"
-version = "0.24.0-rc.6"
+version = "0.24.0-rc.7"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -33,7 +33,7 @@ workspace.
   over the wallet database's own connection.
 
 ### Changed
-- Migrated to `zcash_client_backend 0.24.0-rc.7`.
+- Migrated to `zcash_client_backend 0.24.0-rc.7`, `zcash_pool_migration 0.1.0-rc.6`.
 - `pool_migration::orchard_ironwood::PoolMigrations` now carries the network
   parameters and a clock — `PoolMigrations::for_account` takes them ahead of
   the connection (`for_account(params, clock, conn, account)`; a caller that

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -33,6 +33,7 @@ workspace.
   over the wallet database's own connection.
 
 ### Changed
+- Migrated to `zcash_client_backend 0.24.0-rc.7`.
 - `pool_migration::orchard_ironwood::PoolMigrations` now carries the network
   parameters and a clock — `PoolMigrations::for_account` takes them ahead of
   the connection (`for_account(params, clock, conn, account)`; a caller that

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -10,6 +10,8 @@ workspace.
 
 ## [Unreleased]
 
+## [0.22.0-rc.7] - 2026-08-03
+
 ### Added
 - A `zip318_kind` column on the `transactions` table, recording how each transaction
   classifies against ZIP 318 so that a wallet can label a pool-migration transaction
@@ -79,11 +81,7 @@ workspace.
   row's cache empty — and `replan_threshold` to the default policy;
   `unsatisfiable_kind` and `broadcast_failure_at` need no backfill, since a
   database lacking `unsatisfiable_at` carried neither marks nor
-  broadcast-failure reports. It also restores the `txid` of
-  every `mined` pool-migration transaction stored without one (which is every
-  such row written by a previous release), recovering it from the wallet's own
-  record of the spend and failing with a corrupted-data error naming any row
-  for which no such record exists.
+  broadcast-failure reports.
 - `WalletWrite::truncate_to_height` (and everything routed through it) now also
   rolls every stored pool migration back to the height it actually truncated
   to, clearing unsatisfiability marks and broadcast-failure reports that rest on
@@ -107,10 +105,10 @@ workspace.
   `InputObservation::Invalidated` observations are likewise not produced.
 - The pool-migration transactions table's `txid` column now holds EVERY row's transaction id,
   recorded when the transaction is built, rather than appearing only once a transaction is
-  broadcast. The still-unshipped `orchard_ironwood_migration_unsatisfiability` migration fills it
-  for existing rows by DERIVING each id from that row's own stored PCZT — which works whatever the
-  row's lifecycle state, and, unlike the mined-row recovery it replaces, needs no surviving record
-  of the transaction's spends in the wallet's own tables.
+  broadcast. The `orchard_ironwood_migration_unsatisfiability` migration fills it for existing
+  rows by DERIVING each id from that row's own stored PCZT, which works whatever the row's
+  lifecycle state; it fails with a corrupted-data error naming any row whose stored PCZT yields
+  no id.
 - `pool_migration::orchard_ironwood::PoolMigrations` implements the new
   `zcash_pool_migration` `PoolMigrationRead::mined_height` method, answering
   from the wallet's own `transactions` table. The answer is bounded by the

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_sqlite"
 description = "An SQLite-based Zcash light client"
-version = "0.22.0-rc.6"
+version = "0.22.0-rc.7"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -21,39 +21,6 @@ and this library adheres to Rust's notion of
   wallet's view protects the migration's inputs from its own spends between
   proving and broadcast. A store with no wallet-level transaction records
   implements it as `proven.apply(state)` followed by `replace_migration`.
-
-### Changed
-- `engine::ProveOutcome::Proved` now carries the `ProvedTransaction`, and
-  `engine::prove_transfer` / `engine::prove_preparation` no longer write the
-  proof into the migration state themselves: a caller discharges the returned
-  proof through `PoolMigrationWrite::store_proved_transaction` (nothing else
-  moves a transaction to `Proved`), and persists a `MarkedUnsatisfiable`
-  outcome with `replace_migration` as before. `ProveOutcome` no longer
-  implements `Clone`/`Copy`.
-
-### Fixed
-- `engine::prove_transfer` now re-validates a transfer's persisted anchor boundary
-  against its funding preparations' REAL mined heights, and re-draws it (via
-  `scheduling::draw_anchor_boundary`, from the funding note's actual creation
-  height and the wallet's scanned tip) when the funding note postdates the drawn
-  boundary. The commit-time draw floors the boundary on an ESTIMATE of when the
-  last preparation layer mines (`EST_PREP_LAYER_MINING_BLOCKS`); a preparation
-  that out-mines the estimate — a wallet asleep through one broadcast window is
-  enough — left the boundary below the funding note's creation height, where the
-  note is absent from the tree state and its witness can NEVER be computed. The
-  prover's failure there is indistinguishable from "not scanned yet", so the
-  transfer deferred forever: reported ready to prove, blocked on nothing, proving
-  nothing, permanently — observed in the field on two testnet wallets, wedging
-  the final transfer of otherwise-complete migrations. The re-draw is sound for a
-  `Signed` transfer because the PCZT's anchor and witnesses are deferred to
-  proving (ZIP 374), so the stored artifact pins nothing; ZIP 318 makes anchor
-  selection a proving-time rule. When no grid boundary at or past the funding
-  note's creation has settled within the scanned tip yet, the answer is the
-  ordinary `NotYetProvable` retry. `prove_transfer` takes the network parameters,
-  the scanned tip, and an rng for this; `MigrationState::set_transfer_anchor_boundary`
-  persists the fresh draw.
-
-### Added
 - The `satisfiability` module, holding the vocabulary a store answers a
   committed migration's liveness questions in — `StepSatisfiability` and its
   causes, the observations they are folded from, and the caller policies they
@@ -64,26 +31,22 @@ and this library adheres to Rust's notion of
   that step, record the outcome, and call it again; every step it returns has
   been checked against the store's satisfiability oracle, and every
   determination it makes is persisted before the step is surfaced.
-- `engine::PoolMigrationRead::mined_height`, answering whether this wallet's scan
-  has observed a transaction mined, at or below its fully-scanned height.
-  `satisfiability::advance_migration` asks it about every broadcast-but-unmined
-  transaction it sweeps and promotes the ones that have mined, so which of a
-  migration's transactions are mined now follows the wallet's scan in both
-  directions: forward here, and backward through
+- `engine::PoolMigrationRead::mined_height` (required), answering whether this
+  wallet's scan has observed a transaction mined, at or below its fully-scanned
+  height. It and `check_step_satisfiability` must answer from one view of the
+  wallet's scan. `satisfiability::advance_migration` asks it about every
+  broadcast-but-unmined transaction it sweeps and promotes the ones that have
+  mined, so which of a migration's transactions are mined now follows the wallet's
+  scan in both directions: forward here, and backward through
   `MigrationState::truncate_to_height`. A consumer driving through
   `advance_migration` records only what it alone can know — that it broadcast —
   and no longer calls `MigrationState::mark_mined`, which remains for a consumer
   standing outside that loop. The promotion precedes every check that could
   record a verdict, so chain inclusion outranks an unsatisfiability mark and an
-  open broadcast-failure report without a special case; a transaction seen mined
-  costs the lookup alone and no longer reaches the satisfiability oracle. The sweep also now
-  records `satisfiability::UnsatisfiableCause::InputsSpent` for a broadcast transaction, which it
-  previously dropped: having asked the mining question first and been told the wallet has not seen
-  this transaction mine, a spend of its inputs in a mined transaction is necessarily some OTHER
-  transaction's, so the transfer is known dead now rather than at its expiry — weeks earlier on a
-  privacy-preserving broadcast schedule, and that much sooner to a replan.
-  `PoolMigrationRead::mined_height` documents the store-side consistency this rests on: it and
-  `check_step_satisfiability` must answer from one view of the wallet's scan.
+  open broadcast-failure report. The sweep also now records
+  `satisfiability::UnsatisfiableCause::InputsSpent` for a broadcast transaction
+  whose inputs it sees spent in some other mined transaction, which it previously
+  dropped; such a transfer is known dead at that point rather than at its expiry.
 - `pczt_txid`, deriving a migration transaction's `TxId` from its PCZT (`orchard` feature). A
   migration transaction's id exists from the moment its PCZT is PREPARED — computing it is a
   prerequisite of signing, since the signature hash is derived from it — and never moves
@@ -223,15 +186,19 @@ and this library adheres to Rust's notion of
   this instead of restating the rule.
 
 ### Changed
-- `engine::MigrationState::mark_broadcast` and `mark_mined` no longer take a `TxId`. The id is
+- Migrated to `zcash_client_backend 0.24.0-rc.7`.
+- `engine::ProveOutcome::Proved` now carries the `ProvedTransaction`, and
+  `engine::prove_transfer` / `engine::prove_preparation` no longer write the
+  proof into the migration state themselves: a caller discharges the returned
+  proof through `PoolMigrationWrite::store_proved_transaction` (nothing else
+  moves a transaction to `Proved`), and persists a `MarkedUnsatisfiable`
+  outcome with `replace_migration` as before. `ProveOutcome` no longer
+  implements `Clone`/`Copy`.
+- `engine::MigrationState::mark_broadcast` no longer takes a `TxId`. The id is
   read off the row (`MigrationTransaction::txid`), which is the transaction's own and cannot have
   changed: a consumer broadcasting a stored transaction has nothing to tell the engine that the
   engine does not already know, and being able to pass a mismatched id was a way to lose track of
   a transaction that is on chain.
-- `engine::MigrationTransaction::from_parts` takes the transaction's `TxId`, after
-  `anchor_boundary`.
-- `engine::{CommitError, RebuildError}` gain a `TxId` variant, for a built PCZT whose transaction
-  id cannot be derived.
 - `engine::MigrationState::{transaction_statuses, expired_transactions}` take an
   `satisfiability::DuenessTargets` in place of a single target height; pass
   `DuenessTargets::at(target_height)` for the previous behavior. Under a pair
@@ -257,18 +224,19 @@ and this library adheres to Rust's notion of
   previously have seen a stale value; the derived `replan_required` share is
   unaffected, having always excluded mined transfers.
 - `engine::MigrationTxState::Mined` now carries the mined transaction's txid
-  alongside its height, and `engine::MigrationState::mark_mined` takes it;
-  `MigrationTxState::from_stored` requires the txid payload for `"mined"` rows,
-  and `broadcast_txid` also answers for mined transactions.
+  alongside its height; `MigrationTxState::from_stored` requires the txid
+  payload for `"mined"` rows, and `broadcast_txid` also answers for mined
+  transactions.
 - `state::TransactionStatus::txid` is now populated for a MINED transaction as
   well as a broadcast one; it previously lapsed to `None` once the transaction
   mined. A transaction keeps the txid it was broadcast under, so a consumer
   rendering progress no longer has to hold one from an earlier status view.
-- `engine::MigrationTransaction::from_parts` takes three further parameters,
-  `unsatisfiable` (the unsatisfiability mark, when the transaction has been
-  determined unsatisfiable), `spend_nullifiers` (the transaction's real-spend
-  nullifiers, cached from the built PCZT), and `broadcast_failure_at` (the
-  standing broadcast-failure report); all three have accessors.
+- `engine::MigrationTransaction::from_parts` takes four further parameters: the
+  transaction's `TxId` (after `anchor_boundary`), `unsatisfiable` (the
+  unsatisfiability mark, when the transaction has been determined
+  unsatisfiable), `spend_nullifiers` (the transaction's real-spend nullifiers,
+  cached from the built PCZT), and `broadcast_failure_at` (the standing
+  broadcast-failure report); all four have accessors.
 - `engine::MigrationState::from_parts` and the `engine::commit_preparation`,
   `engine::build_preparation_unsigned`, and
   `engine::commit_preparation_with_funding` entry points each take a further
@@ -302,9 +270,10 @@ and this library adheres to Rust's notion of
   `ProveOutcome::NotYetProvable` with no state change. Match on the outcome,
   and persist the state after `MarkedUnsatisfiable` as after a successful
   proof.
-- `engine::CommitError` and `engine::RebuildError` have a new variant,
+- `engine::CommitError` and `engine::RebuildError` have two new variants:
   `RealSpends`, reported when a built (or rebuilt) migration PCZT presents no
-  well-formed set of real spends to cache nullifiers from.
+  well-formed set of real spends to cache nullifiers from, and `TxId`, for a
+  built PCZT whose transaction id cannot be derived.
 
 ### Removed
 - `engine::MigrationState::{next_step, next_provable, next_broadcastable}`. The
@@ -320,6 +289,18 @@ and this library adheres to Rust's notion of
   `pczt_spends::RealSpendError` describing which of the two conditions held.
 
 ### Fixed
+- `engine::prove_transfer` now re-validates a transfer's persisted anchor boundary
+  against its funding preparations' REAL mined heights, and re-draws it (via
+  `scheduling::draw_anchor_boundary`, from the funding note's actual creation
+  height and the wallet's scanned tip) when the funding note postdates the drawn
+  boundary. Previously a preparation that mined later than the commit-time
+  estimate left the boundary below the funding note's creation height, where the
+  note's witness can never be computed and the transfer deferred forever: reported
+  ready to prove, blocked on nothing, proving nothing. When no grid boundary at or
+  past the funding note's creation has settled within the scanned tip yet, the
+  answer is the ordinary `NotYetProvable` retry. `prove_transfer` takes the network
+  parameters, the scanned tip, and an rng for this;
+  `MigrationState::set_transfer_anchor_boundary` persists the fresh draw.
 - `engine::rebuild_expired_transfer` and
   `engine::rebuild_expired_transfer_unsigned` no longer fail for a transfer
   that was proved or broadcast before it expired; the rebuild now identifies

--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -7,6 +7,8 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.1.0-rc.6] - 2026-08-03
+
 ### Added
 - `engine::ProvedTransaction`: the proof carried out of a successful
   `engine::prove_transfer` / `engine::prove_preparation` call — the proven PCZT

--- a/zcash_pool_migration/Cargo.toml
+++ b/zcash_pool_migration/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_pool_migration"
 description = "Backend-agnostic value-pool migration engine for Zcash wallets"
-version = "0.1.0-rc.5"
+version = "0.1.0-rc.6"
 authors = [
     "Danny Willems <be.danny.willems@gmail.com>",
     "John Boyd <john@coldnoise.net>",


### PR DESCRIPTION
| Crate | Version |
| --- | --- |
| `zcash_protocol` | 0.10.4 |
| `pczt` | 0.9.2 |
| `zcash_client_backend` | 0.24.0-rc.7 |
| `zcash_pool_migration` | 0.1.0-rc.6 |
| `zcash_client_sqlite` | 0.22.0-rc.7 |

## What this round ships

The ZIP 318 work merged since the last round, in three strands:

- **Transaction classification** (#2874). `zcash_protocol::zip318`
  gains the `classify` predicate and its evidence/verdict vocabulary,
  `zcash_client_backend::data_api::zip318` assembles that evidence from a
  decrypted transaction, and `zcash_client_sqlite` persists the verdict in a new
  `zip318_kind` column surfaced through `v_transactions` — so a wallet can label a
  migration transaction in its history without a migration plan, which does not
  survive a seed restore.

- **Migration satisfiability and drive API** (#2871). `zcash_pool_migration` gains
  the `satisfiability` module and `advance_migration`, replacing the raw planning
  kernel (`next_step` and friends are removed), together with persisted
  unsatisfiability marks, broadcast-failure reports, a real-spend nullifier cache,
  and mined-ness derived from the wallet's own scan in both directions.
  `zcash_client_sqlite` carries the matching schema in
  `orchard_ironwood_migration_unsatisfiability`.

- **Proved-transaction persistence and the anchor re-draw** (#2871).
  `PoolMigrationWrite::store_proved_transaction` lands a proved migration
  transaction in the wallet's own transaction store atomically with the migration
  state, and `prove_transfer` now re-draws a transfer's anchor boundary against
  its funding preparations' real mined heights — fixing transfers observed wedged
  in the field, reported ready to prove and proving nothing, permanently.

Alongside those, `zcash_client_backend` fixes two PCZT-path defects: Ironwood
outputs were silently dropped from the stored `SentTransaction` on
`extract_and_store_transaction_from_pczt` (#2893), and `redact_pczt_for_batch_signer` was
leaving existing spend authorization signatures in the batch signing request (#2885).

## Changelog audit notes

Two `## [Unreleased]` sections described deltas between commits rather than the
net difference from the last published version, and were reconciled:

- `zcash_pool_migration`: `mark_mined` acquired and then lost a `TxId` parameter
  within the cycle, so net it is unchanged — only `mark_broadcast` lost one. The
  duplicate `from_parts` and `CommitError`/`RebuildError` entries were
  consolidated, and the section headings put back in `Added` / `Changed` /
  `Removed` / `Fixed` order.
- `zcash_client_sqlite`: the mined-row `txid` recovery from the wallet's own
  spend records was replaced mid-cycle by derivation from each row's stored
  PCZT; only the latter is described now.

One previously undocumented change was added: `pczt`'s `zcp-builder` feature now
enables the `orchard`, `sapling`, and `transparent` features its code requires, so
enabling it alone no longer fails to compile.

`cargo semver-checks` reports no violations for `zcash_protocol` and `pczt` (196
checks each); it skips all checks for the three pre-release crates, since an
rc-to-rc bump admits any change.

## Publishing order

Bottom-up, as committed: `zcash_protocol` → `pczt` → `zcash_client_backend` →
`zcash_pool_migration` → `zcash_client_sqlite`. `zcash_client_backend` and
`zcash_client_sqlite` both depend on APIs introduced in `zcash_protocol 0.10.4`,
and `zcash_pool_migration` on `pczt 0.9.2`, so the workspace requirements for
both were raised in the same commits.

Prepared with Claude Code assistance.
