### PR TITLE
zcash_pool_migration: read the crossing action counts from zcash_protocol

### DIFF
--- a/zcash_pool_migration/src/build/end_to_end.rs
+++ b/zcash_pool_migration/src/build/end_to_end.rs
@@ -16,10 +16,9 @@ use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
 use zcash_primitives::transaction::fees::{FeeRule as _, transparent, zip317};
 use zcash_protocol::consensus::BlockHeight;
 use zcash_protocol::value::Zatoshis;
+use zcash_protocol::zip318::{CROSSING_DESTINATION_ACTIONS, CROSSING_SOURCE_ACTIONS};
 
-use crate::denomination::{
-    DESTINATION_ACTIONS_PER_TRANSFER, SOURCE_ACTIONS_PER_TRANSFER, plan_denominations,
-};
+use crate::denomination::plan_denominations;
 use crate::preparation::{PREP_TX_ACTIONS, PrepInput, plan_preparation};
 
 /// denomination plan -> preparation plan -> build + sign a preparation transaction -> build + sign a
@@ -39,8 +38,7 @@ fn migration_pipeline_end_to_end() {
     //    the true preparation cost (via the real preparation planner) at each step.
     let prep_fee = Zatoshis::const_from_u64(PREP_TX_ACTIONS as u64 * MARGINAL_FEE.into_u64());
     let buffer = Zatoshis::const_from_u64(
-        (SOURCE_ACTIONS_PER_TRANSFER + DESTINATION_ACTIONS_PER_TRANSFER) as u64
-            * MARGINAL_FEE.into_u64(),
+        (CROSSING_SOURCE_ACTIONS + CROSSING_DESTINATION_ACTIONS) as u64 * MARGINAL_FEE.into_u64(),
     );
     let balance_zats = [Zatoshis::const_from_u64(balance)];
     let prep_tx_count = |funding: &[Zatoshis]| {
@@ -165,8 +163,8 @@ fn migration_pipeline_end_to_end() {
             core::iter::empty::<usize>(),
             0,
             0,
-            SOURCE_ACTIONS_PER_TRANSFER,
-            DESTINATION_ACTIONS_PER_TRANSFER,
+            CROSSING_SOURCE_ACTIONS,
+            CROSSING_DESTINATION_ACTIONS,
         )
         .expect("the canonical transfer fee computes");
     assert_eq!(
@@ -179,12 +177,12 @@ fn migration_pipeline_end_to_end() {
     let ironwood_out = bundle_output_value(transfer_pczt.ironwood());
     assert_eq!(
         transfer_pczt.orchard().actions().len(),
-        SOURCE_ACTIONS_PER_TRANSFER,
+        CROSSING_SOURCE_ACTIONS,
         "the transfer's Orchard bundle is padded to the canonical two actions"
     );
     assert_eq!(
         transfer_pczt.ironwood().actions().len(),
-        DESTINATION_ACTIONS_PER_TRANSFER,
+        CROSSING_DESTINATION_ACTIONS,
         "the transfer's Ironwood bundle is a single unpadded action"
     );
     assert_eq!(

--- a/zcash_pool_migration/src/build/transfer.rs
+++ b/zcash_pool_migration/src/build/transfer.rs
@@ -129,6 +129,7 @@ mod tests {
     use rand_chacha::ChaCha8Rng;
     use rand_core::SeedableRng;
     use zcash_protocol::value::COIN;
+    use zcash_protocol::zip318::{CROSSING_DESTINATION_ACTIONS, CROSSING_SOURCE_ACTIONS};
 
     use crate::build::test_util::{
         account, account_derivation, assert_every_spend_is_identifiable, regtest_network,
@@ -136,9 +137,7 @@ mod tests {
     };
     use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
 
-    use crate::denomination::{
-        DESTINATION_ACTIONS_PER_TRANSFER, MAX_RESIDUAL_VALUE, SOURCE_ACTIONS_PER_TRANSFER, zat,
-    };
+    use crate::denomination::{MAX_RESIDUAL_VALUE, zat};
 
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(32))]
@@ -155,7 +154,7 @@ mod tests {
             note_seed in any::<u64>(),
         ) {
             let fvk = account(account_seed);
-            let buffer = (SOURCE_ACTIONS_PER_TRANSFER + DESTINATION_ACTIONS_PER_TRANSFER)
+            let buffer = (CROSSING_SOURCE_ACTIONS + CROSSING_DESTINATION_ACTIONS)
                 as u64
                 * MARGINAL_FEE.into_u64();
             let note_value = crossing_value + buffer;
@@ -202,7 +201,7 @@ mod tests {
     fn stamps_derivation_on_the_spend_needing_a_signature() {
         let fvk = account(13);
         let derivation = account_derivation(13);
-        let buffer = (SOURCE_ACTIONS_PER_TRANSFER + DESTINATION_ACTIONS_PER_TRANSFER) as u64
+        let buffer = (CROSSING_SOURCE_ACTIONS + CROSSING_DESTINATION_ACTIONS) as u64
             * MARGINAL_FEE.into_u64();
         let crossing_value = 5 * COIN;
         let (note, _path, _anchor) = single_note_witness(&fvk, crossing_value + buffer, 13);

--- a/zcash_pool_migration/src/denomination.rs
+++ b/zcash_pool_migration/src/denomination.rs
@@ -148,18 +148,6 @@ pub use zcash_protocol::zip318::{DENOM_CAP, MAX_RESIDUAL_VALUE};
 /// This is a policy default of this crate, not a ZIP 318 constant.
 pub const MIGRATION_MAX_PREPARED_NOTES_PER_RUN: usize = 50;
 
-/// Source-pool (Orchard) logical actions in a canonical migration transfer: the spend and its
-/// change. With [`DESTINATION_ACTIONS_PER_TRANSFER`], this is the canonical transfer shape whose
-/// ZIP-317 fee is the per-note transfer-fee buffer.
-pub(crate) const SOURCE_ACTIONS_PER_TRANSFER: usize = 2;
-
-/// Destination-pool (Ironwood) logical actions in a canonical migration transfer: the single
-/// canonical output, UNPADDED. The Ironwood builder permits a one-action bundle (no padding dummy),
-/// which the migration uses to save proving bandwidth on hardware signers; every migration transfer
-/// shares this shape, so the action count reveals nothing a canonical transfer does not already
-/// reveal.
-pub(crate) const DESTINATION_ACTIONS_PER_TRANSFER: usize = 1;
-
 /// The outcome of denomination planning: the self-funding notes to create, the values that will
 /// cross the turnstile, and the residual kept in the source pool. Produced by a
 /// [`DenominationStrategy`].

--- a/zcash_pool_migration/src/denomination/strategies.rs
+++ b/zcash_pool_migration/src/denomination/strategies.rs
@@ -167,14 +167,13 @@ mod tests {
     use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
     use zcash_protocol::value::{COIN, MAX_MONEY};
 
-    use crate::denomination::{DESTINATION_ACTIONS_PER_TRANSFER, SOURCE_ACTIONS_PER_TRANSFER};
     use crate::preparation::FUNDING_OUTPUTS_PER_TX;
+    use zcash_protocol::zip318::{CROSSING_DESTINATION_ACTIONS, CROSSING_SOURCE_ACTIONS};
 
     /// The ZIP-317 transfer-fee buffer of the canonical transfer shape (all four actions exceed the
     /// grace allowance, so each pays the marginal fee).
     fn zip317_buffer() -> u64 {
-        (SOURCE_ACTIONS_PER_TRANSFER + DESTINATION_ACTIONS_PER_TRANSFER) as u64
-            * MARGINAL_FEE.into_u64()
+        (CROSSING_SOURCE_ACTIONS + CROSSING_DESTINATION_ACTIONS) as u64 * MARGINAL_FEE.into_u64()
     }
 
     /// A count-only preparation-layout stub: one padded transaction per [`FUNDING_OUTPUTS_PER_TX`]

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -63,6 +63,7 @@ use zcash_protocol::{
     TxId,
     consensus::BlockHeight,
     value::{BalanceError, Zatoshis},
+    zip318::{CROSSING_DESTINATION_ACTIONS, CROSSING_SOURCE_ACTIONS},
 };
 
 use zcash_primitives::transaction::fees::{FeeRule as _, transparent, zip317};
@@ -70,10 +71,7 @@ use zcash_primitives::transaction::fees::{FeeRule as _, transparent, zip317};
 #[cfg(feature = "orchard")]
 use crate::satisfiability::{DuenessTargets, UnsatisfiableCause};
 use crate::{
-    denomination::{
-        DESTINATION_ACTIONS_PER_TRANSFER, DenominationPlan, SOURCE_ACTIONS_PER_TRANSFER,
-        plan_denominations,
-    },
+    denomination::{DenominationPlan, plan_denominations},
     preparation::{PREP_TX_ACTIONS, PrepError, PrepInput, PreparationPlan, plan_preparation},
     satisfiability::{ReorgSettleDepth, ReplanThreshold, StepSatisfiability, UnsatisfiableKind},
     scheduling::{self, Schedule},
@@ -1094,8 +1092,8 @@ fn canonical_fees<P: zcash_protocol::consensus::Parameters>(
         core::iter::empty::<usize>(),
         0,
         0,
-        SOURCE_ACTIONS_PER_TRANSFER,
-        DESTINATION_ACTIONS_PER_TRANSFER,
+        CROSSING_SOURCE_ACTIONS,
+        CROSSING_DESTINATION_ACTIONS,
     )?;
     Ok((prep_tx_fee, transfer_fee_buffer))
 }
@@ -2614,8 +2612,7 @@ where
             let unsigned = UnsignedMigrationTx {
                 id,
                 pczt: bytes.clone(),
-                actions: crate::denomination::SOURCE_ACTIONS_PER_TRANSFER
-                    + crate::denomination::DESTINATION_ACTIONS_PER_TRANSFER,
+                actions: CROSSING_SOURCE_ACTIONS + CROSSING_DESTINATION_ACTIONS,
             };
             (bytes, MigrationTxState::AwaitingSignature, Some(unsigned))
         }
@@ -3368,8 +3365,7 @@ where
                 self.unsigned.push(UnsignedMigrationTx {
                     id,
                     pczt: bytes.clone(),
-                    actions: crate::denomination::SOURCE_ACTIONS_PER_TRANSFER
-                        + crate::denomination::DESTINATION_ACTIONS_PER_TRANSFER,
+                    actions: CROSSING_SOURCE_ACTIONS + CROSSING_DESTINATION_ACTIONS,
                 });
             }
             self.transactions.push(MigrationTransaction {
@@ -4101,9 +4097,7 @@ mod commit_tests {
                 regtest_network, single_note_witness, spend_signability, spending_key,
             },
         },
-        denomination::{
-            DESTINATION_ACTIONS_PER_TRANSFER, DenominationPlan, SOURCE_ACTIONS_PER_TRANSFER,
-        },
+        denomination::DenominationPlan,
         preparation::{PREP_TX_ACTIONS, plan_preparation},
         scheduling::{AnchorBucketInterval, SchedulingParams},
     };
@@ -4889,7 +4883,7 @@ mod commit_tests {
         assert_eq!(*unsigned_rebuild.pczt(), rebuilt.pczt);
         assert_eq!(
             unsigned_rebuild.actions(),
-            SOURCE_ACTIONS_PER_TRANSFER + DESTINATION_ACTIONS_PER_TRANSFER
+            CROSSING_SOURCE_ACTIONS + CROSSING_DESTINATION_ACTIONS
         );
         let parsed = pczt::Pczt::parse(&rebuilt.pczt).expect("the rebuilt PCZT parses");
         assert_eq!(
@@ -5468,9 +5462,8 @@ mod commit_tests {
         // Rounds are consecutive prefixes bounded by the action budget; a preparation is
         // PREP_TX_ACTIONS actions, so a budget of one preparation plus one transfer splits the
         // list without ever exceeding the budget (every round is non-empty and within budget).
-        let budget_actions = PREP_TX_ACTIONS
-            + crate::denomination::SOURCE_ACTIONS_PER_TRANSFER
-            + crate::denomination::DESTINATION_ACTIONS_PER_TRANSFER;
+        let budget_actions =
+            PREP_TX_ACTIONS + CROSSING_SOURCE_ACTIONS + CROSSING_DESTINATION_ACTIONS;
         let budget = crate::signing_rounds::SigningRoundBudget::new(
             core::num::NonZeroU32::new(budget_actions as u32).unwrap(),
         );

--- a/zcash_pool_migration/src/signing_rounds.rs
+++ b/zcash_pool_migration/src/signing_rounds.rs
@@ -32,8 +32,8 @@ use crate::engine::{MigrationTransferId, MigrationTxKind};
 pub const PREPARATION_ACTIONS: u32 = crate::preparation::PREP_TX_ACTIONS as u32;
 
 /// The Orchard-family actions a canonical migration transfer carries (2 source + 1 destination).
-pub const TRANSFER_ACTIONS: u32 = (crate::denomination::SOURCE_ACTIONS_PER_TRANSFER
-    + crate::denomination::DESTINATION_ACTIONS_PER_TRANSFER)
+pub const TRANSFER_ACTIONS: u32 = (zcash_protocol::zip318::CROSSING_SOURCE_ACTIONS
+    + zcash_protocol::zip318::CROSSING_DESTINATION_ACTIONS)
     as u32;
 
 /// The number of Orchard-family actions a signer processes for a migration transaction of `kind`.

--- a/zcash_pool_migration/src/zip318_shape.rs
+++ b/zcash_pool_migration/src/zip318_shape.rs
@@ -93,11 +93,14 @@ mod tests {
     use rand_core::SeedableRng;
     use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
     use zcash_protocol::value::COIN;
-    use zcash_protocol::zip318::{PREP_TX_ACTIONS, Zip318Classification, Zip318TxKind};
+    use zcash_protocol::zip318::{
+        CROSSING_DESTINATION_ACTIONS, CROSSING_SOURCE_ACTIONS, PREP_TX_ACTIONS,
+        Zip318Classification, Zip318TxKind,
+    };
 
     use crate::build::test_util::{TARGET_HEIGHT, account, regtest_network, single_note_witness};
     use crate::build::{build_prep_tx, build_transfer_pczt};
-    use crate::denomination::{DESTINATION_ACTIONS_PER_TRANSFER, SOURCE_ACTIONS_PER_TRANSFER, zat};
+    use crate::denomination::zat;
     use crate::preparation::PrepOutput;
 
     /// A wallet on the specified ZIP 318 parameters.
@@ -128,7 +131,7 @@ mod tests {
     /// Builds a transfer crossing `crossing_value`, with the given expiry.
     fn transfer(crossing_value: u64, expiry: u32) -> (pczt::Pczt, FullViewingKey) {
         let fvk = account(7);
-        let buffer = (SOURCE_ACTIONS_PER_TRANSFER + DESTINATION_ACTIONS_PER_TRANSFER) as u64
+        let buffer = (CROSSING_SOURCE_ACTIONS + CROSSING_DESTINATION_ACTIONS) as u64
             * MARGINAL_FEE.into_u64();
         let (note, _path, _anchor) = single_note_witness(&fvk, crossing_value + buffer, 11);
 
@@ -215,10 +218,10 @@ mod tests {
             BlockHeight::from_u32(TARGET_HEIGHT),
             &Zip318Params,
         );
-        assert_eq!(evidence.source_actions(), Some(SOURCE_ACTIONS_PER_TRANSFER));
+        assert_eq!(evidence.source_actions(), Some(CROSSING_SOURCE_ACTIONS));
         assert_eq!(
             evidence.destination_actions(),
-            Some(DESTINATION_ACTIONS_PER_TRANSFER)
+            Some(CROSSING_DESTINATION_ACTIONS)
         );
         assert_eq!(
             evidence.sole_destination_value(),


### PR DESCRIPTION
Second of a small stack cleaning up duplicated ZIP 318 constants in
`zcash_pool_migration`. **Based on #2898**; review that one first, and
this diff will shrink to its own commit once #2898 merges.

`denomination` defined `SOURCE_ACTIONS_PER_TRANSFER` and
`DESTINATION_ACTIONS_PER_TRANSFER`, duplicating
`zcash_protocol::zip318::{CROSSING_SOURCE_ACTIONS,
CROSSING_DESTINATION_ACTIONS}` (added in zcash_protocol 0.10.4).

Those upstream counts are what `zip318::classify` branches on to
recognize a crossing, so the builders here and the classifier there held
independent copies of one shape. Were the crossing shape ever to change,
this crate would keep building the old one while `classify` began
refusing it.

Both local constants are dropped, and every call site now imports the
pair straight from `zcash_protocol::zip318` rather than reaching them
through this crate, so there is one path to them and one name to grep.

Both constants were `pub(crate)`, so there is no public API change and no
changelog entry. 254 tests pass; clippy clean.

**Stack**
1. #2898 - derive the scheduling test bounds from ZIP 318
2. This PR