### PR TITLE
pczt: give ParseError and ExtractError Display and Error impls

### DIFF
--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -10,6 +10,10 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `impl {core::fmt::Display, core::error::Error} for pczt::ParseError`
+- `impl {core::fmt::Display, core::error::Error} for pczt::ExtractError`
+
 ### Changed
 - The `orchard` and `sapling` features are now enabled by default. Consumers
   that require a smaller feature set (such as `no_std` signers) should disable

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -721,6 +721,57 @@ pub enum ExtractError {
     UnsupportedTxVersion { version: u32, version_group_id: u32 },
 }
 
+#[cfg(any(feature = "io-finalizer", feature = "signer", feature = "tx-extractor"))]
+impl core::fmt::Display for ExtractError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ExtractError::IncompatibleLockTimes => {
+                write!(f, "the transparent inputs have incompatible lock times")
+            }
+            ExtractError::IronwoodExtract(e) => {
+                write!(f, "could not extract the Ironwood bundle: {e}")
+            }
+            ExtractError::IronwoodNotSupported => write!(
+                f,
+                "the PCZT carries Ironwood bundle data, but its transaction version has no \
+                 Ironwood bundle"
+            ),
+            ExtractError::IronwoodParse(e) => {
+                write!(f, "could not parse the Ironwood bundle: {e:?}")
+            }
+            ExtractError::OrchardExtract(e) => {
+                write!(f, "could not extract the Orchard bundle: {e}")
+            }
+            ExtractError::OrchardParse(e) => write!(f, "could not parse the Orchard bundle: {e:?}"),
+            ExtractError::SaplingExtract(e) => {
+                write!(f, "could not extract the Sapling bundle: {e}")
+            }
+            ExtractError::SaplingParse(e) => write!(f, "could not parse the Sapling bundle: {e:?}"),
+            ExtractError::TransparentExtract(e) => {
+                write!(f, "could not extract the transparent bundle: {e:?}")
+            }
+            ExtractError::TransparentParse(e) => {
+                write!(f, "could not parse the transparent bundle: {e:?}")
+            }
+            ExtractError::UnknownConsensusBranchId => write!(f, "unknown consensus branch ID"),
+            ExtractError::UnsupportedConsensusBranchId => write!(
+                f,
+                "the consensus branch ID predates the v5 transaction format"
+            ),
+            ExtractError::UnsupportedTxVersion {
+                version,
+                version_group_id,
+            } => write!(
+                f,
+                "unsupported transaction version {version} (version group ID {version_group_id})"
+            ),
+        }
+    }
+}
+
+#[cfg(any(feature = "io-finalizer", feature = "signer", feature = "tx-extractor"))]
+impl core::error::Error for ExtractError {}
+
 /// Errors that can occur while parsing a PCZT.
 #[derive(Debug)]
 pub enum ParseError {
@@ -736,6 +787,22 @@ pub enum ParseError {
     /// The PCZT has an unknown version.
     UnknownVersion(u32),
 }
+
+impl core::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ParseError::NotPczt => write!(f, "the bytes do not contain a PCZT"),
+            ParseError::Invalid(e) => write!(f, "invalid PCZT encoding: {e}"),
+            ParseError::MissingRequiredField(field) => {
+                write!(f, "the PCZT encoding omitted the required field {field}")
+            }
+            ParseError::TooShort => write!(f, "the bytes are too short to contain a PCZT"),
+            ParseError::UnknownVersion(v) => write!(f, "unknown PCZT version {v}"),
+        }
+    }
+}
+
+impl core::error::Error for ParseError {}
 
 #[cfg(all(test, any(feature = "io-finalizer", feature = "signer")))]
 mod extraction_tests {

--- a/zcash_client_sqlite/src/pool_migration/error.rs
+++ b/zcash_client_sqlite/src/pool_migration/error.rs
@@ -69,7 +69,7 @@ pub enum FinalizeError {
 impl fmt::Display for FinalizeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            FinalizeError::Parse(e) => write!(f, "parsing the stored proven PCZT failed: {e:?}"),
+            FinalizeError::Parse(e) => write!(f, "parsing the stored proven PCZT failed: {e}"),
             FinalizeError::Spends(e) => write!(f, "finalizing the PCZT's spends failed: {e:?}"),
             FinalizeError::Extract(e) => {
                 write!(f, "extracting the finalized transaction failed: {e:?}")

--- a/zcash_client_sqlite/src/wallet/init/migrations/orchard_ironwood_migration_unsatisfiability.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/orchard_ironwood_migration_unsatisfiability.rs
@@ -151,7 +151,7 @@ impl schemerz::Migration<Uuid> for Migration {
 fn real_spend_nullifiers(pczt_bytes: &[u8]) -> Result<Vec<[u8; 32]>, WalletMigrationError> {
     let pczt = pczt::Pczt::parse(pczt_bytes).map_err(|e| {
         WalletMigrationError::CorruptedData(format!(
-            "stored pool-migration PCZT does not parse: {e:?}"
+            "stored pool-migration PCZT does not parse: {e}"
         ))
     })?;
     Ok(pczt

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -1894,7 +1894,7 @@ impl<E: fmt::Display> fmt::Display for ProveError<E> {
                 committed.block_count(),
                 configured.block_count()
             ),
-            ProveError::Parse(e) => write!(f, "parsing the stored PCZT failed: {e:?}"),
+            ProveError::Parse(e) => write!(f, "parsing the stored PCZT failed: {e}"),
             ProveError::Serialize(e) => write!(f, "serializing the proven PCZT failed: {e:?}"),
             ProveError::Prover(e) => write!(f, "proving the transfer failed: {e}"),
         }


### PR DESCRIPTION
Position 4 of a stack cleaning up `zcash_pool_migration`. **Based on #2895.**

`pczt::ParseError` and `pczt::ExtractError` derived only `Debug`, so a
caller could not render either in a message without `{:?}`, and neither
participated in an error chain. Every other error type a caller meets on
the way out of this crate is at least `Display`.

`zcash_pool_migration` works around this today by mapping the whole of
`ExtractError` onto a two-variant local type that does implement both,
discarding the detail in the process. The next PR in the stack removes
that workaround, which is what prompted this one; it stands on its own
regardless.

Two inner types (`transparent::pczt::{TxExtractorError, ParseError}`) and
this crate's own per-pool `ParseError`s have no `Display` of their own, so
those variants render their cause with `Debug`. The rest use `Display`.
Giving those types their own `Display` would be a good follow-up.

`source()` is left at the default `None`: the inner types implement
`std::error::Error` inconsistently across the feature matrix, and a
partial chain is worse than none.

**Stack**
1. #2898 - derive the scheduling test bounds from ZIP 318
2. #2899 - crossing action counts direct from `zcash_protocol`
3. #2895 - zip318 review follow-ups for #2874
4. This PR
5. #2902 - move the PCZT txid derivation into `pczt`