### PR TITLE
zcash_pool_migration: share the migration-state test fixtures

### DIFF
--- a/zcash_pool_migration/src/satisfiability.rs
+++ b/zcash_pool_migration/src/satisfiability.rs
@@ -909,13 +909,12 @@ fn broaden_after_discovery<St: PoolMigrationRead>(
 #[cfg(test)]
 mod advance_tests {
     use super::*;
+    use crate::testing::fixtures::{mined, prep, scheduled_transfer, state_with_crossings, tx};
     use alloc::collections::BTreeMap;
     use core::cell::Cell;
-    use zcash_protocol::{TxId, value::Zatoshis};
+    use zcash_protocol::TxId;
 
-    use crate::denomination::DenominationPlan;
-    use crate::engine::{MigrationStatus, MigrationTransaction, MigrationTxKind};
-    use crate::preparation::PreparationPlan;
+    use crate::engine::MigrationTransaction;
 
     /// A store that answers satisfiability from a fixed table — anything absent is satisfiable at
     /// `as_of_height`, the healthy default — and counts what the drive loop asks of it.
@@ -1019,97 +1018,11 @@ mod advance_tests {
         }
     }
 
-    // The state constructors mirror `state.rs`'s test helpers, so a drive-loop test and a kernel
-    // test describe the same migration the same way.
-
-    fn tx(id: u32, kind: MigrationTxKind, state: MigrationTxState) -> MigrationTransaction {
-        // The row's id, and the copy any lifecycle state carries, are one value by construction:
-        // production derives both from the built PCZT, so a fixture that let them differ would be
-        // describing a state the engine cannot produce.
-        let txid = TxId::from_bytes([id as u8; 32]);
-        let state = match state {
-            MigrationTxState::Broadcast { .. } => MigrationTxState::Broadcast { txid },
-            MigrationTxState::Mined { height, .. } => MigrationTxState::Mined { txid, height },
-            other => other,
-        };
-        MigrationTransaction {
-            id: MigrationTransferId(id),
-            kind,
-            pczt: Vec::new(),
-            depends_on: Vec::new(),
-            scheduled_height: BlockHeight::from_u32(0),
-            expiry_height: BlockHeight::from_u32(0),
-            anchor_boundary: None,
-            txid,
-            state,
-            lock_owner: None,
-            unsatisfiable: None,
-            spend_nullifiers: Vec::new(),
-            broadcast_failure_at: None,
-        }
-    }
-
-    fn prep(layer: usize, index: usize) -> MigrationTxKind {
-        MigrationTxKind::Preparation { layer, index }
-    }
-
-    fn transfer(crossing: usize) -> MigrationTxKind {
-        MigrationTxKind::Transfer { crossing }
-    }
-
-    fn mined(height: u32) -> MigrationTxState {
-        MigrationTxState::Mined {
-            txid: TxId::from_bytes([0; 32]),
-            height: BlockHeight::from_u32(height),
-        }
-    }
-
     /// Broadcast. The txid is a placeholder: `tx` replaces it with the row's own id, so a
     /// fixture never states one that production could not have produced.
     fn broadcast() -> MigrationTxState {
         MigrationTxState::Broadcast {
             txid: TxId::from_bytes([0; 32]),
-        }
-    }
-
-    /// A transfer with the given anchor boundary and scheduled broadcast height, in the given
-    /// lifecycle state (never expiring, like `tx`).
-    fn scheduled_transfer(
-        id: u32,
-        crossing: usize,
-        anchor: u32,
-        broadcast: u32,
-        state: MigrationTxState,
-    ) -> MigrationTransaction {
-        let mut t = tx(id, transfer(crossing), state);
-        t.anchor_boundary = Some(BlockHeight::from_u32(anchor));
-        t.scheduled_height = BlockHeight::from_u32(broadcast);
-        t
-    }
-
-    /// A state whose denomination plan carries the given crossing values, so each transfer's
-    /// contribution to the replan threshold is exactly the value at its crossing index.
-    fn state_with_crossings(
-        crossings: &[u64],
-        transactions: Vec<MigrationTransaction>,
-    ) -> MigrationState {
-        let zats = |v: u64| Zatoshis::from_u64(v).expect("test values are valid");
-        let total = zats(crossings.iter().sum());
-        MigrationState {
-            status: MigrationStatus::Committed,
-            denominations: DenominationPlan::from_stored_parts(
-                crossings.iter().copied().map(zats).collect(),
-                zats(15_000),
-                None,
-                Zatoshis::ZERO,
-                total,
-                total,
-            )
-            .expect("a consistent stored plan reconstructs"),
-            preparation: PreparationPlan::from_parts(Vec::new(), Vec::new()),
-            transactions,
-            anchor_bucket_interval: crate::scheduling::AnchorBucketInterval::ZIP_318,
-            replan_threshold: ReplanThreshold::DEFAULT,
         }
     }
 
@@ -1236,6 +1149,7 @@ mod advance_tests {
     fn advance_never_surfaces_a_dead_candidate_and_broadens_on_discovery() {
         let mut state = state_with_crossings(
             &[5_000_000, 90_000_000, 5_000_000],
+            15_000,
             vec![
                 tx(0, prep(0, 0), mined(10)),
                 // A: proved and due at the target height.
@@ -1300,6 +1214,7 @@ mod advance_tests {
     fn advance_replan_when_threshold_crossed() {
         let mut state = state_with_crossings(
             &[30_000_000, 40_000_000, 30_000_000],
+            15_000,
             vec![
                 tx(0, prep(0, 0), mined(10)),
                 scheduled_transfer(1, 0, 1440, 1500, MigrationTxState::Proved),
@@ -1345,6 +1260,7 @@ mod advance_tests {
     fn advance_not_yet_satisfiable_sets_aside_without_marking() {
         let mut state = state_with_crossings(
             &[50_000_000, 50_000_000],
+            15_000,
             vec![
                 tx(0, prep(0, 0), mined(10)),
                 scheduled_transfer(1, 0, 1440, 1500, MigrationTxState::Proved),
@@ -1420,6 +1336,7 @@ mod advance_tests {
     fn advance_is_lazy_when_healthy() {
         let mut state = state_with_crossings(
             &[100_000_000],
+            15_000,
             vec![
                 tx(0, prep(0, 0), mined(10)),
                 scheduled_transfer(1, 0, 1440, 1500, MigrationTxState::Proved),
@@ -1448,6 +1365,7 @@ mod advance_tests {
         // so there is nothing to check at all.
         let mut waiting = state_with_crossings(
             &[100_000_000],
+            15_000,
             vec![
                 tx(0, prep(0, 0), mined(10)),
                 scheduled_transfer(1, 0, 1700, 90_000, MigrationTxState::Signed),
@@ -1480,6 +1398,7 @@ mod advance_tests {
         dependent_b.depends_on = vec![MigrationTransferId(0)];
         let mut state = state_with_crossings(
             &[50_000_000, 50_000_000, 10_000_000],
+            15_000,
             vec![
                 tx(0, prep(0, 0), broadcast()),
                 dependent_a,
@@ -1559,6 +1478,7 @@ mod advance_tests {
         };
         let mut state = state_with_crossings(
             &[100_000_000],
+            15_000,
             vec![tx(0, prep(0, 0), broadcast()), dependent],
         );
         let mut store = TestStore::new(1600, []);
@@ -1609,6 +1529,7 @@ mod advance_tests {
     fn advance_promotion_discharges_a_broadcast_failure_report() {
         let mut state = state_with_crossings(
             &[100_000_000],
+            15_000,
             vec![
                 tx(0, prep(0, 0), mined(10)),
                 scheduled_transfer(1, 0, 1440, 1500, MigrationTxState::Proved),
@@ -1647,6 +1568,7 @@ mod advance_tests {
     fn advance_mined_transaction_skips_the_satisfiability_query() {
         let mut state = state_with_crossings(
             &[50_000_000, 50_000_000],
+            15_000,
             vec![
                 tx(0, prep(0, 0), broadcast()),
                 scheduled_transfer(1, 0, 1440, 1500, broadcast()),
@@ -1683,8 +1605,11 @@ mod advance_tests {
     fn advance_expired_answer_never_overrides_the_kernel() {
         let mut expired = scheduled_transfer(1, 0, 1440, 1500, MigrationTxState::Signed);
         expired.expiry_height = BlockHeight::from_u32(1550);
-        let mut state =
-            state_with_crossings(&[100_000_000], vec![tx(0, prep(0, 0), mined(10)), expired]);
+        let mut state = state_with_crossings(
+            &[100_000_000],
+            15_000,
+            vec![tx(0, prep(0, 0), mined(10)), expired],
+        );
         let mut store = TestStore::new(
             1600,
             [(
@@ -1738,6 +1663,7 @@ mod advance_tests {
         unblocked.depends_on = vec![MigrationTransferId(0)];
         let mut state = state_with_crossings(
             &[5_000_000, 90_000_000, 5_000_000],
+            15_000,
             vec![
                 tx(0, prep(0, 0), mined(10)),
                 // The candidate: proved, due, and dead.
@@ -1802,6 +1728,7 @@ mod advance_tests {
         let migration = || {
             state_with_crossings(
                 &[100_000_000],
+                15_000,
                 vec![
                     tx(0, prep(0, 0), mined(10)),
                     scheduled_transfer(1, 0, 1440, 1500, MigrationTxState::Proved),
@@ -1875,6 +1802,7 @@ mod advance_tests {
     fn advance_holds_at_reevaluate_until_the_oracle_reaches_the_reported_tip() {
         let mut state = state_with_crossings(
             &[50_000_000, 50_000_000],
+            15_000,
             vec![
                 tx(0, prep(0, 0), mined(10)),
                 scheduled_transfer(1, 0, 1440, 1500, MigrationTxState::Proved),
@@ -1962,6 +1890,7 @@ mod advance_tests {
 
         let mut state = state_with_crossings(
             &[50_000_000, 50_000_000],
+            15_000,
             vec![tx(0, prep(0, 0), mined(10)), prep_layer_1, first, second],
         );
         state.report_broadcast_failure(MigrationTransferId(1), BlockHeight::from_u32(1700));
@@ -2018,6 +1947,7 @@ mod advance_tests {
     fn advance_ignores_a_report_on_a_terminal_migration() {
         let mut state = state_with_crossings(
             &[100_000_000],
+            15_000,
             vec![
                 tx(0, prep(0, 0), mined(10)),
                 scheduled_transfer(1, 0, 1440, 1500, MigrationTxState::Proved),
@@ -2064,6 +1994,7 @@ mod advance_tests {
 
         let mut state = state_with_crossings(
             &[50_000_000, 50_000_000],
+            15_000,
             vec![tx(0, prep(0, 0), mined(10)), in_flight, reported],
         );
         state.report_broadcast_failure(MigrationTransferId(2), BlockHeight::from_u32(1700));
@@ -2123,6 +2054,7 @@ mod advance_tests {
 
         let mut state = state_with_crossings(
             &[50_000_000, 50_000_000],
+            15_000,
             vec![tx(0, prep(0, 0), mined(10)), answerable, pending],
         );
         // The first rejection came from a node whose tip the wallet has since scanned past; the
@@ -2182,6 +2114,7 @@ mod advance_tests {
 
         let mut state = state_with_crossings(
             &[50_000_000, 50_000_000],
+            15_000,
             vec![tx(0, prep(0, 0), mined(10)), doomed, live],
         );
         let mut store = TestStore::new(1501, []);

--- a/zcash_pool_migration/src/state.rs
+++ b/zcash_pool_migration/src/state.rs
@@ -1358,6 +1358,9 @@ mod tests {
     use super::*;
     use crate::engine::MigrationTransaction;
     use crate::satisfiability::UnsatisfiableCause;
+    use crate::testing::fixtures::{
+        mined, prep, scheduled_transfer, state_with_crossings, transfer, tx,
+    };
     use zcash_protocol::value::Zatoshis;
 
     use crate::denomination::DenominationPlan;
@@ -1378,42 +1381,6 @@ mod tests {
         ))
     }
 
-    // A migration transaction with the given id/kind/state, no dependencies, scheduled at height 0.
-    fn tx(id: u32, kind: MigrationTxKind, state: MigrationTxState) -> MigrationTransaction {
-        // The row's id, and the copy any lifecycle state carries, are one value by construction:
-        // production derives both from the built PCZT, so a fixture that let them differ would be
-        // describing a state the engine cannot produce.
-        let txid = TxId::from_bytes([id as u8; 32]);
-        let state = match state {
-            MigrationTxState::Broadcast { .. } => MigrationTxState::Broadcast { txid },
-            MigrationTxState::Mined { height, .. } => MigrationTxState::Mined { txid, height },
-            other => other,
-        };
-        MigrationTransaction {
-            id: MigrationTransferId(id),
-            kind,
-            pczt: Vec::new(),
-            depends_on: Vec::new(),
-            scheduled_height: BlockHeight::from_u32(0),
-            expiry_height: BlockHeight::from_u32(0),
-            anchor_boundary: None,
-            txid,
-            state,
-            lock_owner: None,
-            unsatisfiable: None,
-            spend_nullifiers: Vec::new(),
-            broadcast_failure_at: None,
-        }
-    }
-
-    fn prep(layer: usize, index: usize) -> MigrationTxKind {
-        MigrationTxKind::Preparation { layer, index }
-    }
-
-    fn transfer(crossing: usize) -> MigrationTxKind {
-        MigrationTxKind::Transfer { crossing }
-    }
-
     // A state wrapping the given transactions; the plan pieces are empty (unused by state logic).
     fn state_with(transactions: Vec<MigrationTransaction>) -> MigrationState {
         MigrationState {
@@ -1427,40 +1394,6 @@ mod tests {
                 Zatoshis::ZERO,
             )
             .expect("an empty stored plan reconstructs"),
-            preparation: PreparationPlan::from_parts(Vec::new(), Vec::new()),
-            transactions,
-            anchor_bucket_interval: crate::scheduling::AnchorBucketInterval::ZIP_318,
-            replan_threshold: crate::satisfiability::ReplanThreshold::DEFAULT,
-        }
-    }
-
-    fn mined(height: u32) -> MigrationTxState {
-        MigrationTxState::Mined {
-            txid: TxId::from_bytes([0; 32]),
-            height: BlockHeight::from_u32(height),
-        }
-    }
-
-    /// A state whose denomination plan carries the given crossing values and fee buffer, so the
-    /// funding notes are each crossing plus the buffer.
-    fn state_with_crossings(
-        crossings: &[u64],
-        buffer: u64,
-        transactions: Vec<MigrationTransaction>,
-    ) -> MigrationState {
-        let zats = |v: u64| Zatoshis::from_u64(v).expect("test values are valid");
-        let total = zats(crossings.iter().sum());
-        MigrationState {
-            status: MigrationStatus::Committed,
-            denominations: DenominationPlan::from_stored_parts(
-                crossings.iter().copied().map(zats).collect(),
-                zats(buffer),
-                None,
-                Zatoshis::ZERO,
-                total,
-                total,
-            )
-            .expect("a consistent stored plan reconstructs"),
             preparation: PreparationPlan::from_parts(Vec::new(), Vec::new()),
             transactions,
             anchor_bucket_interval: crate::scheduling::AnchorBucketInterval::ZIP_318,
@@ -1696,21 +1629,6 @@ mod tests {
             ),
             None
         );
-    }
-
-    /// A transfer with the given anchor boundary and scheduled broadcast height, in the given
-    /// lifecycle state (never expiring, like `tx`).
-    fn scheduled_transfer(
-        id: u32,
-        crossing: usize,
-        anchor: u32,
-        broadcast: u32,
-        state: MigrationTxState,
-    ) -> MigrationTransaction {
-        let mut t = tx(id, transfer(crossing), state);
-        t.anchor_boundary = Some(BlockHeight::from_u32(anchor));
-        t.scheduled_height = BlockHeight::from_u32(broadcast);
-        t
     }
 
     /// Only transfers still needing a proof are scheduled: preparations and already-proved,

--- a/zcash_pool_migration/src/testing/fixtures.rs
+++ b/zcash_pool_migration/src/testing/fixtures.rs
@@ -1,8 +1,23 @@
 //! Fixtures for this crate's own unit tests.
 //!
-//! Most of these are re-exported from [`zcash_pool_migration_memory`], the test-support crate; see
-//! [`account_derivation`] for the one that cannot be.
+//! The PCZT-shaped helpers come from [`zcash_pool_migration_memory`], the test-support crate; the
+//! rest are defined here because they name types this crate owns. See [`account_derivation`] for
+//! what decides which is which.
 
+use alloc::vec::Vec;
+
+use zcash_protocol::TxId;
+use zcash_protocol::consensus::BlockHeight;
+use zcash_protocol::value::Zatoshis;
+
+use crate::denomination::DenominationPlan;
+use crate::engine::{
+    MigrationState, MigrationStatus, MigrationTransaction, MigrationTransferId, MigrationTxKind,
+    MigrationTxState,
+};
+use crate::preparation::PreparationPlan;
+
+#[cfg(feature = "orchard")]
 pub(crate) use zcash_pool_migration_memory::{
     TARGET_HEIGHT, account, assert_every_spend_is_identifiable, regtest_network,
     shared_anchor_witnesses, single_note_witness, spend_signability, spending_key,
@@ -16,6 +31,7 @@ pub(crate) use zcash_pool_migration_memory::{
 /// tests are a second compilation of it, so the two `AccountDerivation` types are distinct: passing
 /// the memory crate's value to this build's `build_prep_tx` is a type error. Every sibling above
 /// returns a type owned by another crate, so none of them has the problem.
+#[cfg(feature = "orchard")]
 pub(crate) fn account_derivation(seed: u64) -> crate::build::AccountDerivation {
     let mut seed_fingerprint = [0u8; 32];
     seed_fingerprint[..8].copy_from_slice(&seed.to_le_bytes());
@@ -23,4 +39,84 @@ pub(crate) fn account_derivation(seed: u64) -> crate::build::AccountDerivation {
         zip32::fingerprint::SeedFingerprint::from_bytes(seed_fingerprint),
         zip32::AccountId::ZERO,
     )
+}
+
+pub(crate) fn tx(id: u32, kind: MigrationTxKind, state: MigrationTxState) -> MigrationTransaction {
+    // The row's id, and the copy any lifecycle state carries, are one value by construction:
+    // production derives both from the built PCZT, so a fixture that let them differ would be
+    // describing a state the engine cannot produce.
+    let txid = TxId::from_bytes([id as u8; 32]);
+    let state = match state {
+        MigrationTxState::Broadcast { .. } => MigrationTxState::Broadcast { txid },
+        MigrationTxState::Mined { height, .. } => MigrationTxState::Mined { txid, height },
+        other => other,
+    };
+    MigrationTransaction {
+        id: MigrationTransferId(id),
+        kind,
+        pczt: Vec::new(),
+        depends_on: Vec::new(),
+        scheduled_height: BlockHeight::from_u32(0),
+        expiry_height: BlockHeight::from_u32(0),
+        anchor_boundary: None,
+        txid,
+        state,
+        lock_owner: None,
+        unsatisfiable: None,
+        spend_nullifiers: Vec::new(),
+        broadcast_failure_at: None,
+    }
+}
+
+pub(crate) fn prep(layer: usize, index: usize) -> MigrationTxKind {
+    MigrationTxKind::Preparation { layer, index }
+}
+
+pub(crate) fn transfer(crossing: usize) -> MigrationTxKind {
+    MigrationTxKind::Transfer { crossing }
+}
+
+pub(crate) fn mined(height: u32) -> MigrationTxState {
+    MigrationTxState::Mined {
+        txid: TxId::from_bytes([0; 32]),
+        height: BlockHeight::from_u32(height),
+    }
+}
+
+pub(crate) fn scheduled_transfer(
+    id: u32,
+    crossing: usize,
+    anchor: u32,
+    broadcast: u32,
+    state: MigrationTxState,
+) -> MigrationTransaction {
+    let mut t = tx(id, transfer(crossing), state);
+    t.anchor_boundary = Some(BlockHeight::from_u32(anchor));
+    t.scheduled_height = BlockHeight::from_u32(broadcast);
+    t
+}
+
+pub(crate) fn state_with_crossings(
+    crossings: &[u64],
+    buffer: u64,
+    transactions: Vec<MigrationTransaction>,
+) -> MigrationState {
+    let zats = |v: u64| Zatoshis::from_u64(v).expect("test values are valid");
+    let total = zats(crossings.iter().sum());
+    MigrationState {
+        status: MigrationStatus::Committed,
+        denominations: DenominationPlan::from_stored_parts(
+            crossings.iter().copied().map(zats).collect(),
+            zats(buffer),
+            None,
+            Zatoshis::ZERO,
+            total,
+            total,
+        )
+        .expect("a consistent stored plan reconstructs"),
+        preparation: PreparationPlan::from_parts(Vec::new(), Vec::new()),
+        transactions,
+        anchor_bucket_interval: crate::scheduling::AnchorBucketInterval::ZIP_318,
+        replan_threshold: crate::satisfiability::ReplanThreshold::DEFAULT,
+    }
 }

--- a/zcash_pool_migration/src/testing/mod.rs
+++ b/zcash_pool_migration/src/testing/mod.rs
@@ -21,7 +21,7 @@
 //! means, and `scenarios` holds the fixed data both of the above speak about.
 
 mod conformance;
-#[cfg(all(test, feature = "orchard"))]
+#[cfg(test)]
 pub(crate) mod fixtures;
 mod scenarios;
 mod strategies;


### PR DESCRIPTION
Position 7 of a stack cleaning up `zcash_pool_migration`. **Based on #2904.**

`state` and `satisfiability` each carried the same six test fixtures, and
`satisfiability` said so in a comment:

> The state constructors mirror `state.rs`'s test helpers, so a drive-loop
> test and a kernel test describe the same migration the same way.

Five of the six were byte-identical, doc comments included. The sixth,
`state_with_crossings`, differed only in that `satisfiability`'s copy had
inlined the fee-buffer parameter as a literal `15_000`; the shared version
keeps the parameter and those call sites now pass what was hardcoded.

They move to `testing::fixtures`, next to the fixtures gathered there in
#2904. They construct `MigrationTransaction` and `MigrationState` by
field, so they could not live in `zcash_pool_migration_memory` at any
visibility -- a module inside this crate is the only home that works.

`testing::fixtures` is now gated on `cfg(test)` alone rather than also on
`orchard`, since these six need neither the feature nor the memory crate.
The parts that do need it are gated individually.

No API change of any kind: every item involved is private test code.
248 tests pass; clippy clean; `--no-default-features` and
`--features orchard,test-dependencies` both build.

**Stack**
1. #2898 - derive the scheduling test bounds from ZIP 318
2. #2899 - crossing action counts direct from `zcash_protocol`
3. #2895 - zip318 review follow-ups for #2874
4. #2901 - Display and Error for the pczt error types
5. #2902 - move the PCZT txid derivation into `pczt`
6. #2904 - gather the test fixtures into one module
7. This PR