### PR TITLE
zcash_client_sqlite: classify migration transactions against ZIP 318 at store time

### DIFF
--- a/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
+++ b/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
@@ -28,7 +28,11 @@ use {
     shardtree::error::ShardTreeError,
     std::collections::HashMap,
     zcash_client_backend::{
-        data_api::{Account as _, SentTransaction, SentTransactionOutput, wallet::TargetHeight},
+        data_api::{
+            Account as _, SentTransaction, SentTransactionOutput,
+            anchor_retention::PoolMigrationParams, wallet::TargetHeight,
+            zip318::classify_decrypted_tx,
+        },
         decrypt_transaction,
         wallet::{Note, Recipient},
     },
@@ -473,7 +477,7 @@ where
 
         let params = &self.params;
         self.store.replace_migration_with(state, |dbtx| {
-            crate::wallet::store_transaction_to_be_sent(
+            let tx_ref = crate::wallet::store_transaction_to_be_sent(
                 dbtx,
                 params,
                 // A migration transaction has no transparent outputs, so the gap-limit machinery
@@ -482,7 +486,30 @@ where
                 &zcash_keys::keys::transparent::gap_limits::GapLimits::default(),
                 &sent,
             )
-            .map_err(|e| Error::Wallet(Box::new(e)))
+            .map_err(|e| Error::Wallet(Box::new(e)))?;
+
+            // Record how the transaction classifies against ZIP 318, in the same database
+            // transaction as the record itself. The enhance path stamps this for transactions the
+            // wallet learns about by scanning, but a scheduled migration transaction sits stored
+            // and UNMINED from proving until its broadcast height — up to days — and during that
+            // window a wallet that wants to label (or hold back) its own migration traffic would
+            // otherwise read "not classified". This is the same one-moment argument the enhance
+            // path documents: the parsed transaction and its decrypted outputs are both in hand
+            // right here, and nowhere later. The enhance path re-stamps the same answer after the
+            // transaction mines, which is idempotent.
+            //
+            // Parameters are the SPECIFIED defaults, exactly as the enhance path reasons: the only
+            // wallet-overridable value is the anchor bucket interval, and this evidence source
+            // cannot evaluate the anchor clause at all, so the override cannot change the answer.
+            let migration_params = PoolMigrationParams::from(AnchorRetentionInterval::default());
+            let classification = classify_decrypted_tx(
+                &tx,
+                decrypted.orchard_outputs(),
+                decrypted.ironwood_outputs(),
+                &migration_params,
+            );
+            crate::wallet::put_zip318_classification(dbtx, tx_ref, classification)
+                .map_err(|e| Error::Wallet(Box::new(e)))
         })
     }
 }

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -3521,12 +3521,14 @@ pub(crate) fn get_max_height_hash(
     .optional()
 }
 
+/// Returns the [`TxRef`] of the stored transaction row, so a caller can attach further
+/// per-transaction facts (e.g. its ZIP 318 classification) in the same database transaction.
 pub(crate) fn store_transaction_to_be_sent<P: consensus::Parameters>(
     conn: &rusqlite::Transaction,
     params: &P,
     #[cfg(feature = "transparent-inputs")] gap_limits: &GapLimits,
     sent_tx: &SentTransaction<AccountUuid>,
-) -> Result<(), SqliteClientError> {
+) -> Result<TxRef, SqliteClientError> {
     let tx_ref = put_tx_data(
         conn,
         sent_tx.tx(),
@@ -3766,7 +3768,7 @@ pub(crate) fn store_transaction_to_be_sent<P: consensus::Parameters>(
         queue_tx_status(conn, sent_tx.tx().txid())?;
     }
 
-    Ok(())
+    Ok(tx_ref)
 }
 
 pub(crate) fn set_transaction_status<P: consensus::Parameters>(

--- a/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
+++ b/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
@@ -1262,6 +1262,34 @@ fn proving_persists_the_finalized_transaction_to_the_wallet() {
         !spendable_values(&mut run).contains(&funding_value),
         "the funding note is spent in the wallet's view from the moment the proof is persisted",
     );
+
+    // The stored row carries its ZIP 318 classification from this same atomic write — while the
+    // transaction is still UNMINED. The enhance path only stamps classifications for transactions
+    // the wallet learns about by scanning, i.e. after they mine; a scheduled transfer sits stored
+    // and unmined until its broadcast height, and a wallet labeling (or holding back) its own
+    // migration traffic during that window must not read "not classified" there.
+    let (zip318_kind, mined_height): (i64, Option<i64>) = run
+        .st
+        .wallet_mut()
+        .conn_mut()
+        .query_row(
+            "SELECT zip318_kind, mined_height FROM transactions WHERE txid = :txid",
+            rusqlite::named_params![":txid": txid.as_ref()],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("reads the stored transaction's classification");
+    assert_eq!(
+        mined_height, None,
+        "premise: the transfer is still unmined when the classification must already be present",
+    );
+    assert_eq!(
+        zip318_kind,
+        zcash_protocol::zip318::Zip318Classification::Conforms(
+            zcash_protocol::zip318::Zip318TxKind::Transfer
+        )
+        .to_code(),
+        "the stored transfer is classified as a ZIP 318 transfer at store time",
+    );
 }
 
 /// The adapter reports the WALLET's anchor retention interval as its anchor bucket interval, and


### PR DESCRIPTION
Fixes #2908.

A scheduled migration transaction is stored into the wallet's own tables at PROVE time (`finalize_and_store_proved`) and then sits unmined until its scheduled broadcast height — up to days. The enhance path only stamps `zip318_kind` for transactions the wallet learns about by scanning, i.e. after they mine, so through that whole window the stored row read "not classified" and a wallet wanting to label (or hold back) its own in-flight migration traffic had nothing to key on.

`finalize_and_store_proved` now records the classification in the same database transaction as the wallet record itself, using the identical evidence and parameter reasoning as the enhance path: the parsed transaction and its decrypted outputs are both in hand exactly here, and the anchor clause is unanswerable either way, so the specified defaults cannot change the answer. The enhance path re-stamps the same value after the transaction mines, which is idempotent.

`store_transaction_to_be_sent` now returns the stored row's `TxRef` so the classification write can attach to it in the same transaction; the existing caller discards the value unchanged.

Tested in `proving_persists_the_finalized_transaction_to_the_wallet`: the stored transfer must carry `zip318_kind = 3` (transfer) while still **unmined** — the assertion fails `0 != 3` without the change and passes with it under real proving. Full `zcash_client_sqlite` suite (`--all-features`): 543 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)