### PR TITLE
zcash_pool_migration: re-spread a missed broadcast schedule on resume

### DIFF
--- a/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
+++ b/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
@@ -354,7 +354,10 @@ impl Run {
     fn advance(&mut self, state: &mut MigrationState) -> AdvanceStep {
         let targets = self.targets();
         let mut store = self.store();
-        satisfiability::advance_migration(&mut store, state, targets, &ADVANCE)
+        // A seeded RNG per drive call (only the overdue shift's anchor redraw consumes it), so
+        // the simulation stays deterministic.
+        let mut rng = ChaCha8Rng::seed_from_u64(0x318);
+        satisfiability::advance_migration(&mut store, state, targets, &ADVANCE, &mut rng)
             .expect("the store and its satisfiability oracle answer")
     }
 

--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -7,7 +7,31 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- `satisfiability::overdue_shift_tolerance`: how many blocks a step may lag the
+  served target before `satisfiability::advance_migration` re-spreads the
+  remaining broadcast schedule, as a function of the schedule's transfer delay
+  distribution (a quarter of its mean; 16 blocks under the ZIP 318 parameters).
+- `scheduling::redraw_anchor_boundary`: the recency-weighted anchor draw for a
+  transfer whose broadcast schedule has moved, floored at the boundary being
+  replaced.
+
 ### Changed
+- `satisfiability::advance_migration` now re-spreads a missed broadcast
+  schedule: when the `Prove` or `Broadcast` step it would surface is more than
+  `satisfiability::overdue_shift_tolerance` blocks past its scheduled height at
+  the served (estimated-tip) target — the tolerance derived from the transfer
+  delay the migration's persisted anchor bucket interval implies — the
+  scheduled height of every not-yet-broadcast transaction is first shifted
+  forward by the overdue amount, and the shifted state is persisted with the
+  call's other writes. After wallet downtime, at most one overdue step is
+  released immediately; the rest keep their drawn inter-broadcast gaps instead
+  of broadcasting as a cluster. A deferred transfer whose proof is still to
+  come also has its anchor boundary redrawn against its shifted schedule
+  (`scheduling::redraw_anchor_boundary`), keeping deferred anchors within the
+  ZIP 318 age distribution; a proved transfer keeps the boundary its proof was
+  built against. The function now takes a `CryptoRng` for those draws — pass
+  the same RNG the other engine entry points use.
 - `state::AdvanceStep` selection now offers, within each queue, the candidate
   that has been ready longest rather than the first one in storage order: the
   earliest scheduled height for a broadcast or a rebuild, and the earliest

--- a/zcash_pool_migration/src/satisfiability.rs
+++ b/zcash_pool_migration/src/satisfiability.rs
@@ -19,11 +19,13 @@
 use alloc::vec::Vec;
 use core::fmt;
 
+use rand_core::{CryptoRng, RngCore};
 use zcash_protocol::consensus::BlockHeight;
 
 use crate::engine::{
     MigrationState, MigrationTransferId, MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
 };
+use crate::scheduling::{DelayDistribution, SchedulingParams};
 use crate::state::AdvanceStep;
 
 /// The share of planned transfer value (an integer percent) above which a migration with
@@ -333,6 +335,34 @@ pub fn classify_input_observations(
     StepSatisfiability::Satisfiable { as_of_height }
 }
 
+/// How many blocks a named step's scheduled height may lag the SERVED target
+/// ([`DuenessTargets::effective`]) before [`advance_migration`] re-spreads the remaining
+/// schedule: a quarter of `transfer_delay`'s mean inter-broadcast gap, clamped to at least one
+/// block. Under the ZIP 318 parameters (a 66-block mean) that is 16 blocks, about 20 minutes at
+/// the target block spacing.
+///
+/// A lag within the tolerance is ordinary wake-up slop (an OS timer delivered late, a block or
+/// two of estimation error), and the step is served as scheduled. A larger lag means the wallet
+/// slept through part of its broadcast schedule, and serving the backlog as-is would cluster
+/// broadcasts the drawn delays exist to spread apart — so the whole pending schedule is shifted
+/// forward by the overdue amount instead (see the overdue-shift step in the flow
+/// [`advance_migration`] documents).
+///
+/// The tolerance is a FUNCTION of the schedule's own scale rather than a constant, because
+/// "late" only means anything relative to the gaps the schedule draws: a lag that is noise
+/// against ZIP 318's 66-block mean would swallow whole broadcast windows on a test network whose
+/// delays are compressed by [`SchedulingParams::new_with_default_distributions`]. A quarter of
+/// the mean keeps the trigger comfortably above wake-up slop while still re-spreading well
+/// before the lag reaches a typical inter-broadcast gap.
+///
+/// [`advance_migration`] evaluates this against the transfer delay derived from the migration's
+/// PERSISTED anchor bucket interval (via the default ZIP 318 ratio), so the tolerance tracks the
+/// schedule as it was committed; a migration committed under hand-overridden delay
+/// distributions is judged by that ratio-derived approximation.
+pub fn overdue_shift_tolerance(transfer_delay: &DelayDistribution) -> u32 {
+    (transfer_delay.mean().get() / 4).max(1)
+}
+
 /// Drive-level policy for [`advance_migration`]: a struct, so future knobs join without signature
 /// churn.
 #[derive(Clone, Copy, Debug)]
@@ -386,7 +416,7 @@ impl AdvanceConfig {
 /// | schedule dueness in the prove and broadcast queues | expiry as a DECISION: the kernel's dead set, [`MigrationState::expired_transactions`] and [`AdvanceStep::Rebuild`] eligibility, the drain-time [`Replan`](crate::state::AdvanceStep::Replan) gate |
 /// | the doomed-broadcast withhold — a transfer whose expiry has probably passed is not offered, and [`transaction_statuses`](MigrationState::transaction_statuses) reports [`Blocker::ExpiryImminent`](crate::state::Blocker::ExpiryImminent); protective and reversible, since the scanned path still owns the verdict | the dependency closure of [`MigrationState::record_satisfiability`], which writes `Inherited` marks into the store |
 /// | the prove-side expiry skip: proving a transfer that has probably lapsed is wasted work, and skipping it is reversible | anchor-boundary settledness, since an estimate cannot conjure a commitment-tree checkpoint |
-/// | | the [`Expired`](crate::state::Blocker::Expired) blocker in `transaction_statuses`, a rendered determination |
+/// | the overdue re-spread ([`overdue_shift_tolerance`]): a step lagging the served target by more than the tolerance shifts the whole pending schedule forward by the lag. The shift PERSISTS, but what it persists is a schedule, never a verdict: it re-times the service of steps and records no determination, so an overshooting estimate can only delay broadcasts, not condemn work | the [`Expired`](crate::state::Blocker::Expired) blocker in `transaction_statuses`, a rendered determination |
 ///
 /// The clamp in [`new`](Self::new) guarantees `effective >= scanned`, so the transposition
 /// hazard — an estimate reaching a destructive check — is unrepresentable by construction rather
@@ -454,17 +484,37 @@ impl DuenessTargets {
 ///    finding the rejection transient and returning the transaction to the broadcast queue in
 ///    this same call.
 /// 1. It asks the planning kernel what to do next, decided purely from the persisted state.
-/// 2. It puts the transaction the kernel names to the store's satisfiability oracle
+/// 2. A named `Prove` or `Broadcast` candidate whose scheduled height lags the SERVED target
+///    ([`DuenessTargets::effective`]) by more than the schedule-scaled tolerance
+///    ([`overdue_shift_tolerance`], sized from the transfer delay the migration's persisted
+///    anchor bucket interval implies) means the wallet
+///    slept through part of its broadcast schedule, and the whole pending schedule is shifted
+///    forward by the lag before anything else happens: the
+///    candidate comes due exactly at the served target — so it is still released in this call,
+///    which is ZIP 318's "at most one overdue transfer is released immediately" — while every
+///    other not-yet-broadcast transaction re-spreads behind it with its drawn gaps intact,
+///    instead of the missed steps broadcasting as a cluster. A shifted transfer whose PROOF is
+///    still to come also has its anchor boundary redrawn against the shifted schedule
+///    ([`redraw_anchor_boundary`](crate::scheduling::redraw_anchor_boundary)): its stored
+///    boundary was in-distribution for the original broadcast height, and broadcasting it
+///    `delta` blocks late — with every deferred sibling late by the SAME `delta` — would carry
+///    an anchor age no honest draw produces, a linkable fingerprint. (A `Proved` transfer's
+///    proof pins its anchor, so its boundary is kept; a preparation draws none.) The anchor
+///    redraw is why this function takes a [`CryptoRng`]: the drawn boundaries are
+///    privacy-relevant observables. A `Rebuild` candidate never triggers the shift: the rebuild
+///    itself redraws its transfer's schedule from the target, and an expired candidate's stale
+///    height would overstate the shift for the still-live remainder.
+/// 3. It puts the transaction the kernel names to the store's satisfiability oracle
 ///    ([`PoolMigrationRead::check_step_satisfiability`]) — the wallet's live view of whether that
 ///    pre-signed artifact can still execute.
-/// 3. A candidate the wallet reports PERMANENTLY obstructed (its inputs seen spent elsewhere, or
+/// 4. A candidate the wallet reports PERMANENTLY obstructed (its inputs seen spent elsewhere, or
 ///    unable to ever exist) is recorded through [`MigrationState::record_satisfiability`], and the
 ///    kernel is asked again — the recorded marks, and everything stranded behind them, now
 ///    filtered out of its queues. A candidate the wallet cannot YET vouch for is set aside for the
 ///    rest of this call (no mark: the honest reading of "retry after further sync"), so the
 ///    migration's other work still surfaces, and the kernel is asked again.
-/// 4. The step that survives verification is returned, with every determination made along the way
-///    already written back to the store.
+/// 5. The step that survives verification is returned, with every determination made along the way
+///    — including a shifted schedule — already written back to the store.
 ///
 /// So a consumer never spends proving or broadcast work on a transaction whose inputs are gone,
 /// and a migration whose plan has been undercut — most often by an ordinary wallet spend consuming
@@ -611,11 +661,12 @@ impl DuenessTargets {
 /// [`prove_transfer`]: crate::engine::prove_transfer
 /// [`prove_preparation`]: crate::engine::prove_preparation
 /// [`rebuild_expired_transfer`]: crate::engine::rebuild_expired_transfer
-pub fn advance_migration<St: PoolMigrationWrite>(
+pub fn advance_migration<St: PoolMigrationWrite, R: RngCore + CryptoRng>(
     store: &mut St,
     state: &mut MigrationState,
     targets: DuenessTargets,
     config: &AdvanceConfig,
+    rng: &mut R,
 ) -> Result<AdvanceStep, St::Error> {
     // Whether any determination has been recorded, and so whether the state must be written back
     // before a step is surfaced.
@@ -784,10 +835,23 @@ pub fn advance_migration<St: PoolMigrationWrite>(
         return Ok(AdvanceStep::Reevaluate);
     }
 
-    // Plan, verify, record, plan again. Every iteration either breaks, grows `set_aside`, or
+    // The overdue-shift tolerance, sized to the schedule AS COMMITTED: the persisted anchor
+    // bucket interval is the state's own record of its schedule's scale, and the default ZIP 318
+    // ratio recovers the transfer delay it was (absent a hand-override) drawn from. Judging
+    // overdueness by the committed scale rather than a caller-supplied current one is what keeps
+    // the tolerance meaningful for a migration committed under different parameters.
+    let overdue_tolerance = overdue_shift_tolerance(
+        &SchedulingParams::new_with_default_distributions(state.anchor_bucket_interval())
+            .transfer_delay(),
+    );
+
+    // Plan, verify, record, plan again. Every iteration either breaks, grows `set_aside`,
     // strictly grows the marked set — strictly, because the kernel never names an already-marked
     // transaction (they are in its dead set), so a recorded discovery marks at least the candidate
-    // that produced it. Both are bounded by the transaction count, so the loop terminates.
+    // that produced it — or shifts the schedule. The first two are bounded by the transaction
+    // count; each shift raises every pending scheduled height by more than the overdue-shift
+    // tolerance toward the fixed served target, above which no shift triggers, so shifts are
+    // bounded too and the loop terminates.
     let step = loop {
         let step = state.next_step(targets, &set_aside);
         let candidate = match step {
@@ -811,6 +875,37 @@ pub fn advance_migration<St: PoolMigrationWrite>(
             // spin the loop. Anything already recorded is still persisted below.
             break AdvanceStep::Waiting;
         };
+        // THE OVERDUE SHIFT: ZIP 318's missed-schedule policy ("at most one overdue transfer is
+        // released immediately; the rest are re-spread"). A candidate more than the
+        // schedule-scaled tolerance past its scheduled height means the wallet slept through
+        // part of the schedule, and serving the backlog as-is would cluster broadcasts the
+        // drawn delays exist to spread apart. Shifting EVERY pending transaction forward by
+        // the lag moves this candidate's schedule to exactly the served target — the next
+        // planning pass names it again, still due, so it is released in this call — while the
+        // rest re-spread behind it with their inter-broadcast gaps intact. The shift also
+        // redraws the anchor boundary of every deferred not-yet-proved transfer against its new
+        // schedule (see `shift_schedule`), so deferral never broadcasts an anchor whose age is
+        // out of the ZIP 318 draw's distribution.
+        //
+        // Judged and sized at the ESTIMATE (`targets.effective()`), which is what lets a
+        // wall-clock-woken wallet re-spread without syncing first; legal there because the shift
+        // persists a SCHEDULE, never a verdict — it re-times service, records no determination,
+        // and destroys no work (see the `DuenessTargets` classification). `Rebuild` is
+        // deliberately not a trigger: the rebuild redraws its own transfer's schedule from the
+        // target, and sizing a shift by an expired candidate's stale height would overstate it
+        // for everything still live.
+        if matches!(
+            step,
+            AdvanceStep::Prove { .. } | AdvanceStep::Broadcast { .. }
+        ) {
+            let scheduled = u32::from(tx.scheduled_height());
+            let served = u32::from(targets.effective());
+            if scheduled.saturating_add(overdue_tolerance) < served {
+                state.shift_schedule(served - scheduled, rng);
+                dirty = true;
+                continue;
+            }
+        }
         let answer = store.check_step_satisfiability(tx, config.reorg_settle_depth())?;
         match answer {
             StepSatisfiability::Satisfiable { .. } => break step,
@@ -1126,6 +1221,13 @@ mod advance_tests {
         AdvanceConfig::new(ReorgSettleDepth::new(10))
     }
 
+    /// A fresh seeded RNG per drive call; only the overdue shift's anchor redraw consumes it, so
+    /// tests that never shift are unaffected by the draws.
+    fn rng() -> rand_chacha::ChaCha8Rng {
+        use rand_core::SeedableRng;
+        rand_chacha::ChaCha8Rng::seed_from_u64(0xA5)
+    }
+
     /// Which half of the store interface fails, for the error-propagation test.
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
     enum Failure {
@@ -1238,11 +1340,15 @@ mod advance_tests {
             &[5_000_000, 90_000_000, 5_000_000],
             vec![
                 tx(0, prep(0, 0), mined(10)),
-                // A: proved and due at the target height.
+                // A: proved and due at the target height. Overdue by more than the tolerance, so
+                // this call also shifts the schedule (and redraws B's and C's boundaries against
+                // their shifted heights) before anything is verified.
                 scheduled_transfer(1, 0, 1440, 1500, MigrationTxState::Proved),
-                // B and C: signed, boundaries long settled, broadcasts weeks out.
-                scheduled_transfer(2, 1, 1440, 90_000, MigrationTxState::Signed),
-                scheduled_transfer(3, 2, 1440, 90_000, MigrationTxState::Signed),
+                // B and C: signed, boundaries settled, broadcasts still to come. Their schedules
+                // sit close enough that even after the shift their (redrawn) boundaries remain
+                // below the scanned tip, so B's prove is servable in this same call.
+                scheduled_transfer(2, 1, 1440, 1_700, MigrationTxState::Signed),
+                scheduled_transfer(3, 2, 1440, 1_700, MigrationTxState::Signed),
             ],
         );
         let mut store = TestStore::new(
@@ -1258,6 +1364,7 @@ mod advance_tests {
             &mut state,
             DuenessTargets::at(BlockHeight::from_u32(1601)),
             &config(),
+            &mut rng(),
         )
         .expect("the store never fails");
 
@@ -1274,7 +1381,7 @@ mod advance_tests {
         assert_eq!(
             state.transactions()[3].unsatisfiable_at(),
             Some(marked),
-            "the broaden sweep marks a transfer whose own broadcast is weeks away"
+            "the broaden sweep marks a transfer whose own broadcast is still to come"
         );
         assert_eq!(
             state.transactions()[2].unsatisfiable_at(),
@@ -1320,6 +1427,7 @@ mod advance_tests {
             &mut state,
             DuenessTargets::at(BlockHeight::from_u32(1601)),
             &config(),
+            &mut rng(),
         )
         .expect("the store never fails");
 
@@ -1347,8 +1455,10 @@ mod advance_tests {
             &[50_000_000, 50_000_000],
             vec![
                 tx(0, prep(0, 0), mined(10)),
-                scheduled_transfer(1, 0, 1440, 1500, MigrationTxState::Proved),
-                scheduled_transfer(2, 1, 1440, 1500, MigrationTxState::Proved),
+                // Due but within the overdue-shift tolerance of the target, so the schedule
+                // holds and this test stays about the set-aside alone.
+                scheduled_transfer(1, 0, 1440, 1590, MigrationTxState::Proved),
+                scheduled_transfer(2, 1, 1440, 1590, MigrationTxState::Proved),
             ],
         );
         let mut store = TestStore::new(
@@ -1366,6 +1476,7 @@ mod advance_tests {
             &mut state,
             DuenessTargets::at(BlockHeight::from_u32(1601)),
             &config(),
+            &mut rng(),
         )
         .expect("the store never fails");
 
@@ -1394,14 +1505,15 @@ mod advance_tests {
         store.set_answer(
             MigrationTransferId(1),
             StepSatisfiability::Satisfiable {
-                as_of_height: BlockHeight::from_u32(1700),
+                as_of_height: BlockHeight::from_u32(1600),
             },
         );
         let step = advance_migration(
             &mut store,
             &mut state,
-            DuenessTargets::at(BlockHeight::from_u32(1701)),
+            DuenessTargets::at(BlockHeight::from_u32(1601)),
             &config(),
+            &mut rng(),
         )
         .expect("the store never fails");
         assert_eq!(
@@ -1422,7 +1534,9 @@ mod advance_tests {
             &[100_000_000],
             vec![
                 tx(0, prep(0, 0), mined(10)),
-                scheduled_transfer(1, 0, 1440, 1500, MigrationTxState::Proved),
+                // Due within the overdue-shift tolerance: a healthy wallet woke on time (give or
+                // take ordinary wake-up slop), so nothing reschedules and nothing is written.
+                scheduled_transfer(1, 0, 1440, 1590, MigrationTxState::Proved),
             ],
         );
         let mut store = TestStore::new(1600, []);
@@ -1432,6 +1546,7 @@ mod advance_tests {
             &mut state,
             DuenessTargets::at(BlockHeight::from_u32(1601)),
             &config(),
+            &mut rng(),
         )
         .expect("the store never fails");
 
@@ -1459,6 +1574,7 @@ mod advance_tests {
             &mut waiting,
             DuenessTargets::at(BlockHeight::from_u32(1601)),
             &config(),
+            &mut rng(),
         )
         .expect("the store never fails");
         assert_eq!(step, AdvanceStep::Waiting);
@@ -1508,6 +1624,7 @@ mod advance_tests {
             &mut state,
             DuenessTargets::at(BlockHeight::from_u32(1601)),
             &config(),
+            &mut rng(),
         )
         .expect("the store never fails");
 
@@ -1569,6 +1686,7 @@ mod advance_tests {
             &mut state,
             DuenessTargets::at(BlockHeight::from_u32(1601)),
             &config(),
+            &mut rng(),
         )
         .expect("the store never fails");
 
@@ -1625,6 +1743,7 @@ mod advance_tests {
             &mut state,
             DuenessTargets::at(BlockHeight::from_u32(1601)),
             &config(),
+            &mut rng(),
         )
         .expect("the store never fails");
 
@@ -1660,6 +1779,7 @@ mod advance_tests {
             &mut state,
             DuenessTargets::at(BlockHeight::from_u32(1601)),
             &config(),
+            &mut rng(),
         )
         .expect("the store never fails");
 
@@ -1701,6 +1821,7 @@ mod advance_tests {
             &mut state,
             DuenessTargets::at(BlockHeight::from_u32(1601)),
             &config(),
+            &mut rng(),
         )
         .expect("the store never fails");
 
@@ -1767,6 +1888,7 @@ mod advance_tests {
             &mut state,
             DuenessTargets::at(BlockHeight::from_u32(1601)),
             &config(),
+            &mut rng(),
         )
         .expect("the store never fails");
 
@@ -1817,7 +1939,8 @@ mod advance_tests {
                 &mut store,
                 &mut state,
                 DuenessTargets::at(BlockHeight::from_u32(1601)),
-                &config()
+                &config(),
+                &mut rng()
             ),
             Err(StoreFailed)
         );
@@ -1847,7 +1970,8 @@ mod advance_tests {
                 &mut store,
                 &mut state,
                 DuenessTargets::at(BlockHeight::from_u32(1601)),
-                &config()
+                &config(),
+                &mut rng()
             ),
             Err(StoreFailed)
         );
@@ -1891,7 +2015,8 @@ mod advance_tests {
                 &mut store,
                 &mut state,
                 DuenessTargets::at(BlockHeight::from_u32(1601)),
-                &config()
+                &config(),
+                &mut rng()
             )
             .expect("the store never fails"),
             AdvanceStep::Reevaluate,
@@ -1926,7 +2051,8 @@ mod advance_tests {
                 &mut store,
                 &mut state,
                 DuenessTargets::at(BlockHeight::from_u32(1701)),
-                &config()
+                &config(),
+                &mut rng()
             )
             .expect("the store never fails"),
             AdvanceStep::Broadcast {
@@ -1974,7 +2100,8 @@ mod advance_tests {
                 &mut store,
                 &mut state,
                 DuenessTargets::at(BlockHeight::from_u32(1701)),
-                &config()
+                &config(),
+                &mut rng()
             )
             .expect("the store never fails"),
             AdvanceStep::Replan,
@@ -2032,7 +2159,8 @@ mod advance_tests {
                 &mut store,
                 &mut state,
                 DuenessTargets::at(BlockHeight::from_u32(1601)),
-                &config()
+                &config(),
+                &mut rng()
             )
             .expect("the store never fails"),
             AdvanceStep::Complete,
@@ -2084,7 +2212,8 @@ mod advance_tests {
                 &mut store,
                 &mut state,
                 DuenessTargets::at(BlockHeight::from_u32(1601)),
-                &config()
+                &config(),
+                &mut rng()
             )
             .expect("the store never fails"),
             AdvanceStep::Reevaluate,
@@ -2136,7 +2265,8 @@ mod advance_tests {
                 &mut store,
                 &mut state,
                 DuenessTargets::at(BlockHeight::from_u32(1601)),
-                &config()
+                &config(),
+                &mut rng()
             )
             .expect("the store never fails"),
             AdvanceStep::Reevaluate,
@@ -2173,10 +2303,10 @@ mod advance_tests {
     /// are both judged the same way.
     #[test]
     fn advance_serves_the_schedule_by_estimate_and_withholds_a_doomed_broadcast() {
-        let mut doomed = scheduled_transfer(1, 0, 1440, 1500, MigrationTxState::Proved);
-        doomed.expiry_height = BlockHeight::from_u32(1600);
+        let mut doomed = scheduled_transfer(1, 0, 1440, 1690, MigrationTxState::Proved);
+        doomed.expiry_height = BlockHeight::from_u32(1695);
         doomed.depends_on = vec![MigrationTransferId(0)];
-        let mut live = scheduled_transfer(2, 1, 1440, 1500, MigrationTxState::Proved);
+        let mut live = scheduled_transfer(2, 1, 1440, 1690, MigrationTxState::Proved);
         live.expiry_height = BlockHeight::from_u32(2000);
         live.depends_on = vec![MigrationTransferId(0)];
 
@@ -2186,12 +2316,13 @@ mod advance_tests {
         );
         let mut store = TestStore::new(1501, []);
         // Scanned to 1500 (target 1501), estimated tip 1700 (target 1701): both transfers are due
-        // by the estimate and neither is due by the scan, and the first one's expiry lies in the
-        // doomed window `1501 <= 1600 < 1701`.
+        // by the estimate — within the overdue-shift tolerance, so the schedule holds — and
+        // neither is due by the scan, and the first one's expiry lies in the doomed window
+        // `1501 <= 1695 < 1701`.
         let targets = DuenessTargets::new(BlockHeight::from_u32(1501), BlockHeight::from_u32(1701));
 
         assert_eq!(
-            advance_migration(&mut store, &mut state, targets, &config())
+            advance_migration(&mut store, &mut state, targets, &config(), &mut rng())
                 .expect("the store never fails"),
             AdvanceStep::Broadcast {
                 id: MigrationTransferId(2)
@@ -2216,13 +2347,237 @@ mod advance_tests {
             advance_migration(
                 &mut store,
                 &mut state,
-                DuenessTargets::at(BlockHeight::from_u32(1501)),
+                DuenessTargets::at(BlockHeight::from_u32(1691)),
                 &config(),
+                &mut rng(),
             )
             .expect("the store never fails"),
             AdvanceStep::Broadcast {
                 id: MigrationTransferId(1)
             },
         );
+    }
+
+    /// A step overdue by more than the schedule-scaled tolerance ([`overdue_shift_tolerance`])
+    /// shifts the WHOLE pending schedule
+    /// forward by the overdue amount before it is surfaced: the trigger comes due exactly at the
+    /// served target — ZIP 318's one immediately-released overdue transfer — every other pending
+    /// transaction keeps its drawn gap behind it, served schedules stay put, and the shifted
+    /// state is persisted by the time the step is returned. Judged at the ESTIMATE, so the
+    /// re-spread happens in a broadcast-only session, without syncing first.
+    #[test]
+    fn overdue_step_shifts_the_pending_schedule() {
+        let mut state = state_with_crossings(
+            &[40_000_000, 30_000_000, 30_000_000],
+            vec![
+                tx(0, prep(0, 0), mined(10)),
+                scheduled_transfer(1, 0, 720, 1_000, MigrationTxState::Proved),
+                scheduled_transfer(2, 1, 720, 1_066, MigrationTxState::Signed),
+                scheduled_transfer(3, 2, 720, 900, broadcast()),
+            ],
+        );
+        let mut store = TestStore::new(1_010, []);
+
+        // Scanned to 1_010 (target 1_011); the wall-clock estimate has the tip at 2_000 (target
+        // 2_001), so the named broadcast is 1_001 blocks overdue.
+        let step = advance_migration(
+            &mut store,
+            &mut state,
+            DuenessTargets::new(BlockHeight::from_u32(1_011), BlockHeight::from_u32(2_001)),
+            &config(),
+            &mut rng(),
+        )
+        .expect("the store never fails");
+
+        assert_eq!(
+            step,
+            AdvanceStep::Broadcast {
+                id: MigrationTransferId(1)
+            },
+            "the overdue transfer is still released in this call"
+        );
+        let scheduled: Vec<u32> = state
+            .transactions()
+            .iter()
+            .map(|t| u32::from(t.scheduled_height()))
+            .collect();
+        assert_eq!(
+            scheduled,
+            vec![0, 2_001, 2_067, 900],
+            "pending schedules shift by the overdue amount (gaps intact); served ones stay put"
+        );
+        assert_eq!(store.replaced.get(), 1, "the shifted schedule is persisted");
+        let stored: Vec<u32> = store
+            .stored
+            .as_ref()
+            .expect("persisted")
+            .transactions()
+            .iter()
+            .map(|t| u32::from(t.scheduled_height()))
+            .collect();
+        assert_eq!(
+            stored, scheduled,
+            "the store agrees by the time the step is surfaced"
+        );
+
+        // The anchor consequences of the deferral. The PROVED trigger keeps the boundary its
+        // proof was built against; the deferred SIGNED transfer's boundary is redrawn
+        // in-distribution against its shifted schedule — within `ANCHOR_AGE_CAP` (4) buckets
+        // strictly below the most recent grid boundary at the new height — because keeping the
+        // old one would broadcast an anchor age no honest draw produces.
+        assert_eq!(
+            state.transactions()[1].anchor_boundary(),
+            Some(BlockHeight::from_u32(720)),
+            "the proved transfer's proof pins its anchor"
+        );
+        let new_schedule = u32::from(state.transactions()[2].scheduled_height());
+        let most_recent = new_schedule - (new_schedule % 144);
+        let boundary = u32::from(
+            state.transactions()[2]
+                .anchor_boundary()
+                .expect("a transfer keeps carrying a boundary"),
+        );
+        assert_eq!(boundary % 144, 0, "the redrawn boundary is on the grid");
+        assert!(
+            boundary >= most_recent - 4 * 144 && boundary < most_recent,
+            "boundary {boundary} is in-distribution for schedule {new_schedule}"
+        );
+    }
+
+    /// The tolerance boundary: a step at most [`overdue_shift_tolerance`] blocks past its
+    /// schedule is ordinary wake-up slop, served as scheduled with nothing rescheduled or
+    /// written; one block further and the whole pending schedule moves. The fixture's committed
+    /// interval is the ZIP 318 one, so the tolerance under test is the mainnet value the drive
+    /// call derives from the persisted state.
+    #[test]
+    fn overdue_shift_tolerance_boundary() {
+        // A quarter of the ZIP 318 mean of 66: the value `advance_migration` derives from the
+        // fixture's persisted ZIP 318 interval.
+        let tolerance = overdue_shift_tolerance(&SchedulingParams::ZIP_318.transfer_delay());
+        assert_eq!(tolerance, 16, "a quarter of the 66-block ZIP 318 mean");
+        let make = || {
+            state_with_crossings(
+                &[50_000_000, 50_000_000],
+                vec![
+                    tx(0, prep(0, 0), mined(10)),
+                    scheduled_transfer(1, 0, 720, 1_000, MigrationTxState::Proved),
+                    scheduled_transfer(2, 1, 720, 1_050, MigrationTxState::Signed),
+                ],
+            )
+        };
+
+        // Exactly AT the tolerance: the schedule holds.
+        let mut state = make();
+        let mut store = TestStore::new(1_000 + tolerance, []);
+        let step = advance_migration(
+            &mut store,
+            &mut state,
+            DuenessTargets::at(BlockHeight::from_u32(1_000 + tolerance)),
+            &config(),
+            &mut rng(),
+        )
+        .expect("the store never fails");
+        assert_eq!(
+            step,
+            AdvanceStep::Broadcast {
+                id: MigrationTransferId(1)
+            }
+        );
+        assert_eq!(
+            u32::from(state.transactions()[1].scheduled_height()),
+            1_000,
+            "within tolerance the schedule holds"
+        );
+        assert_eq!(store.replaced.get(), 0, "and nothing is written");
+
+        // One block past it: the pending schedule shifts.
+        let mut state = make();
+        let mut store = TestStore::new(1_000 + tolerance + 1, []);
+        let step = advance_migration(
+            &mut store,
+            &mut state,
+            DuenessTargets::at(BlockHeight::from_u32(1_000 + tolerance + 1)),
+            &config(),
+            &mut rng(),
+        )
+        .expect("the store never fails");
+        assert_eq!(
+            step,
+            AdvanceStep::Broadcast {
+                id: MigrationTransferId(1)
+            },
+            "the trigger is released at the served target it was shifted to"
+        );
+        assert_eq!(
+            u32::from(state.transactions()[1].scheduled_height()),
+            1_000 + tolerance + 1,
+        );
+        assert_eq!(
+            u32::from(state.transactions()[2].scheduled_height()),
+            1_050 + tolerance + 1,
+        );
+        assert_eq!(store.replaced.get(), 1);
+    }
+
+    /// The tolerance is a function of the schedule's own scale: a quarter of the mean transfer
+    /// gap, so compressed test-network parameters compress it in proportion, clamped to at least
+    /// one block at the degenerate end.
+    #[test]
+    fn overdue_shift_tolerance_scales_with_the_transfer_delay() {
+        use crate::scheduling::AnchorBucketInterval;
+        let for_interval = |blocks: u32| {
+            overdue_shift_tolerance(
+                &SchedulingParams::new_with_default_distributions(AnchorBucketInterval::custom(
+                    core::num::NonZeroU32::new(blocks).expect("nonzero"),
+                ))
+                .transfer_delay(),
+            )
+        };
+        assert_eq!(
+            for_interval(144),
+            16,
+            "the ZIP 318 grid gives the mainnet value"
+        );
+        // A twelfth of the grid scales the mean to 5, and the tolerance to a quarter of that.
+        assert_eq!(for_interval(12), 1);
+        // Degenerate one-block grids clamp to a tolerance of one rather than zero, so ordinary
+        // one-block estimation error never triggers a rewrite of the whole schedule.
+        assert_eq!(for_interval(1), 1);
+    }
+
+    /// The shift triggers on a PROVE step too: a wallet that slept through both its proving
+    /// wake-ups and a broadcast window re-spreads at the FIRST step it is offered, so the backlog
+    /// is already re-spread by the time the proofs land — and the prove itself is still surfaced
+    /// in the same call, since a transfer's proving is anchor-gated, not schedule-gated.
+    #[test]
+    fn overdue_prove_shifts_the_pending_schedule() {
+        let mut state = state_with_crossings(
+            &[100_000_000],
+            vec![
+                tx(0, prep(0, 0), mined(10)),
+                scheduled_transfer(1, 0, 720, 1_000, MigrationTxState::Signed),
+            ],
+        );
+        let mut store = TestStore::new(2_000, []);
+
+        let step = advance_migration(
+            &mut store,
+            &mut state,
+            DuenessTargets::at(BlockHeight::from_u32(2_001)),
+            &config(),
+            &mut rng(),
+        )
+        .expect("the store never fails");
+
+        assert!(
+            matches!(step, AdvanceStep::Prove { id, .. } if id == MigrationTransferId(1)),
+            "the prove is still surfaced in the shifting call: {step:?}"
+        );
+        assert_eq!(
+            u32::from(state.transactions()[1].scheduled_height()),
+            2_001,
+            "its broadcast window re-spread to the served target"
+        );
+        assert_eq!(store.replaced.get(), 1);
     }
 }

--- a/zcash_pool_migration/src/scheduling.rs
+++ b/zcash_pool_migration/src/scheduling.rs
@@ -62,7 +62,11 @@
 //!   with its broadcasts. That is a scheduling-engine runtime policy over live network activity.
 //! - AT MOST ONE OVERDUE TRANSFER at wallet open: when a wallet reopens after being offline past
 //!   several scheduled heights, at most one overdue transfer is released immediately (the rest are
-//!   re-spread). That requires the persisted schedule and wall-clock state the engine owns.
+//!   re-spread). That requires the persisted schedule and wall-clock state the engine owns; the
+//!   drive API implements it as the overdue shift (see
+//!   [`advance_migration`](crate::satisfiability::advance_migration) and
+//!   [`overdue_shift_tolerance`](crate::satisfiability::overdue_shift_tolerance)), which moves the
+//!   whole pending schedule forward by the overdue amount rather than redrawing it.
 //!
 //! This module supplies the heights and anchors those policies act on; it does not enact them.
 //!
@@ -771,8 +775,74 @@ pub fn draw_anchor_boundary<R: RngCore + CryptoRng>(
         u32::from(funding_creation_height),
         most_recent,
     )?;
+    Some(BlockHeight::from_u32(sample_recency_weighted_boundary(
+        interval,
+        lowest,
+        highest,
+        most_recent,
+        rng,
+    )))
+}
 
-    // Rejection-sample the geometric age until the candidate lands in [lowest, highest].
+/// Select a REPLACEMENT boundary for a transfer whose broadcast schedule has moved out from under
+/// its drawn anchor — the overdue shift
+/// ([`advance_migration`](crate::satisfiability::advance_migration)) defers every pending
+/// broadcast when a wallet resumes after downtime, and a boundary that was in-distribution for
+/// the ORIGINAL schedule sits `delta` blocks too old against the shifted one. With
+/// [`ANCHOR_AGE_CAP`] at 4 buckets, even a modest shift leaves an anchor age no honest draw
+/// produces, and every deferred transfer of one wallet would carry the SAME excess age — a
+/// linkable fingerprint. Redrawing against the new schedule restores the age distribution the
+/// anchor cohorts rely on.
+///
+/// The draw is [`draw_anchor_boundary`]'s recency-weighted draw against the NEW
+/// `broadcast_height`, with the candidate set floored at `prior_boundary` — the boundary being
+/// replaced — instead of the funding constraints: every note witnessable in the prior boundary's
+/// tree state is witnessable in every later one, so the floor preserves provability without the
+/// funding-note heights this crate's state does not hold. (A funding note that POSTDATES the
+/// prior boundary is the separate staleness `prove_transfer` re-validates and re-draws for at
+/// proving time, with the real mined heights in hand.) The prior boundary also subsumes the
+/// NU6.3-activation bound, which it satisfies by construction.
+///
+/// Returns `None` when no candidate at or above `prior_boundary` lies strictly below the most
+/// recent boundary at `broadcast_height` — possible only when the prior boundary was itself
+/// drawn against a tip past the new schedule (a proving-time re-draw followed by a small shift);
+/// the caller keeps the prior boundary, which remains provable.
+///
+/// [`prove_transfer`]: crate::engine::prove_transfer
+pub fn redraw_anchor_boundary<R: RngCore + CryptoRng>(
+    interval: AnchorBucketInterval,
+    prior_boundary: BlockHeight,
+    broadcast_height: BlockHeight,
+    rng: &mut R,
+) -> Option<BlockHeight> {
+    let most_recent = boundary_at_or_below_u32(&interval, u32::from(broadcast_height));
+    // Highest candidate: strictly below the most recent boundary (age >= 1), one interval down.
+    let highest = most_recent.checked_sub(interval.block_count().get())?;
+    let lowest = boundary_at_or_above_u32(&interval, u32::from(prior_boundary));
+    if lowest > highest {
+        return None;
+    }
+    Some(BlockHeight::from_u32(sample_recency_weighted_boundary(
+        interval,
+        lowest,
+        highest,
+        most_recent,
+        rng,
+    )))
+}
+
+/// The rejection-sampling core shared by [`draw_anchor_boundary`] and
+/// [`redraw_anchor_boundary`]: draw recency-weighted ages until `most_recent - age * interval`
+/// lands in `[lowest, highest]`, and return that candidate. The caller guarantees
+/// `lowest <= highest` and `highest = most_recent - interval` (both grid boundaries), so age 1
+/// always yields `highest` and the loop terminates.
+fn sample_recency_weighted_boundary<R: RngCore>(
+    interval: AnchorBucketInterval,
+    lowest: u32,
+    highest: u32,
+    most_recent: u32,
+    rng: &mut R,
+) -> u32 {
     loop {
         let age = draw_anchor_age(rng);
         if age > ANCHOR_AGE_CAP {
@@ -788,7 +858,7 @@ pub fn draw_anchor_boundary<R: RngCore + CryptoRng>(
             None => continue,
         };
         if candidate >= lowest && candidate <= highest {
-            return Some(BlockHeight::from_u32(candidate));
+            return candidate;
         }
     }
 }
@@ -1918,6 +1988,62 @@ mod tests {
         // A mid-interval tip (not itself a boundary) must yield identical draws.
         check_anchor_golden(act, funding, tip + 100, 1, &exp_seed1);
         check_anchor_golden(act, funding, tip + MODULUS - 1, 42, &exp_seed42);
+    }
+
+    // --- redraw_anchor_boundary ---------------------------------------------------------------
+
+    proptest! {
+        /// A replacement boundary, when one exists, is on the grid, at or above the boundary it
+        /// replaces, and in-distribution against the NEW broadcast height: within
+        /// [`ANCHOR_AGE_CAP`] buckets strictly below its most recent grid boundary. `None` arises
+        /// exactly when no candidate at or above the prior boundary lies strictly below that
+        /// most recent boundary.
+        #[test]
+        fn redraw_anchor_boundary_props(
+            seed in any::<u64>(),
+            prior_bucket in 0u32..100,
+            broadcast in 0u32..5_000_000,
+            blocks in 2u32..10_000,
+        ) {
+            let i = interval(blocks);
+            let prior = prior_bucket.saturating_mul(blocks);
+            let chosen = redraw_anchor_boundary(i, bh(prior), bh(broadcast), &mut rng(seed));
+            let most_recent = broadcast - (broadcast % blocks);
+            match chosen {
+                Some(b) => {
+                    let b = u32::from(b);
+                    prop_assert!(i.is_boundary(bh(b)));
+                    prop_assert!(b >= prior, "replacement {b} regressed below the prior {prior}");
+                    prop_assert!(b < most_recent, "age >= 1: strictly below {most_recent}");
+                    prop_assert!(
+                        b + ANCHOR_AGE_CAP * blocks >= most_recent,
+                        "replacement {b} is older than the age cap allows"
+                    );
+                }
+                None => prop_assert!(
+                    most_recent < blocks || prior > most_recent - blocks,
+                    "a non-empty candidate window must yield a draw"
+                ),
+            }
+        }
+    }
+
+    /// The endpoints of the replacement window: a prior boundary above the window keeps its
+    /// (still-provable) anchor by yielding `None`, and a prior boundary AT the window's single
+    /// candidate returns that candidate deterministically.
+    #[test]
+    fn redraw_anchor_boundary_window_endpoints() {
+        // Broadcast 1_900: most recent boundary 1_872, highest candidate 1_728.
+        assert_eq!(
+            redraw_anchor_boundary(modulus(), bh(1_872), bh(1_900), &mut rng(1)),
+            None,
+            "a prior at the most recent boundary has no strictly-older candidate to move to"
+        );
+        assert_eq!(
+            redraw_anchor_boundary(modulus(), bh(1_728), bh(1_900), &mut rng(1)),
+            Some(bh(1_728)),
+            "a single-candidate window is deterministic"
+        );
     }
 
     /// The two axes of [`SchedulingParams`] are independent: changing only the anchor bucket

--- a/zcash_pool_migration/src/state.rs
+++ b/zcash_pool_migration/src/state.rs
@@ -718,6 +718,68 @@ impl MigrationState {
         self.recompute_status();
     }
 
+    /// Shifts the scheduled height of every transaction that has not yet been broadcast forward
+    /// by `delta` blocks, preserving the schedule's inter-broadcast gaps.
+    ///
+    /// This is the RE-SPREAD half of ZIP 318's missed-schedule policy — at most one overdue
+    /// transfer is released immediately; the rest are re-spread — applied by
+    /// [`advance_migration`](crate::satisfiability::advance_migration) when the step it would
+    /// surface lags the served target by more than
+    /// the schedule-scaled tolerance
+    /// ([`overdue_shift_tolerance`](crate::satisfiability::overdue_shift_tolerance)). Shifting
+    /// every pending transaction by the same delta moves the whole remaining schedule forward in
+    /// block-time without redrawing it, so the gaps between broadcasts — the observable the drawn
+    /// exponential delays exist to shape — survive the wallet's absence unchanged, instead of the
+    /// missed steps piling up and broadcasting as a cluster.
+    ///
+    /// Only PENDING transactions shift ([`AwaitingSignature`](MigrationTxState::AwaitingSignature),
+    /// [`Signed`](MigrationTxState::Signed), [`Proved`](MigrationTxState::Proved)): an in-flight
+    /// or mined transaction's schedule has already been served, and moving it would only distort
+    /// the record of when it was due. Expiry heights are untouched — a pre-signed transaction's
+    /// expiry is effecting data under ZIP 203, fixed at signing — so a large enough shift can move
+    /// a pending schedule past its own expiry; such a transaction self-heals through the ordinary
+    /// expiry path (its rebuild redraws both schedule and expiry). Heights saturate rather than
+    /// overflow.
+    ///
+    /// A shifted TRANSFER whose proof is still to come ([`AwaitingSignature`](MigrationTxState::AwaitingSignature)
+    /// or [`Signed`](MigrationTxState::Signed)) also gets its anchor boundary REDRAWN against the
+    /// shifted schedule ([`redraw_anchor_boundary`](crate::scheduling::redraw_anchor_boundary)):
+    /// the stored boundary was drawn to be in-distribution relative to the ORIGINAL broadcast
+    /// height, so keeping it would broadcast an anchor `delta` blocks older than any honest draw —
+    /// and every deferred transfer of this wallet older by the SAME `delta`, a linkable
+    /// fingerprint. The redraw is sound exactly as `prove_transfer`'s proving-time redraw is:
+    /// ZIP 374 defers the anchor and witnesses to proving, so nothing in the stored artifact pins
+    /// the old boundary. A [`Proved`](MigrationTxState::Proved) transfer's proof DOES pin its
+    /// anchor, so its boundary is kept (re-anchoring it would mean discarding the proof), and a
+    /// preparation carries no drawn boundary at all. In the rare case where no candidate exists at
+    /// or above the prior boundary (see [`redraw_anchor_boundary`](crate::scheduling::redraw_anchor_boundary)),
+    /// the prior — still provable — boundary is kept.
+    pub(crate) fn shift_schedule<R: RngCore + CryptoRng>(&mut self, delta: u32, rng: &mut R) {
+        let interval = self.anchor_bucket_interval;
+        for tx in &mut self.transactions {
+            match tx.state {
+                MigrationTxState::Broadcast { .. } | MigrationTxState::Mined { .. } => continue,
+                MigrationTxState::AwaitingSignature | MigrationTxState::Signed => {
+                    tx.scheduled_height = tx.scheduled_height + delta;
+                    if matches!(tx.kind, MigrationTxKind::Transfer { .. })
+                        && let Some(prior) = tx.anchor_boundary
+                        && let Some(fresh) = crate::scheduling::redraw_anchor_boundary(
+                            interval,
+                            prior,
+                            tx.scheduled_height,
+                            rng,
+                        )
+                    {
+                        tx.anchor_boundary = Some(fresh);
+                    }
+                }
+                MigrationTxState::Proved => {
+                    tx.scheduled_height = tx.scheduled_height + delta;
+                }
+            }
+        }
+    }
+
     /// Records that the transaction `id` was mined under `txid` at `height`, then recomputes the
     /// overall status. This is what lets a later preparation layer or the transfers become
     /// actionable. Recording the txid on `Mined` (rather than dropping it once broadcast is
@@ -1150,7 +1212,11 @@ impl MigrationState {
     /// A missed schedule degrades gracefully rather than requiring reconciliation: a wallet that
     /// slept through a transfer's proving wake-ups and its broadcast height is simply offered
     /// `Prove` and then `Broadcast` for it as soon as it wakes — or `Rebuild`, once the transfer
-    /// has expired.
+    /// has expired. The drive layer adds the RE-SPREAD on top:
+    /// [`advance_migration`](crate::satisfiability::advance_migration) shifts the whole pending
+    /// schedule forward ([`Self::shift_schedule`]) before serving a step overdue by more than
+    /// [`overdue_shift_tolerance`](crate::satisfiability::overdue_shift_tolerance) allows, so this
+    /// kernel judges the shifted schedule and at most one overdue step is ever released at once.
     pub(crate) fn next_step(
         &self,
         targets: DuenessTargets,
@@ -1975,6 +2041,96 @@ mod tests {
                 kind: transfer(0),
             }
         );
+    }
+
+    /// `shift_schedule` moves every PENDING schedule forward by the same delta — preserving the
+    /// inter-broadcast gaps — and leaves served schedules (in-flight and mined rows) and every
+    /// expiry height untouched. A deferred transfer whose proof is still to come has its anchor
+    /// boundary REDRAWN in-distribution against its shifted schedule; a proved transfer's proof
+    /// pins its anchor, and a preparation carries none.
+    #[test]
+    fn shift_schedule_moves_only_pending_schedules() {
+        let mut s = state_with(vec![
+            tx(0, prep(0, 0), MigrationTxState::AwaitingSignature),
+            tx(1, prep(0, 1), MigrationTxState::Signed),
+            tx(2, transfer(0), MigrationTxState::Proved),
+            tx(
+                3,
+                transfer(1),
+                MigrationTxState::Broadcast {
+                    txid: TxId::from_bytes([3; 32]),
+                },
+            ),
+            tx(4, transfer(2), mined(500)),
+            tx(5, transfer(3), MigrationTxState::Signed),
+            tx(6, transfer(4), MigrationTxState::AwaitingSignature),
+        ]);
+        for (i, h) in [
+            (0usize, 100u32),
+            (1, 200),
+            (2, 300),
+            (3, 400),
+            (4, 500),
+            (5, 600),
+            (6, 700),
+        ] {
+            s.transactions[i].scheduled_height = BlockHeight::from_u32(h);
+            s.transactions[i].expiry_height = BlockHeight::from_u32(h + 140_000);
+        }
+        // The transfers carry drawn boundaries on the ZIP 318 grid (the state's interval);
+        // 144 = 1 * 144.
+        for i in [2usize, 5, 6] {
+            s.transactions[i].anchor_boundary = Some(BlockHeight::from_u32(144));
+        }
+
+        s.shift_schedule(100_000, &mut ChaCha8Rng::seed_from_u64(7));
+
+        let scheduled: Vec<u32> = s
+            .transactions
+            .iter()
+            .map(|t| u32::from(t.scheduled_height))
+            .collect();
+        assert_eq!(
+            scheduled,
+            vec![100_100, 100_200, 100_300, 400, 500, 100_600, 100_700],
+            "pending schedules shift; served ones stay put"
+        );
+        // Expiry is effecting data, fixed at signing: no shift may touch it.
+        let expiries: Vec<u32> = s
+            .transactions
+            .iter()
+            .map(|t| u32::from(t.expiry_height))
+            .collect();
+        assert_eq!(
+            expiries,
+            vec![
+                140_100, 140_200, 140_300, 140_400, 140_500, 140_600, 140_700
+            ]
+        );
+
+        // The proved transfer's proof pins its anchor: the boundary is untouched.
+        assert_eq!(
+            s.transactions[2].anchor_boundary,
+            Some(BlockHeight::from_u32(144)),
+            "a proved transfer keeps the boundary its proof was built against"
+        );
+        // The unproved transfers' boundaries are redrawn in-distribution against the SHIFTED
+        // schedule: within `ANCHOR_AGE_CAP` (4) buckets strictly below the most recent grid
+        // boundary at the new scheduled height. The old boundary sits far outside that window,
+        // so the redraw is guaranteed to have replaced it.
+        for i in [5usize, 6] {
+            let new_schedule = u32::from(s.transactions[i].scheduled_height);
+            let most_recent = new_schedule - (new_schedule % 144);
+            let boundary = u32::from(s.transactions[i].anchor_boundary.expect("still a transfer"));
+            assert_eq!(boundary % 144, 0, "the redrawn boundary is on the grid");
+            assert!(
+                boundary >= most_recent - 4 * 144 && boundary < most_recent,
+                "boundary {boundary} is in-distribution for schedule {new_schedule}"
+            );
+        }
+        // The preparations never carry a boundary, before or after.
+        assert_eq!(s.transactions[0].anchor_boundary, None);
+        assert_eq!(s.transactions[1].anchor_boundary, None);
     }
 
     #[test]

--- a/zcash_pool_migration/tests/engine_commit.rs
+++ b/zcash_pool_migration/tests/engine_commit.rs
@@ -18,9 +18,9 @@ use zcash_protocol::value::COIN;
 
 use zcash_pool_migration::build::sign_pczt;
 use zcash_pool_migration::engine::{
-    MigrationPlan, MigrationStatus, MigrationTxKind, MigrationTxState, PoolMigrationRead,
-    PoolMigrationWrite, batch_unsigned_by_action_budget, build_preparation_unsigned,
-    commit_preparation, plan_migration,
+    MigrationPlan, MigrationState, MigrationStatus, MigrationTxKind, MigrationTxState,
+    PoolMigrationRead, PoolMigrationWrite, batch_unsigned_by_action_budget,
+    build_preparation_unsigned, commit_preparation, plan_migration,
 };
 use zcash_pool_migration::pczt_txid::{pczt_txid, stored_pczt_txid};
 use zcash_pool_migration::preparation::PREP_TX_ACTIONS;
@@ -167,20 +167,21 @@ fn commits_a_multi_layer_migration_in_one_pass() {
     let config = AdvanceConfig::new(ReorgSettleDepth::new(10));
     // A height past every scheduled broadcast (so each transaction is due, not blocked on the
     // schedule) but within every expiry window (so none is expired and offered for rebuild): the
-    // latest scheduled height. This exercises the dependency-ordering walk, not expiry handling.
-    let target = state
-        .transactions()
-        .iter()
-        .map(|t| t.scheduled_height())
-        .max()
-        .expect("the committed migration has transactions");
-    match advance_migration(
-        &mut backend,
-        &mut state,
-        DuenessTargets::at(target),
-        &config,
-    )
-    .expect("the store answers")
+    // latest scheduled height. This exercises the dependency-ordering walk, not schedule
+    // handling — and because the drive layer RE-SPREADS a schedule this overdue (the whole
+    // pending schedule shifts forward before the first step of each backlog is served), the
+    // target is recomputed from the current schedule before every call rather than fixed once.
+    let latest_scheduled = |state: &MigrationState| {
+        state
+            .transactions()
+            .iter()
+            .map(|t| t.scheduled_height())
+            .max()
+            .expect("the committed migration has transactions")
+    };
+    let targets = DuenessTargets::at(latest_scheduled(&state));
+    match advance_migration(&mut backend, &mut state, targets, &config, &mut rng)
+        .expect("the store answers")
     {
         AdvanceStep::Prove { id, .. } | AdvanceStep::Broadcast { id } => {
             assert!(layer0_ids.contains(&id), "layer 0 broadcasts first")
@@ -196,13 +197,9 @@ fn commits_a_multi_layer_migration_in_one_pass() {
         .filter(|t| matches!(t.kind(), MigrationTxKind::Preparation { layer: 1, .. }))
         .map(|t| t.id())
         .collect();
-    match advance_migration(
-        &mut backend,
-        &mut state,
-        DuenessTargets::at(target),
-        &config,
-    )
-    .expect("the store answers")
+    let targets = DuenessTargets::at(latest_scheduled(&state));
+    match advance_migration(&mut backend, &mut state, targets, &config, &mut rng)
+        .expect("the store answers")
     {
         AdvanceStep::Prove { id, .. } | AdvanceStep::Broadcast { id } => {
             assert!(
@@ -215,13 +212,9 @@ fn commits_a_multi_layer_migration_in_one_pass() {
     for id in &layer1_ids {
         state.mark_mined(*id, BlockHeight::from_u32(2_000_020));
     }
-    match advance_migration(
-        &mut backend,
-        &mut state,
-        DuenessTargets::at(target),
-        &config,
-    )
-    .expect("the store answers")
+    let targets = DuenessTargets::at(latest_scheduled(&state));
+    match advance_migration(&mut backend, &mut state, targets, &config, &mut rng)
+        .expect("the store answers")
     {
         AdvanceStep::Prove { id, .. } | AdvanceStep::Broadcast { id } => {
             let tx = state
@@ -403,6 +396,7 @@ fn advance_promotes_a_proved_transaction_whose_broadcast_was_never_recorded() {
         &mut state,
         DuenessTargets::at(BlockHeight::from_u32(TARGET_HEIGHT + 10)),
         &AdvanceConfig::new(ReorgSettleDepth::new(10)),
+        &mut rng,
     )
     .expect("the mock store never fails");
 


### PR DESCRIPTION
When a wallet sleeps through part of its ZIP 318 broadcast schedule, the missed steps must not build up and broadcast as a cluster: the drawn inter-arrival delays exist precisely to keep a wallet's broadcasts temporally decoupled. This implements the missed-schedule policy that `zcash_pool_migration::scheduling` had documented as out of scope for the pure planner ("at most one overdue transfer is released immediately; the rest are re-spread").

### What this does

- `satisfiability::advance_migration` now checks the `Prove`/`Broadcast` candidate the kernel names against the served (estimated-tip) target. If its scheduled height lags by more than the overdue-shift tolerance, the scheduled height of every not-yet-broadcast transaction is shifted forward by the lag before the step is served, and the shifted state is persisted with the call's other writes. The triggering step comes due exactly at the served target, so it is still released in the same call; everything behind it keeps its drawn inter-broadcast gaps.
- The tolerance is a function of the schedule's own scale rather than a constant: `satisfiability::overdue_shift_tolerance` returns a quarter of the transfer delay's mean (16 blocks ≈ 20 minutes under the ZIP 318 parameters), clamped to at least one block. `advance_migration` derives the transfer delay from the migration's **persisted** anchor bucket interval via the default ZIP 318 ratio, so overdueness is judged against the schedule as committed, and compressed test-network schedules compress the tolerance in proportion.
- Deferral redraws the anchors it invalidates. A transfer's boundary is drawn in-distribution against its scheduled broadcast height, so a deferred transfer that kept its boundary would broadcast with an anchor age outside the recency-weighted draw (`ANCHOR_AGE_CAP` is four buckets) — and every deferred transfer of the wallet would carry the same excess age, a linkable fingerprint. The shift therefore redraws the boundary of every deferred **not-yet-proved** transfer against its shifted schedule (`scheduling::redraw_anchor_boundary`), floored at the boundary being replaced so provability is preserved; the redraw is sound for a `Signed`/`AwaitingSignature` PCZT because ZIP 374 defers anchors and witnesses to proving. A `Proved` transfer's proof pins its anchor, so its boundary is kept, and preparations draw none. These draws are why `advance_migration` now takes a `CryptoRng`.
- Only pending transactions (`AwaitingSignature`/`Signed`/`Proved`) shift; in-flight and mined rows have had their schedules served. Expiry heights are effecting data under ZIP 203 and never move: a pending transaction whose shifted schedule passes its own expiry self-heals through the existing expiry/rebuild path, which redraws both. `Rebuild` candidates never trigger the shift, since a rebuild redraws its own schedule and an expired candidate's stale height would overstate the shift for the still-live remainder.
- The shift is judged and sized at `DuenessTargets::effective`, which is what lets a wall-clock-woken wallet re-spread without syncing first. It is legal there because it persists a schedule, never a verdict — it re-times service, records no determination, and destroys no work — and it is added to the `DuenessTargets` classification table on that basis.

### Testing

Unit tests cover the pending-only shift (gaps and expiries preserved, proved anchors pinned, unproved anchors redrawn in-distribution), the estimate-driven shift with persistence, the exact tolerance boundary, the trigger firing on a `Prove` step, the tolerance scaling (ZIP 318 grid, compressed grid, and the one-block clamp), and `redraw_anchor_boundary`'s window properties and endpoints. The `zcash_client_sqlite` pool-migration suite and the expensive chain-sim tests pass; the multi-layer commit walk in `engine_commit.rs` now recomputes its drive target from the possibly-shifted schedule.

---

Filed with Claude Code assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Gsndy5ri9eYvtH31DnHTQ
