### PR TITLE
zcash_client_sqlite: cover the preparation branch of ZIP 318 classification, and make storing a sent transaction idempotent

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -14,6 +14,10 @@ workspace.
 - The `orchard` feature is now enabled by default. Consumers that require a
   smaller feature set should disable default features and enable only the
   features they need.
+- `data_api::WalletWrite::store_transactions_to_be_sent` is now required to be
+  idempotent: storing a transaction the wallet has already recorded must
+  replace that record rather than fail. An implementation that inserts its
+  sent-output records must upsert them instead.
 
 ## [0.24.0-rc.7] - 2026-08-03
 

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -3892,6 +3892,11 @@ pub trait WalletWrite:
     /// stored transactions. Once spend records exist, the outputs are protected from
     /// double-selection by the spend tracking mechanism, so the explicit locks are no
     /// longer needed.
+    ///
+    /// Implementations must be idempotent: storing a transaction the wallet has already
+    /// recorded replaces that record rather than failing, so that a caller which stores a
+    /// transaction and then dies before transmitting it can store the same transaction again
+    /// when it resumes.
     fn store_transactions_to_be_sent(
         &mut self,
         transactions: &[SentTransaction<<Self as WalletRead>::AccountId>],

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -57,6 +57,9 @@ workspace.
   one in progress.
 
 ### Changed
+- `WalletWrite::store_transactions_to_be_sent` now upserts each transaction's
+  sent-output records, so storing a transaction the wallet has already
+  recorded replaces that record instead of failing.
 - Persisting a pool-migration state with any terminal status through
   `replace_migration` now releases the note reservations held by its
   never-broadcast transactions, in the same write: a migration superseded in

--- a/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
+++ b/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
@@ -458,8 +458,10 @@ where
     /// signatures it assembles, so a PCZT that would not survive broadcast is rejected here
     /// rather than recorded. The outputs are recovered by trial decryption under the account's
     /// unified full viewing key (every real output of a migration transaction is internal to the
-    /// migrating account; the padded dummies decrypt under no key). Idempotent at the wallet
-    /// layer: re-fetching after a crashed submission upserts the same record.
+    /// migrating account; the padded dummies decrypt under no key). Idempotent: every write it
+    /// makes upserts, so a consumer that crashed between obtaining these bytes and submitting
+    /// them obtains the same bytes, over the same record, when the drive loop offers the
+    /// broadcast again.
     ///
     /// After submitting, the consumer records the outcome exactly as before:
     /// [`MigrationState::mark_broadcast`] on success, or

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -5355,8 +5355,7 @@ fn delete_retrieval_queue_entry(
     Ok(())
 }
 
-// A utility function for creation of parameters for use in `insert_sent_output`
-// and `put_sent_output`
+// A utility function for creation of parameters for use in `put_sent_output`
 fn recipient_params<P: consensus::Parameters>(
     conn: &Connection,
     _params: &P,
@@ -5457,6 +5456,10 @@ fn flag_previously_received_change(
 }
 
 /// Records information about a transaction output that your wallet created.
+///
+/// Upserting, via [`put_sent_output`]: re-storing a transaction the wallet already recorded —
+/// a flow that obtains a transaction's bytes, dies before submitting them, and is handed the
+/// same transaction again — overwrites that output's row instead of failing on it.
 pub(crate) fn insert_sent_output<P: consensus::Parameters>(
     conn: &rusqlite::Transaction,
     params: &P,
@@ -5464,32 +5467,16 @@ pub(crate) fn insert_sent_output<P: consensus::Parameters>(
     from_account_uuid: AccountUuid,
     output: &SentTransactionOutput<AccountUuid>,
 ) -> Result<(), SqliteClientError> {
-    let mut stmt_insert_sent_output = conn.prepare_cached(
-        "INSERT INTO sent_notes (
-            transaction_id, output_pool, output_index, from_account_id,
-            to_address, to_account_id, value, memo)
-         VALUES (
-            :transaction_id, :output_pool, :output_index, :from_account_id,
-            :to_address, :to_account_id, :value, :memo)",
-    )?;
-
-    let (from_account_id, to_address, to_account_id, pool_type) =
-        recipient_params(conn, params, from_account_uuid, output.recipient())?;
-    let sql_args = named_params![
-        ":transaction_id": tx_ref.0,
-        ":output_pool": &pool_code(pool_type),
-        ":output_index": &i64::try_from(output.output_index()).unwrap(),
-        ":from_account_id": from_account_id.0,
-        ":to_address": &to_address,
-        ":to_account_id": to_account_id.map(|a| a.0),
-        ":value": &i64::from(ZatBalance::from(output.value())),
-        ":memo": memo_repr(output.memo())
-    ];
-
-    stmt_insert_sent_output.execute(sql_args)?;
-    flag_previously_received_change(conn, tx_ref)?;
-
-    Ok(())
+    put_sent_output(
+        conn,
+        params,
+        from_account_uuid,
+        tx_ref,
+        output.output_index(),
+        output.recipient(),
+        output.value(),
+        output.memo(),
+    )
 }
 
 /// Records information about a transaction output that your wallet created, from the constituent

--- a/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
+++ b/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
@@ -708,10 +708,10 @@ impl Run {
     /// this wallet's own selection can play the role of a SIBLING wallet on the same seed: the
     /// sibling shares every note but holds no record of this wallet's unbroadcast crossing, so
     /// nothing excludes the crossing's inputs from ITS selection. Since
-    /// `store_proved_transaction` records those marks at proving time — which is exactly what
-    /// keeps this wallet's own sweeps off a migration input, the protection under test in
-    /// `proving_persists_the_finalized_transaction_to_the_wallet` — simulating the sibling's
-    /// independent view requires lifting them.
+    /// `take_transaction_for_broadcast` records those marks at the broadcast seam — which is
+    /// exactly what keeps this wallet's own sweeps off a migration input, the protection under
+    /// test in `broadcast_persists_the_finalized_transaction_to_the_wallet` — simulating the
+    /// sibling's independent view requires lifting them.
     fn forget_pending_spend_marks(&mut self, txid: TxId) {
         let conn = self.st.wallet_mut().conn_mut();
         conn.execute(

--- a/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
+++ b/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
@@ -1340,6 +1340,144 @@ fn broadcast_persists_the_finalized_transaction_to_the_wallet() {
     );
 }
 
+/// Recording a PREPARATION transaction at the broadcast seam classifies it against ZIP 318 too,
+/// and that classification survives the transaction being mined and scanned.
+///
+/// The transfer's case is covered by `broadcast_persists_the_finalized_transaction_to_the_wallet`;
+/// the preparation is the other half, and it is not the same assertion twice. A preparation takes
+/// the OTHER branch of the classifier — it carries no destination-pool action at all, so it is
+/// judged as a padded Orchard-only send-to-self rather than as a crossing carrying a canonical
+/// denomination — and nothing in the transfer's case would notice that branch answering wrongly
+/// (or answering `Nonconforming` because the built transaction's action count drifted from the
+/// specified padding).
+///
+/// The post-mining half pins what the write's durability actually rests on: the classification is
+/// written by a plain `UPDATE` of a column that `put_tx_data` does not mention, and scanning the
+/// mined transaction re-upserts that very row. The re-upsert must not reset it.
+///
+/// Note what this does NOT cover: nothing here runs the enhance path, so the record written at the
+/// broadcast seam is the only thing that ever classifies these transactions in this simulation.
+/// That is the point rather than a gap — it is why recording must classify at all — but it means
+/// the commit-time claim that the enhance path later re-stamps the same value is pinned by
+/// `store_decrypted_tx`'s own tests, not by this one.
+#[test]
+#[cfg_attr(
+    feature = "ignore-expensive-tests",
+    ignore = "covered by the expensive-test CI matrix"
+)]
+fn broadcast_persists_a_preparations_zip318_classification() {
+    // The same single-crossing scenario the transfer's case uses, for the same reason: it is the
+    // cheapest shape that has a preparation at all.
+    const SINGLE: &str = "Gwen, 0.0152 ZEC (a single minimum-denomination note)";
+    let scenario = scenarios()
+        .into_iter()
+        .find(|scenario| scenario.label == SINGLE)
+        .expect("the single-crossing scenario exists");
+
+    let mut run = Run::setup(&scenario);
+    let mut committed = run.plan_and_commit(&scenario);
+
+    // The first step a healthy migration names is a preparation's proof: no crossing is provable
+    // while a preparation it depends on is unmined. The batch is earliest-ready first, so its
+    // head is that preparation; proving the one is all this test needs.
+    let mut waited = 0u32;
+    let (prep_id, kind) = loop {
+        match run.advance(&mut committed.state) {
+            AdvanceStep::Prove { transactions } => {
+                break (transactions[0].id(), transactions[0].kind());
+            }
+            AdvanceStep::Waiting => {
+                assert!(
+                    waited < MAX_WAITING_BLOCKS,
+                    "no preparation came due within {MAX_WAITING_BLOCKS} blocks",
+                );
+                waited += 1;
+                run.mine_empty_block();
+            }
+            other => panic!("a healthy migration never needs {other:?} before its preparations"),
+        }
+    };
+    assert!(
+        matches!(kind, MigrationTxKind::Preparation { .. }),
+        "premise: the first provable transaction is a preparation, not a crossing",
+    );
+    assert_eq!(
+        run.perform_prove(&mut committed.state, prep_id, kind),
+        ProveStepOutcome::Proved,
+    );
+
+    let txid = committed
+        .state
+        .transactions()
+        .iter()
+        .find(|t| t.id() == prep_id)
+        .expect("the preparation is present")
+        .txid();
+    let stored_classification = |run: &mut Run| -> (i64, Option<i64>) {
+        run.st
+            .wallet_mut()
+            .conn_mut()
+            .query_row(
+                "SELECT zip318_kind, mined_height FROM transactions WHERE txid = :txid",
+                rusqlite::named_params![":txid": txid.as_ref()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("reads the stored transaction's classification")
+    };
+    let expected = zcash_protocol::zip318::Zip318Classification::Conforms(
+        zcash_protocol::zip318::Zip318TxKind::Preparation,
+    )
+    .to_code();
+
+    // Proving alone leaves no wallet-side record to classify: the migration store's half is all
+    // that is written, and the transaction enters the wallet's view at the broadcast seam.
+    assert!(
+        run.st
+            .wallet()
+            .get_transaction(txid)
+            .expect("queries the wallet")
+            .is_none(),
+        "premise: proving leaves no record in the wallet's transaction tables",
+    );
+
+    // Taking the transaction for broadcast is the write under test, and it is called here rather
+    // than through `perform_broadcast` so that the record can be observed in the window the seam
+    // opens: recorded, but not yet submitted and so still UNMINED.
+    let tx = run
+        .store()
+        .take_transaction_for_broadcast(&committed.state, prep_id)
+        .expect("finalizes and records the broadcastable preparation");
+
+    let (zip318_kind, mined_height) = stored_classification(&mut run);
+    assert_eq!(
+        mined_height, None,
+        "premise: the preparation is still unmined when the classification must already be present",
+    );
+    assert_eq!(
+        zip318_kind, expected,
+        "the recorded preparation is classified as a ZIP 318 preparation before it mines",
+    );
+
+    // Submitting mines and scans the transaction, so the wallet now re-learns it the way it learns
+    // about any transaction: through `put_tx_data` and the enhance path. This is the tail of
+    // `perform_broadcast`, the transaction having already been taken above.
+    let (height, _) = run.st.generate_next_block_from_tx(1, &tx);
+    run.st.scan_cached_blocks(height, 1);
+    committed.state.mark_broadcast(prep_id);
+    committed.state.mark_mined(prep_id, height);
+    run.persist(&committed.state);
+
+    let (zip318_kind, mined_height) = stored_classification(&mut run);
+    assert!(
+        mined_height.is_some(),
+        "premise: the preparation is mined once it has been broadcast and scanned",
+    );
+    assert_eq!(
+        zip318_kind, expected,
+        "mining and rescanning the preparation leaves its recorded classification intact",
+    );
+}
+
 /// The adapter reports the WALLET's anchor retention interval as its anchor bucket interval, and
 /// every anchor a committed migration draws lands on that grid.
 ///

--- a/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
+++ b/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
@@ -1304,6 +1304,35 @@ fn broadcast_persists_the_finalized_transaction_to_the_wallet() {
         "the recorded outputs account for the funding note minus the fee",
     );
 
+    // RE-ENTRY: a consumer that crashed between obtaining the bytes and submitting them left the
+    // transaction `Proved`, so the drive loop offers its broadcast again and it arrives back
+    // here. The same bytes come out, and the record it left is neither duplicated nor disturbed.
+    let sent_note_count = |run: &mut Run| -> i64 {
+        run.st
+            .wallet_mut()
+            .conn_mut()
+            .query_row(
+                "SELECT COUNT(*)
+                 FROM sent_notes
+                 JOIN transactions ON transactions.id_tx = sent_notes.transaction_id
+                 WHERE transactions.txid = :txid",
+                rusqlite::named_params![":txid": txid.as_ref()],
+                |row| row.get(0),
+            )
+            .expect("counts the recorded sent outputs")
+    };
+    let recorded_outputs = sent_note_count(&mut run);
+    let re_extracted = run
+        .store()
+        .take_transaction_for_broadcast(&committed.state, transfer_id)
+        .expect("re-entering after a crashed submission returns the transaction again");
+    assert_eq!(re_extracted.txid(), txid);
+    assert_eq!(
+        sent_note_count(&mut run),
+        recorded_outputs,
+        "re-entering records no second copy of the transaction's outputs",
+    );
+
     // The funding note is now marked spent, so the wallet's own input selection no longer offers
     // it: the double-spend window between proving and broadcast is closed.
     assert!(


### PR DESCRIPTION
Follow-up to the review nit on #2909 ([r3713310394](https://github.com/zcash/librustzcash/pull/2909#discussion_r3713310394)): the same test, for preparation transactions. Writing it surfaced a second thing, so the PR now carries both.

## The preparation branch of the ZIP 318 classifier

A preparation takes the OTHER branch of the classifier. It carries no destination-pool action, so `classify` routes it to `classify_preparation` (a padded Orchard-only send-to-self) rather than `classify_crossing` (the canonical two-action bundle carrying a canonical denomination). Nothing in the transfer's case would notice that branch answering wrongly, including the realistic case where a built preparation's action count has drifted from `preparation_tx_actions()` and it silently classifies as `Nonconforming`.

Since this PR was opened, #2799 moved the wallet-side record — and with it the ZIP 318 stamp — off the prove seam: `store_proved_transaction` now records the proof in the migration store alone, and `take_transaction_for_broadcast` writes the wallet record. The test follows it there. It calls that seam directly rather than going through the simulation's broadcast helper, so the record is still observed in the window the seam opens: recorded, not yet submitted, and so still unmined. It also asserts that proving leaves no wallet-side record at all, which is what makes that window the classification's earliest observable moment. Renamed to `broadcast_persists_a_preparations_zip318_classification`, after its sibling.

The test also asserts the classification survives the transaction being mined and scanned. That is not a restatement of the first assertion: the classification lives in a column that a plain `UPDATE` writes and that `put_tx_data`'s `ON CONFLICT DO UPDATE` does not mention, and scanning re-upserts that same row.

## `store_transactions_to_be_sent` was not idempotent

`take_transaction_for_broadcast` documents itself as idempotent, and its durability argument requires it to be. A consumer that obtains broadcastable bytes and dies before submitting them leaves the transaction `Proved`, so the drive loop offers its broadcast again — and the second call failed on `UNIQUE constraint failed: sent_notes.…`. Nothing clears that, so the migration wedges: the only way to obtain the bytes is the call that now always errors.

Every write `store_transaction_to_be_sent` makes already upserted or ignored its conflict — `put_tx_data`, `mark_note_spent`'s `ON CONFLICT DO NOTHING`, `unlock_spent_notes` — except the sent outputs, which were inserted strictly. `insert_sent_output` now delegates to `put_sent_output`, whose upsert it otherwise duplicated verbatim, so this removes SQL rather than adding any. `WalletWrite::store_transactions_to_be_sent` states the obligation, so a caller can rely on it across implementations rather than on one backend's incidental behaviour.

## Verification

Both halves were checked by mutation rather than assumed.

Removing the `put_zip318_classification` call from `take_transaction_for_broadcast`: both classification tests fail at their recorded-but-unmined assertion — preparation `left: 0, right: 2`, transfer `left: 0, right: 3`.

Reverting `insert_sent_output` to its strict insert: the new re-entry assertion fails with `UNIQUE constraint failed: sent_notes.transaction_id, sent_notes.output_pool, sent_notes.output_index`.

Nothing in this simulation runs the enhance path, so the broadcast seam's write is the only thing that ever classifies these transactions here — which is why it must classify at all. The test's doc comment says that explicitly rather than claiming to cover the enhance path's later re-stamp, which `store_decrypted_tx`'s own tests pin.

The full `zcash_client_sqlite` suite plus the simulation's expensive tests are green at each commit, via `git rebase --exec`:

```
running 10 tests
test a_send_max_sweep_marks_the_migration_and_forces_a_replan ... ok
test a_rejected_broadcast_is_withheld_until_the_wallet_can_adjudicate_it ... ok
test broadcast_persists_a_preparations_zip318_classification ... ok
test a_settled_reorg_below_a_broadcast_crossings_anchor_marks_it ... ok
test cancel_returns_the_balance_and_retains_the_record ... ok
test broadcast_persists_the_finalized_transaction_to_the_wallet ... ok
test migration_anchors_to_the_wallets_configured_retention_grid ... ok
test proving_locks_the_spent_notes_without_taking_them_from_the_user ... ok
test proving_refuses_to_take_a_note_another_flow_has_reserved ... ok
test migration_proves_end_to_end_against_a_funded_wallet ... ok

test result: ok. 10 passed; 0 failed
```

Two `zip317_spend` failures seen along the way are pre-existing and unrelated: they are `#[ignore]`d with `// FIXME: #1316 This requires support for dust outputs.` and fail on a clean tree too.

## Changelog

No longer test-only, so no longer changelog-free. `### Changed` entries in both `zcash_client_backend` (implementations must now upsert) and `zcash_client_sqlite` (this one does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
