### PR TITLE
zcash_pool_migration: add a Cancelled status; stop retaining anchors for terminal migrations

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -10,6 +10,14 @@ workspace.
 
 ## [Unreleased]
 
+### Fixed
+- Anchor-checkpoint retention is no longer owed to a migration that has reached
+  any terminal status. The grids of `failed`, `superseded`, and `cancelled`
+  migrations were retained for the lifetime of the wallet, because retention
+  excluded only `complete` migrations; nothing will drive a terminal migration
+  further, so those checkpoints were kept for proofs that will never be
+  requested and, the migration being terminal, were never revisited.
+
 ### Changed
 - The `orchard` feature is now enabled by default. Consumers that require a
   smaller feature set should disable default features and enable only the

--- a/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
+++ b/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
@@ -2104,6 +2104,7 @@ mod tests {
     use crate::AccountUuid;
     use crate::util::SystemClock;
 
+    use core::num::NonZeroU32;
     use std::collections::BTreeSet;
     use zcash_client_backend::data_api::testing::TestBuilder;
     use zcash_client_backend::wallet::LockOwner;
@@ -2156,6 +2157,95 @@ mod tests {
     #[test]
     fn get_migration_empty_is_none() {
         assert_empty_is_none(&fresh_store());
+    }
+
+    /// A migration in `status`, recorded under `interval`. The plan itself is empty filler: the
+    /// test using this is about which grids a status still owes retention to, and nothing else.
+    fn migration_under(status: MigrationStatus, interval: AnchorBucketInterval) -> MigrationState {
+        MigrationState::from_parts(
+            status,
+            DenominationPlan::from_stored_parts(
+                Vec::new(),
+                Zatoshis::ZERO,
+                None,
+                Zatoshis::ZERO,
+                Zatoshis::ZERO,
+                Zatoshis::ZERO,
+            )
+            .expect("an empty stored plan reconstructs"),
+            PreparationPlan::from_parts(Vec::new(), Vec::new()),
+            Vec::new(),
+            interval,
+            ReplanThreshold::DEFAULT,
+        )
+    }
+
+    /// Anchor-checkpoint retention is owed by every NON-TERMINAL migration, and by no terminal one
+    /// — not merely by every migration that is not `complete`.
+    ///
+    /// The distinction is the point: `complete` is the only terminal status a migration reaches by
+    /// finishing its work, so a query written against it alone lets a `failed`, `superseded`, or
+    /// `cancelled` migration pin its grid for the lifetime of the wallet. Nothing will ever drive
+    /// those migrations again, so the checkpoints are kept for proofs that will never be requested,
+    /// and being terminal they are never revisited to notice.
+    ///
+    /// One account per status, each under its own grid, so the surviving intervals name exactly
+    /// which statuses still owe retention.
+    #[test]
+    fn anchor_retention_is_owed_by_every_non_terminal_status() {
+        /// Grid width recorded for the first status; each subsequent one takes the next block
+        /// count, so an interval identifies the status that was recorded under it.
+        const FIRST_GRID_BLOCKS: u32 = 10;
+
+        let mut conn = fresh_conn();
+        let mut expected: BTreeSet<u32> = BTreeSet::new();
+
+        for (i, status) in MigrationStatus::ALL.iter().copied().enumerate() {
+            let blocks = FIRST_GRID_BLOCKS + u32::try_from(i).expect("a handful of statuses");
+            let interval =
+                AnchorBucketInterval::custom(NonZeroU32::new(blocks).expect("nonzero grid"));
+            let account = insert_account(&conn);
+            let mut store = PoolMigrations::for_account(NET, SystemClock, conn, account)
+                .expect("the account exists");
+            store
+                .replace_migration(&migration_under(status, interval))
+                .expect("persists the migration");
+            conn = store.into_inner();
+
+            if !status.is_terminal() {
+                expected.insert(blocks);
+            }
+        }
+
+        let active: BTreeSet<u32> = super::active_anchor_bucket_intervals(&conn)
+            .expect("reads the active grids")
+            .into_iter()
+            .map(|interval| interval.block_count().get())
+            .collect();
+
+        assert_eq!(
+            active, expected,
+            "exactly the non-terminal migrations' grids are still retained"
+        );
+
+        // Spelled out for the three statuses the previous `status <> 'complete'` query retained
+        // forever, since that is the regression this pins.
+        for status in [
+            MigrationStatus::Failed,
+            MigrationStatus::Superseded,
+            MigrationStatus::Cancelled,
+        ] {
+            let position = MigrationStatus::ALL
+                .iter()
+                .position(|s| *s == status)
+                .expect("every status is in ALL");
+            let blocks =
+                FIRST_GRID_BLOCKS + u32::try_from(position).expect("a handful of statuses");
+            assert!(
+                !active.contains(&blocks),
+                "{status:?} must not pin its {blocks}-block grid",
+            );
+        }
     }
 
     /// A transaction's `lock_owner` round-trips exactly through the store's `BLOB` column: a

--- a/zcash_client_sqlite/src/pool_migration/store.rs
+++ b/zcash_client_sqlite/src/pool_migration/store.rs
@@ -508,8 +508,8 @@ fn resolve_migration_id(
         .optional()?)
 }
 
-/// The distinct anchor bucket intervals, in blocks, of every migration in `t.migrations` that is
-/// not yet complete — the grids the wallet still owes anchor-checkpoint retention to.
+/// The distinct anchor bucket intervals, in blocks, of every migration in `t.migrations` that has
+/// not reached a terminal status — the grids the wallet still owes anchor-checkpoint retention to.
 ///
 /// This is read from the database rather than from any in-memory configuration on purpose. A
 /// migration's transfers are anchored to boundaries of the grid it was COMMITTED under, and are
@@ -518,18 +518,29 @@ fn resolve_migration_id(
 /// a boundary the migration still needs without retaining it — unrecoverably, since the checkpoint
 /// is gone by the time anything notices.
 ///
-/// A `complete` migration has no transfer left to prove, so its grid is dropped.
+/// A TERMINAL migration has no transfer left to prove, so its grid is dropped. For `complete` that
+/// is because every transfer mined; for the policy determinations (`failed`, `superseded`,
+/// `cancelled`) it is because nothing will drive the migration further, so retaining checkpoints
+/// for proofs that will never be requested costs storage to no purpose — and, since a terminal
+/// migration is never revisited, costs it forever.
+///
+/// The excluded set is [`MigrationStatus::terminal`], not a list of literals written out here: a
+/// second list is a second place for a new status to be forgotten, and forgetting it here fails
+/// silently, as unbounded retention rather than as an error.
 pub(crate) fn active_anchor_bucket_intervals(
     conn: &Connection,
     t: &Tables,
 ) -> Result<BTreeSet<NonZeroU32>, Error> {
+    let terminal: Vec<MigrationStatus> = MigrationStatus::terminal().collect();
+    let placeholders = vec!["?"; terminal.len()].join(", ");
     let mut stmt = conn.prepare(&format!(
-        "SELECT DISTINCT anchor_bucket_interval FROM {} WHERE status <> ?",
+        "SELECT DISTINCT anchor_bucket_interval FROM {} WHERE status NOT IN ({placeholders})",
         t.migrations
     ))?;
-    let rows = stmt.query_map(params![MigrationStatus::Complete.as_ref()], |row| {
-        row.get::<_, u32>(0)
-    })?;
+    let rows = stmt.query_map(
+        rusqlite::params_from_iter(terminal.iter().map(AsRef::<str>::as_ref)),
+        |row| row.get::<_, u32>(0),
+    )?;
     rows.map(|blocks| NonZeroU32::new(blocks?).ok_or(Error::Corrupt("anchor_bucket_interval")))
         .collect()
 }

--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -8,6 +8,13 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+- `state::MigrationState::mark_cancelled`, which moves a non-terminal migration
+  to that status. A no-op on an already-terminal migration, so terminality is
+  never overwritten. This is a status change only: it does not release any hold
+  the migration's transactions have on the wallet's notes.
+- `engine::MigrationStatus::ALL`, `engine::MigrationStatus::is_terminal`, and
+  `engine::MigrationStatus::terminal`, so that a store can express terminality
+  as a query without restating which statuses are terminal.
 - `satisfiability::overdue_shift_tolerance`: how many blocks a step may lag the
   served target before `satisfiability::advance_migration` re-spreads the
   remaining broadcast schedule, as a function of the schedule's transfer delay
@@ -17,6 +24,9 @@ and this library adheres to Rust's notion of
   replaced.
 
 ### Changed
+- `engine::MigrationStatus` has added variant `Cancelled`: a terminal status
+  recording that the user abandoned the migration, distinct from `Failed` so
+  that a deliberate abandonment is distinguishable from a migration that broke. 
 - `satisfiability::advance_migration` now re-spreads a missed broadcast
   schedule: when the `Prove` or `Broadcast` step it would surface is more than
   `satisfiability::overdue_shift_tolerance` blocks past its scheduled height at

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -597,6 +597,60 @@ pub enum MigrationStatus {
     /// remaining value must be carried by a new plan. Like `Failed`, a POLICY determination —
     /// never revisited by chain state.
     Superseded,
+    /// Abandoned at the user's request: terminal, set by [`MigrationState::mark_cancelled`] as the
+    /// consumer's response to a migration the user has chosen not to carry out. Like `Failed` and
+    /// `Superseded`, a POLICY determination — never revisited by chain state, unlike the
+    /// chain-derived `Complete`.
+    ///
+    /// Distinct from `Failed` on purpose: the two record different histories, and only this one
+    /// says the wallet was working as intended. Collapsing them would leave nothing able to tell a
+    /// deliberate abandonment from a migration that broke.
+    Cancelled,
+}
+
+impl MigrationStatus {
+    /// Every status, in lifecycle order. The enumeration a caller needs in order to talk about the
+    /// status SET rather than one status: a store expressing terminality as a query
+    /// (`WHERE status NOT IN (..)`) derives its list from here through [`is_terminal`], so the
+    /// database's notion of terminal cannot drift from this crate's.
+    ///
+    /// [`is_terminal`]: Self::is_terminal
+    pub const ALL: &'static [MigrationStatus] = &[
+        MigrationStatus::Planning,
+        MigrationStatus::Committed,
+        MigrationStatus::InProgress,
+        MigrationStatus::Complete,
+        MigrationStatus::Failed,
+        MigrationStatus::Superseded,
+        MigrationStatus::Cancelled,
+    ];
+
+    /// Whether this status is TERMINAL: the migration has finished, one way or another, and a new
+    /// migration may replace it. A non-terminal migration is still in progress.
+    ///
+    /// Written as an exhaustive match rather than a set lookup so that adding a status fails to
+    /// compile until its terminality is decided here. That decision is load-bearing well beyond
+    /// this function: it is what the commit guard admits a replacement on, and what a store
+    /// excludes from anchor-checkpoint retention.
+    pub fn is_terminal(self) -> bool {
+        match self {
+            MigrationStatus::Planning
+            | MigrationStatus::Committed
+            | MigrationStatus::InProgress => false,
+            MigrationStatus::Complete
+            | MigrationStatus::Failed
+            | MigrationStatus::Superseded
+            | MigrationStatus::Cancelled => true,
+        }
+    }
+
+    /// The terminal statuses, for a caller that must name the whole set at once — a store
+    /// restricting a query to migrations that are still live, for instance. Derived from
+    /// [`is_terminal`](Self::is_terminal) over [`ALL`](Self::ALL) rather than listed again, so
+    /// there is one place where terminality is decided.
+    pub fn terminal() -> impl Iterator<Item = MigrationStatus> {
+        Self::ALL.iter().copied().filter(|s| s.is_terminal())
+    }
 }
 
 impl AsRef<str> for MigrationStatus {
@@ -611,6 +665,7 @@ impl AsRef<str> for MigrationStatus {
             MigrationStatus::Complete => "complete",
             MigrationStatus::Failed => "failed",
             MigrationStatus::Superseded => "superseded",
+            MigrationStatus::Cancelled => "cancelled",
         }
     }
 }
@@ -637,6 +692,7 @@ impl TryFrom<&str> for MigrationStatus {
             "complete" => MigrationStatus::Complete,
             "failed" => MigrationStatus::Failed,
             "superseded" => MigrationStatus::Superseded,
+            "cancelled" => MigrationStatus::Cancelled,
             _ => return Err(ParseMigrationStatusError),
         })
     }
@@ -3466,19 +3522,65 @@ mod tests {
         assert_eq!(MigrationStatus::Complete.as_ref(), "complete");
         assert_eq!(MigrationStatus::Failed.as_ref(), "failed");
         assert_eq!(MigrationStatus::Superseded.as_ref(), "superseded");
+        assert_eq!(MigrationStatus::Cancelled.as_ref(), "cancelled");
 
-        for status in [
-            MigrationStatus::Planning,
-            MigrationStatus::Committed,
-            MigrationStatus::InProgress,
-            MigrationStatus::Complete,
-            MigrationStatus::Failed,
-            MigrationStatus::Superseded,
-        ] {
+        for status in MigrationStatus::ALL.iter().copied() {
             assert_eq!(MigrationStatus::try_from(status.as_ref()), Ok(status));
         }
 
         assert!(MigrationStatus::try_from("not_a_status").is_err());
+    }
+
+    /// [`MigrationStatus::ALL`] really lists every variant, in the positions the exhaustive match
+    /// below assigns. This matters beyond tidiness: a store derives the set of terminal statuses by
+    /// filtering `ALL`, so a variant missing from it would be treated as non-terminal by every
+    /// query built that way, however carefully [`MigrationStatus::is_terminal`] was written.
+    ///
+    /// The match is exhaustive, so adding a variant fails to compile here until it is given a
+    /// position, and the assertions then check `ALL` agrees.
+    #[test]
+    fn migration_status_all_lists_every_variant() {
+        fn position(status: MigrationStatus) -> usize {
+            match status {
+                MigrationStatus::Planning => 0,
+                MigrationStatus::Committed => 1,
+                MigrationStatus::InProgress => 2,
+                MigrationStatus::Complete => 3,
+                MigrationStatus::Failed => 4,
+                MigrationStatus::Superseded => 5,
+                MigrationStatus::Cancelled => 6,
+            }
+        }
+        // Every entry sits where the match says it does. A variant omitted from `ALL` shifts each
+        // later entry off its position, so this catches the omission rather than the count alone.
+        for (i, status) in MigrationStatus::ALL.iter().copied().enumerate() {
+            assert_eq!(position(status), i, "{status:?} is out of place in ALL");
+        }
+        // And nothing is missing from the END, where a shift would leave the survivors in place.
+        assert_eq!(
+            MigrationStatus::ALL.len(),
+            position(MigrationStatus::Cancelled) + 1
+        );
+    }
+
+    /// The terminal set is exactly the four finished statuses, and `terminal()` agrees with
+    /// `is_terminal` (it is derived from it, so this pins the DERIVATION, and with it the set a
+    /// store excludes from anchor-checkpoint retention).
+    #[test]
+    fn migration_status_terminal_set_is_the_finished_statuses() {
+        let terminal: Vec<MigrationStatus> = MigrationStatus::terminal().collect();
+        assert_eq!(
+            terminal,
+            vec![
+                MigrationStatus::Complete,
+                MigrationStatus::Failed,
+                MigrationStatus::Superseded,
+                MigrationStatus::Cancelled,
+            ]
+        );
+        for status in MigrationStatus::ALL.iter().copied() {
+            assert_eq!(status.is_terminal(), terminal.contains(&status));
+        }
     }
 
     /// Every `UnsatisfiableKind` variant's wire name is pinned to its literal string, and

--- a/zcash_pool_migration/src/state.rs
+++ b/zcash_pool_migration/src/state.rs
@@ -680,14 +680,13 @@ impl MigrationState {
             > u128::from(self.replan_threshold.percent()) * u128::from(total)
     }
 
-    /// Whether this migration has reached a terminal status (`Complete`, `Failed`, or
-    /// `Superseded`), so a new migration may replace it. A non-terminal migration is still in
-    /// progress and must not be overwritten.
+    /// Whether this migration has reached a terminal status, so a new migration may replace it. A
+    /// non-terminal migration is still in progress and must not be overwritten.
+    ///
+    /// Delegates to [`MigrationStatus::is_terminal`], which is where terminality is decided; a
+    /// second list here could disagree with the one a store queries on.
     pub fn is_terminal(&self) -> bool {
-        matches!(
-            self.status,
-            MigrationStatus::Complete | MigrationStatus::Failed | MigrationStatus::Superseded
-        )
+        self.status.is_terminal()
     }
 
     /// Moves a non-terminal migration to [`MigrationStatus::Superseded`], the consumer's response
@@ -697,6 +696,22 @@ impl MigrationState {
     pub fn mark_superseded(&mut self) {
         if !self.is_terminal() {
             self.status = MigrationStatus::Superseded;
+        }
+    }
+
+    /// Moves a non-terminal migration to [`MigrationStatus::Cancelled`], the consumer's response to
+    /// a user who has chosen to abandon the migration: after this, the commit guard accepts a
+    /// replacement migration. A no-op on an already-terminal migration — terminality is never
+    /// overwritten by policy, so whichever terminal status got there first remains the truthful
+    /// history.
+    ///
+    /// Cancelling is a STATUS change and nothing more. It does not release any hold the migration's
+    /// transactions have on the wallet's notes, so a consumer that has proved transactions is not
+    /// done after calling this; see the pool-migration cancel flow for what else a wallet-backed
+    /// store must do.
+    pub fn mark_cancelled(&mut self) {
+        if !self.is_terminal() {
+            self.status = MigrationStatus::Cancelled;
         }
     }
 
@@ -2213,6 +2228,63 @@ mod tests {
         failed.status = MigrationStatus::Failed;
         failed.mark_superseded();
         assert_eq!(failed.status, MigrationStatus::Failed);
+    }
+
+    /// `mark_cancelled` is a closure operator on the status order: idempotent, landing in the
+    /// terminal set, and fixing every status already in it. The three assertions below are those
+    /// three laws in order.
+    #[test]
+    fn mark_cancelled_is_terminal_and_policy_stable() {
+        // LANDS IN THE TERMINAL SET.
+        let mut s = state_with(vec![tx(0, transfer(0), MigrationTxState::Signed)]);
+        s.mark_cancelled();
+        assert_eq!(s.status, MigrationStatus::Cancelled);
+        assert!(s.is_terminal());
+
+        // IDEMPOTENT, and a recompute does not resurrect it either.
+        s.mark_cancelled();
+        s.recompute_status();
+        assert_eq!(s.status, MigrationStatus::Cancelled);
+
+        // TERMINALITY-PRESERVING: a completed migration is not cancelled over. Its transfers are
+        // mined, so saying otherwise would deny work the chain has already accepted.
+        let mut done = state_with(vec![tx(0, transfer(0), mined(10))]);
+        done.recompute_status();
+        assert_eq!(done.status, MigrationStatus::Complete);
+        done.mark_cancelled();
+        assert_eq!(done.status, MigrationStatus::Complete);
+
+        // Nor a failed one: the post-mortem is the truthful history, and rewriting it to look like
+        // a deliberate user action would lose exactly the distinction `Cancelled` exists to draw.
+        let mut failed = state_with(vec![tx(0, transfer(0), MigrationTxState::Signed)]);
+        failed.status = MigrationStatus::Failed;
+        failed.mark_cancelled();
+        assert_eq!(failed.status, MigrationStatus::Failed);
+
+        // Nor a superseded one, symmetrically; and cancelling is not superseded over in turn.
+        let mut superseded = state_with(vec![tx(0, transfer(0), MigrationTxState::Signed)]);
+        superseded.mark_superseded();
+        superseded.mark_cancelled();
+        assert_eq!(superseded.status, MigrationStatus::Superseded);
+        let mut cancelled = state_with(vec![tx(0, transfer(0), MigrationTxState::Signed)]);
+        cancelled.mark_cancelled();
+        cancelled.mark_superseded();
+        assert_eq!(cancelled.status, MigrationStatus::Cancelled);
+    }
+
+    /// A cancelled migration whose transactions were already broadcast is not resurrected to
+    /// `InProgress` by a status recompute, and detecting one of them mined does not resurrect it
+    /// either. This is the case `recompute_status`'s terminal guard exists for, and it is
+    /// reachable for `Cancelled` in a way it is not for `Superseded`: the user cancels precisely
+    /// when transactions are already in flight.
+    #[test]
+    fn cancelled_survives_broadcast_and_mining() {
+        let mut s = state_with(vec![tx(0, transfer(0), MigrationTxState::Signed)]);
+        s.mark_cancelled();
+        s.mark_broadcast(MigrationTransferId(0));
+        assert_eq!(s.status, MigrationStatus::Cancelled);
+        s.mark_mined(MigrationTransferId(0), BlockHeight::from_u32(10));
+        assert_eq!(s.status, MigrationStatus::Cancelled);
     }
 
     #[test]

--- a/zcash_pool_migration/src/testing/strategies.rs
+++ b/zcash_pool_migration/src/testing/strategies.rs
@@ -162,6 +162,7 @@ pub fn arb_migration_status() -> impl Strategy<Value = MigrationStatus> {
         Just(MigrationStatus::Complete),
         Just(MigrationStatus::Failed),
         Just(MigrationStatus::Superseded),
+        Just(MigrationStatus::Cancelled),
     ]
 }
 


### PR DESCRIPTION
First of three stacked patches toward issue #2903, which asks for a way to
RESET a proposed migration so a stuck user can start over, and so a Keystone
plan whose pre-signing went stale overnight can be re-shown.

We are building a CANCEL rather than a reset: the migration record stays and
moves to a terminal status. The stuck state is the artifact support needs in
order to answer "how did this user get here", and some of what a wipe would
erase is not ours to erase, since a broadcast or mined transaction happened
whether or not we forget it. The commit guard already accepts a replacement
migration as soon as the outstanding one `is_terminal()`, so terminality, not
deletion, is what a caller needs in order to re-plan.

This patch carries only the parts that stand on their own. The later two add
retaining more than one migration per account (at most one non-terminal), and
cancel itself.

## MigrationStatus::Cancelled

Distinct from `Failed` on purpose. Support needs to tell a deliberate
abandonment from a migration that broke, and reusing `Failed` for both
discards exactly the provenance the status exists to keep. The `status`
column is free-form `TEXT` with no CHECK constraint, so no schema migration
is required.

Worth knowing for anyone consuming this: the Swift SDK's pool-migration FFI
already hand-rolls this cancel, persisting the run as `Failed` and saying so
in its own docs. `Cancelled` gives it the distinction and frees `Failed` to
mean an actual failure.

## Terminality moves onto the status

`ALL`, `is_terminal`, and `terminal` now live on `MigrationStatus`.
`MigrationState::is_terminal` decided this until now, which left a store with
no way to ask the question except by writing its own list of literals, and
the anchor-retention query below needs exactly that set.

The completeness of `ALL` gets its own test. An exhaustive match forces a
DECISION about a new variant in `is_terminal`, but nothing forces that
variant into `ALL`, and a terminal set derived by filtering `ALL` would then
treat the missing variant as non-terminal however carefully `is_terminal` was
written. The test maps each variant to a position with an exhaustive match,
so a new variant fails to compile until it is placed, then checks `ALL`
agrees in both order and length.

## MigrationState::mark_cancelled

Mirrors `mark_superseded`: a no-op on an already-terminal migration, so a
recorded `Complete` or a `Failed` post-mortem is never overwritten. The
properties the tests pin are the ones that make it a closure operator on the
status order: idempotent, lands in the terminal set, fixes everything already
in it.

It is a status change only. It does not release any hold the migration's
transactions have on the wallet's notes; that belongs to the store and comes
in a later patch.

## Anchor retention for terminal migrations (a pre-existing bug)

Retention excluded only `complete` migrations, so the grids of `failed` and
`superseded` ones were retained for the lifetime of the wallet: checkpoints
kept alive for proofs that will never be requested, and never revisited
because the migration is terminal. Independent of the rest of this PR, and
the reason this patch is worth landing on its own.

The excluded set is now `MigrationStatus::terminal` rather than literals in
the SQL. A second list is a second place for a new status to be forgotten,
and forgetting it there fails silently, as unbounded retention rather than as
an error.

## Testing

- `zcash_pool_migration --all-features`: 243 lib + 17 integration pass.
- `zcash_client_sqlite --all-features`: 540 pass, 0 fail, 6 ignored.
- `cargo fmt --check` and `cargo clippy --all-features --all-targets -D warnings`
  clean.

## Note for downstream consumers

Adding a variant is a silent behaviour change for any match on
`MigrationStatus` with a catch-all arm. The Swift SDK's `derive_state` has
one, so a `Cancelled` run would be derived there as in-progress, and its
compiler will not flag it. `Superseded` already falls into that arm today, so
the gap predates this change, but this is the moment it starts to matter.

Nothing in this workspace matches the enum with a catch-all; the only two
exhaustive matches, `AsRef<str>` and `TryFrom<&str>`, are updated here.

Generated with [Claude Code](https://claude.com/claude-code)
