### PR TITLE
zcash_client_sqlite: report a ZIP 318 classification write that names no transaction

### DIFF
--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -5163,18 +5163,29 @@ pub(crate) fn put_tx_data(
 /// reports as unclassified rather than as a decision that the transaction is not a migration
 /// transaction. Rows written before this column existed keep that default, and need the
 /// transaction rescanned before they can be labelled.
+///
+/// `tx_ref` must name an existing row. An `UPDATE` matching nothing is not a SQLite error, so
+/// without the row-count check below this would report success having written nothing, and the
+/// transaction would afterwards read as never classified — indistinguishable from one that was
+/// never a candidate, which is the distinction the "not classified" code exists to preserve.
 pub(crate) fn put_zip318_classification(
     conn: &rusqlite::Connection,
     tx_ref: TxRef,
     classification: zcash_protocol::zip318::Zip318Classification,
 ) -> Result<(), SqliteClientError> {
-    conn.execute(
+    let rows_affected = conn.execute(
         "UPDATE transactions SET zip318_kind = :zip318_kind WHERE id_tx = :id_tx",
         named_params![
             ":zip318_kind": classification.to_code(),
             ":id_tx": tx_ref.0,
         ],
     )?;
+    if rows_affected != 1 {
+        return Err(SqliteClientError::CorruptedData(format!(
+            "ZIP 318 classification names transaction {}, which does not exist",
+            tx_ref.0,
+        )));
+    }
 
     Ok(())
 }
@@ -5939,6 +5950,7 @@ mod tests {
         TxId,
         consensus::{BlockHeight, NetworkUpgrade, Parameters},
         value::Zatoshis,
+        zip318::{Zip318Classification, Zip318TxKind},
     };
 
     use crate::{
@@ -5949,8 +5961,8 @@ mod tests {
 
     use super::{
         KeyScope, ShieldedPool, TxQueryType, TxRef, account_birthday,
-        flag_previously_received_change, min_shared_checkpoint_height, queue_tx_retrieval,
-        select_truncation_height,
+        flag_previously_received_change, min_shared_checkpoint_height, put_zip318_classification,
+        queue_tx_retrieval, select_truncation_height,
     };
 
     use incrementalmerkletree::frontier::Frontier;
@@ -7502,6 +7514,92 @@ mod tests {
         assert!(
             !is_change(&tx, pool),
             "an external-scope note must not be reclassified as change"
+        );
+    }
+
+    /// A ZIP 318 classification write must name a transaction that exists.
+    ///
+    /// `UPDATE ... WHERE id_tx = ?` matching no row is not a SQLite error, so without an explicit
+    /// row-count check this reports success having written nothing. That failure is invisible
+    /// afterwards: the transaction reads as the "not classified" default, which is exactly the
+    /// value a transaction nothing ever looked at reads as. The whole point of that code being a
+    /// real value rather than NULL is to keep "we never looked" distinct from "we looked and it is
+    /// not a migration transaction", and a silently dropped write collapses the two.
+    #[test]
+    fn put_zip318_classification_rejects_an_unknown_transaction() {
+        // Placeholders for columns this never reads; they exist to satisfy the table's NOT NULL
+        // constraints, so any well-formed value will do.
+        const TXID: [u8; 32] = [7; 32];
+        const OBSERVED_HEIGHT: i64 = 0;
+
+        const PRESENT: i64 = 1;
+        /// A row id no transaction has, standing in for a `TxRef` that has outlived its row.
+        const ABSENT: i64 = 404;
+
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+        let conn = st.wallet_mut().conn_mut();
+        conn.execute(
+            "INSERT INTO transactions (id_tx, txid, min_observed_height)
+             VALUES (:id_tx, :txid, :min_observed_height)",
+            named_params! {
+                ":id_tx": PRESENT,
+                ":txid": &TXID[..],
+                ":min_observed_height": OBSERVED_HEIGHT,
+            },
+        )
+        .unwrap();
+
+        let classification = Zip318Classification::Conforms(Zip318TxKind::Transfer);
+
+        // Control: naming a row that exists writes it, so the rejection below is about the missing
+        // row and not about the write path being broken outright.
+        put_zip318_classification(conn, TxRef(PRESENT), classification).unwrap();
+        let stored: i64 = conn
+            .query_row(
+                "SELECT zip318_kind FROM transactions WHERE id_tx = :id_tx",
+                named_params! { ":id_tx": PRESENT },
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            stored,
+            classification.to_code(),
+            "naming an existing transaction records the classification",
+        );
+
+        // Re-classifying a transaction that is ALREADY classified must remain allowed, and this is
+        // the case the row-count check is most at risk of breaking. Both writers into this column
+        // legitimately run over the same row: proving classifies a migration transaction when it
+        // stores it, and the enhance path re-derives the same answer once it mines. A check that
+        // counted rows whose value actually changed rather than rows matched would reject that
+        // second, identical write as if it had named a missing transaction.
+        put_zip318_classification(conn, TxRef(PRESENT), classification)
+            .expect("re-writing an unchanged classification is not a missing row");
+
+        // The same holds when the value does change, which is what a re-classification looks like
+        // when the later writer has strictly more evidence than the earlier one.
+        let refined = Zip318Classification::Nonconforming;
+        put_zip318_classification(conn, TxRef(PRESENT), refined)
+            .expect("re-writing a different classification is not a missing row");
+        let stored: i64 = conn
+            .query_row(
+                "SELECT zip318_kind FROM transactions WHERE id_tx = :id_tx",
+                named_params! { ":id_tx": PRESENT },
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            stored,
+            refined.to_code(),
+            "the later classification replaces the earlier one",
+        );
+
+        assert_matches!(
+            put_zip318_classification(conn, TxRef(ABSENT), classification),
+            Err(SqliteClientError::CorruptedData(_))
         );
     }
 }


### PR DESCRIPTION
Closes #2912. Stacked on #2911 (base is `dw/zip318-preparation-store-time-test`); review that one first.

## The problem

`wallet::put_zip318_classification` issued

```sql
UPDATE transactions SET zip318_kind = :zip318_kind WHERE id_tx = :id_tx
```

and discarded the affected-row count. An `UPDATE` matching no row is not a SQLite error, so a call naming a `TxRef` that does not identify a row returned `Ok(())` having written nothing.

The failure is invisible afterwards. The transaction reads as the "not classified" default, which is the same value a transaction nothing ever looked at reads as. Keeping "we never looked" distinct from "we looked and it is not a migration transaction" is exactly why that code is a real value rather than NULL, and a silently dropped write collapses the two.

Not reachable today: both callers (`store_decrypted_tx`, and `finalize_and_store_proved` via the `TxRef` #2909 made `store_transaction_to_be_sent` return) get the `TxRef` from a `put_tx_data` immediately beforehand in the same database transaction. The point is that the signature promised the classification had been recorded and could not distinguish that from there being no such transaction.

## The fix

Check the row count and return `SqliteClientError::CorruptedData`, following the existing idiom a few thousand lines up in the same file (the UIVK upgrade's `rows_affected != 1` guard). No new error variant, so no API change.

## Re-classification is still allowed

Worth being explicit, since it is what this check is most at risk of breaking: the guard counts rows MATCHED, not rows whose value changed. SQLite counts a row matched by the `WHERE` even when the assignment writes an identical value, so re-stamping an already-classified transaction still returns 1 and is accepted.

That matters because two writers legitimately run over the same row: proving classifies a migration transaction as it stores it, and the enhance path re-derives the same answer once it mines. A check written against `changes()`-with-different-value semantics would have rejected that second write as if it had named a missing transaction. The test pins both the identical re-write and the value-changing re-write.

## Test

`put_zip318_classification_rejects_an_unknown_transaction` covers the control (an existing row is written), both re-classification cases, and the rejection.

Full crate suite green: 500 lib tests, 7 `pool_migration_prove_chain_sim`, 3 others.

🤖 Generated with [Claude Code](https://claude.com/claude-code)