### PR TITLE
zcash_client_sqlite: classify transactions the wallet builds as it stores them

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -92,6 +92,21 @@ workspace.
   migration's transfers demotes that record exactly as it always demoted a
   pending migration's state. `failed`, `superseded`, and `cancelled` records
   are policy determinations and are not revisited.
+- The `orchard` feature is now enabled by default. Consumers that require a
+  smaller feature set should disable default features and enable only the
+  features they need.
+- A migration transaction is now classified against ZIP 318 when broadcast stores
+  it, in the same database transaction as the record itself, rather than only
+  once it has mined and been enhanced.
+- `WalletWrite::store_transactions_to_be_sent` now likewise classifies each
+  transaction as it stores it, so a transaction the wallet built is labelled
+  without waiting for it to mine. This covers canonical crossings built through
+  the ordinary proposal flow, not only those the pool-migration engine
+  constructs.
+- Neither change makes the NOT CLASSIFIED default safe to read as a decision.
+  Clients must still render it as "no label yet" rather than as "not a migration
+  transaction": rows written before the column existed keep that default, and
+  need the transaction rescanned before they can be labelled.
 
 ### Fixed
 - Anchor-checkpoint retention is no longer owed to a migration that has reached
@@ -100,11 +115,6 @@ workspace.
   excluded only `complete` migrations; nothing will drive a terminal migration
   further, so those checkpoints were kept for proofs that will never be
   requested and, the migration being terminal, were never revisited.
-
-### Changed
-- The `orchard` feature is now enabled by default. Consumers that require a
-  smaller feature set should disable default features and enable only the
-  features they need.
 
 ## [0.22.0-rc.7] - 2026-08-03
 

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -106,8 +106,12 @@ use wallet::{
 };
 
 #[cfg(feature = "orchard")]
-use zcash_client_backend::data_api::{
-    IRONWOOD_SHARD_HEIGHT, ORCHARD_SHARD_HEIGHT, ll::ReceivedOrchardOutput,
+use zcash_client_backend::{
+    data_api::{
+        IRONWOOD_SHARD_HEIGHT, ORCHARD_SHARD_HEIGHT, ll::ReceivedOrchardOutput,
+        zip318::classify_decrypted_tx,
+    },
+    decrypt_transaction,
 };
 
 #[cfg(feature = "transparent-inputs")]
@@ -2333,14 +2337,65 @@ impl<P: consensus::Parameters, CL: Clock, R: RngCore> WalletWrite
         &mut self,
         transactions: &[SentTransaction<<Self as WalletRead>::AccountId>],
     ) -> Result<(), <Self as WalletRead>::Error> {
+        // Every account's key, not just the sending one, and for the same reason the enhance path
+        // uses every account's: `is_send_to_self` is refuted by an output on an address that is
+        // the wallet's but EXTERNAL to the account. Decrypting under the sender's key alone would
+        // leave a cross-account output undecryptable and therefore uncounted, so a transaction
+        // paying another account of this same wallet could be judged send-to-self here and not
+        // send-to-self once it mined, which is precisely the relabelling the classification's
+        // monotonicity contract forbids.
+        #[cfg(feature = "orchard")]
+        let ufvks = self.get_unified_full_viewing_keys()?;
+        // The wallet's OWN grid, not the specified default. Unlike the enhance path — which cannot
+        // reach it through `LowLevelWalletRead` and documents that it settles for the defaults
+        // because no clause it can answer consults the grid — this site has the store in hand, so
+        // it can simply ask. That keeps it correct by construction rather than by an argument that
+        // would have to be revisited if `PoolMigrationParams` ever gained a second overridable
+        // value.
+        #[cfg(feature = "orchard")]
+        let zip318 = self.pool_migration_params();
+        #[cfg(feature = "orchard")]
+        let chain_tip = chain_tip_height(self.conn.0)?;
+
         for sent_tx in transactions {
-            wallet::store_transaction_to_be_sent(
+            #[cfg_attr(not(feature = "orchard"), allow(unused_variables))]
+            let tx_ref = wallet::store_transaction_to_be_sent(
                 self.conn.0,
                 &self.params,
                 #[cfg(feature = "transparent-inputs")]
                 &self.gap_limits,
                 sent_tx,
             )?;
+
+            // Record how the transaction classifies against ZIP 318 in the same database
+            // transaction as the record itself, so a transaction the wallet BUILT is labelled from
+            // the moment it is stored rather than only once it has mined and been enhanced. The
+            // ordinary send flow can produce a canonical crossing — `propose_transfer` consults
+            // `is_canonical_crossing` when shaping a step — and until now such a transaction sat
+            // in the wallet's own history reading "not classified" despite the wallet having had
+            // complete evidence for it all along.
+            //
+            // This is the same one-moment argument `finalize_and_store_proved` makes for migration
+            // transactions, and it uses the same evidence source, so the predicate has one
+            // implementation rather than one per store. The outputs are recovered by trial
+            // decryption rather than from the `SentTransaction`'s own outputs because
+            // `classify_decrypted_tx` is that single implementation; re-deriving its evidence from
+            // a different output representation would be a second copy to keep in step.
+            //
+            // The transaction is not mined, so no mined height is available; the enhance path
+            // passes the chain tip in the same situation.
+            #[cfg(feature = "orchard")]
+            {
+                let decrypted =
+                    decrypt_transaction(&self.params, None, chain_tip, sent_tx.tx(), &ufvks);
+                let classification = classify_decrypted_tx(
+                    sent_tx.tx(),
+                    decrypted.orchard_outputs(),
+                    decrypted.ironwood_outputs(),
+                    &zip318,
+                );
+                wallet::put_zip318_classification(self.conn.0, tx_ref, classification)?;
+            }
         }
         Ok(())
     }

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -2993,4 +2993,100 @@ pub(crate) mod tests {
             }
         }
     }
+
+    /// A transaction the wallet BUILDS is classified against ZIP 318 as it is stored, not only
+    /// once it has mined and been enhanced.
+    ///
+    /// `store_transactions_to_be_sent` had no classification step, so an ordinary send sat in the
+    /// wallet's own history reading "not classified" — the value that means nothing ever looked at
+    /// it — despite the wallet having had complete evidence for it since the moment it built it.
+    /// A client rendering that as "no label yet" showed no label for a transaction it had itself
+    /// just created.
+    ///
+    /// The assertion is that a DECISION was recorded, and then which one. An ordinary payment is
+    /// refuted rather than left undecided because every clause `classify` needs is answerable from
+    /// a transaction in hand: the bundles are there to be counted and the expiry is there to be
+    /// tested. Refutation is not a weaker outcome than conformance here; it is the correct label,
+    /// and the one a wallet filtering its own migration traffic needs.
+    #[test]
+    #[cfg(feature = "orchard")]
+    fn an_ordinary_send_is_classified_when_it_is_stored() {
+        use zcash_protocol::zip318::Zip318Classification;
+
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_block_cache(BlockCache::new())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let account = st.test_account().cloned().unwrap();
+        let account_id = account.id();
+
+        // Fund the account with a note comfortably larger than the payment and its fee.
+        let fvk = OrchardPoolTester::test_account_fvk(&st);
+        let note_value = Zatoshis::const_from_u64(100_000);
+        let (h, _, _) = st.generate_next_block(&fvk, AddressType::DefaultExternal, note_value);
+        st.scan_cached_blocks(h, 1);
+        assert_eq!(st.get_total_balance(account_id), note_value);
+
+        // Advance so the note's shard completes and an anchor is available.
+        for _ in 0..5 {
+            let (h, _) = st.generate_empty_block();
+            st.scan_cached_blocks(h, 1);
+        }
+
+        // An ordinary payment to somebody else, through the standard proposal flow.
+        let to_sk = OrchardPoolTester::sk(&[0xf5; 32]);
+        let to: Address = OrchardPoolTester::sk_default_address(&to_sk);
+        let request = TransactionRequest::new(vec![Payment::without_memo(
+            to.to_zcash_address(st.network()),
+            Zatoshis::const_from_u64(10_000),
+        )])
+        .unwrap();
+        let change_strategy =
+            single_output_change_strategy(StandardFeeRule::Zip317, None, ShieldedPool::Orchard);
+        let proposal = st
+            .propose_transfer(
+                account_id,
+                &GreedyInputSelector::new(),
+                &change_strategy,
+                request,
+                ConfirmationsPolicy::MIN,
+            )
+            .unwrap();
+        let created = st
+            .create_proposed_transactions::<Infallible, _, Infallible, _>(
+                account.usk(),
+                OvkPolicy::Sender,
+                &proposal,
+            )
+            .unwrap();
+        assert_eq!(created.len(), 1);
+        let sent_txid = created[0];
+
+        let (zip318_kind, mined_height): (i64, Option<i64>) = st
+            .wallet_mut()
+            .conn_mut()
+            .query_row(
+                "SELECT zip318_kind, mined_height FROM transactions WHERE txid = :txid",
+                named_params![":txid": sent_txid.as_ref()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+
+        assert_eq!(
+            mined_height, None,
+            "premise: the transaction is stored and unmined, so nothing has enhanced it",
+        );
+        assert_ne!(
+            zip318_kind,
+            Zip318Classification::Unknown.to_code(),
+            "storing a transaction the wallet built records a classification decision for it",
+        );
+        assert_eq!(
+            zip318_kind,
+            Zip318Classification::Nonconforming.to_code(),
+            "an ordinary payment is refuted, not left undecided",
+        );
+    }
 }


### PR DESCRIPTION
Closes #2913. Third in a stack: #2911 -> #2915 -> this. Base is `dw/zip318-classification-missing-row`; review the earlier two first.

## The problem

`WalletDb::store_transactions_to_be_sent` recorded a transaction the wallet had just built without classifying it, discarding the `TxRef` that #2909 made `store_transaction_to_be_sent` return. The transaction then read as "not classified" until it mined and the enhance path stamped it.

That is the value meaning *nothing ever looked at this transaction*. A client rendering it as "no label yet" — which the `Zip318Classification` docs require — showed no label for a transaction the wallet had itself created moments earlier, despite having had complete evidence for it since it built it.

This is not only cosmetic for ordinary payments. The ordinary send flow can produce a canonical crossing: `propose_transfer` consults `is_canonical_crossing` when shaping a step. A genuine ZIP 318 crossing built outside the migration engine was equally unlabelled.

## The fix

Classify in the same database transaction as the record itself, via the returned `TxRef`, using `classify_decrypted_tx` — the same evidence source as the migration and enhance paths, so the predicate keeps one implementation.

The outputs are recovered by trial decryption rather than read off the `SentTransaction`'s own outputs for exactly that reason: those are `SentTransactionOutput`s, not `DecryptedOutput`s, and adapting them would be a second copy of the evidence derivation to keep in step. The `data_api::zip318` module documentation warns against precisely that. The wallet has just proved this transaction, so trial-decrypting its own handful of outputs is not a meaningful cost next to what it already spent.

## Two choices worth review attention

**Every account's viewing key, not just the sender's.** `is_send_to_self` is refuted by an output on an address that is the wallet's but EXTERNAL to the account. Decrypting under the sending account's key alone would leave a cross-account output undecryptable and therefore uncounted, so a transaction paying another account of the same wallet could be judged send-to-self here and not send-to-self once it mined. `Zip318Classification` is contractually monotone — "once decided, never decided differently" — so that relabelling is not something the store may do. Using every key matches what the enhance path already does.

**The wallet's own parameters, not the specified defaults.** The enhance path uses `PoolMigrationParams::from(AnchorRetentionInterval::default())` and documents why: `LowLevelWalletRead` cannot reach the store's grid, and no clause that evidence source can answer consults it anyway. Both halves are true, but the second is an argument that has to be revisited whenever `PoolMigrationParams` changes. This site has the store in hand, so it calls `pool_migration_params()` and is correct by construction instead. (Same observation as the last paragraph of #2913.)

## Test

`an_ordinary_send_is_classified_when_it_is_stored` drives the standard proposal flow and asserts the stored, still-unmined row carries a decision — specifically `Nonconforming`, since every clause `classify` needs is answerable from a transaction in hand, so an ordinary payment is refuted rather than left undecided.

Full crate suite green in both feature configurations: 501 lib tests, 7 `pool_migration_prove_chain_sim`, 3 others; clippy clean with and without `orchard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)