### PR TITLE
CHANGELOG: record store-time ZIP 318 classification

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -102,6 +102,24 @@ workspace.
 - The `orchard` feature is now enabled by default. Consumers that require a
   smaller feature set should disable default features and enable only the
   features they need.
+- A migration transaction is now classified against ZIP 318 when proving stores
+  it, in the same database transaction as the record itself, rather than only
+  once it has mined and been enhanced. A scheduled transfer is stored UNMINED
+  until its broadcast height, which may be days away, and through that whole
+  window `transactions.zip318_kind` previously read as the NOT CLASSIFIED
+  default. A wallet that labels, or holds back, its own in-flight migration
+  traffic now has the classification available from the moment the transaction
+  is recorded. The enhance path writes the same value again after the
+  transaction mines.
+- `WalletWrite::store_transactions_to_be_sent` now likewise classifies each
+  transaction as it stores it, so a transaction the wallet built is labelled
+  without waiting for it to mine. This covers canonical crossings built through
+  the ordinary proposal flow, not only those the pool-migration engine
+  constructs.
+- Neither change makes the NOT CLASSIFIED default safe to read as a decision.
+  Clients must still render it as "no label yet" rather than as "not a migration
+  transaction": rows written before the column existed keep that default, and
+  need the transaction rescanned before they can be labelled.
 
 ## [0.22.0-rc.7] - 2026-08-03
 


### PR DESCRIPTION
Top of the stack: #2911 -> #2915 -> #2916 -> this. Base is `dw/zip318-classify-standard-send`.

Adds the `zcash_client_sqlite` changelog entries for two consumer-visible changes:

- **Classifying a migration transaction when proving stores it** — this landed in #2909 without a changelog entry, which is what prompted the whole stack. A scheduled transfer sits stored and unmined until its broadcast height, potentially days, and through that window `transactions.zip318_kind` read as the NOT CLASSIFIED default.
- **Classifying every to-be-sent transaction as the wallet stores it** — #2916 in this stack.

Both change what a client reading `transactions.zip318_kind` sees, so both belong in the changelog.

A third bullet restates the rule that the NOT CLASSIFIED default must be rendered as "no label yet" and not as "not a migration transaction". It is not new, but these two changes narrow the set of rows carrying that default to pre-column ones, and that is exactly the point at which a client author is most likely to assume the default now means something.

**Not included:** #2915 (rejecting a classification write that names no transaction). That guard is on a `pub(crate)` function and is unreachable from both current callers, which derive the `TxRef` from a `put_tx_data` immediately beforehand in the same database transaction. Nothing a consumer can observe changes, so there is nothing to tell them. Happy to add an entry if you would rather have the internal hardening recorded.

Changelog-only commit, per the repo's dedicated-commit rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)