### PR TITLE
zcash_client_sqlite: sanitize trust_status in v_transactions

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -15,6 +15,15 @@ workspace.
   smaller feature set should disable default features and enable only the
   features they need.
 
+### Fixed
+- `v_transactions` now exposes `trust_status` as `IFNULL(trust_status, 0)`,
+  the same interpretation every reader inside this crate already applies. The
+  raw column is NULL for any transaction no caller has explicitly marked via
+  `set_tx_trust` — today, every transaction — and exposing that NULL caused a
+  foreign consumer decoding the column strictly to fail its entire history
+  query. The underlying column is unchanged, so "never evaluated" remains
+  distinguishable from an explicit mark for readers that want the distinction.
+
 ## [0.22.0-rc.7] - 2026-08-03
 
 ### Added

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -1533,7 +1533,7 @@ SELECT accounts.uuid                AS account_uuid,
        -- between shielded pools; NULL when it is not such a transfer. A transaction is one
        -- exactly when this column is non-NULL.
        pool_crossings.crossing_value AS pool_crossing_value,
-       transactions.trust_status,
+       IFNULL(transactions.trust_status, 0) AS trust_status,
        transactions.zip318_kind
 FROM notes
 JOIN accounts ON accounts.id = notes.account_id

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -171,6 +171,7 @@ migration_modules!(
     v_transactions_pool_crossing,
     v_transactions_shielding_balance,
     v_transactions_transparent_history,
+    v_transactions_trust_status_ifnull,
     v_transactions_zip318_kind,
     v_tx_outputs_key_scopes,
     v_tx_outputs_return_addrs,
@@ -391,6 +392,7 @@ pub(super) fn all_migrations<
         Box::new(orchard_ironwood_migration_anchor_interval::Migration),
         Box::new(v_tx_outputs_transparent_addresses::Migration),
         Box::new(orchard_ironwood_migration_unsatisfiability::Migration),
+        Box::new(v_transactions_trust_status_ifnull::Migration),
     ]
 }
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_trust_status_ifnull.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_transactions_trust_status_ifnull.rs
@@ -1,0 +1,456 @@
+//! Sanitizes `trust_status` in `v_transactions`: NULL reads as untrusted (0).
+//!
+//! `transactions.trust_status` is an opt-in marker written by `set_tx_trust`, added without a
+//! default or a backfill, so it is NULL for every transaction no caller has explicitly marked —
+//! today, that is every row of every wallet. Every reader inside this crate already consumes the
+//! column as `IFNULL(trust_status, 0)`: an unevaluated transaction is treated exactly like one
+//! explicitly marked untrusted. The view a client queries for its history was the one exception —
+//! it exposed the raw column, handing NULL to foreign consumers that this crate never hands to
+//! itself. A mobile SDK decoding the column strictly failed on the first row and lost the whole
+//! history query (field, 2026-08-04).
+//!
+//! The view now applies the same `IFNULL` convention as the crate's own readers. The underlying
+//! column is untouched: NULL ("never evaluated") remains distinguishable from an explicit mark for
+//! any future reader that wants the distinction, and `set_tx_trust` semantics are unchanged.
+
+use std::collections::HashSet;
+
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+
+use crate::wallet::init::WalletMigrationError;
+
+use super::v_transactions_zip318_kind;
+
+/// This migration recreates `v_transactions` with `trust_status` sanitized to `IFNULL(.., 0)`.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x5e41489c_5263_4a3a_9a96_9efdd945b5c6);
+
+/// `v_transactions_zip318_kind` is the previous recreation of the view this one replaces.
+pub(super) const DEPENDENCIES: &[Uuid] = &[v_transactions_zip318_kind::MIGRATION_ID];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Sanitizes trust_status in v_transactions: NULL reads as untrusted."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        transaction.execute_batch(
+            "DROP VIEW v_transactions;
+            CREATE VIEW v_transactions AS
+            WITH
+            notes AS (
+                -- Outputs received in this transaction
+                SELECT ro.account_id              AS account_id,
+                       ro.transaction_id          AS transaction_id,
+                       ro.pool                    AS pool,
+                       id_within_pool_table,
+                       ro.value                   AS value,
+                       ro.value                   AS received_value,
+                       0                          AS spent_value,
+                       0                          AS spent_note_count,
+                       CASE
+                            WHEN ro.is_change THEN 1
+                            ELSE 0
+                       END AS change_note_count,
+                       CASE
+                            WHEN ro.is_change THEN 0
+                            ELSE 1
+                       END AS received_count,
+                       CASE
+                         WHEN (ro.memo IS NULL OR ro.memo = X'F6')
+                           THEN 0
+                         ELSE 1
+                       END AS memo_present,
+                       -- The wallet cannot receive transparent outputs in shielding transactions.
+                       CASE
+                         WHEN ro.pool = 0
+                           THEN 1
+                         ELSE 0
+                       END AS does_not_match_shielding
+                FROM v_received_outputs ro
+                UNION
+                -- Outputs spent in this transaction
+                SELECT ro.account_id              AS account_id,
+                       ros.transaction_id         AS transaction_id,
+                       ro.pool                    AS pool,
+                       id_within_pool_table,
+                       -ro.value                  AS value,
+                       0                          AS received_value,
+                       ro.value                   AS spent_value,
+                       1                          AS spent_note_count,
+                       0                          AS change_note_count,
+                       0                          AS received_count,
+                       0                          AS memo_present,
+                       -- The wallet cannot spend shielded outputs in shielding transactions.
+                       CASE
+                         WHEN ro.pool != 0
+                           THEN 1
+                         ELSE 0
+                       END AS does_not_match_shielding
+                FROM v_received_outputs ro
+                JOIN v_received_output_spends ros
+                     ON ros.pool = ro.pool
+                     AND ros.received_output_id = ro.id_within_pool_table
+            ),
+            -- What each account spent and received in each pool, per transaction. A pool the account
+            -- received value in but spent nothing from is a pool that value crossed into from
+            -- elsewhere, which is what `pool_crossings` below is built on.
+            notes_by_pool AS (
+                SELECT account_id, transaction_id, pool,
+                       SUM(spent_note_count)                   AS spent_note_count,
+                       SUM(received_count + change_note_count) AS received_note_count,
+                       SUM(received_value)                     AS received_value
+                FROM notes
+                GROUP BY account_id, transaction_id, pool
+            ),
+            -- Obtain a count of the notes that the wallet created in each transaction,
+            -- not counting change notes.
+            sent_note_counts AS (
+                SELECT sent_notes.from_account_id     AS account_id,
+                       sent_notes.transaction_id      AS transaction_id,
+                       COUNT(DISTINCT sent_notes.id)  AS sent_notes,
+                       SUM(
+                         CASE
+                           WHEN (sent_notes.memo IS NULL OR sent_notes.memo = X'F6' OR ro.transaction_id IS NOT NULL)
+                             THEN 0
+                           ELSE 1
+                         END
+                       ) AS memo_count
+                FROM sent_notes
+                LEFT JOIN v_received_outputs ro ON sent_notes.id = ro.sent_note_id
+                WHERE COALESCE(ro.is_change, 0) = 0
+                GROUP BY account_id, sent_notes.transaction_id
+            ),
+            -- Identifies the transactions that are wallet-internal transfers moving an account's own
+            -- funds between shielded pools, and reports the value that crossed. `crossing_value` is
+            -- non-NULL exactly for such a transaction, so it carries both the classification and the
+            -- amount; see the `pool_crossing_value` column below.
+            pool_crossings AS (
+                SELECT notes_by_pool.account_id     AS account_id,
+                       notes_by_pool.transaction_id AS transaction_id,
+                       CASE WHEN (
+                            -- Every note spent and every output received by the wallet is shielded.
+                            SUM(CASE WHEN notes_by_pool.pool = 0 THEN notes_by_pool.spent_note_count + notes_by_pool.received_note_count ELSE 0 END) = 0
+                            -- The transaction spends at least one of the account's notes.
+                            AND SUM(notes_by_pool.spent_note_count) > 0
+                            -- At least one output was received in a pool the account spent nothing
+                            -- from, so value crossed between pools.
+                            AND SUM(CASE WHEN notes_by_pool.spent_note_count = 0 THEN notes_by_pool.received_note_count ELSE 0 END) > 0
+                            -- We do not know about any external outputs of the transaction.
+                            AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
+                       )
+                       -- The total value received in the pools the account did not spend from. The
+                       -- condition above guarantees at least one such output, so when this branch is
+                       -- taken the sum is never NULL.
+                       THEN SUM(CASE WHEN notes_by_pool.spent_note_count = 0 THEN notes_by_pool.received_value ELSE 0 END)
+                       END AS crossing_value
+                FROM notes_by_pool
+                LEFT JOIN sent_note_counts
+                     ON sent_note_counts.account_id = notes_by_pool.account_id
+                     AND sent_note_counts.transaction_id = notes_by_pool.transaction_id
+                GROUP BY notes_by_pool.account_id, notes_by_pool.transaction_id
+            ),
+            blocks_max_height AS (
+                SELECT MAX(blocks.height) AS max_height FROM blocks
+            )
+            SELECT accounts.uuid                AS account_uuid,
+                   transactions.mined_height    AS mined_height,
+                   transactions.txid            AS txid,
+                   transactions.tx_index        AS tx_index,
+                   transactions.expiry_height   AS expiry_height,
+                   transactions.raw             AS raw,
+                   SUM(notes.value)             AS account_balance_delta,
+                   SUM(notes.spent_value)       AS total_spent,
+                   SUM(notes.received_value)    AS total_received,
+                   transactions.fee             AS fee_paid,
+                   SUM(notes.change_note_count) > 0  AS has_change,
+                   MAX(COALESCE(sent_note_counts.sent_notes, 0))  AS sent_note_count,
+                   SUM(notes.received_count)         AS received_note_count,
+                   SUM(notes.memo_present) + MAX(COALESCE(sent_note_counts.memo_count, 0)) AS memo_count,
+                   blocks.time                       AS block_time,
+                   (
+                        transactions.mined_height IS NULL
+                        AND transactions.expiry_height BETWEEN 1 AND blocks_max_height.max_height
+                   ) AS expired_unmined,
+                   SUM(notes.spent_note_count) AS spent_note_count,
+                   (
+                        -- All of the wallet-spent and wallet-received notes are consistent with a
+                        -- shielding transaction.
+                        SUM(notes.does_not_match_shielding) = 0
+                        -- The transaction contains at least one wallet-spent output.
+                        AND SUM(notes.spent_note_count) > 0
+                        -- The transaction contains at least one wallet-received note.
+                        AND (SUM(notes.received_count) + SUM(notes.change_note_count)) > 0
+                        -- We do not know about any external outputs of the transaction.
+                        AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
+                   ) AS is_shielding,
+                   -- The value that crossed pools, when this transaction is a wallet-internal transfer
+                   -- between shielded pools; NULL when it is not such a transfer. A transaction is one
+                   -- exactly when this column is non-NULL.
+                   pool_crossings.crossing_value AS pool_crossing_value,
+                   IFNULL(transactions.trust_status, 0) AS trust_status,
+                   transactions.zip318_kind
+            FROM notes
+            JOIN accounts ON accounts.id = notes.account_id
+            JOIN transactions ON transactions.id_tx = notes.transaction_id
+            LEFT JOIN blocks_max_height
+            LEFT JOIN blocks ON blocks.height = transactions.mined_height
+            LEFT JOIN sent_note_counts
+                 ON sent_note_counts.account_id = notes.account_id
+                 AND sent_note_counts.transaction_id = notes.transaction_id
+            LEFT JOIN pool_crossings
+                 ON pool_crossings.account_id = notes.account_id
+                 AND pool_crossings.transaction_id = notes.transaction_id
+            GROUP BY notes.account_id, notes.transaction_id",
+        )?;
+        Ok(())
+    }
+
+    fn down(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        transaction.execute_batch(
+            "DROP VIEW v_transactions;
+            CREATE VIEW v_transactions AS
+            WITH
+            notes AS (
+                -- Outputs received in this transaction
+                SELECT ro.account_id              AS account_id,
+                       ro.transaction_id          AS transaction_id,
+                       ro.pool                    AS pool,
+                       id_within_pool_table,
+                       ro.value                   AS value,
+                       ro.value                   AS received_value,
+                       0                          AS spent_value,
+                       0                          AS spent_note_count,
+                       CASE
+                            WHEN ro.is_change THEN 1
+                            ELSE 0
+                       END AS change_note_count,
+                       CASE
+                            WHEN ro.is_change THEN 0
+                            ELSE 1
+                       END AS received_count,
+                       CASE
+                         WHEN (ro.memo IS NULL OR ro.memo = X'F6')
+                           THEN 0
+                         ELSE 1
+                       END AS memo_present,
+                       -- The wallet cannot receive transparent outputs in shielding transactions.
+                       CASE
+                         WHEN ro.pool = 0
+                           THEN 1
+                         ELSE 0
+                       END AS does_not_match_shielding
+                FROM v_received_outputs ro
+                UNION
+                -- Outputs spent in this transaction
+                SELECT ro.account_id              AS account_id,
+                       ros.transaction_id         AS transaction_id,
+                       ro.pool                    AS pool,
+                       id_within_pool_table,
+                       -ro.value                  AS value,
+                       0                          AS received_value,
+                       ro.value                   AS spent_value,
+                       1                          AS spent_note_count,
+                       0                          AS change_note_count,
+                       0                          AS received_count,
+                       0                          AS memo_present,
+                       -- The wallet cannot spend shielded outputs in shielding transactions.
+                       CASE
+                         WHEN ro.pool != 0
+                           THEN 1
+                         ELSE 0
+                       END AS does_not_match_shielding
+                FROM v_received_outputs ro
+                JOIN v_received_output_spends ros
+                     ON ros.pool = ro.pool
+                     AND ros.received_output_id = ro.id_within_pool_table
+            ),
+            -- What each account spent and received in each pool, per transaction. A pool the account
+            -- received value in but spent nothing from is a pool that value crossed into from
+            -- elsewhere, which is what `pool_crossings` below is built on.
+            notes_by_pool AS (
+                SELECT account_id, transaction_id, pool,
+                       SUM(spent_note_count)                   AS spent_note_count,
+                       SUM(received_count + change_note_count) AS received_note_count,
+                       SUM(received_value)                     AS received_value
+                FROM notes
+                GROUP BY account_id, transaction_id, pool
+            ),
+            -- Obtain a count of the notes that the wallet created in each transaction,
+            -- not counting change notes.
+            sent_note_counts AS (
+                SELECT sent_notes.from_account_id     AS account_id,
+                       sent_notes.transaction_id      AS transaction_id,
+                       COUNT(DISTINCT sent_notes.id)  AS sent_notes,
+                       SUM(
+                         CASE
+                           WHEN (sent_notes.memo IS NULL OR sent_notes.memo = X'F6' OR ro.transaction_id IS NOT NULL)
+                             THEN 0
+                           ELSE 1
+                         END
+                       ) AS memo_count
+                FROM sent_notes
+                LEFT JOIN v_received_outputs ro ON sent_notes.id = ro.sent_note_id
+                WHERE COALESCE(ro.is_change, 0) = 0
+                GROUP BY account_id, sent_notes.transaction_id
+            ),
+            -- Identifies the transactions that are wallet-internal transfers moving an account's own
+            -- funds between shielded pools, and reports the value that crossed. `crossing_value` is
+            -- non-NULL exactly for such a transaction, so it carries both the classification and the
+            -- amount; see the `pool_crossing_value` column below.
+            pool_crossings AS (
+                SELECT notes_by_pool.account_id     AS account_id,
+                       notes_by_pool.transaction_id AS transaction_id,
+                       CASE WHEN (
+                            -- Every note spent and every output received by the wallet is shielded.
+                            SUM(CASE WHEN notes_by_pool.pool = 0 THEN notes_by_pool.spent_note_count + notes_by_pool.received_note_count ELSE 0 END) = 0
+                            -- The transaction spends at least one of the account's notes.
+                            AND SUM(notes_by_pool.spent_note_count) > 0
+                            -- At least one output was received in a pool the account spent nothing
+                            -- from, so value crossed between pools.
+                            AND SUM(CASE WHEN notes_by_pool.spent_note_count = 0 THEN notes_by_pool.received_note_count ELSE 0 END) > 0
+                            -- We do not know about any external outputs of the transaction.
+                            AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
+                       )
+                       -- The total value received in the pools the account did not spend from. The
+                       -- condition above guarantees at least one such output, so when this branch is
+                       -- taken the sum is never NULL.
+                       THEN SUM(CASE WHEN notes_by_pool.spent_note_count = 0 THEN notes_by_pool.received_value ELSE 0 END)
+                       END AS crossing_value
+                FROM notes_by_pool
+                LEFT JOIN sent_note_counts
+                     ON sent_note_counts.account_id = notes_by_pool.account_id
+                     AND sent_note_counts.transaction_id = notes_by_pool.transaction_id
+                GROUP BY notes_by_pool.account_id, notes_by_pool.transaction_id
+            ),
+            blocks_max_height AS (
+                SELECT MAX(blocks.height) AS max_height FROM blocks
+            )
+            SELECT accounts.uuid                AS account_uuid,
+                   transactions.mined_height    AS mined_height,
+                   transactions.txid            AS txid,
+                   transactions.tx_index        AS tx_index,
+                   transactions.expiry_height   AS expiry_height,
+                   transactions.raw             AS raw,
+                   SUM(notes.value)             AS account_balance_delta,
+                   SUM(notes.spent_value)       AS total_spent,
+                   SUM(notes.received_value)    AS total_received,
+                   transactions.fee             AS fee_paid,
+                   SUM(notes.change_note_count) > 0  AS has_change,
+                   MAX(COALESCE(sent_note_counts.sent_notes, 0))  AS sent_note_count,
+                   SUM(notes.received_count)         AS received_note_count,
+                   SUM(notes.memo_present) + MAX(COALESCE(sent_note_counts.memo_count, 0)) AS memo_count,
+                   blocks.time                       AS block_time,
+                   (
+                        transactions.mined_height IS NULL
+                        AND transactions.expiry_height BETWEEN 1 AND blocks_max_height.max_height
+                   ) AS expired_unmined,
+                   SUM(notes.spent_note_count) AS spent_note_count,
+                   (
+                        -- All of the wallet-spent and wallet-received notes are consistent with a
+                        -- shielding transaction.
+                        SUM(notes.does_not_match_shielding) = 0
+                        -- The transaction contains at least one wallet-spent output.
+                        AND SUM(notes.spent_note_count) > 0
+                        -- The transaction contains at least one wallet-received note.
+                        AND (SUM(notes.received_count) + SUM(notes.change_note_count)) > 0
+                        -- We do not know about any external outputs of the transaction.
+                        AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
+                   ) AS is_shielding,
+                   -- The value that crossed pools, when this transaction is a wallet-internal transfer
+                   -- between shielded pools; NULL when it is not such a transfer. A transaction is one
+                   -- exactly when this column is non-NULL.
+                   pool_crossings.crossing_value AS pool_crossing_value,
+                   transactions.trust_status,
+                   transactions.zip318_kind
+            FROM notes
+            JOIN accounts ON accounts.id = notes.account_id
+            JOIN transactions ON transactions.id_tx = notes.transaction_id
+            LEFT JOIN blocks_max_height
+            LEFT JOIN blocks ON blocks.height = transactions.mined_height
+            LEFT JOIN sent_note_counts
+                 ON sent_note_counts.account_id = notes.account_id
+                 AND sent_note_counts.transaction_id = notes.transaction_id
+            LEFT JOIN pool_crossings
+                 ON pool_crossings.account_id = notes.account_id
+                 AND pool_crossings.transaction_id = notes.transaction_id
+            GROUP BY notes.account_id, notes.transaction_id",
+        )?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use secrecy::Secret;
+    use tempfile::NamedTempFile;
+    use zcash_protocol::consensus::Network;
+
+    use crate::WalletDb;
+    use crate::testing::db::{test_clock, test_rng};
+    use crate::wallet::init::WalletMigrator;
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+
+    /// The sanitization is part of the view's stored SELECT, so it can be asserted on an empty
+    /// wallet: the semantic NULL-to-zero path needs populated note tables to produce a row, but
+    /// the stored schema text IS the contract this migration exists to change, and querying the
+    /// column forces SQLite to resolve it (a `CREATE VIEW` naming a missing column succeeds and
+    /// fails only at first use).
+    #[test]
+    fn the_view_sanitizes_trust_status() {
+        let data_file = NamedTempFile::new().unwrap();
+        let mut db_data = WalletDb::for_path(
+            data_file.path(),
+            Network::TestNetwork,
+            test_clock(),
+            test_rng(),
+        )
+        .unwrap();
+
+        WalletMigrator::new()
+            .with_seed(Secret::new(vec![0xab; 32]))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, &[super::MIGRATION_ID])
+            .unwrap();
+
+        let count: i64 = db_data
+            .conn
+            .query_row("SELECT COUNT(trust_status) FROM v_transactions", [], |row| {
+                row.get(0)
+            })
+            .expect("the trust_status column resolves when v_transactions is queried");
+        assert_eq!(count, 0);
+
+        let view_sql: String = db_data
+            .conn
+            .query_row(
+                "SELECT sql FROM sqlite_master WHERE type = 'view' AND name = 'v_transactions'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("the view's stored SELECT is readable");
+        assert!(
+            view_sql.contains("IFNULL(transactions.trust_status, 0) AS trust_status"),
+            "the view must expose the sanitized column, not the raw nullable one",
+        );
+    }
+}


### PR DESCRIPTION
Fixes #2918.

`transactions.trust_status` is an opt-in marker written by `set_tx_trust`, added without a default or a backfill, so it is NULL for every transaction no caller has explicitly marked — today, every row of every wallet, since nothing calls `set_tx_trust` yet. Every reader inside this crate already consumes the column as `IFNULL(trust_status, 0)`, treating an unevaluated transaction exactly like one explicitly marked untrusted. The view a client queries for its history was the one exception: it exposed the raw column, handing NULL to foreign consumers that this crate never hands to itself. A mobile SDK decoding the column strictly failed on the first row and lost its entire history query (field, 2026-08-04).

This recreates `v_transactions` with `IFNULL(transactions.trust_status, 0) AS trust_status` — a new schema migration depending on `v_transactions_zip318_kind` (the view's previous recreation), with the canonical view text in `db.rs` updated to match. The underlying column is untouched: NULL ("never evaluated") remains distinguishable from an explicit mark for any future reader that wants the distinction, and `set_tx_trust` semantics are unchanged.

Tests: the standard `migrate` graph test, plus a queryability + stored-SELECT assertion (a `CREATE VIEW` naming a missing column succeeds and fails only at first use, and an empty wallet cannot produce view rows, so the stored schema text is the asserted contract). Full `zcash_client_sqlite` suite `--all-features`: 545 passed, 0 failed, including the schema-verification tests pinning the migrated schema against `db.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)