### PR TITLE
zcash_pool_migration: fix redraw test broken by the #2898/#2910 semantic merge conflict

### DIFF
--- a/zcash_pool_migration/src/scheduling.rs
+++ b/zcash_pool_migration/src/scheduling.rs
@@ -2030,12 +2030,22 @@ mod tests {
     fn redraw_anchor_boundary_window_endpoints() {
         // Broadcast 1_900: most recent boundary 1_872, highest candidate 1_728.
         assert_eq!(
-            redraw_anchor_boundary(modulus(), bh(1_872), bh(1_900), &mut rng(1)),
+            redraw_anchor_boundary(
+                AnchorBucketInterval::ZIP_318,
+                bh(1_872),
+                bh(1_900),
+                &mut rng(1)
+            ),
             None,
             "a prior at the most recent boundary has no strictly-older candidate to move to"
         );
         assert_eq!(
-            redraw_anchor_boundary(modulus(), bh(1_728), bh(1_900), &mut rng(1)),
+            redraw_anchor_boundary(
+                AnchorBucketInterval::ZIP_318,
+                bh(1_728),
+                bh(1_900),
+                &mut rng(1)
+            ),
             Some(bh(1_728)),
             "a single-candidate window is deterministic"
         );


### PR DESCRIPTION
`main` does not currently compile for `zcash_pool_migration` test targets: #2898 removed the scheduling test module's `modulus()` helper in favor of direct `AnchorBucketInterval::ZIP_318` references, and #2910 (merged immediately after) added `redraw_anchor_boundary_window_endpoints`, which calls it. Each PR was green in isolation; the textual merge was clean; the combination fails with `cannot find function `modulus``, which is what the red wall on `main`'s tip (per-feature clippy, Orchard/all-features test jobs, bitrot) reduces to.

Two-line fix: use the direct `AnchorBucketInterval::ZIP_318` reference, as the surrounding tests now do.

Opened ready-for-review rather than draft since it unbreaks `main` for everything behind it.

---

Filed with Claude Code assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Gsndy5ri9eYvtH31DnHTQ
