### PR TITLE
zcash_client_sqlite: pool-migration history read API (Phase B2)

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -11,6 +11,16 @@ workspace.
 ## [Unreleased]
 
 ### Added
+- `pool_migration::MigrationUuid`: the stable external identity of one
+  pool-migration record, safe to hand across an FFI (row ids are not stable
+  across a restore).
+- `pool_migration::MigrationSummary` and, on each pool facade
+  (`pool_migration::orchard_ironwood::PoolMigrations`), the history read API:
+  `latest_migration` (the most recent record whatever its status — what a UI
+  renders once `get_migration` reports `None` for a finished migration),
+  `list_migrations` (newest-first summaries projected in SQL, reading no
+  stored PCZTs), and `get_migration_by_id` (one record's full state,
+  historical or pending).
 - A schema migration giving each pool-migration record a durable identity — a
   `uuid` column (random per row, backfilled for existing rows) and a nullable
   `committed_height` column (`NULL` for rows that predate it) — and rescoping
@@ -24,8 +34,11 @@ workspace.
   retained as history rather than returned here, and committing a replacement
   migration no longer destroys the record of the one it replaces. A caller
   that rendered a finished migration from `get_migration` (which now returns
-  `None` for it) should read the retained record instead once the history
-  accessors land; until then the rows are present but unexposed.
+  `None` for it) should use `latest_migration` (or `list_migrations` /
+  `get_migration_by_id`) instead.
+- A newly committed pool migration's record is stamped with the wallet's chain
+  height at first persistence (`MigrationSummary::committed_height`); records
+  that predate the column report `None`.
 - Wallet truncation now revisits every retained `complete` pool-migration
   record as well as the pending one, so a reorg that un-mines a PREVIOUS
   migration's transfers demotes that record exactly as it always demoted a

--- a/zcash_client_sqlite/src/pool_migration.rs
+++ b/zcash_client_sqlite/src/pool_migration.rs
@@ -85,3 +85,113 @@ mod error;
 mod store;
 
 pub mod orchard_ironwood;
+
+use uuid::Uuid;
+use zcash_pool_migration::engine::MigrationStatus;
+use zcash_protocol::{consensus::BlockHeight, value::Zatoshis};
+
+/// The stable external identity of one pool-migration record, following the
+/// [`AccountUuid`](crate::AccountUuid) precedent: random per record, preserved across every
+/// rewrite of the record's state, and safe to hand across an FFI — unlike the store's row ids,
+/// which are not stable across a restore or an export. Obtained from
+/// [`MigrationSummary::id`], and resolved back through a pool facade's `get_migration_by_id`.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct MigrationUuid(Uuid);
+
+impl MigrationUuid {
+    /// Constructs a `MigrationUuid` from a bare [`Uuid`] value.
+    ///
+    /// The resulting identifier is not guaranteed to correspond to any migration stored in a
+    /// [`WalletDb`](crate::WalletDb).
+    pub fn from_uuid(value: Uuid) -> Self {
+        MigrationUuid(value)
+    }
+
+    /// Exposes the underlying [`Uuid`] value.
+    pub fn expose_uuid(&self) -> Uuid {
+        self.0
+    }
+}
+
+/// One row of a migration-history listing: the identity, status, and aggregate progress of a
+/// single migration an account has run, PROJECTED IN SQL from the store's typed columns.
+///
+/// Deliberately not a [`MigrationState`](zcash_pool_migration::engine::MigrationState): a full
+/// state carries every transaction's (proven) PCZT and runs to megabytes, so a list of states
+/// would deserialize every proof the account ever produced in order to render a history screen.
+/// A summary is what the screen needs; the full state of one migration is a follow-up
+/// `get_migration_by_id` call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MigrationSummary {
+    pub(crate) id: MigrationUuid,
+    pub(crate) status: MigrationStatus,
+    pub(crate) committed_height: Option<BlockHeight>,
+    pub(crate) total_input: Zatoshis,
+    pub(crate) total_migratable: Zatoshis,
+    pub(crate) change: Option<Zatoshis>,
+    pub(crate) transaction_count: usize,
+    pub(crate) mined_count: usize,
+    pub(crate) in_flight_count: usize,
+    pub(crate) unsatisfiable_count: usize,
+    pub(crate) value_migrated: Zatoshis,
+}
+
+impl MigrationSummary {
+    /// The migration's stable identity, resolvable to its full state through the pool facade's
+    /// `get_migration_by_id`.
+    pub fn id(&self) -> MigrationUuid {
+        self.id
+    }
+
+    /// The migration's lifecycle status.
+    pub fn status(&self) -> MigrationStatus {
+        self.status
+    }
+
+    /// The chain height the migration was committed at, if recorded (`None` for records that
+    /// predate the column).
+    pub fn committed_height(&self) -> Option<BlockHeight> {
+        self.committed_height
+    }
+
+    /// The total value of the notes the migration's plan drew on.
+    pub fn total_input(&self) -> Zatoshis {
+        self.total_input
+    }
+
+    /// The total value the plan set out to migrate across the pool boundary.
+    pub fn total_migratable(&self) -> Zatoshis {
+        self.total_migratable
+    }
+
+    /// The value returned to the source pool as change by the plan, when any.
+    pub fn change(&self) -> Option<Zatoshis> {
+        self.change
+    }
+
+    /// How many transactions the migration comprises, whatever their state.
+    pub fn transaction_count(&self) -> usize {
+        self.transaction_count
+    }
+
+    /// How many of its transactions have been observed mined.
+    pub fn mined_count(&self) -> usize {
+        self.mined_count
+    }
+
+    /// How many of its transactions are broadcast but not yet observed mined.
+    pub fn in_flight_count(&self) -> usize {
+        self.in_flight_count
+    }
+
+    /// How many of its transactions carry a standing unsatisfiability determination.
+    pub fn unsatisfiable_count(&self) -> usize {
+        self.unsatisfiable_count
+    }
+
+    /// The value that has actually crossed the pool boundary: the sum of the crossing values
+    /// whose transfer has been observed mined.
+    pub fn value_migrated(&self) -> Zatoshis {
+        self.value_migrated
+    }
+}

--- a/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
+++ b/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
@@ -269,6 +269,33 @@ impl<C: Borrow<Connection>, P, CL> PoolMigrations<C, P, CL> {
     pub fn migration_lock_owners(&self) -> Result<BTreeSet<LockOwner>, Error> {
         self.store.migration_lock_owners()
     }
+
+    /// The account's most recent migration WHATEVER its status: what a UI renders, where a
+    /// finished migration must stay visible after the pending-only
+    /// [`get_migration`](zcash_pool_migration::engine::PoolMigrationRead::get_migration) has
+    /// moved on to `None`.
+    ///
+    /// Inherent rather than on [`PoolMigrationRead`]: the engine never reads history, so the
+    /// trait would tax every store implementation with a method the engine never calls.
+    pub fn latest_migration(&self) -> Result<Option<MigrationState>, Error> {
+        self.store.latest_migration()
+    }
+
+    /// Every migration this account has run, newest first, as cheap SQL-projected summaries: no
+    /// stored PCZT is read or parsed. Resolve a row to its full state with
+    /// [`get_migration_by_id`](Self::get_migration_by_id).
+    pub fn list_migrations(&self) -> Result<Vec<crate::pool_migration::MigrationSummary>, Error> {
+        self.store.list_migrations()
+    }
+
+    /// The full state of the migration identified by `id` — historical or pending — or `None`
+    /// when this account has no such migration.
+    pub fn get_migration_by_id(
+        &self,
+        id: crate::pool_migration::MigrationUuid,
+    ) -> Result<Option<MigrationState>, Error> {
+        self.store.get_migration_by_id(id)
+    }
 }
 
 impl<C: Borrow<Connection>, P, CL> PoolMigrationRead for PoolMigrations<C, P, CL> {
@@ -2134,7 +2161,14 @@ mod tests {
         // row through `accounts(uuid)`.
         conn.execute_batch(
             "CREATE TABLE accounts (id INTEGER PRIMARY KEY, uuid BLOB NOT NULL);
-             CREATE UNIQUE INDEX accounts_uuid ON accounts (uuid);",
+             CREATE UNIQUE INDEX accounts_uuid ON accounts (uuid);
+             -- A minimal stand-in for the wallet's scan queue, which the identity-stamping half
+             -- of `replace_migration` reads the chain tip from (empty: no chain view yet).
+             CREATE TABLE scan_queue (
+                block_range_start INTEGER NOT NULL,
+                block_range_end INTEGER NOT NULL,
+                priority INTEGER NOT NULL
+             );",
         )
         .expect("create accounts table");
         init_migration_tables(&conn).expect("create tables");
@@ -2244,6 +2278,182 @@ mod tests {
             Some(successor),
             "the successor is the migration in progress"
         );
+    }
+
+    /// A migration with one crossing of `value` zatoshis carried by one transfer in `tx_state`,
+    /// for exercising the history projections: the crossing list is what `value_migrated` sums
+    /// over, and the transfer's lifecycle state is what gates that sum.
+    fn migration_with_transfer(
+        status: MigrationStatus,
+        value: u64,
+        tx_state: MigrationTxState,
+    ) -> MigrationState {
+        let value = Zatoshis::const_from_u64(value);
+        let txid = match tx_state {
+            MigrationTxState::Broadcast { txid } | MigrationTxState::Mined { txid, .. } => txid,
+            _ => TxId::from_bytes([7; 32]),
+        };
+        MigrationState::from_parts(
+            status,
+            DenominationPlan::from_stored_parts(
+                vec![value],
+                Zatoshis::ZERO,
+                None,
+                Zatoshis::ZERO,
+                value,
+                value,
+            )
+            .expect("a consistent stored plan reconstructs"),
+            PreparationPlan::from_parts(Vec::new(), Vec::new()),
+            vec![MigrationTransaction::from_parts(
+                MigrationTransferId::new(0),
+                MigrationTxKind::Transfer { crossing: 0 },
+                vec![0xAB; 4],
+                Vec::new(),
+                BlockHeight::from_u32(10),
+                BlockHeight::from_u32(0),
+                None,
+                txid,
+                tx_state,
+                None,
+                None,
+                vec![[9; 32]],
+                None,
+            )],
+            AnchorBucketInterval::ZIP_318,
+            ReplanThreshold::DEFAULT,
+        )
+    }
+
+    /// The history reads: `latest_migration` keeps a finished migration visible after the
+    /// pending-only `get_migration` has moved on; `list_migrations` projects newest-first
+    /// summaries IN SQL — proven by corrupting every stored PCZT first, which a projection that
+    /// parsed them could not survive — and `get_migration_by_id` resolves a summary's identity
+    /// back to the full state, historical or pending.
+    #[test]
+    fn history_reads_survive_replacement() {
+        let mut conn = fresh_conn();
+        let account = insert_account(&conn);
+
+        // A finished migration: one 40k crossing, mined.
+        let mined = MigrationTxState::Mined {
+            txid: TxId::from_bytes([0xA0; 32]),
+            height: BlockHeight::from_u32(90),
+        };
+        let finished = migration_with_transfer(MigrationStatus::Complete, 40_000, mined);
+        PoolMigrations::for_account(NET, SystemClock, &mut conn, account)
+            .expect("account exists")
+            .replace_migration(&finished)
+            .expect("persist finished");
+
+        // Its successor: pending, one 25k crossing, proved but not yet broadcast.
+        let successor =
+            migration_with_transfer(MigrationStatus::Committed, 25_000, MigrationTxState::Proved);
+        PoolMigrations::for_account(NET, SystemClock, &mut conn, account)
+            .expect("account exists")
+            .replace_migration(&successor)
+            .expect("persist successor");
+
+        // The listing never touches the stored PCZTs: corrupt them all, and it must not notice.
+        conn.execute(
+            "UPDATE orchard_ironwood_migration_transactions SET pczt = X'DEAD'",
+            [],
+        )
+        .expect("corrupt every stored pczt");
+
+        let store =
+            PoolMigrations::for_account(NET, SystemClock, &mut conn, account).expect("account");
+        let summaries = store.list_migrations().expect("list");
+        assert_eq!(summaries.len(), 2, "history retains both migrations");
+
+        let newest = &summaries[0];
+        assert_eq!(newest.status(), MigrationStatus::Committed);
+        assert_eq!(newest.total_migratable(), Zatoshis::const_from_u64(25_000));
+        assert_eq!(newest.transaction_count(), 1);
+        assert_eq!(newest.mined_count(), 0);
+        assert_eq!(newest.value_migrated(), Zatoshis::ZERO);
+
+        let history = &summaries[1];
+        assert_eq!(history.status(), MigrationStatus::Complete);
+        assert_eq!(history.transaction_count(), 1);
+        assert_eq!(history.mined_count(), 1);
+        assert_eq!(
+            history.value_migrated(),
+            Zatoshis::const_from_u64(40_000),
+            "the mined transfer's crossing value has crossed"
+        );
+        assert_ne!(newest.id(), history.id());
+
+        // The latest migration is the successor, whatever `get_migration` says; the identities
+        // resolve to the full states (with the corrupted bytes read back verbatim, unparsed).
+        let latest = store.latest_migration().expect("latest");
+        assert_eq!(
+            latest.as_ref().map(|s| s.status()),
+            Some(MigrationStatus::Committed)
+        );
+        assert_eq!(
+            store
+                .get_migration_by_id(history.id())
+                .expect("by id")
+                .map(|s| s.status()),
+            Some(MigrationStatus::Complete),
+            "a historical record resolves by identity"
+        );
+        assert_eq!(
+            store
+                .get_migration_by_id(crate::pool_migration::MigrationUuid::from_uuid(
+                    Uuid::new_v4()
+                ))
+                .expect("by unknown id"),
+            None,
+            "an unknown identity resolves to nothing"
+        );
+    }
+
+    /// A freshly committed migration is stamped with the chain height the wallet knew at first
+    /// persistence — the "when" a history listing sorts by — and the stamp never moves with the
+    /// tip afterwards. With no chain view at all, no value is invented.
+    #[test]
+    fn committed_height_is_stamped_at_first_persistence() {
+        let mut conn = fresh_conn();
+        let account = insert_account(&conn);
+
+        // No chain view: nothing to stamp.
+        let first = migration_under(MigrationStatus::Committed, AnchorBucketInterval::ZIP_318);
+        PoolMigrations::for_account(NET, SystemClock, &mut conn, account)
+            .expect("account exists")
+            .replace_migration(&first)
+            .expect("persist without a chain view");
+        let committed = |conn: &Connection| -> Vec<Option<u32>> {
+            conn.prepare("SELECT committed_height FROM orchard_ironwood_migrations ORDER BY id")
+                .unwrap()
+                .query_map([], |r| r.get(0))
+                .unwrap()
+                .collect::<Result<_, _>>()
+                .unwrap()
+        };
+        assert_eq!(committed(&conn), vec![None]);
+
+        // The wallet learns a chain tip; re-persisting the SAME migration does not invent a
+        // stamp for it retroactively, but its successor is stamped at first persistence.
+        conn.execute(
+            "INSERT INTO scan_queue (block_range_start, block_range_end, priority)
+             VALUES (0, 1001, 0)",
+            [],
+        )
+        .expect("record a scan range");
+        let mut ended = first.clone();
+        ended.mark_superseded();
+        PoolMigrations::for_account(NET, SystemClock, &mut conn, account)
+            .expect("account exists")
+            .replace_migration(&ended)
+            .expect("re-persist");
+        let second = migration_under(MigrationStatus::Committed, AnchorBucketInterval::ZIP_318);
+        PoolMigrations::for_account(NET, SystemClock, &mut conn, account)
+            .expect("account exists")
+            .replace_migration(&second)
+            .expect("persist successor");
+        assert_eq!(committed(&conn), vec![None, Some(1_000)]);
     }
 
     /// A migration in `status`, recorded under `interval`. The plan itself is empty filler: the

--- a/zcash_client_sqlite/src/pool_migration/store.rs
+++ b/zcash_client_sqlite/src/pool_migration/store.rs
@@ -412,6 +412,129 @@ impl<C: Borrow<Connection>> Store<C> {
         read_migration(self.conn.borrow(), self.tables, self.account_id)
     }
 
+    /// The account's most recent migration WHATEVER its status — the record a UI renders, where a
+    /// finished migration must remain visible after [`get_migration`](Self::get_migration) (the
+    /// pending-only drive read) has moved on to `None`. Recency is row order: rows are only ever
+    /// inserted, and the identity-preserving rewrite re-inserts a migration in place of itself,
+    /// so a later row id is a later migration.
+    pub(crate) fn latest_migration(&self) -> Result<Option<MigrationState>, Error> {
+        let conn = self.conn.borrow();
+        let row: Option<i64> = conn
+            .query_row(
+                &format!(
+                    "SELECT id FROM {} WHERE account_id = ? ORDER BY id DESC LIMIT 1",
+                    self.tables.migrations
+                ),
+                params![self.account_id.0],
+                |row| row.get(0),
+            )
+            .optional()?;
+        row.map(|id| read_migration_row(conn, self.tables, id))
+            .transpose()
+    }
+
+    /// The full state of the account's migration identified by `uuid` — historical or pending —
+    /// or `None` when the account has no such migration.
+    pub(crate) fn get_migration_by_id(
+        &self,
+        id: crate::pool_migration::MigrationUuid,
+    ) -> Result<Option<MigrationState>, Error> {
+        let conn = self.conn.borrow();
+        let row: Option<i64> = conn
+            .query_row(
+                &format!(
+                    "SELECT id FROM {} WHERE account_id = ? AND uuid = ?",
+                    self.tables.migrations
+                ),
+                params![self.account_id.0, id.expose_uuid()],
+                |row| row.get(0),
+            )
+            .optional()?;
+        row.map(|id| read_migration_row(conn, self.tables, id))
+            .transpose()
+    }
+
+    /// Every migration the account has run, newest first, PROJECTED IN SQL: the aggregate counts
+    /// and mined value are computed by the database over the typed columns, and no stored PCZT is
+    /// ever read, let alone parsed — a full [`MigrationState`] runs to megabytes of proofs, and a
+    /// history listing must render without deserializing any of them.
+    pub(crate) fn list_migrations(
+        &self,
+    ) -> Result<Vec<crate::pool_migration::MigrationSummary>, Error> {
+        let conn = self.conn.borrow();
+        let t = self.tables;
+        // The lifecycle discriminants and the transfer kind are the engine's wire names, written
+        // through `AsRef<str>` on the way in; stated here via the same constants' values rather
+        // than re-derived per row.
+        let mut stmt = conn.prepare(&format!(
+            "SELECT m.uuid, m.status, m.committed_height,
+                    m.note_split_total_input, m.note_split_total_migratable, m.note_split_change,
+                    (SELECT COUNT(*) FROM {tx} t WHERE t.migration_id = m.id),
+                    (SELECT COUNT(*) FROM {tx} t
+                      WHERE t.migration_id = m.id AND t.state = 'mined'),
+                    (SELECT COUNT(*) FROM {tx} t
+                      WHERE t.migration_id = m.id AND t.state = 'broadcast'),
+                    (SELECT COUNT(*) FROM {tx} t
+                      WHERE t.migration_id = m.id AND t.unsatisfiable_at IS NOT NULL),
+                    (SELECT IFNULL(SUM(cv.value), 0)
+                       FROM {tx} t
+                       JOIN {cv} cv
+                         ON cv.migration_id = t.migration_id AND cv.ordinal = t.kind_crossing
+                      WHERE t.migration_id = m.id AND t.kind = 'transfer' AND t.state = 'mined')
+               FROM {m} m
+              WHERE m.account_id = ?
+              ORDER BY m.id DESC",
+            m = t.migrations,
+            tx = t.transactions,
+            cv = t.crossing_values,
+        ))?;
+        let rows = stmt.query_map(params![self.account_id.0], |row| {
+            Ok((
+                row.get::<_, uuid::Uuid>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<u32>>(2)?,
+                row.get::<_, u64>(3)?,
+                row.get::<_, u64>(4)?,
+                row.get::<_, Option<u64>>(5)?,
+                row.get::<_, u64>(6)?,
+                row.get::<_, u64>(7)?,
+                row.get::<_, u64>(8)?,
+                row.get::<_, u64>(9)?,
+                row.get::<_, u64>(10)?,
+            ))
+        })?;
+        rows.map(|row| {
+            let (
+                uuid,
+                status,
+                committed_height,
+                total_input,
+                total_migratable,
+                change,
+                total,
+                mined,
+                in_flight,
+                unsatisfiable,
+                value_migrated,
+            ) = row?;
+            Ok(crate::pool_migration::MigrationSummary {
+                id: crate::pool_migration::MigrationUuid::from_uuid(uuid),
+                status: MigrationStatus::try_from(status.as_str())
+                    .map_err(|_| Error::Corrupt("status"))?,
+                committed_height: committed_height.map(BlockHeight::from_u32),
+                total_input: Zatoshis::from_u64(total_input)?,
+                total_migratable: Zatoshis::from_u64(total_migratable)?,
+                change: change.map(Zatoshis::from_u64).transpose()?,
+                transaction_count: total as usize,
+                mined_count: mined as usize,
+                in_flight_count: in_flight as usize,
+                unsatisfiable_count: unsatisfiable as usize,
+                value_migrated: Zatoshis::from_u64(value_migrated)?,
+            })
+        })
+        .collect()
+    }
+
     /// Returns the set of [`LockOwner`]s under which this account's in-progress migration has
     /// locked notes (empty if the account has no migration, or none of its transactions hold a
     /// lock).
@@ -1537,8 +1660,10 @@ fn replace_migration_row(
             migration_id
         }
         None => {
-            // A fresh record: mint its identity. `committed_height` is not stamped here; rows
-            // created before the stamping existed carry NULL, and no value is invented.
+            // A fresh record: mint its identity, and stamp the chain height the wallet
+            // currently knows as its commit height — the "when" a history listing sorts by.
+            // `None` when the wallet has no chain view yet (a fixture, a wallet before first
+            // sync); the column is nullable and no value is invented.
             tx.execute(
                 &format!(
                     "INSERT INTO {} (account_id, status, note_split_fee_buffer, note_split_change,
@@ -1551,7 +1676,7 @@ fn replace_migration_row(
                 named_params! {
                     ":account_id": account_id.0,
                     ":uuid": uuid::Uuid::new_v4(),
-                    ":committed_height": None::<u32>,
+                    ":committed_height": crate::wallet::chain_tip_height(tx)?.map(u32::from),
                     ":status": state.status().as_ref(),
                     ":fee_buffer": ns.note_fee_buffer().into_u64(),
                     ":change": ns.change().map(Zatoshis::into_u64),

--- a/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
+++ b/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
@@ -682,15 +682,22 @@ impl Run {
     /// `proving_persists_the_finalized_transaction_to_the_wallet` — simulating the sibling's
     /// independent view requires lifting them.
     fn forget_pending_spend_marks(&mut self, txid: TxId) {
-        self.st
-            .wallet_mut()
-            .conn_mut()
-            .execute(
-                "DELETE FROM orchard_received_note_spends
-                 WHERE transaction_id IN (SELECT id_tx FROM transactions WHERE txid = :txid)",
-                rusqlite::named_params![":txid": txid.as_ref()],
-            )
-            .expect("lifts the pending spend marks");
+        let conn = self.st.wallet_mut().conn_mut();
+        conn.execute(
+            "DELETE FROM orchard_received_note_spends
+             WHERE transaction_id IN (SELECT id_tx FROM transactions WHERE txid = :txid)",
+            rusqlite::named_params![":txid": txid.as_ref()],
+        )
+        .expect("lifts the pending spend marks");
+        // The sibling also knows nothing of THIS wallet's advisory note locks — they are local
+        // database state, not chain state — so simulating its spend through this wallet's own
+        // machinery must lift them too.
+        conn.execute_batch(
+            "UPDATE orchard_received_notes
+                SET lock_expiry_height = NULL, lock_owner = NULL
+              WHERE lock_owner IS NOT NULL",
+        )
+        .expect("lifts the advisory locks a sibling would not see");
     }
 
     /// The wallet's fully-scanned height: the chain state every satisfiability observation the
@@ -896,11 +903,14 @@ impl Run {
         // The drive's determinations are durable: what the store holds agrees with what the drive
         // returned.
         assert_eq!(
-            self.stored_migration()
+            self.store()
+                .latest_migration()
+                .expect("the history reads back")
                 .expect("the migration is in the store")
                 .status(),
             MigrationStatus::Complete,
-            "{}: the store agrees the migration is complete",
+            "{}: the store agrees the migration is complete (as retained history: a terminal \
+             migration leaves the pending-only read)",
             scenario.label
         );
 
@@ -1669,10 +1679,13 @@ fn a_send_max_sweep_marks_the_migration_and_forces_a_replan() {
     committed.state.mark_superseded();
     run.persist(&committed.state);
     assert!(
-        run.stored_migration()
-            .expect("the store holds the migration")
+        run.store()
+            .latest_migration()
+            .expect("the history reads back")
+            .expect("the store retains the migration")
             .is_terminal(),
-        "the persisted migration is terminal, so a replacement may take its place",
+        "the persisted migration is terminal (retained history, gone from the pending-only \
+         read), so a replacement may take its place",
     );
 
     // Now the guard accepts, and the remaining balance is committed to a fresh migration.


### PR DESCRIPTION
Phase B2 of the cancel-instead-of-reset stack (#2903), stacked on #2921 (B1), which is stacked on #2914 (A).

Retained history is invisible without a way to read it — and the Swift SDK's "migration finished" screen breaks the moment `get_migration` goes pending-only — so this is what makes B1's retention mean something:

- **`MigrationUuid`**: the record's stable external identity (following the `AccountUuid` precedent; row ids are not stable across a restore and must not cross an FFI).
- **`latest_migration()`**: the most recent record *whatever its status* — what a UI renders.
- **`list_migrations()`**: newest-first `MigrationSummary` rows **projected entirely in SQL** (status, committed height, plan totals, per-lifecycle transaction counts, and `value_migrated` = the sum of crossing values whose transfer has mined). A full `MigrationState` carries every proven PCZT and runs to megabytes; the listing reads none of them, pinned by a test that corrupts every stored PCZT byte first.
- **`get_migration_by_id()`**: one record's full state, historical or pending.
- **`committed_height` stamping**: a freshly inserted record is stamped with the chain height the wallet knew at first persistence; the stamp never moves, and no value is invented without a chain view.

Placement is inherent on the concrete `PoolMigrations` facade, not on `PoolMigrationRead`: the engine never reads history, so the trait would tax every store with methods the engine never calls.

One deliberate deviation from the plan doc (sec. 6 item 6): identity is **not** carried on `MigrationState`. B1's row-side identity carry-over already gives uuid stability across every rewrite (pinned by test), and state-carried identity would force either an equality quotient on `MigrationState` or a breaking `from_parts` change, for no caller that exists. Flagged for review rather than decided silently.

---

Filed with Claude Code assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Gsndy5ri9eYvtH31DnHTQ
