### PR TITLE
zcash_client_backend, zcash_client_sqlite: Add a bulk address-exposure API

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -10,6 +10,14 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `zcash_client_backend::data_api::WalletWrite::expose_address_range`, which
+  exposes the addresses at a range of transparent child indices. It has a
+  default implementation in terms of
+  `WalletWrite::get_address_for_index`; backends that can perform the range as a
+  single unit of work should override it.
+- `zcash_client_backend::data_api::testing::transparent::expose_address_range`
+
 ## [0.24.0-rc.6] - 2026-07-29
 
 ### Added

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -3797,6 +3797,46 @@ pub trait WalletWrite:
         request: UnifiedAddressRequest,
     ) -> Result<Option<UnifiedAddress>, <Self as WalletRead>::Error>;
 
+    /// Generates, persists, and marks as exposed the addresses of the specified account at each
+    /// transparent child index in the given range, returning them in ascending index order.
+    ///
+    /// This is equivalent to calling [`get_address_for_index`] once per index in the range, with
+    /// the diversifier index corresponding to each transparent child index, and discarding the
+    /// indices for which that method returns `Ok(None)`. Implementations may perform the whole
+    /// range as a single unit of work; the default implementation does not, and simply calls
+    /// [`get_address_for_index`] in a loop.
+    ///
+    /// The primary use for this method is to expose a deep range of addresses ahead of scanning,
+    /// so that a wallet that discovers transparent outputs by scanning blocks (rather than by
+    /// querying an address index) covers every address it has issued. Doing so one address at a
+    /// time can be prohibitively slow: an implementation that commits each address separately
+    /// performs a transaction per address, whereas an implementation of this method may commit
+    /// once for the entire range.
+    ///
+    /// # WARNINGS
+    ///
+    /// The warning on [`get_address_for_index`] concerning transparent receivers outside the
+    /// wallet's gap limit applies to every address produced by this method.
+    ///
+    /// [`get_address_for_index`]: Self::get_address_for_index
+    #[cfg(feature = "transparent-inputs")]
+    fn expose_address_range(
+        &mut self,
+        account: <Self as WalletRead>::AccountId,
+        range: Range<NonHardenedChildIndex>,
+        request: UnifiedAddressRequest,
+    ) -> Result<Vec<(NonHardenedChildIndex, UnifiedAddress)>, <Self as WalletRead>::Error> {
+        let mut result = vec![];
+        for index in transparent::keys::NonHardenedChildRange::from(range) {
+            if let Some(address) =
+                self.get_address_for_index(account, DiversifierIndex::from(index), request)?
+            {
+                result.push((index, address));
+            }
+        }
+        Ok(result)
+    }
+
     /// Updates the wallet's view of the blockchain.
     ///
     /// This method is used to provide the wallet with information about the state of the

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -1180,6 +1180,69 @@ where
     assert_eq!(query_height, h0);
 }
 
+/// Tests that [`WalletWrite::expose_address_range`] is equivalent to exposing each index of the
+/// range individually with [`WalletWrite::get_address_for_index`].
+pub fn expose_address_range<DSF>(ds_factory: DSF, cache: impl TestCache)
+where
+    DSF: DataStoreFactory,
+{
+    use transparent::keys::NonHardenedChildIndex;
+    use zcash_keys::keys::ReceiverRequirement::*;
+    use zip32::DiversifierIndex;
+
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(ds_factory)
+        .with_block_cache(cache)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let account_uuid = st.test_account().unwrap().id();
+    let request = UnifiedAddressRequest::unsafe_custom(Allow, Allow, Require);
+
+    let index = |i: u32| NonHardenedChildIndex::from_index(i).unwrap();
+    let range = index(5)..index(25);
+
+    let exposed = st
+        .wallet_mut()
+        .expose_address_range(account_uuid, range.clone(), request)
+        .unwrap();
+
+    // Every index in the range has a transparent receiver, so every one of them is returned, in
+    // ascending order.
+    assert_eq!(
+        exposed.iter().map(|(i, _)| *i).collect::<Vec<_>>(),
+        (5..25).map(index).collect::<Vec<_>>()
+    );
+
+    // Each address is the one that would have been exposed at that index individually. Exposing
+    // an address that has already been exposed at a different address for the same index is an
+    // error, so these calls also assert that the range was recorded as exposed.
+    for (i, address) in &exposed {
+        assert_eq!(
+            st.wallet_mut()
+                .get_address_for_index(account_uuid, DiversifierIndex::from(*i), request)
+                .unwrap()
+                .as_ref(),
+            Some(address)
+        );
+    }
+
+    // The transparent receivers of the exposed addresses are known to the wallet.
+    let external_taddrs = st
+        .wallet()
+        .get_transparent_receivers(account_uuid, false, true)
+        .unwrap();
+    for (i, address) in &exposed {
+        let taddr = address
+            .transparent()
+            .expect("a transparent receiver was required");
+        assert!(
+            external_taddrs.contains_key(taddr),
+            "the address exposed at index {i:?} is a known transparent receiver"
+        );
+    }
+}
+
 /// Builds a test 1-of-1 multisig redeem script from a single keypair.
 #[cfg(feature = "transparent-key-import")]
 fn build_test_redeem_script() -> (script::Redeem, secp256k1::SecretKey) {

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -10,6 +10,13 @@ workspace.
 
 ## [Unreleased]
 
+### Changed
+- `WalletDb` implements the new `WalletWrite::expose_address_range` method,
+  exposing the whole range in a single database transaction and reading the
+  account and the chain tip height once for the range instead of once per
+  address. Exposing a deep range of addresses is substantially faster than the
+  equivalent sequence of `WalletWrite::get_address_for_index` calls.
+
 ## [0.22.0-rc.6] - 2026-07-29
 
 ### Added

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -1803,6 +1803,18 @@ impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL: Clock, R:
         self.transactionally(|wdb| wdb.get_address_for_index(account, diversifier_index, request))
     }
 
+    #[cfg(feature = "transparent-inputs")]
+    fn expose_address_range(
+        &mut self,
+        account: <Self as WalletRead>::AccountId,
+        range: Range<NonHardenedChildIndex>,
+        request: UnifiedAddressRequest,
+    ) -> Result<Vec<(NonHardenedChildIndex, UnifiedAddress)>, <Self as WalletRead>::Error> {
+        // The whole range is exposed in a single transaction; exposing a deep range one
+        // transaction per address is dominated by the per-address commit.
+        self.transactionally(|wdb| wdb.expose_address_range(account, range, request))
+    }
+
     fn update_chain_tip(
         &mut self,
         tip_height: BlockHeight,
@@ -2212,6 +2224,50 @@ impl<P: consensus::Parameters, CL: Clock, R: RngCore> WalletWrite
         } else {
             Err(SqliteClientError::AccountUnknown)
         }
+    }
+
+    #[cfg(feature = "transparent-inputs")]
+    fn expose_address_range(
+        &mut self,
+        account: <Self as WalletRead>::AccountId,
+        range: Range<NonHardenedChildIndex>,
+        request: UnifiedAddressRequest,
+    ) -> Result<Vec<(NonHardenedChildIndex, UnifiedAddress)>, <Self as WalletRead>::Error> {
+        use ::transparent::keys::NonHardenedChildRange;
+        use zcash_keys::keys::AddressGenerationError::*;
+
+        // The account (and with it the deserialization of its UIVK) and the chain tip height are
+        // read once for the whole range, instead of once per address as `get_address_for_index`
+        // must do.
+        let account = self
+            .get_account(account)?
+            .ok_or(SqliteClientError::AccountUnknown)?;
+        let chain_tip_height = wallet::chain_tip_height(self.conn.borrow())?;
+        let exposure_height = chain_tip_height.unwrap_or(account.birthday());
+
+        let mut result = vec![];
+        for index in NonHardenedChildRange::from(range) {
+            let diversifier_index = DiversifierIndex::from(index);
+            match account.uivk().address(diversifier_index, request) {
+                Ok(address) => {
+                    upsert_address(
+                        self.conn.borrow(),
+                        &self.params,
+                        account.internal_id(),
+                        diversifier_index,
+                        &address,
+                        Some(exposure_height),
+                        true,
+                    )?;
+
+                    result.push((index, address));
+                }
+                Err(InvalidTransparentChildIndex(_)) | Err(InvalidSaplingDiversifierIndex(_)) => (),
+                Err(e) => return Err(SqliteClientError::AddressGeneration(e)),
+            }
+        }
+
+        Ok(result)
     }
 
     fn update_chain_tip(

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -3263,6 +3263,14 @@ mod tests {
         );
     }
 
+    #[test]
+    fn expose_address_range() {
+        zcash_client_backend::data_api::testing::transparent::expose_address_range(
+            TestDbFactory::default(),
+            BlockCache::new(),
+        );
+    }
+
     /// Deriving an address that already exists as a standalone (`Foreign`) import upgrades the
     /// existing row in place — same `id`, derived scope, import columns cleared — rather than
     /// inserting a duplicate row for the same transparent receiver, and any UTXO already


### PR DESCRIPTION
### Problem

There is no way to expose a range of addresses other than N calls to `WalletWrite::get_address_for_index`. In `zcash_client_sqlite` that method wraps itself in its own `transactionally(..)` — one commit per address — and its inner implementation additionally re-reads and deserializes the account's UIVK and reads the chain tip height on every call, around a single derivation and a single `upsert_address`.

This matters to wallets that discover transparent outputs by scanning blocks rather than by querying an address index: such a wallet must expose the whole range of addresses it has issued *before* scanning, or the scan will not match outputs paying addresses it has not yet exposed. An exchange sizing that range to its issuance high-water mark is exposing tens of thousands of addresses, one commit at a time, on its wallet writer thread.

Wallet users most likely to experience this slowdown are users who generate thousands of transparent addresses which remain unfunded. This is a common pattern at businesses which give users Zcash deposit addresses which may never receive funds, such as when a user almost checks out then decides not to purchase something. 

zecd hits this directly, and the shape of its workaround is the argument for the API:

- [`src/wallet/actor.rs#L2072-L2177`](https://github.com/zecrocks/zecd/blob/86a32fee976adf3841b8acbe424de14b8c0dcdee/src/wallet/actor.rs#L2072-L2177)
  — `preexpose_transparent_chunk`, a hand-rolled chunked driver over `get_address_for_index` with its
  own resume cursor, progress heartbeat and completion logging.
- [`src/wallet/actor.rs#L2140-L2149`](https://github.com/zecrocks/zecd/blob/86a32fee976adf3841b8acbe424de14b8c0dcdee/src/wallet/actor.rs#L2140-L2149)
  — the loop itself, wrapped in `WalletDb::transactionally` specifically to get one commit per chunk
  instead of one per address. This is precisely the batching the proposed method makes a first-class
  operation, and it is only reachable because `transactionally` happens to be public.
- [`src/wallet/actor.rs#L336-L340`](https://github.com/zecrocks/zecd/blob/86a32fee976adf3841b8acbe424de14b8c0dcdee/src/wallet/actor.rs#L336-L340)
  and [`#L2400-L2420`](https://github.com/zecrocks/zecd/blob/86a32fee976adf3841b8acbe424de14b8c0dcdee/src/wallet/actor.rs#L2400-L2420)
  — a 1000-index chunk size and an explicit `yield_now` at the chunk boundary, both needed because
  the derivation runs on a single-writer actor thread that also serves RPCs.
- [`regtest-harness/tests/regtest_transparent_preexpose_responsive.rs`](https://github.com/zecrocks/zecd/blob/86a32fee976adf3841b8acbe424de14b8c0dcdee/regtest-harness/tests/regtest_transparent_preexpose_responsive.rs)
  — a whole end-to-end regression test asserting the daemon stays responsive throughout a deep
  pre-exposure, written after a release where chunking sliced the work but still blocked the runtime.

### Change

Add `WalletWrite::expose_address_range`, with a default implementation that calls
`get_address_for_index` in a loop (so no other backend has to change), and override it in
`zcash_client_sqlite` to run the whole range in one transaction with the account load and the
chain-tip read hoisted out of the loop.

Exposing 2000 addresses on a file-backed wallet database, release build:

| path | rate |
| --- | --- |
| `get_address_for_index`, one call at a time | 116 addresses/s |
| `get_address_for_index`, one transaction | 493 addresses/s |
| `expose_address_range` | 1174 addresses/s |

The middle row is what zecd already achieves for itself at
[`actor.rs#L2140-L2149`](https://github.com/zecrocks/zecd/blob/86a32fee976adf3841b8acbe424de14b8c0dcdee/src/wallet/actor.rs#L2140-L2149);
the remaining factor of two is the per-call account load and chain-tip read, which is only reachable
from inside the implementation. The final rate is close to the rate at which the addresses can be
derived at all.

### Note on the signature

There is no `key_scope` parameter: this is a batch of `get_address_for_index`, which has no scope
argument and always writes the external key scope. Widening it to expose internal or ephemeral
ranges would be a larger semantic decision, and is easy to add later. The method is gated on
`transparent-inputs`, as the range it takes is a range of transparent child indices.

### Testing

New shared test `data_api::testing::transparent::expose_address_range` (the range is equivalent to
exposing each index individually, and the resulting receivers are known to the wallet), wired into
`zcash_client_sqlite`. Both crates' suites pass under `--all-features`.

### Related Issues

Sub-issue of #2470, which currently has no address-generation or address-exposure item. Independent
of the two gap-maintenance PRs; can land in any order.
