### PR TITLE
zcash_client_sqlite: cancel a pool migration (Phase C)

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -11,6 +11,15 @@ workspace.
 ## [Unreleased]
 
 ### Added
+- `pool_migration::orchard_ironwood::PoolMigrations::cancel_migration` and
+  `pool_migration::CancelOutcome`: cancel the account's migration at the
+  user's request. Releases the note reservations of its never-broadcast
+  transactions (returning them to default note selection immediately), then
+  records the terminal `cancelled` status, without deserializing the migration
+  state — so it works on a record that no longer parses. Transactions already
+  broadcast cannot be recalled; the outcome reports them rather than refusing.
+  With no pending migration, only the repair half runs: the latest retained
+  record's reservations are released and its status is untouched.
 - `pool_migration::orchard_ironwood::PoolMigrations::take_transaction_for_broadcast`:
   finalizes a proved migration transaction, records it in the wallet's own
   transaction tables, and returns the broadcastable `Transaction`, in one
@@ -40,6 +49,11 @@ workspace.
   one in progress.
 
 ### Changed
+- Persisting a pool-migration state with any terminal status through
+  `replace_migration` now releases the note reservations held by its
+  never-broadcast transactions, in the same write: a migration superseded in
+  response to `Replan` (or marked failed or cancelled through the engine) no
+  longer strands its live transfers' locks until they expire.
 - Proving a migration transaction no longer writes it into the wallet's own
   transaction tables: `store_proved_transaction` records the proof in the
   migration store alone, and the wallet-side record (raw transaction, sent

--- a/zcash_client_sqlite/src/pool_migration.rs
+++ b/zcash_client_sqlite/src/pool_migration.rs
@@ -87,7 +87,7 @@ mod store;
 pub mod orchard_ironwood;
 
 use uuid::Uuid;
-use zcash_pool_migration::engine::MigrationStatus;
+use zcash_pool_migration::engine::{MigrationStatus, MigrationTransferId};
 use zcash_protocol::{consensus::BlockHeight, value::Zatoshis};
 
 /// The stable external identity of one pool-migration record, following the
@@ -193,5 +193,38 @@ impl MigrationSummary {
     /// whose transfer has been observed mined.
     pub fn value_migrated(&self) -> Zatoshis {
         self.value_migrated
+    }
+}
+
+/// What a [`cancel_migration`](orchard_ironwood::PoolMigrations::cancel_migration) call found and
+/// did, transaction by transaction: cancel is honest about what it cannot undo, so it SUCCEEDS
+/// and reports rather than refusing once something is in flight (refusal would reintroduce the
+/// stuck state cancel exists to remove).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct CancelOutcome {
+    pub(crate) in_flight: Vec<MigrationTransferId>,
+    pub(crate) mined: Vec<MigrationTransferId>,
+    pub(crate) released: Vec<MigrationTransferId>,
+}
+
+impl CancelOutcome {
+    /// Transactions already BROADCAST when cancel ran: they cannot be recalled, and coins may
+    /// still land. Their wallet-side records (spend marks included) are untouched — a mempool may
+    /// mine them whatever the wallet does next — and their inclusion or expiry plays out on
+    /// chain. A UI renders these as "N transactions are already on their way".
+    pub fn in_flight(&self) -> &[MigrationTransferId] {
+        &self.in_flight
+    }
+
+    /// Transactions already MINED: part of chain history, reported for completeness.
+    pub fn mined(&self) -> &[MigrationTransferId] {
+        &self.mined
+    }
+
+    /// Never-broadcast transactions whose note reservations were released: their advisory locks
+    /// are cleared, so the notes they would have spent return to DEFAULT note selection
+    /// immediately rather than at lock expiry.
+    pub fn released(&self) -> &[MigrationTransferId] {
+        &self.released
     }
 }

--- a/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
+++ b/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
@@ -298,6 +298,29 @@ impl<C: Borrow<Connection>, P, CL> PoolMigrations<C, P, CL> {
     }
 }
 
+impl<C: BorrowMut<Connection>, P, CL> PoolMigrations<C, P, CL> {
+    /// Cancel this account's migration at the user's request: release every note reservation its
+    /// never-broadcast transactions hold, then move the record to the terminal `Cancelled`
+    /// status — in that order, in one database transaction, so a crash between the two leaves a
+    /// still-pending migration that a retried cancel finishes. After this returns, the engine
+    /// drives nothing, the released notes are back in DEFAULT note selection immediately (rather
+    /// than at lock expiry), and a replacement migration may be planned and committed over the
+    /// full balance; the cancelled record remains readable through
+    /// [`latest_migration`](Self::latest_migration) and its siblings.
+    ///
+    /// Works WITHOUT deserializing the migration state — the primary use case is an
+    /// unrecoverable wallet, and a record that will not parse is one of the ways to get there —
+    /// and is honest about what it cannot undo: transactions already broadcast may still mine,
+    /// and the returned [`CancelOutcome`](crate::pool_migration::CancelOutcome) reports them
+    /// rather than refusing (a refusal would reintroduce the stuck state cancel exists to
+    /// remove). Calling with no pending migration performs only the REPAIR half on the latest
+    /// retained record, releasing reservations a terminal record may still hold (for instance
+    /// one recorded `Failed` by an older client) without rewriting its status.
+    pub fn cancel_migration(&mut self) -> Result<crate::pool_migration::CancelOutcome, Error> {
+        self.store.cancel_migration()
+    }
+}
+
 impl<C: Borrow<Connection>, P, CL> PoolMigrationRead for PoolMigrations<C, P, CL> {
     type Error = Error;
 
@@ -2173,6 +2196,13 @@ mod tests {
                 block_range_start INTEGER NOT NULL,
                 block_range_end INTEGER NOT NULL,
                 priority INTEGER NOT NULL
+             );
+             -- A minimal stand-in for the source pool's received-note rows: the columns note
+             -- locking records on them, which cancel and every terminal transition release.
+             CREATE TABLE orchard_received_notes (
+                id INTEGER PRIMARY KEY,
+                lock_expiry_height INTEGER,
+                lock_owner BLOB
              );",
         )
         .expect("create accounts table");
@@ -2459,6 +2489,317 @@ mod tests {
             .replace_migration(&second)
             .expect("persist successor");
         assert_eq!(committed(&conn), vec![None, Some(1_000)]);
+    }
+
+    /// A locked source-note row under `owner`, standing in for the reservation the prover takes.
+    fn lock_note(conn: &Connection, id: u32, owner: [u8; 32]) {
+        conn.execute(
+            "INSERT INTO orchard_received_notes (id, lock_expiry_height, lock_owner)
+             VALUES (:id, 99999, :owner)",
+            rusqlite::named_params![":id": id, ":owner": owner],
+        )
+        .unwrap();
+    }
+
+    /// The owners currently holding locks in the stand-in note table.
+    fn locked_owners(conn: &Connection) -> Vec<[u8; 32]> {
+        conn.prepare(
+            "SELECT lock_owner FROM orchard_received_notes
+              WHERE lock_owner IS NOT NULL ORDER BY id",
+        )
+        .unwrap()
+        .query_map([], |r| r.get(0))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap()
+    }
+
+    /// Cancel classifies every transaction off its lifecycle column, releases exactly the
+    /// never-broadcast transactions' reservations (another flow's lock is untouched), flips the
+    /// record to `Cancelled`, and leaves it readable as history while `get_migration` moves on.
+    #[test]
+    fn cancel_releases_reservations_and_terminates() {
+        use zcash_pool_migration::engine::MigrationLockOwner;
+
+        let mut conn = fresh_conn();
+        let account = insert_account(&conn);
+
+        let owner = [7u8; 32];
+        let rival = [9u8; 32];
+        lock_note(&conn, 1, owner);
+        lock_note(&conn, 2, rival);
+
+        // One transaction per disposition: proved-and-locked (released), broadcast (in flight),
+        // mined (history).
+        let mined_state = MigrationTxState::Mined {
+            txid: TxId::from_bytes([0xC0; 32]),
+            height: BlockHeight::from_u32(50),
+        };
+        let mut proved = migration_with_transfer(
+            MigrationStatus::InProgress,
+            40_000,
+            MigrationTxState::Proved,
+        );
+        let mut txs = proved.transactions().to_vec();
+        txs[0] = MigrationTransaction::from_parts(
+            txs[0].id(),
+            txs[0].kind(),
+            txs[0].pczt().to_vec(),
+            txs[0].depends_on().to_vec(),
+            txs[0].scheduled_height(),
+            txs[0].expiry_height(),
+            txs[0].anchor_boundary(),
+            txs[0].txid(),
+            MigrationTxState::Proved,
+            Some(MigrationLockOwner::from_bytes(owner)),
+            None,
+            txs[0].spend_nullifiers().to_vec(),
+            None,
+        );
+        txs.push(MigrationTransaction::from_parts(
+            MigrationTransferId::new(1),
+            MigrationTxKind::Preparation { layer: 0, index: 0 },
+            vec![1],
+            Vec::new(),
+            BlockHeight::from_u32(5),
+            BlockHeight::from_u32(0),
+            None,
+            TxId::from_bytes([0xB0; 32]),
+            MigrationTxState::Broadcast {
+                txid: TxId::from_bytes([0xB0; 32]),
+            },
+            None,
+            None,
+            Vec::new(),
+            None,
+        ));
+        txs.push(MigrationTransaction::from_parts(
+            MigrationTransferId::new(2),
+            MigrationTxKind::Preparation { layer: 0, index: 1 },
+            vec![2],
+            Vec::new(),
+            BlockHeight::from_u32(5),
+            BlockHeight::from_u32(0),
+            None,
+            TxId::from_bytes([0xC0; 32]),
+            mined_state,
+            None,
+            None,
+            Vec::new(),
+            None,
+        ));
+        proved = MigrationState::from_parts(
+            MigrationStatus::InProgress,
+            proved.denominations().clone(),
+            proved.preparation().clone(),
+            txs,
+            AnchorBucketInterval::ZIP_318,
+            ReplanThreshold::DEFAULT,
+        );
+        PoolMigrations::for_account(NET, SystemClock, &mut conn, account)
+            .expect("account exists")
+            .replace_migration(&proved)
+            .expect("persist");
+
+        let outcome = PoolMigrations::for_account(NET, SystemClock, &mut conn, account)
+            .expect("account exists")
+            .cancel_migration()
+            .expect("cancel succeeds");
+
+        assert_eq!(outcome.released(), &[MigrationTransferId::new(0)]);
+        assert_eq!(outcome.in_flight(), &[MigrationTransferId::new(1)]);
+        assert_eq!(outcome.mined(), &[MigrationTransferId::new(2)]);
+        assert_eq!(
+            locked_owners(&conn),
+            vec![rival],
+            "the migration's reservation is released; the rival flow's is untouched"
+        );
+
+        let store =
+            PoolMigrations::for_account(NET, SystemClock, &mut conn, account).expect("account");
+        assert_eq!(store.get_migration().expect("read"), None);
+        assert_eq!(
+            store
+                .latest_migration()
+                .expect("history reads back")
+                .map(|s| s.status()),
+            Some(MigrationStatus::Cancelled),
+            "the cancelled record is retained history"
+        );
+        // A replacement commits over it.
+        let successor = migration_under(MigrationStatus::Committed, AnchorBucketInterval::ZIP_318);
+        PoolMigrations::for_account(NET, SystemClock, &mut conn, account)
+            .expect("account exists")
+            .replace_migration(&successor)
+            .expect("the commit guard's terminality requirement is satisfied");
+    }
+
+    /// Cancel succeeds against a migration whose STATE will not deserialize: it never parses the
+    /// record — the primary use case is an unrecoverable wallet, and a corrupt row is one of the
+    /// ways to get there.
+    #[test]
+    fn cancel_survives_a_corrupt_migration() {
+        let mut conn = fresh_conn();
+        let account = insert_account(&conn);
+        let live =
+            migration_with_transfer(MigrationStatus::Committed, 40_000, MigrationTxState::Proved);
+        PoolMigrations::for_account(NET, SystemClock, &mut conn, account)
+            .expect("account exists")
+            .replace_migration(&live)
+            .expect("persist");
+
+        // Corrupt the transaction row's KIND, which the state reader must parse and cancel must
+        // not.
+        conn.execute(
+            "UPDATE orchard_ironwood_migration_transactions SET kind = 'garbage'",
+            [],
+        )
+        .expect("corrupts the row");
+        assert!(
+            PoolMigrations::for_account(NET, SystemClock, &mut conn, account)
+                .expect("account exists")
+                .get_migration()
+                .is_err(),
+            "premise: the state no longer deserializes"
+        );
+
+        let outcome = PoolMigrations::for_account(NET, SystemClock, &mut conn, account)
+            .expect("account exists")
+            .cancel_migration()
+            .expect("cancel does not read what it does not need");
+        assert_eq!(outcome.released(), &[MigrationTransferId::new(0)]);
+        let status: String = conn
+            .query_row("SELECT status FROM orchard_ironwood_migrations", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(status, "cancelled");
+    }
+
+    /// Cancel with no PENDING migration performs the repair half only: the latest retained
+    /// record's reservations are released, and its recorded status — history — is untouched.
+    #[test]
+    fn cancel_repairs_an_already_terminal_record_without_rewriting_it() {
+        use zcash_pool_migration::engine::MigrationLockOwner;
+
+        let mut conn = fresh_conn();
+        let account = insert_account(&conn);
+        let owner = [4u8; 32];
+        lock_note(&conn, 1, owner);
+
+        let mut txs =
+            migration_with_transfer(MigrationStatus::Failed, 40_000, MigrationTxState::Proved)
+                .transactions()
+                .to_vec();
+        txs[0] = MigrationTransaction::from_parts(
+            txs[0].id(),
+            txs[0].kind(),
+            txs[0].pczt().to_vec(),
+            txs[0].depends_on().to_vec(),
+            txs[0].scheduled_height(),
+            txs[0].expiry_height(),
+            txs[0].anchor_boundary(),
+            txs[0].txid(),
+            MigrationTxState::Proved,
+            Some(MigrationLockOwner::from_bytes(owner)),
+            None,
+            txs[0].spend_nullifiers().to_vec(),
+            None,
+        );
+        let failed =
+            migration_with_transfer(MigrationStatus::Failed, 40_000, MigrationTxState::Proved);
+        let failed = MigrationState::from_parts(
+            MigrationStatus::Failed,
+            failed.denominations().clone(),
+            failed.preparation().clone(),
+            txs,
+            AnchorBucketInterval::ZIP_318,
+            ReplanThreshold::DEFAULT,
+        );
+        // Insert the terminal record DIRECTLY as an old client would have left it (the
+        // terminal-transition release in `replace_migration` would otherwise discharge the lock
+        // on the way in, which is itself the behavior `supersede_releases_reservations` pins).
+        PoolMigrations::for_account(NET, SystemClock, &mut conn, account)
+            .expect("account exists")
+            .replace_migration(&failed)
+            .expect("persist");
+        // Re-take the lock, modeling the stranded field state.
+        conn.execute(
+            "UPDATE orchard_received_notes SET lock_owner = :owner, lock_expiry_height = 99999",
+            rusqlite::named_params![":owner": owner],
+        )
+        .unwrap();
+
+        let outcome = PoolMigrations::for_account(NET, SystemClock, &mut conn, account)
+            .expect("account exists")
+            .cancel_migration()
+            .expect("repair succeeds");
+        assert_eq!(outcome.released(), &[MigrationTransferId::new(0)]);
+        assert!(locked_owners(&conn).is_empty(), "the stranded lock is gone");
+        let status: String = conn
+            .query_row("SELECT status FROM orchard_ironwood_migrations", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(status, "failed", "history is never rewritten");
+    }
+
+    /// EVERY terminal transition that flows through the ordinary persist path releases the
+    /// never-broadcast reservations: the consumer's `mark_superseded` response to `Replan` must
+    /// not strand the live transfers' locks behind a record nothing will revisit.
+    #[test]
+    fn supersede_releases_reservations_on_persist() {
+        use zcash_pool_migration::engine::MigrationLockOwner;
+
+        let mut conn = fresh_conn();
+        let account = insert_account(&conn);
+        let owner = [5u8; 32];
+        lock_note(&conn, 1, owner);
+
+        let live = migration_with_transfer(
+            MigrationStatus::InProgress,
+            40_000,
+            MigrationTxState::Proved,
+        );
+        let mut txs = live.transactions().to_vec();
+        txs[0] = MigrationTransaction::from_parts(
+            txs[0].id(),
+            txs[0].kind(),
+            txs[0].pczt().to_vec(),
+            txs[0].depends_on().to_vec(),
+            txs[0].scheduled_height(),
+            txs[0].expiry_height(),
+            txs[0].anchor_boundary(),
+            txs[0].txid(),
+            MigrationTxState::Proved,
+            Some(MigrationLockOwner::from_bytes(owner)),
+            None,
+            txs[0].spend_nullifiers().to_vec(),
+            None,
+        );
+        let mut live = MigrationState::from_parts(
+            MigrationStatus::InProgress,
+            live.denominations().clone(),
+            live.preparation().clone(),
+            txs,
+            AnchorBucketInterval::ZIP_318,
+            ReplanThreshold::DEFAULT,
+        );
+        PoolMigrations::for_account(NET, SystemClock, &mut conn, account)
+            .expect("account exists")
+            .replace_migration(&live)
+            .expect("persist live");
+        assert_eq!(locked_owners(&conn), vec![owner]);
+
+        live.mark_superseded();
+        PoolMigrations::for_account(NET, SystemClock, &mut conn, account)
+            .expect("account exists")
+            .replace_migration(&live)
+            .expect("persist superseded");
+        assert!(
+            locked_owners(&conn).is_empty(),
+            "persisting the terminal state released the reservation"
+        );
     }
 
     /// A migration in `status`, recorded under `interval`. The plan itself is empty filler: the

--- a/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
+++ b/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
@@ -298,7 +298,15 @@ impl<C: Borrow<Connection>, P, CL> PoolMigrations<C, P, CL> {
     }
 }
 
-impl<C: BorrowMut<Connection>, P, CL> PoolMigrations<C, P, CL> {
+/// Cancellation, the one inherent method that must WRITE, and so the one that cannot join the
+/// read-only inherent block above: those methods need only a shared `Borrow<Connection>`, and
+/// `BorrowMut` is a strict subtrait of it, so merging the two would force every reader to hold a
+/// mutable borrow. It does not join the `BorrowMut` block below either, which is gated on the
+/// `orchard` feature and additionally bounded by `P` and `CL`; cancel requires none of the three.
+impl<C, P, CL> PoolMigrations<C, P, CL>
+where
+    C: BorrowMut<Connection>,
+{
     /// Cancel this account's migration at the user's request: release every note reservation its
     /// never-broadcast transactions hold, then move the record to the terminal `Cancelled`
     /// status — in that order, in one database transaction, so a crash between the two leaves a
@@ -2519,8 +2527,6 @@ mod tests {
     /// record to `Cancelled`, and leaves it readable as history while `get_migration` moves on.
     #[test]
     fn cancel_releases_reservations_and_terminates() {
-        use zcash_pool_migration::engine::MigrationLockOwner;
-
         let mut conn = fresh_conn();
         let account = insert_account(&conn);
 
@@ -2680,8 +2686,6 @@ mod tests {
     /// record's reservations are released, and its recorded status — history — is untouched.
     #[test]
     fn cancel_repairs_an_already_terminal_record_without_rewriting_it() {
-        use zcash_pool_migration::engine::MigrationLockOwner;
-
         let mut conn = fresh_conn();
         let account = insert_account(&conn);
         let owner = [4u8; 32];
@@ -2749,8 +2753,6 @@ mod tests {
     /// not strand the live transfers' locks behind a record nothing will revisit.
     #[test]
     fn supersede_releases_reservations_on_persist() {
-        use zcash_pool_migration::engine::MigrationLockOwner;
-
         let mut conn = fresh_conn();
         let account = insert_account(&conn);
         let owner = [5u8; 32];

--- a/zcash_client_sqlite/src/pool_migration/store.rs
+++ b/zcash_client_sqlite/src/pool_migration/store.rs
@@ -578,6 +578,34 @@ impl<C: BorrowMut<Connection>> Store<C> {
         self.replace_migration_with(state, |_| Ok(()))
     }
 
+    /// Cancel the account's migration: release every note reservation its never-broadcast
+    /// transactions hold, then move its record to the terminal `cancelled` status — in that
+    /// order, in one database transaction, so every crash prefix leaves a still-pending
+    /// migration that a retried cancel finishes (the reverse order could leave a terminal
+    /// record nothing will revisit while its reservations stand).
+    ///
+    /// Deliberately performed WITHOUT deserializing the migration state: the primary use case is
+    /// an unrecoverable wallet, and a record that will not parse is one of the ways to get
+    /// there. Everything needed — each transaction's lifecycle state and lock-owner token — is
+    /// readable from typed columns.
+    ///
+    /// When the account has no PENDING migration, the latest retained record (if any) gets the
+    /// REPAIR half only: its never-broadcast transactions' reservations are released, and its
+    /// terminal status is left exactly as recorded — cancel never rewrites history, but a
+    /// stranded reservation is not history, and the field contains terminal records (the mobile
+    /// SDK's hand-rolled cancel persisted `failed`) whose locks nothing else will release before
+    /// they expire.
+    pub(crate) fn cancel_migration(
+        &mut self,
+    ) -> Result<crate::pool_migration::CancelOutcome, Error> {
+        let tables = self.tables;
+        let account_id = self.account_id;
+        let tx = self.conn.borrow_mut().transaction()?;
+        let outcome = cancel_migration(&tx, tables, account_id)?;
+        tx.commit()?;
+        Ok(outcome)
+    }
+
     /// Replace the migration as [`replace_migration`](Self::replace_migration) does, then run
     /// `and_then` inside the SAME database transaction, so the store update and whatever the
     /// caller must record alongside it commit or roll back as one atomic write. This is the seam a
@@ -758,6 +786,102 @@ pub(crate) fn truncate_to_height(
         }
     }
     Ok(())
+}
+
+/// The classification a cancel makes of one migration transaction, straight off its lifecycle
+/// column: everything before broadcast is releasable (its reservation can be cleared and it will
+/// never be submitted), everything at or past broadcast is chain reality to report, not undo.
+fn classify_for_cancel(
+    conn: &Connection,
+    t: &Tables,
+    migration_id: i64,
+) -> Result<(crate::pool_migration::CancelOutcome, Vec<[u8; 32]>), Error> {
+    let mut outcome = crate::pool_migration::CancelOutcome::default();
+    let mut owners: Vec<[u8; 32]> = Vec::new();
+    let mut stmt = conn.prepare(&format!(
+        "SELECT transfer_id, state, lock_owner FROM {} WHERE migration_id = ? ORDER BY transfer_id",
+        t.transactions
+    ))?;
+    let rows = stmt.query_map(params![migration_id], |row| {
+        Ok((
+            row.get::<_, u32>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, Option<[u8; 32]>>(2)?,
+        ))
+    })?;
+    for row in rows {
+        let (transfer_id, state, lock_owner) = row?;
+        let id = MigrationTransferId::new(transfer_id);
+        match state.as_str() {
+            "broadcast" => outcome.in_flight.push(id),
+            "mined" => outcome.mined.push(id),
+            // `awaiting_signature`, `signed`, `proved` — and, defensively, anything a future
+            // release might add before broadcast: never submitted, so releasable.
+            _ => {
+                outcome.released.push(id);
+                if let Some(owner) = lock_owner {
+                    owners.push(owner);
+                }
+            }
+        }
+    }
+    Ok((outcome, owners))
+}
+
+/// Release the note reservations held under `owners` on the migration's SOURCE pool: the lock
+/// columns note locking records on the received-note rows are cleared wherever they name one of
+/// these tokens. Scoped strictly by owner token — which the prover derived from each
+/// transaction's own spent notes — so no other flow's reservation can be touched.
+fn release_lock_owners(conn: &Connection, t: &Tables, owners: &[[u8; 32]]) -> Result<(), Error> {
+    let mut stmt = conn.prepare(&format!(
+        "UPDATE {} SET lock_expiry_height = NULL, lock_owner = NULL WHERE lock_owner = ?",
+        t.source_notes
+    ))?;
+    for owner in owners {
+        stmt.execute(params![owner])?;
+    }
+    Ok(())
+}
+
+/// The body of [`Store::cancel_migration`]; see its documentation for the contract, the ordering
+/// argument, and the no-pending repair behavior.
+fn cancel_migration(
+    tx: &rusqlite::Transaction,
+    t: &Tables,
+    account_id: AccountRef,
+) -> Result<crate::pool_migration::CancelOutcome, Error> {
+    let (migration_id, is_pending) = match resolve_migration_id(tx, t, account_id)? {
+        Some(id) => (Some(id), true),
+        None => {
+            // No pending migration: the repair half only, on the latest retained record.
+            let latest: Option<i64> = tx
+                .query_row(
+                    &format!(
+                        "SELECT id FROM {} WHERE account_id = ? ORDER BY id DESC LIMIT 1",
+                        t.migrations
+                    ),
+                    params![account_id.0],
+                    |row| row.get(0),
+                )
+                .optional()?;
+            (latest, false)
+        }
+    };
+    let Some(migration_id) = migration_id else {
+        return Ok(crate::pool_migration::CancelOutcome::default());
+    };
+
+    let (outcome, owners) = classify_for_cancel(tx, t, migration_id)?;
+    // Release BEFORE the status flip (and in the same transaction): a crash between the two
+    // leaves a still-pending migration a retried cancel finishes.
+    release_lock_owners(tx, t, &owners)?;
+    if is_pending {
+        tx.execute(
+            &format!("UPDATE {} SET status = ? WHERE id = ?", t.migrations),
+            params![MigrationStatus::Cancelled.wire_name(), migration_id],
+        )?;
+    }
+    Ok(outcome)
 }
 
 /// The account's migration IN PROGRESS, if any: resolves the pending row (see
@@ -1615,6 +1739,28 @@ fn replace_migration_row(
     // ever addresses it as "the account's migration" again — which is how a migration enters the
     // retained history. Children are deleted explicitly in case foreign-key cascades are not
     // enabled.
+    // A state persisted as TERMINAL is leaving service: nothing will ever broadcast its pending
+    // transactions, so the reservations they hold are released here, in the same write that
+    // records the terminal status. This is what discharges the release obligation for EVERY
+    // terminal transition that flows through the ordinary persist path — the consumer's
+    // `mark_superseded` response to `Replan`, an engine-side `mark_cancelled`, a `Failed`
+    // post-mortem — not only the store-level cancel (which exists for records this path cannot
+    // read).
+    if state.is_terminal() {
+        let owners: Vec<[u8; 32]> = state
+            .transactions()
+            .iter()
+            .filter(|t| {
+                !matches!(
+                    t.state(),
+                    MigrationTxState::Broadcast { .. } | MigrationTxState::Mined { .. }
+                )
+            })
+            .filter_map(|t| t.lock_owner().map(|o| *o.as_bytes()))
+            .collect();
+        release_lock_owners(tx, t, &owners)?;
+    }
+
     let ns = state.denominations();
     let migration_id = match prior {
         Some(migration_id) => {

--- a/zcash_client_sqlite/src/pool_migration/store.rs
+++ b/zcash_client_sqlite/src/pool_migration/store.rs
@@ -788,6 +788,14 @@ pub(crate) fn truncate_to_height(
     Ok(())
 }
 
+/// What [`classify_for_cancel`] hands back: the outcome to report to the caller, paired with the
+/// lock-owner tokens whose reservations the cancel must then release. The two travel together
+/// because one pass over the transaction rows produces both.
+type CancelClassification = (
+    crate::pool_migration::CancelOutcome,
+    Vec<MigrationLockOwner>,
+);
+
 /// The classification a cancel makes of one migration transaction, straight off its lifecycle
 /// column: everything before broadcast is releasable (its reservation can be cleared and it will
 /// never be submitted), everything at or past broadcast is chain reality to report, not undo.
@@ -795,9 +803,9 @@ fn classify_for_cancel(
     conn: &Connection,
     t: &Tables,
     migration_id: i64,
-) -> Result<(crate::pool_migration::CancelOutcome, Vec<[u8; 32]>), Error> {
+) -> Result<CancelClassification, Error> {
     let mut outcome = crate::pool_migration::CancelOutcome::default();
-    let mut owners: Vec<[u8; 32]> = Vec::new();
+    let mut owners: Vec<MigrationLockOwner> = Vec::new();
     let mut stmt = conn.prepare(&format!(
         "SELECT transfer_id, state, lock_owner FROM {} WHERE migration_id = ? ORDER BY transfer_id",
         t.transactions
@@ -820,7 +828,7 @@ fn classify_for_cancel(
             _ => {
                 outcome.released.push(id);
                 if let Some(owner) = lock_owner {
-                    owners.push(owner);
+                    owners.push(MigrationLockOwner::from_bytes(owner));
                 }
             }
         }
@@ -832,15 +840,24 @@ fn classify_for_cancel(
 /// columns note locking records on the received-note rows are cleared wherever they name one of
 /// these tokens. Scoped strictly by owner token — which the prover derived from each
 /// transaction's own spent notes — so no other flow's reservation can be touched.
-fn release_lock_owners(conn: &Connection, t: &Tables, owners: &[[u8; 32]]) -> Result<(), Error> {
+///
+/// Returns the number of note rows actually unlocked, which is informational only: it is NOT the
+/// number of owners, since one token may hold several notes and a token whose notes have already
+/// expired or been released holds none. Callers must not treat a zero here as a failure.
+fn release_lock_owners(
+    conn: &Connection,
+    t: &Tables,
+    owners: &[MigrationLockOwner],
+) -> Result<usize, Error> {
     let mut stmt = conn.prepare(&format!(
         "UPDATE {} SET lock_expiry_height = NULL, lock_owner = NULL WHERE lock_owner = ?",
         t.source_notes
     ))?;
+    let mut released = 0;
     for owner in owners {
-        stmt.execute(params![owner])?;
+        released += stmt.execute(params![owner.as_bytes()])?;
     }
-    Ok(())
+    Ok(released)
 }
 
 /// The body of [`Store::cancel_migration`]; see its documentation for the contract, the ordering
@@ -874,7 +891,14 @@ fn cancel_migration(
     let (outcome, owners) = classify_for_cancel(tx, t, migration_id)?;
     // Release BEFORE the status flip (and in the same transaction): a crash between the two
     // leaves a still-pending migration a retried cancel finishes.
-    release_lock_owners(tx, t, &owners)?;
+    let released = release_lock_owners(tx, t, &owners)?;
+    tracing::debug!(
+        "cancel released {released} note reservation(s) across {} never-broadcast transaction(s); \
+         {} in flight, {} already mined",
+        outcome.released.len(),
+        outcome.in_flight.len(),
+        outcome.mined.len()
+    );
     if is_pending {
         tx.execute(
             &format!("UPDATE {} SET status = ? WHERE id = ?", t.migrations),
@@ -1747,7 +1771,7 @@ fn replace_migration_row(
     // post-mortem — not only the store-level cancel (which exists for records this path cannot
     // read).
     if state.is_terminal() {
-        let owners: Vec<[u8; 32]> = state
+        let owners: Vec<MigrationLockOwner> = state
             .transactions()
             .iter()
             .filter(|t| {
@@ -1756,9 +1780,14 @@ fn replace_migration_row(
                     MigrationTxState::Broadcast { .. } | MigrationTxState::Mined { .. }
                 )
             })
-            .filter_map(|t| t.lock_owner().map(|o| *o.as_bytes()))
+            .filter_map(|t| t.lock_owner())
             .collect();
-        release_lock_owners(tx, t, &owners)?;
+        let released = release_lock_owners(tx, t, &owners)?;
+        tracing::debug!(
+            "released {released} note reservation(s) held by {} transaction(s) of the migration \
+             now persisted as terminal",
+            owners.len()
+        );
     }
 
     let ns = state.denominations();

--- a/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
+++ b/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
@@ -1773,6 +1773,162 @@ fn proving_refuses_to_take_a_note_another_flow_has_reserved() {
     );
 }
 
+/// The whole cancel affordance, end to end against a funded wallet: a committed-and-proved
+/// migration is cancelled at the user's request, its reservation is released so the account's
+/// notes return to DEFAULT selection immediately, the record is terminal-but-retained, and a
+/// replacement migration plans over the FULL spendable balance — the assertion that fails for
+/// the wrong reason if any cleanup is skipped (a plan over a shrunken balance still "succeeds").
+#[test]
+#[cfg_attr(
+    feature = "ignore-expensive-tests",
+    ignore = "covered by the expensive-test CI matrix"
+)]
+fn cancel_returns_the_balance_and_retains_the_record() {
+    use zcash_client_backend::data_api::InputSource;
+    use zcash_client_backend::data_api::locking::OutputLockStore;
+    use zcash_client_backend::data_api::wallet::TargetHeight;
+    use zcash_client_backend::data_api::wallet::input_selection::{LockFilter, LockedInputPolicy};
+    use zcash_pool_migration::wallet::WalletMigration;
+    use zcash_protocol::ShieldedPool;
+
+    let scenario = scenario_named(SMALLEST);
+    let mut run = Run::setup(&scenario);
+    let mut committed = run.plan_and_commit(&scenario);
+
+    // Prove the (single) preparation, taking the reservation on the account's only note.
+    let prep_id = committed
+        .state
+        .transactions()
+        .iter()
+        .find(|t| matches!(t.kind(), MigrationTxKind::Preparation { .. }))
+        .expect("the migration has a preparation transaction")
+        .id();
+    let account_id = run.account_id;
+    let anchor = {
+        let tip = run
+            .st
+            .wallet()
+            .chain_height()
+            .expect("reads the chain height")
+            .expect("the wallet has a chain tip");
+        highest_rooted_orchard_checkpoint(run.st.wallet_mut(), tip)
+            .expect("a rooted Orchard checkpoint exists")
+    };
+    let outcome = {
+        let mut prover =
+            WalletMigrationProver::new(run.st.wallet_mut(), account_id, run.fvk.clone());
+        engine::prove_preparation(&mut prover, &mut committed.state, prep_id, anchor)
+            .expect("proves the preparation transaction")
+    };
+    let engine::ProveOutcome::Proved(proven) = outcome else {
+        panic!("expected a proof, got {outcome:?}");
+    };
+    run.store()
+        .store_proved_transaction(&mut committed.state, proven)
+        .expect("records the proof");
+    assert!(
+        !run.st
+            .wallet()
+            .get_locked_outputs(account_id)
+            .expect("reads the locked outputs")
+            .is_empty(),
+        "premise: the proved preparation holds a reservation"
+    );
+
+    // CANCEL. One call: reservations released, record terminal, outcome reported.
+    let outcome = run.store().cancel_migration().expect("cancel succeeds");
+    let never_broadcast: Vec<_> = committed
+        .state
+        .transactions()
+        .iter()
+        .map(|t| t.id())
+        .collect();
+    assert_eq!(
+        outcome.released(),
+        never_broadcast.as_slice(),
+        "every never-broadcast transaction — the proved preparation and the still-signed \
+         transfer alike — is released"
+    );
+    assert!(outcome.in_flight().is_empty());
+
+    // The reservation is gone NOW — not at lock expiry — so default selection sees every note.
+    assert!(
+        run.st
+            .wallet()
+            .get_locked_outputs(account_id)
+            .expect("reads the locked outputs")
+            .is_empty(),
+        "cancel released the reservation"
+    );
+    let target = {
+        let tip = run
+            .st
+            .wallet()
+            .chain_height()
+            .expect("reads the chain height")
+            .expect("the wallet has a chain tip");
+        TargetHeight::from(u32::from(tip) + 1)
+    };
+    let default_selectable: u64 = run
+        .st
+        .wallet()
+        .select_unspent_notes(
+            account_id,
+            &[ShieldedPool::Orchard],
+            target,
+            &[],
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
+        )
+        .expect("selects under the DEFAULT lock policy")
+        .orchard()
+        .iter()
+        .map(|note| note.note().value().inner())
+        .sum();
+    assert!(
+        default_selectable > 0,
+        "the account's notes are back in default selection"
+    );
+
+    // The record is terminal-but-retained; the drive read has moved on.
+    {
+        let store = run.store();
+        assert_eq!(store.get_migration().expect("read"), None);
+        assert_eq!(
+            store
+                .latest_migration()
+                .expect("history reads back")
+                .map(|s| s.status()),
+            Some(MigrationStatus::Cancelled),
+        );
+    }
+
+    // A replacement migration plans over the FULL balance — not a shrunken one. Planning reads
+    // the wallet's spendable notes, so this is the assertion that fails for the wrong reason if
+    // any cleanup were skipped: a plan over a shrunken balance still "succeeds".
+    let migratable = {
+        let stored = run.store().latest_migration().expect("history reads back");
+        let adapter = WalletMigration::new(
+            run.st.wallet(),
+            run.account_id,
+            run.usk.clone(),
+            MigrationTestStore::holding(stored),
+        );
+        let mut rng = ChaCha8Rng::seed_from_u64(0xCA);
+        let plan = engine::plan_migration(&run.network, &adapter, &mut rng)
+            .expect("a replacement migration plans over the released balance");
+        plan.denominations().total_migratable()
+    };
+    assert!(
+        migratable > Zatoshis::ZERO,
+        "the replacement plan migrates a nonzero balance"
+    );
+    assert_eq!(
+        migratable, scenario.expected_migrated,
+        "the replacement plan covers exactly what the original planned — the full balance, \
+         not the fraction a stranded reservation would leave"
+    );
+}
+
 /// The scenario the unsatisfiability machinery exists for: while a committed migration waits out
 /// its privacy schedule, the user spends the whole balance — a "send max" to an external address —
 /// consuming the very funding notes the pre-signed crossings were built to spend.

--- a/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
+++ b/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
@@ -1784,13 +1784,6 @@ fn proving_refuses_to_take_a_note_another_flow_has_reserved() {
     ignore = "covered by the expensive-test CI matrix"
 )]
 fn cancel_returns_the_balance_and_retains_the_record() {
-    use zcash_client_backend::data_api::InputSource;
-    use zcash_client_backend::data_api::locking::OutputLockStore;
-    use zcash_client_backend::data_api::wallet::TargetHeight;
-    use zcash_client_backend::data_api::wallet::input_selection::{LockFilter, LockedInputPolicy};
-    use zcash_pool_migration::wallet::WalletMigration;
-    use zcash_protocol::ShieldedPool;
-
     let scenario = scenario_named(SMALLEST);
     let mut run = Run::setup(&scenario);
     let mut committed = run.plan_and_commit(&scenario);


### PR DESCRIPTION
Phase C of the cancel-instead-of-reset stack: resolves the user-facing half of #2903. Stacked on #2799 (locks + store-at-broadcast) ← #2923 (B2) ← #2921 (B1) ← #2914 (A).

With the earlier phases in place — history retention, the pending-only drive read, advisory locks as the only prove-to-broadcast reservation, and the wallet record binding at broadcast — cancel is thin, exactly as the design intended:

- **`PoolMigrations::cancel_migration`**: release the note reservations of every never-broadcast transaction, then flip the record to `Cancelled` — in that order, in one database transaction, so every crash prefix leaves a still-pending migration a retried cancel finishes. It **never deserializes the migration state** (the primary use case is an unrecoverable wallet; a record that won't parse is one way to get there): lifecycle and lock-owner tokens are typed columns.
- **`CancelOutcome`** reports honestly instead of refusing: `in_flight` (broadcast; may still mine — "N transactions are already on their way"), `mined`, and `released` (reservations cleared, notes back in **default** note selection immediately rather than at lock expiry).
- **Repair for already-terminal records**: with no pending migration, cancel releases the latest retained record's stranded reservations without touching its status — history is never rewritten, but a stranded lock is not history. This is what frees records an older client persisted as `failed`.
- **Every terminal transition releases**: persisting any terminal state through `replace_migration` clears its never-broadcast transactions' reservations in the same write, so `mark_superseded` in response to `Replan` (the engine-initiated sibling of cancel) cannot strand the live transfers' locks.
- **E2E** in the chain-sim suite: cancel after commit-and-prove returns the notes to default selection immediately, the record reads back `Cancelled` via `latest_migration` while `get_migration` reports `None`, and a replacement migration **plans over exactly the full balance** — the assertion that fails for the wrong reason if any cleanup is skipped.

Store-level unit tests cover the outcome classification, the corrupt-record path, the already-terminal repair, and the supersede-path release. The full chain-sim suite (expensive tests included) passes on this branch tip.

---

Filed with Claude Code assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Gsndy5ri9eYvtH31DnHTQ
