### PR TITLE
zcash_client_sqlite: expose scheduled migration transactions as views

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -446,6 +446,16 @@ Type safety is paramount. This is a security-critical codebase.
 
 - All public API items MUST have complete `rustdoc` doc comments (`///`).
   * Document all error cases
+- **Documentation defines semantics, non-contextually and briefly.** A doc
+  comment must make sense to a reader with no knowledge of the change, branch,
+  or discussion that produced the item: state what the item MEANS — its
+  contract, invariants, preconditions, ordering/atomicity guarantees, units —
+  and stop. Describe implementation concerns or rationale only when strictly
+  necessary (e.g. a constraint the signature cannot express), and then in a
+  clause, not a paragraph. Do not narrate design history, motivate the item by
+  other work items, or restate what a sibling does (link to it instead).
+  Brevity is load-bearing: over-long documentation does not get read; seek a
+  high signal-to-noise ratio.
 - Crate-level docs use `//!` at the top of `lib.rs`.
 - Reference ZIP/BIP specs with markdown links: `/// [ZIP 316]: https://zips.z.cash/zip-0316`
 - Use backtick links for cross-references to other items.
@@ -618,15 +628,21 @@ artifacts of a development session, not repository history. Never commit them.
   semantic change. This includes updating the version of a dependency whose
   types appear in the public API: types from two semver-incompatible versions
   of a crate do not unify, so a consumer must upgrade that dependency in
-  lockstep. CHANGELOG updates must **only** reflect completed changes.
-  since the last release, and never interstitial changes in APIs that have been
-  changed multiple times since the last release. The CHANGELOG entry **MUST** be
-  part of the commit that makes the API change. For newly added crates, the CHANGELOG
-  should include **ONLY** a line indicating the initial release; as there is no prior
-  release, there are no API changes for a user to adapt to. CHANGELOG entries should
-  provide **only** the information needed for end users to adapt to API changes, and
-  **never** describe implementation details or contracts that are not visible to
-  a user of the public API.
+  lockstep. CHANGELOG updates must **only** reflect completed changes since the
+  last release, and never interstitial changes in APIs that have been changed
+  multiple times since the last release. The CHANGELOG entry **MUST** be part
+  of the commit that makes the API change — never a separate CHANGELOG-only
+  commit, and never a batched "changelogs" commit at the end of a branch. For
+  newly added crates, the CHANGELOG should include **ONLY** a line indicating
+  the initial release; as there is no prior release, there are no API changes
+  for a user to adapt to. CHANGELOG entries should provide **only** the
+  information needed for end users to adapt to API changes, and **never**
+  describe implementation details or contracts that are not visible to a user
+  of the public API. `Added` entries are pointers — the fully-qualified item
+  path, with behavior left to the rustdoc, which is canonical. `Changed`
+  entries describe the diff against the prior API (old -> new, migration
+  steps, semantic changes) rather than re-documenting the API, and keep the
+  rationale out: state the change, not why the old behavior was wrong.
 - **A CHANGELOG entry under an already-published version heading** (a released
   `## [x.y.z] - DATE` section) is the historical record of what that release
   shipped. Correct such an entry only when it was inaccurate as written; never

--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -10,6 +10,12 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `TxId::as_hex`, an encoder producing the canonical byte-reversed display
+  form previously only available via `TxId`'s `Display` impl.
+- `TxId::from_hex`, parsing the canonical (byte-reversed) hexadecimal display
+  form produced by `TxId`'s `Display` impl.
+
 ## [0.10.4] - 2026-08-03
 
 ### Added

--- a/components/zcash_protocol/src/txid.rs
+++ b/components/zcash_protocol/src/txid.rs
@@ -1,4 +1,4 @@
-use alloc::string::ToString;
+use alloc::string::{String, ToString};
 use core::fmt;
 use corez::io::{self, Read, Write};
 
@@ -31,7 +31,7 @@ impl fmt::Debug for TxId {
 
 impl fmt::Display for TxId {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(&ReverseHex::encode(&self.0))
+        formatter.write_str(&self.as_hex())
     }
 }
 
@@ -55,6 +55,18 @@ impl TxId {
     /// Wraps the given byte array as a TxId value
     pub const fn from_bytes(bytes: [u8; 32]) -> Self {
         TxId(bytes)
+    }
+
+    /// Encodes this transaction ID in its canonical hexadecimal representation.
+    pub fn as_hex(&self) -> String {
+        ReverseHex::encode(&self.0)
+    }
+
+    /// Parses a transaction id from its canonical hexadecimal representation — the byte-reversed
+    /// form produced by this type's [`Display`](fmt::Display) impl, as shown by block explorers
+    /// and node RPCs. Returns `None` if the input is not exactly 64 hexadecimal digits.
+    pub fn from_hex(s: &str) -> Option<Self> {
+        ReverseHex::decode(s).map(TxId::from_bytes)
     }
 
     /// Reads a 32-byte txid directly from the provided reader.
@@ -85,5 +97,31 @@ pub mod testing {
     /// An arbitrary transaction id (32 random bytes)
     pub fn arb_txid() -> impl Strategy<Value = TxId> {
         any::<[u8; 32]>().prop_map(TxId::from_bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TxId;
+    use alloc::string::ToString;
+
+    /// `from_hex` inverts `Display` exactly, and is NOT the inverse of hex-encoding the internal
+    /// bytes: the two encodings are mutually byte-reversed, checked with an asymmetric pattern.
+    #[test]
+    fn from_hex_inverts_display() {
+        let bytes: [u8; 32] = core::array::from_fn(|i| i as u8);
+        let txid = TxId::from_bytes(bytes);
+        assert_eq!(TxId::from_hex(&txid.to_string()), Some(txid));
+        assert_eq!(
+            TxId::from_hex(&hex::encode(bytes)),
+            Some(TxId::from_bytes({
+                let mut r = bytes;
+                r.reverse();
+                r
+            })),
+            "internal-order hex parses as the REVERSED id"
+        );
+        assert_eq!(TxId::from_hex("beef"), None);
+        assert_eq!(TxId::from_hex("zz"), None);
     }
 }

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -11,6 +11,14 @@ workspace.
 ## [Unreleased]
 
 ### Added
+- The `v_migration_transactions` view: one row per SCHEDULED pool-migration
+  transaction (belonging to a non-terminal migration and not yet broadcast),
+  with its identity, kind, lifecycle state, scheduled and expiry heights,
+  values, and ZIP 318 classification code.
+- The `v_transactions_with_pending_migrations` view: `v_transactions` plus the
+  scheduled migration transactions projected into the same column shape.
+  `v_transactions` itself is unchanged; a consumer that wants pending
+  migration activity in one merged feed reads this view instead.
 - `pool_migration::orchard_ironwood::PoolMigrations::cancel_migration` and
   `pool_migration::CancelOutcome`: cancel the account's migration at the
   user's request. Releases the note reservations of its never-broadcast

--- a/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
+++ b/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
@@ -149,6 +149,17 @@ pub(crate) fn account_index_sql() -> String {
     store::create_account_index_sql(&TABLES)
 }
 
+/// The Orchard -> Ironwood transactions-table DDL, from the store's one generator, for the
+/// `orchard_ironwood_migration_txid_blob` schema migration's table rebuild.
+pub(crate) fn transactions_table_sql() -> String {
+    store::create_transactions_sql(&TABLES)
+}
+
+/// The due-transactions index DDL, from the store's one generator, recreated by the same rebuild.
+pub(crate) fn tx_due_index_sql() -> String {
+    store::create_tx_due_index_sql(&TABLES)
+}
+
 /// The anchor bucket grids, in blocks, of every Orchard -> Ironwood migration in this database
 /// that is not yet complete.
 ///

--- a/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
+++ b/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
@@ -160,6 +160,12 @@ pub(crate) fn tx_due_index_sql() -> String {
     store::create_tx_due_index_sql(&TABLES)
 }
 
+/// The `v_migration_transactions` view DDL over the Orchard -> Ironwood tables, from the store's
+/// one generator, for the `v_migration_transactions` schema migration.
+pub(crate) fn migration_tx_view_sql() -> String {
+    store::create_migration_tx_view_sql(&TABLES)
+}
+
 /// The anchor bucket grids, in blocks, of every Orchard -> Ironwood migration in this database
 /// that is not yet complete.
 ///

--- a/zcash_client_sqlite/src/pool_migration/store.rs
+++ b/zcash_client_sqlite/src/pool_migration/store.rs
@@ -318,6 +318,83 @@ pub(crate) fn create_tx_due_index_sql(t: &Tables) -> String {
     )
 }
 
+/// The `v_migration_transactions` view DDL: one row per SCHEDULED migration transaction — a
+/// transaction of a non-terminal migration that has not yet been broadcast (and so has no row in
+/// the wallet's `transactions` table). Values are projected from the migration store's typed
+/// columns: a transfer spends its funding note (crossing value plus the per-note fee buffer,
+/// which IS the canonical transfer's ZIP-317 fee) and receives the crossing; a preparation's
+/// values are the sums of its input and output rows. Every wire name, classification code, and
+/// the terminal-status list are generated from their defining types.
+pub(crate) fn create_migration_tx_view_sql(t: &Tables) -> String {
+    use zcash_pool_migration::engine::{MigrationTxKind, MigrationTxState};
+    use zcash_protocol::zip318::{Zip318Classification, Zip318TxKind};
+
+    let transfer = MigrationTxKind::Transfer { crossing: 0 };
+    let pending_states = [
+        MigrationTxState::AwaitingSignature,
+        MigrationTxState::Signed,
+        MigrationTxState::Proved,
+    ]
+    .iter()
+    .map(|st| format!("'{}'", st.as_ref()))
+    .collect::<Vec<_>>()
+    .join(", ");
+    format!(
+        "CREATE VIEW v_migration_transactions AS
+        SELECT accounts.uuid AS account_uuid,
+               m.uuid AS migration_uuid,
+               mt.txid AS txid,
+               mt.kind AS kind,
+               mt.state AS state,
+               mt.scheduled_height AS scheduled_height,
+               mt.expiry_height AS expiry_height,
+               CASE mt.kind WHEN '{transfer}' THEN cv.value + m.note_split_fee_buffer
+                    ELSE pin.value_in END AS value_spent,
+               CASE mt.kind WHEN '{transfer}' THEN cv.value
+                    ELSE pout.value_out END AS value_received,
+               CASE mt.kind WHEN '{transfer}' THEN m.note_split_fee_buffer
+                    ELSE pin.value_in - pout.value_out END AS fee,
+               CASE mt.kind WHEN '{transfer}' THEN cv.value END AS pool_crossing_value,
+               CASE mt.kind WHEN '{transfer}' THEN 1 ELSE pin.input_count END AS spent_note_count,
+               CASE mt.kind WHEN '{transfer}' THEN 1
+                    ELSE pout.output_count - pout.change_count END AS received_note_count,
+               CASE mt.kind WHEN '{transfer}' THEN 0
+                    ELSE pout.change_count > 0 END AS has_change,
+               CASE mt.kind WHEN '{transfer}' THEN {transfer_code}
+                    ELSE {prep_code} END AS zip318_kind
+        FROM {tx} mt
+        JOIN {migrations} m ON m.id = mt.migration_id
+        JOIN accounts ON accounts.id = m.account_id
+        LEFT JOIN {cv} cv
+               ON cv.migration_id = mt.migration_id AND cv.ordinal = mt.kind_crossing
+        LEFT JOIN (SELECT migration_id, layer, tx_index,
+                          SUM(value) AS value_in, COUNT(*) AS input_count
+                     FROM {pin} GROUP BY migration_id, layer, tx_index) pin
+               ON pin.migration_id = mt.migration_id
+              AND pin.layer = mt.kind_layer AND pin.tx_index = mt.kind_index
+        LEFT JOIN (SELECT migration_id, layer, tx_index,
+                          SUM(value) AS value_out, COUNT(*) AS output_count,
+                          SUM(role = '{change}') AS change_count
+                     FROM {pout} GROUP BY migration_id, layer, tx_index) pout
+               ON pout.migration_id = mt.migration_id
+              AND pout.layer = mt.kind_layer AND pout.tx_index = mt.kind_index
+        WHERE m.status NOT IN ({terminal})
+          AND mt.state IN ({pending_states})
+          AND NOT EXISTS (SELECT 1 FROM transactions tt WHERE tt.txid = mt.txid)",
+        transfer = transfer.as_ref(),
+        transfer_code = Zip318Classification::Conforms(Zip318TxKind::Transfer).to_code(),
+        prep_code = Zip318Classification::Conforms(Zip318TxKind::Preparation).to_code(),
+        change = "change",
+        tx = t.transactions,
+        migrations = t.migrations,
+        cv = t.crossing_values,
+        pin = t.prep_inputs,
+        pout = t.prep_outputs,
+        terminal = terminal_status_sql_list(),
+        pending_states = pending_states,
+    )
+}
+
 /// The at-most-one-PENDING-migration-per-account invariant, as a database constraint: a PARTIAL
 /// unique index over the non-terminal rows. An account accumulates terminal migrations without
 /// limit — they are the history the store retains — while the engine's commit guard admits a new

--- a/zcash_client_sqlite/src/pool_migration/store.rs
+++ b/zcash_client_sqlite/src/pool_migration/store.rs
@@ -11,7 +11,7 @@
 //! and reject a non-NULL blob that is not exactly 32 bytes); and each cached real-spend
 //! `nullifier`, one per row of the spend-nullifier child table, held to its 32-byte width by a
 //! `CHECK` and read back through those same fixed-size impls. All amounts are zatoshi `INTEGER`
-//! columns; the broadcast `txid` is stored as hex `TEXT`.
+//! columns; the `txid` is stored as the transaction id's raw internal bytes (`TxId::as_ref`).
 //!
 //! The preparation plan's layers/transactions grid has no tables of its own: each input and output
 //! row carries its transaction's `(layer, tx_index)` coordinate, and every transaction a real plan
@@ -238,7 +238,7 @@ fn create_prep_direct_funding_sql(t: &Tables) -> String {
     )
 }
 
-fn create_transactions_sql(t: &Tables) -> String {
+pub(crate) fn create_transactions_sql(t: &Tables) -> String {
     // `unsatisfiable_at` and `unsatisfiable_kind` are one value in two columns — the height an
     // unsatisfiability observation rests on, and which observation it was — so they are `NULL`
     // together or non-`NULL` together, and the read path rejects a row where they disagree.
@@ -260,7 +260,7 @@ fn create_transactions_sql(t: &Tables) -> String {
             expiry_height INTEGER NOT NULL,
             anchor_boundary INTEGER,
             state TEXT NOT NULL,
-            txid TEXT,
+            txid BLOB,
             mined_height INTEGER,
             lock_owner BLOB,
             unsatisfiable_at INTEGER,
@@ -311,7 +311,7 @@ fn create_spend_nullifiers_sql(t: &Tables) -> String {
     )
 }
 
-fn create_tx_due_index_sql(t: &Tables) -> String {
+pub(crate) fn create_tx_due_index_sql(t: &Tables) -> String {
     format!(
         "CREATE INDEX IF NOT EXISTS {} ON {} (state, scheduled_height)",
         t.tx_due_index, t.transactions
@@ -1210,16 +1210,7 @@ fn read_transactions(
         // is required rather than optional — and it is the SAME value the lifecycle state carries
         // once broadcast, which is why the state is reassembled from it below rather than from a
         // separately stored copy that could disagree.
-        let txid = r
-            .txid
-            .ok_or(Error::Corrupt("txid"))
-            .and_then(|s| {
-                hex::decode(&s)
-                    .ok()
-                    .and_then(|v| <[u8; 32]>::try_from(v).ok())
-                    .ok_or(Error::Corrupt("txid"))
-            })
-            .map(TxId::from_bytes)?;
+        let txid = r.txid.map(TxId::from_bytes).ok_or(Error::Corrupt("txid"))?;
         let state = MigrationTxState::from_stored(
             &r.state,
             Some(<[u8; 32]>::from(txid)),
@@ -1318,7 +1309,7 @@ struct TxRow {
     state: String,
     /// The hex-encoded consensus transaction ID the transaction was broadcast under; `NULL` until
     /// it is broadcast. Unrelated to `transfer_id` above.
-    txid: Option<String>,
+    txid: Option<[u8; 32]>,
     mined_height: Option<u32>,
     /// The stored lock-owner token, read directly as a fixed-size blob: `rusqlite`'s `[u8; 32]`
     /// `FromSql` impl errors cleanly (`InvalidBlobSize`) if a non-NULL blob is not exactly 32
@@ -1982,7 +1973,7 @@ fn replace_migration_row(
                 ":expiry_height": u32::from(mtx.expiry_height()),
                 ":anchor_boundary": mtx.anchor_boundary().map(u32::from),
                 ":state": tx_state.as_ref(),
-                ":txid": hex::encode(mtx.txid().as_ref()),
+                ":txid": mtx.txid().as_ref(),
                 ":mined_height": tx_state.mined_height().map(u32::from),
                 ":lock_owner": mtx.lock_owner().map(|o| *o.as_bytes()),
                 ":unsatisfiable_at": unsatisfiable_at.map(u32::from),

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -733,7 +733,7 @@ CREATE TABLE orchard_ironwood_migration_transactions (
     expiry_height INTEGER NOT NULL,
     anchor_boundary INTEGER,
     state TEXT NOT NULL,
-    txid TEXT,
+    txid BLOB,
     mined_height INTEGER,
     lock_owner BLOB,
     unsatisfiable_at INTEGER,

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -1390,6 +1390,54 @@ SELECT
 FROM transparent_received_output_spends s
 JOIN transparent_received_outputs rn ON rn.id = s.transparent_received_output_id";
 
+/// One row per SCHEDULED pool-migration transaction: a transaction of a non-terminal migration
+/// that has not yet been broadcast (equivalently: has no row in `transactions`). Columns carry
+/// the transaction's identity (`account_uuid`, `migration_uuid`, `txid`), kind and lifecycle
+/// `state` wire names, `scheduled_height` and `expiry_height`, its values in zatoshis
+/// (`value_spent`, `value_received`, `fee`, and `pool_crossing_value` for a transfer), note
+/// counts, and its ZIP 318 classification code. Generated from the pool-migration store's
+/// tables; see `pool_migration::store::create_migration_tx_view_sql`.
+pub(super) fn view_migration_transactions() -> String {
+    crate::pool_migration::orchard_ironwood::migration_tx_view_sql()
+}
+
+/// `v_transactions` plus the scheduled pool-migration transactions of
+/// `view_migration_transactions`, projected into the same column shape (no mined height, block
+/// time, or raw bytes; `account_balance_delta` is minus the transaction's fee, every real output
+/// being internal to the account). `v_transactions` itself is unchanged; a consumer opts into
+/// the merged feed by reading this view instead.
+pub(super) const VIEW_TRANSACTIONS_WITH_PENDING_MIGRATIONS: &str = "
+CREATE VIEW v_transactions_with_pending_migrations AS
+SELECT account_uuid, mined_height, txid, tx_index, expiry_height, raw, account_balance_delta,
+       total_spent, total_received, fee_paid, has_change, sent_note_count, received_note_count,
+       memo_count, block_time, expired_unmined, spent_note_count, is_shielding,
+       pool_crossing_value, trust_status, zip318_kind
+FROM v_transactions
+UNION ALL
+SELECT vmt.account_uuid          AS account_uuid,
+       NULL                      AS mined_height,
+       vmt.txid                  AS txid,
+       NULL                      AS tx_index,
+       vmt.expiry_height         AS expiry_height,
+       NULL                      AS raw,
+       -vmt.fee                  AS account_balance_delta,
+       vmt.value_spent           AS total_spent,
+       vmt.value_received        AS total_received,
+       vmt.fee                   AS fee_paid,
+       vmt.has_change            AS has_change,
+       0                         AS sent_note_count,
+       vmt.received_note_count   AS received_note_count,
+       0                         AS memo_count,
+       NULL                      AS block_time,
+       (vmt.expiry_height BETWEEN 1 AND (SELECT MAX(blocks.height) FROM blocks))
+                                 AS expired_unmined,
+       vmt.spent_note_count      AS spent_note_count,
+       0                         AS is_shielding,
+       vmt.pool_crossing_value   AS pool_crossing_value,
+       NULL                      AS trust_status,
+       vmt.zip318_kind           AS zip318_kind
+FROM v_migration_transactions vmt";
+
 pub(super) const VIEW_TRANSACTIONS: &str = "
 CREATE VIEW v_transactions AS
 WITH

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -928,6 +928,7 @@ mod tests {
             db::view_ironwood_shard_scan_ranges(st.network()),
             db::view_ironwood_shard_unscanned_ranges(),
             db::VIEW_IRONWOOD_SHARDS_SCAN_STATE.to_owned(),
+            db::view_migration_transactions(),
             db::view_orchard_shard_scan_ranges(st.network()),
             db::view_orchard_shard_unscanned_ranges(),
             db::VIEW_ORCHARD_SHARDS_SCAN_STATE.to_owned(),
@@ -937,6 +938,7 @@ mod tests {
             db::view_sapling_shard_unscanned_ranges(),
             db::VIEW_SAPLING_SHARDS_SCAN_STATE.to_owned(),
             db::VIEW_TRANSACTIONS.to_owned(),
+            db::VIEW_TRANSACTIONS_WITH_PENDING_MIGRATIONS.to_owned(),
             db::VIEW_TX_OUTPUTS.to_owned(),
         ];
 

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -141,6 +141,7 @@ migration_modules!(
     orchard_ironwood_broadcast_binding,
     orchard_ironwood_migration_anchor_interval,
     orchard_ironwood_migration_history,
+    orchard_ironwood_migration_txid_blob,
     orchard_ironwood_migration_tables,
     orchard_ironwood_migration_unsatisfiability,
     orchard_note_version,
@@ -395,6 +396,7 @@ pub(super) fn all_migrations<
         Box::new(orchard_ironwood_migration_unsatisfiability::Migration),
         Box::new(orchard_ironwood_migration_history::Migration),
         Box::new(orchard_ironwood_broadcast_binding::Migration),
+        Box::new(orchard_ironwood_migration_txid_blob::Migration),
     ]
 }
 

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -174,6 +174,7 @@ migration_modules!(
     v_transactions_pool_crossing,
     v_transactions_shielding_balance,
     v_transactions_transparent_history,
+    v_migration_transactions,
     v_transactions_zip318_kind,
     v_tx_outputs_key_scopes,
     v_tx_outputs_return_addrs,
@@ -397,6 +398,7 @@ pub(super) fn all_migrations<
         Box::new(orchard_ironwood_migration_history::Migration),
         Box::new(orchard_ironwood_broadcast_binding::Migration),
         Box::new(orchard_ironwood_migration_txid_blob::Migration),
+        Box::new(v_migration_transactions::Migration),
     ]
 }
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/orchard_ironwood_migration_txid_blob.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/orchard_ironwood_migration_txid_blob.rs
@@ -1,0 +1,221 @@
+//! Converts `orchard_ironwood_migration_transactions.txid` from hex `TEXT` to a raw-byte `BLOB`,
+//! matching the wallet's own `transactions.txid` so the two can be compared and joined directly.
+
+use std::collections::HashSet;
+
+use rusqlite::named_params;
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+use zcash_protocol::TxId;
+
+use super::orchard_ironwood_broadcast_binding;
+use crate::wallet::init::WalletMigrationError;
+
+/// Identifies this migration in the wallet's schema-migration DAG.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x62ccc269_f988_4bb2_8958_2cbaaa44dea3);
+
+pub(super) const DEPENDENCIES: &[Uuid] = &[orchard_ironwood_broadcast_binding::MIGRATION_ID];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Stores pool-migration transaction ids as raw bytes rather than hex text."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        // SQLite cannot change a column's declared type, so the table is rebuilt: rename aside,
+        // create the current shape, copy rows across converting `txid`, drop the old table, and
+        // recreate the index it carried. The rename runs under `legacy_alter_table` so the child
+        // tables' foreign-key clauses keep naming `orchard_ironwood_migration_transactions` (the
+        // replacement) rather than being rewritten to follow the doomed `_old` table.
+        //
+        // The conversion inverts the store's own HISTORICAL text encoding, which was
+        // `hex::encode(TxId::as_ref())` — the id's INTERNAL bytes — at both of the sites that
+        // ever wrote this column (`replace_migration` and the `..._unsatisfiability` repair).
+        // That encoding is byte-reversed relative to the id's canonical display form, so
+        // `TxId::from_hex` (the `Display` inverse) must NOT be used here: it would write reversed
+        // blobs and silently break every txid join for migrated rows. The test below pins the
+        // direction with an asymmetric byte pattern.
+        transaction.execute_batch(&format!(
+            "PRAGMA legacy_alter_table = ON;
+             ALTER TABLE orchard_ironwood_migration_transactions
+                RENAME TO orchard_ironwood_migration_transactions_old;
+             PRAGMA legacy_alter_table = OFF;
+             {};",
+            crate::pool_migration::orchard_ironwood::transactions_table_sql(),
+        ))?;
+
+        {
+            let mut read = transaction.prepare(
+                "SELECT migration_id, transfer_id, kind, kind_layer, kind_index, kind_crossing,
+                        pczt, scheduled_height, expiry_height, anchor_boundary, state, txid,
+                        mined_height, lock_owner, unsatisfiable_at, unsatisfiable_kind,
+                        broadcast_failure_at
+                   FROM orchard_ironwood_migration_transactions_old",
+            )?;
+            let mut write = transaction.prepare(
+                "INSERT INTO orchard_ironwood_migration_transactions (
+                        migration_id, transfer_id, kind, kind_layer, kind_index, kind_crossing,
+                        pczt, scheduled_height, expiry_height, anchor_boundary, state, txid,
+                        mined_height, lock_owner, unsatisfiable_at, unsatisfiable_kind,
+                        broadcast_failure_at)
+                 VALUES (:migration_id, :transfer_id, :kind, :kind_layer, :kind_index,
+                         :kind_crossing, :pczt, :scheduled_height, :expiry_height,
+                         :anchor_boundary, :state, :txid, :mined_height, :lock_owner,
+                         :unsatisfiable_at, :unsatisfiable_kind, :broadcast_failure_at)",
+            )?;
+            let mut rows = read.query([])?;
+            while let Some(row) = rows.next()? {
+                let txid: Option<[u8; 32]> = row
+                    .get::<_, Option<String>>(11)?
+                    .map(|s| {
+                        // All previous encodings of the txid as hex wrote incorrect hexadecimal
+                        // representations instead of the canonical, byte-reversed form.
+                        // This decoding and storing as BLOB fixes that error.
+                        hex::decode(&s)
+                            .ok()
+                            .and_then(|v| <[u8; 32]>::try_from(v).ok())
+                            .ok_or(WalletMigrationError::CorruptedData(
+                                "pool-migration txid is not 32 bytes of hex".into(),
+                            ))
+                    })
+                    .transpose()?
+                    .map(|bytes| *TxId::from_bytes(bytes).as_ref());
+                let preserve = |idx: usize| row.get::<_, rusqlite::types::Value>(idx);
+                write.execute(named_params! {
+                    ":migration_id": preserve(0)?,
+                    ":transfer_id": preserve(1)?,
+                    ":kind": preserve(2)?,
+                    ":kind_layer": preserve(3)?,
+                    ":kind_index": preserve(4)?,
+                    ":kind_crossing": preserve(5)?,
+                    ":pczt": preserve(6)?,
+                    ":scheduled_height": preserve(7)?,
+                    ":expiry_height": preserve(8)?,
+                    ":anchor_boundary": preserve(9)?,
+                    ":state": preserve(10)?,
+                    ":txid": txid,
+                    ":mined_height": preserve(12)?,
+                    ":lock_owner": preserve(13)?,
+                    ":unsatisfiable_at": preserve(14)?,
+                    ":unsatisfiable_kind": preserve(15)?,
+                    ":broadcast_failure_at": preserve(16)?,
+                })?;
+            }
+        }
+
+        transaction.execute_batch(&format!(
+            "DROP TABLE orchard_ironwood_migration_transactions_old;
+             {};",
+            crate::pool_migration::orchard_ironwood::tx_due_index_sql(),
+        ))?;
+
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    use super::*;
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[MIGRATION_ID]);
+    }
+
+    /// The stored hex encodes the id's INTERNAL bytes, so the converted blob equals the decoded
+    /// hex — NOT its reverse, which is the id's display form (`TxId`'s `Display`). Both a real
+    /// row and a NULL-txid row survive the rebuild.
+    #[test]
+    fn conversion_preserves_internal_byte_order() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "-- The migrator runs every schema migration with foreign-key enforcement off.
+             PRAGMA foreign_keys = OFF;
+             -- The parent table the transactions table's foreign key names: the rename step
+             -- re-parses the schema, so the reference target must exist.
+             CREATE TABLE orchard_ironwood_migrations (id INTEGER PRIMARY KEY);
+             CREATE TABLE orchard_ironwood_migration_transactions (
+                migration_id INTEGER NOT NULL,
+                transfer_id INTEGER NOT NULL,
+                kind TEXT NOT NULL,
+                kind_layer INTEGER,
+                kind_index INTEGER,
+                kind_crossing INTEGER,
+                pczt BLOB NOT NULL,
+                scheduled_height INTEGER NOT NULL,
+                expiry_height INTEGER NOT NULL,
+                anchor_boundary INTEGER,
+                state TEXT NOT NULL,
+                txid TEXT,
+                mined_height INTEGER,
+                lock_owner BLOB,
+                unsatisfiable_at INTEGER,
+                unsatisfiable_kind TEXT,
+                broadcast_failure_at INTEGER,
+                PRIMARY KEY (migration_id, transfer_id)
+             );",
+        )
+        .unwrap();
+        // An asymmetric byte pattern, so a byte-order reversal cannot go unnoticed.
+        let bytes: [u8; 32] = core::array::from_fn(|i| i as u8);
+        conn.execute_batch(&format!(
+            "INSERT INTO orchard_ironwood_migration_transactions
+                (migration_id, transfer_id, kind, kind_crossing, pczt, scheduled_height,
+                 expiry_height, state, txid)
+             VALUES (1, 0, 'transfer', 0, X'AB', 10, 20, 'proved', '{}'),
+                    (1, 1, 'transfer', 1, X'CD', 10, 20, 'signed', NULL);",
+            hex::encode(bytes),
+        ))
+        .unwrap();
+
+        let tx = conn.transaction().unwrap();
+        RusqliteMigration::up(&Migration, &tx).unwrap();
+        tx.commit().unwrap();
+
+        let stored: Vec<Option<[u8; 32]>> = conn
+            .prepare(
+                "SELECT txid FROM orchard_ironwood_migration_transactions ORDER BY transfer_id",
+            )
+            .unwrap()
+            .query_map([], |r| r.get(0))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(stored, vec![Some(bytes), None]);
+        // The executable statement of the encoding claim: the historical text was the internal
+        // bytes' hex, which is NOT the id's display form — so a `Display`-inverting parse
+        // (`TxId::from_hex`) would have produced the reversed bytes.
+        let txid = zcash_protocol::TxId::from_bytes(bytes);
+        assert_ne!(hex::encode(bytes), txid.to_string());
+        assert_eq!(
+            zcash_protocol::TxId::from_hex(&hex::encode(bytes)).map(|t| *t.as_ref()),
+            Some({
+                let mut r = bytes;
+                r.reverse();
+                r
+            }),
+            "the Display inverse reverses internal-order hex: exactly why it is not used here"
+        );
+    }
+}

--- a/zcash_client_sqlite/src/wallet/init/migrations/orchard_ironwood_migration_unsatisfiability.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/orchard_ironwood_migration_unsatisfiability.rs
@@ -922,6 +922,20 @@ mod tests {
             "the mined row is exempt from the backfill, so it caches nothing",
         );
 
+        // The read below goes through the CURRENT store, which reads `txid` as the id's raw bytes,
+        // while this migration writes the hex text that its own schema declares. The descendant
+        // `..._txid_blob` is what converts the column, and it is an unconditional descendant, so
+        // no wallet ever presents the reader with the text form. Running it here is what puts the
+        // fixture at the schema the reader requires; the repair under test is still this
+        // migration's, and a txid it failed to write would arrive below as NULL either way.
+        let tx = conn.transaction().unwrap();
+        RusqliteMigration::up(
+            &super::super::orchard_ironwood_migration_txid_blob::Migration,
+            &tx,
+        )
+        .unwrap();
+        tx.commit().unwrap();
+
         let store = PoolMigrations::for_account((), (), &conn, AccountUuid::from_uuid(account))
             .expect("the account exists");
         let state = store

--- a/zcash_client_sqlite/src/wallet/init/migrations/v_migration_transactions.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/v_migration_transactions.rs
@@ -1,0 +1,262 @@
+//! Adds two views over the pool-migration store's transactions:
+//!
+//! - `v_migration_transactions`: one row per SCHEDULED migration transaction (belonging to a
+//!   non-terminal migration and not yet broadcast), with its identity, kind, lifecycle state,
+//!   schedule, and values projected from the store's typed columns.
+//! - `v_transactions_with_pending_migrations`: `v_transactions` plus those scheduled
+//!   transactions projected into the same column shape, for a consumer that wants one merged
+//!   activity feed. `v_transactions` itself is unchanged.
+
+use std::collections::HashSet;
+
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+
+use super::{orchard_ironwood_migration_txid_blob, v_transactions_zip318_kind};
+use crate::wallet::init::WalletMigrationError;
+
+/// Identifies this migration in the wallet's schema-migration DAG.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x1060fd09_1dc8_4208_b368_295d297eb045);
+
+pub(super) const DEPENDENCIES: &[Uuid] = &[
+    orchard_ironwood_migration_txid_blob::MIGRATION_ID,
+    v_transactions_zip318_kind::MIGRATION_ID,
+];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Adds views exposing scheduled pool-migration transactions."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        transaction.execute_batch(&format!(
+            "{};\n{};",
+            crate::pool_migration::orchard_ironwood::migration_tx_view_sql(),
+            crate::wallet::db::VIEW_TRANSACTIONS_WITH_PENDING_MIGRATIONS,
+        ))?;
+        Ok(())
+    }
+
+    fn down(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        transaction.execute_batch(
+            "DROP VIEW v_transactions_with_pending_migrations;
+             DROP VIEW v_migration_transactions;",
+        )?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::Connection;
+
+    use super::*;
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[MIGRATION_ID]);
+    }
+
+    /// A reduced stand-in for the tables the views read (full schema-path equality is
+    /// `verify_schema`'s job), populated with one of everything the row-set predicate
+    /// distinguishes.
+    fn fixture(conn: &Connection) {
+        conn.execute_batch(
+            "CREATE TABLE accounts (id INTEGER PRIMARY KEY, uuid BLOB NOT NULL);
+             CREATE TABLE transactions (id_tx INTEGER PRIMARY KEY, txid BLOB NOT NULL);
+             CREATE TABLE blocks (height INTEGER PRIMARY KEY);
+             INSERT INTO accounts (id, uuid) VALUES (1, X'11');",
+        )
+        .unwrap();
+        crate::pool_migration::orchard_ironwood::init_migration_tables(conn).unwrap();
+        conn.execute_batch(
+            "INSERT INTO orchard_ironwood_migrations
+                (id, account_id, status, note_split_fee_buffer, note_split_change,
+                 note_split_prep_fees, note_split_total_input, note_split_total_migratable,
+                 uuid)
+             VALUES (10, 1, 'in_progress', 15000, NULL, 30000, 500000, 400000, X'AA'),
+                    (11, 1, 'cancelled',   15000, NULL, 30000, 500000, 400000, X'BB');
+             INSERT INTO orchard_ironwood_migration_crossing_values
+                (migration_id, ordinal, value) VALUES (10, 0, 100000), (11, 0, 100000);
+             INSERT INTO orchard_ironwood_migration_prep_inputs
+                (migration_id, layer, tx_index, ordinal, source, value)
+             VALUES (10, 0, 0, 0, 'wallet', 300000), (10, 0, 0, 1, 'wallet', 200000);
+             INSERT INTO orchard_ironwood_migration_prep_outputs
+                (migration_id, layer, tx_index, ordinal, role, value)
+             VALUES (10, 0, 0, 0, 'funding', 115000), (10, 0, 0, 1, 'intermediate', 200000),
+                    (10, 0, 0, 2, 'change', 155000);
+             INSERT INTO orchard_ironwood_migration_transactions
+                (migration_id, transfer_id, kind, kind_layer, kind_index, kind_crossing, pczt,
+                 scheduled_height, expiry_height, state, txid)
+             VALUES
+                -- A signed preparation of the pending migration: scheduled.
+                (10, 0, 'preparation', 0, 0, NULL, X'01', 1000, 40000, 'signed',    X'A0'),
+                -- A proved transfer of the pending migration: scheduled.
+                (10, 1, 'transfer', NULL, NULL, 0,   X'02', 1100, 40000, 'proved',  X'A1'),
+                -- Broadcast: it lives in the wallet's transactions table, not here.
+                (10, 2, 'transfer', NULL, NULL, 0,   X'03', 1200, 40000, 'broadcast', X'A2'),
+                -- A proved transfer whose parent is TERMINAL: neither history nor pending.
+                (11, 0, 'transfer', NULL, NULL, 0,   X'04', 1300, 40000, 'proved',  X'A3'),
+                -- Proved, pending parent, but already recorded in the wallet (a legacy
+                -- prove-stored row): the wallet's row wins.
+                (10, 3, 'transfer', NULL, NULL, 0,   X'05', 1400, 40000, 'proved',  X'A4');
+             INSERT INTO transactions (id_tx, txid) VALUES (1, X'A2'), (2, X'A4');
+             INSERT INTO blocks (height) VALUES (500);",
+        )
+        .unwrap();
+    }
+
+    /// The dedicated view exposes exactly the scheduled transactions — pending parent, not yet
+    /// broadcast, not already in the wallet's tables — with values projected per kind: a
+    /// preparation's fee is inputs minus outputs, a transfer's is the per-note fee buffer (the
+    /// canonical transfer's ZIP-317 fee), and the crossing value is the transfer's
+    /// pool-crossing value.
+    #[test]
+    fn scheduled_rows_and_values() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        fixture(&conn);
+        let tx = conn.transaction().unwrap();
+        RusqliteMigration::up(&Migration, &tx).unwrap();
+        tx.commit().unwrap();
+
+        type Row = (
+            String,
+            String,
+            i64,
+            i64,
+            i64,
+            i64,
+            Option<i64>,
+            i64,
+            i64,
+            i64,
+            i64,
+        );
+        let rows: Vec<Row> = conn
+            .prepare(
+                "SELECT kind, state, scheduled_height, value_spent, value_received, fee,
+                        pool_crossing_value, spent_note_count, received_note_count, has_change,
+                        zip318_kind
+                   FROM v_migration_transactions ORDER BY scheduled_height",
+            )
+            .unwrap()
+            .query_map([], |r| {
+                Ok((
+                    r.get(0)?,
+                    r.get(1)?,
+                    r.get(2)?,
+                    r.get(3)?,
+                    r.get(4)?,
+                    r.get(5)?,
+                    r.get(6)?,
+                    r.get(7)?,
+                    r.get(8)?,
+                    r.get(9)?,
+                    r.get(10)?,
+                ))
+            })
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+
+        assert_eq!(
+            rows,
+            vec![
+                // The preparation: 500_000 in, 470_000 out (fee 30_000), one change output.
+                (
+                    "preparation".into(),
+                    "signed".into(),
+                    1000,
+                    500_000,
+                    470_000,
+                    30_000,
+                    None,
+                    2,
+                    2,
+                    1,
+                    2
+                ),
+                // The transfer: crossing 100_000 plus the 15_000 buffer spent; fee = buffer.
+                (
+                    "transfer".into(),
+                    "proved".into(),
+                    1100,
+                    115_000,
+                    100_000,
+                    15_000,
+                    Some(100_000),
+                    1,
+                    1,
+                    0,
+                    3
+                ),
+            ],
+            "broadcast, terminal-parent, and wallet-recorded rows are excluded"
+        );
+    }
+
+    /// The union view carries every `v_transactions` column: scheduled rows project into the
+    /// common shape (no mined height, no raw bytes, balance delta = -fee) and sit beside the
+    /// wallet's own rows without touching `v_transactions` itself.
+    #[test]
+    fn union_view_projects_the_common_shape() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        fixture(&conn);
+        // The union's first arm reads v_transactions; a reduced stand-in view over the fixture
+        // table keeps this test about the PROJECTION, not about v_transactions' own body.
+        conn.execute_batch(
+            "CREATE VIEW v_transactions AS
+             SELECT X'11' AS account_uuid, 500 AS mined_height, txid, 0 AS tx_index,
+                    40000 AS expiry_height, X'00' AS raw, -1000 AS account_balance_delta,
+                    2000 AS total_spent, 1000 AS total_received, 1000 AS fee_paid,
+                    0 AS has_change, 1 AS sent_note_count, 1 AS received_note_count,
+                    0 AS memo_count, 123 AS block_time, 0 AS expired_unmined,
+                    1 AS spent_note_count, 0 AS is_shielding, NULL AS pool_crossing_value,
+                    NULL AS trust_status, 0 AS zip318_kind
+             FROM transactions;",
+        )
+        .unwrap();
+        let tx = conn.transaction().unwrap();
+        RusqliteMigration::up(&Migration, &tx).unwrap();
+        tx.commit().unwrap();
+
+        let rows: Vec<(Option<i64>, i64, Option<i64>, i64)> = conn
+            .prepare(
+                "SELECT mined_height, account_balance_delta, fee_paid, zip318_kind
+                   FROM v_transactions_with_pending_migrations
+                  ORDER BY mined_height IS NULL, account_balance_delta",
+            )
+            .unwrap()
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+
+        assert_eq!(
+            rows,
+            vec![
+                // The wallet's own two rows...
+                (Some(500), -1000, Some(1000), 0),
+                (Some(500), -1000, Some(1000), 0),
+                // ...then the scheduled preparation and transfer, deltas of minus their fees.
+                (None, -30_000, Some(30_000), 2),
+                (None, -15_000, Some(15_000), 3),
+            ]
+        );
+    }
+}


### PR DESCRIPTION
The activity-view half of the store-at-broadcast design (plan D7 item 3), stacked on #2926. `v_transactions` is untouched, per the option-A decision: a dedicated view plus an opt-in union.

- **`orchard_ironwood_migration_txid_blob`** (schema migration): the migration store's txids move from hex `TEXT` to raw-byte `BLOB`, matching `transactions.txid` so the views can compare and join directly. Conversion goes through `TxId` in Rust — never SQL text manipulation — because a txid's display form is byte-reversed relative to its internal bytes, exactly the trap a SQL-level conversion would fall into silently; a unit test pins the byte order with an asymmetric pattern. The rebuild runs under `legacy_alter_table` so the child tables' foreign keys aren't rewritten to follow the discarded table.
- **`v_migration_transactions`**: one row per *scheduled* transaction — non-terminal parent, not yet broadcast, absent from the wallet's `transactions` table (which also dedupes legacy prove-stored rows). Columns: account and migration identity, kind, lifecycle state, scheduled/expiry heights, values, note counts, ZIP 318 classification code. Values are projected entirely from typed columns (no PCZT reads): a transfer's fee is the per-note fee buffer — definitionally the ZIP-317 fee of the canonical 2-Orchard + 1-Ironwood transfer shape, so its change is zero by construction — and a preparation's values are sums over its input/output rows. All wire names, classification codes, and the terminal-status list are generated from their defining types.
- **`v_transactions_with_pending_migrations`**: `v_transactions UNION ALL` the scheduled rows projected into its exact column shape (NULL mined height/raw/block time; `account_balance_delta = -fee`, every real output being internal). A consumer opts into the merged feed by switching one view name; existing `v_transactions` consumers see no change. This also improves on what store-at-prove ever provided: the whole committed schedule appears, signed transactions included, not just the proved prefix.

Verified: view unit tests (row-set predicate and per-kind values; union projection), `verify_schema`/canonical-DDL equality, the full pool-migration suite, all 9 chain-sim tests including expensive, clippy.

---

Filed with Claude Code assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Gsndy5ri9eYvtH31DnHTQ
