### PR TITLE
Bound transaction creation to a maximum size

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -16,6 +16,26 @@ workspace.
   address into an account as watch-only, without any associated key material.
 - `zcash_client_backend::wallet::TransparentAddressSource::StandaloneAddress`
 - `zcash_client_backend::wallet::TransparentAddressMetadata::standalone_address`
+- `zcash_client_backend::proposal::Step::estimated_serialized_size`, a
+  conservative upper-bound estimate of the serialized byte size of the
+  transaction a step describes. The estimate sums the per-element byte costs of
+  every input, output, and change output (using the v4 Sapling sizes, the
+  Orchard `ACTION_SIZE` plus per-action spend authorization signatures and
+  proof shares, and the standard P2PKH transparent sizes) plus per-bundle
+  overhead added only for bundles that are present. It never under-counts, so
+  comparing it against `MAX_BLOCK_BYTES` is a safe size bound for rejecting
+  proposals that cannot be mined.
+- `zcash_client_backend::proposal::Step::check_transaction_size`, which
+  validates a step's estimated serialized size against `MAX_BLOCK_BYTES` and
+  returns `ProposalError::TransactionTooLarge` if exceeded. Called by the
+  input-selection paths (`propose_transaction`, `propose_send_max`,
+  `propose_shielding`); not called during proposal deserialization, so
+  previously-persisted proposals remain recoverable.
+- `zcash_client_backend::proposal::ProposalError::TransactionTooLarge`, returned
+  by `check_transaction_size` when the step's estimated serialized size exceeds
+  `MAX_BLOCK_BYTES`. Carries the estimated size, the limit, and the total
+  shielded input count so a wallet can explain the situation to a user in terms
+  of notes rather than bytes.
 
 ### Changed
 - The `orchard` feature is now enabled by default. Consumers that require a
@@ -350,23 +370,6 @@ workspace.
 - `zcash_client_backend::data_api::locking::OutputLockStore` (re-exported as
   `zcash_client_backend::data_api::OutputLockStore`), the extracted storage
   contract for output locks, with `AccountId` and `Error` associated types.
-- `zcash_client_backend::proposal::Step::estimated_serialized_size`, a
-  conservative upper-bound estimate of the serialized byte size of the
-  transaction a step describes. The estimate sums the per-element byte costs of
-  every input, output, and change output (using the v4 Sapling sizes, the
-  Orchard `ACTION_SIZE` plus per-action spend authorization signatures and
-  proof shares, and the standard P2PKH transparent sizes) plus per-bundle
-  overhead added only for bundles that are present. It never under-counts, so
-  comparing it against `MAX_BLOCK_BYTES` is a safe size bound for rejecting
-  proposals that cannot be mined.
-- `zcash_client_backend::proposal::ProposalError::TransactionTooLarge`, returned
-  by `Step::from_parts` when the step's estimated serialized size exceeds
-  `MAX_BLOCK_BYTES`. Carries the estimated size, the limit, and the total
-  shielded input count so a wallet can explain the situation to a user in terms
-  of notes rather than bytes. Input selection now rejects oversized proposals
-  at construction time rather than letting them reach the transaction builder,
-  where proof generation would waste the caller's resources on a transaction
-  that can never be included in a block.
 
 ### Changed
 - Migrated to `zcash_primitives 0.30.0`, `zcash_transparent 0.10.0`,

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -353,14 +353,18 @@ workspace.
 - `zcash_client_backend::proposal::Step::estimated_serialized_size`, a
   conservative upper-bound estimate of the serialized byte size of the
   transaction a step describes. The estimate sums the per-element byte costs of
-  every input, output, and change output (using the v4 Sapling sizes and the
-  Orchard `ACTION_SIZE` as upper bounds) plus a fixed transaction-overhead
-  constant. It never under-counts, so comparing it against `MAX_BLOCK_BYTES` is
-  a safe size bound for rejecting proposals that cannot be mined.
+  every input, output, and change output (using the v4 Sapling sizes, the
+  Orchard `ACTION_SIZE` plus per-action spend authorization signatures and
+  proof shares, and the standard P2PKH transparent sizes) plus per-bundle
+  overhead added only for bundles that are present. It never under-counts, so
+  comparing it against `MAX_BLOCK_BYTES` is a safe size bound for rejecting
+  proposals that cannot be mined.
 - `zcash_client_backend::proposal::ProposalError::TransactionTooLarge`, returned
   by `Step::from_parts` when the step's estimated serialized size exceeds
-  `MAX_BLOCK_BYTES`. Input selection now rejects oversized proposals at
-  construction time rather than letting them reach the transaction builder,
+  `MAX_BLOCK_BYTES`. Carries the estimated size, the limit, and the total
+  shielded input count so a wallet can explain the situation to a user in terms
+  of notes rather than bytes. Input selection now rejects oversized proposals
+  at construction time rather than letting them reach the transaction builder,
   where proof generation would waste the caller's resources on a transaction
   that can never be included in a block.
 

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -350,6 +350,19 @@ workspace.
 - `zcash_client_backend::data_api::locking::OutputLockStore` (re-exported as
   `zcash_client_backend::data_api::OutputLockStore`), the extracted storage
   contract for output locks, with `AccountId` and `Error` associated types.
+- `zcash_client_backend::proposal::Step::estimated_serialized_size`, a
+  conservative upper-bound estimate of the serialized byte size of the
+  transaction a step describes. The estimate sums the per-element byte costs of
+  every input, output, and change output (using the v4 Sapling sizes and the
+  Orchard `ACTION_SIZE` as upper bounds) plus a fixed transaction-overhead
+  constant. It never under-counts, so comparing it against `MAX_BLOCK_BYTES` is
+  a safe size bound for rejecting proposals that cannot be mined.
+- `zcash_client_backend::proposal::ProposalError::TransactionTooLarge`, returned
+  by `Step::from_parts` when the step's estimated serialized size exceeds
+  `MAX_BLOCK_BYTES`. Input selection now rejects oversized proposals at
+  construction time rather than letting them reach the transaction builder,
+  where proof generation would waste the caller's resources on a transaction
+  that can never be included in a block.
 
 ### Changed
 - Migrated to `zcash_primitives 0.30.0`, `zcash_transparent 0.10.0`,

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -943,6 +943,7 @@ where
             proposed_version,
         )?,
     };
+    proposal.check_transaction_size()?;
     if let Some(request) = lock_inputs {
         let lock_expiry_height = target_height + request.for_blocks();
         lock_proposal_inputs(wallet_db, &proposal, request.owner(), lock_expiry_height)?;
@@ -1254,6 +1255,8 @@ where
         )
         .map_err(Error::from)?;
 
+    proposal.check_transaction_size()?;
+
     if let Some(request) = lock_inputs {
         let lock_expiry_height = target_height + request.for_blocks();
         lock_proposal_inputs(wallet_db, &proposal, request.owner(), lock_expiry_height)?;
@@ -1444,6 +1447,11 @@ where
     // The transaction version is carried on the proposal, chosen when the proposal was
     // constructed; `None` builds at the version implied by the target height.
     let proposed_version = proposal.proposed_version();
+
+    // Defense-in-depth: reject oversized proposals at the build entry point, so a
+    // proposal from a third-party input selector or a deserialized proposal that
+    // bypassed the `propose_*` wrappers cannot reach the expensive proving path.
+    proposal.check_transaction_size()?;
 
     if let Some(expiry_height) = expiry_height {
         let min_target_height = BlockHeight::from(proposal.min_target_height());
@@ -2885,6 +2893,10 @@ where
     if proposal.steps().len() > 1 {
         return Err(Error::ProposalNotSupported);
     }
+
+    // Defense-in-depth: reject oversized proposals at the build entry point.
+    proposal.check_transaction_size()?;
+
     let fee_rule = proposal.fee_rule();
     let min_target_height = proposal.min_target_height();
 

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -1967,7 +1967,7 @@ fn build_proposal<FeeRuleT: FeeRule + Clone, NoteRef>(
         .expect("removing payments from a TransactionRequest preserves validity");
 
         let mut steps = vec![];
-        steps.push(Step::from_parts(
+        let step0 = Step::from_parts(
             &[],
             tr0,
             payment_pools,
@@ -1979,11 +1979,13 @@ fn build_proposal<FeeRuleT: FeeRule + Clone, NoteRef>(
             false,
             #[cfg(feature = "orchard")]
             ironwood_active,
-        )?);
+        )?;
+        step0.check_transaction_size(&[])?;
+        steps.push(step0);
 
         let tr1 =
             TransactionRequest::new(ephemeral_step.tr1_payments).expect("valid by construction");
-        steps.push(Step::from_parts(
+        let step1 = Step::from_parts(
             &steps,
             tr1,
             ephemeral_step.tr1_payment_pools,
@@ -1995,7 +1997,9 @@ fn build_proposal<FeeRuleT: FeeRule + Clone, NoteRef>(
             false,
             #[cfg(feature = "orchard")]
             ironwood_active,
-        )?);
+        )?;
+        step1.check_transaction_size(&steps)?;
+        steps.push(step1);
 
         return Proposal::multi_step(
             fee_rule.clone(),
@@ -2005,7 +2009,7 @@ fn build_proposal<FeeRuleT: FeeRule + Clone, NoteRef>(
         );
     }
 
-    Proposal::single_step(
+    let proposal = Proposal::single_step(
         transaction_request,
         payment_pools,
         transparent_inputs,
@@ -2018,7 +2022,9 @@ fn build_proposal<FeeRuleT: FeeRule + Clone, NoteRef>(
         false,
         #[cfg(feature = "orchard")]
         ironwood_active,
-    )
+    )?;
+    proposal.steps().first().check_transaction_size(&[])?;
+    Ok(proposal)
 }
 
 #[cfg(feature = "transparent-inputs")]
@@ -2073,7 +2079,7 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
         )?;
 
         if balance.total() >= shielding_threshold {
-            Proposal::single_step(
+            let proposal = Proposal::single_step(
                 TransactionRequest::empty(),
                 BTreeMap::new(),
                 transparent_inputs,
@@ -2086,8 +2092,9 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
                 true,
                 #[cfg(feature = "orchard")]
                 ironwood_active_at(params, target_height),
-            )
-            .map_err(InputSelectorError::Proposal)
+            )?;
+            proposal.steps().first().check_transaction_size(&[])?;
+            Ok(proposal)
         } else {
             Err(InputSelectorError::InsufficientFunds {
                 available: balance.total(),
@@ -2248,7 +2255,7 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
         // `is_shielding = true` for the legacy "no payment, all value in change"
         // shape produced by `propose_shielding`. From the wallet's perspective
         // this is still a transparent -> shielded transfer of coinbase value.
-        Proposal::single_step(
+        let proposal = Proposal::single_step(
             request,
             payment_pools,
             transparent_inputs,
@@ -2264,8 +2271,9 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
             false,
             #[cfg(feature = "orchard")]
             ironwood_active_at(params, target_height),
-        )
-        .map_err(InputSelectorError::Proposal)
+        )?;
+        proposal.steps().first().check_transaction_size(&[])?;
+        Ok(proposal)
     }
 }
 

--- a/zcash_client_backend/src/data_api/wallet/input_selection.rs
+++ b/zcash_client_backend/src/data_api/wallet/input_selection.rs
@@ -1980,7 +1980,6 @@ fn build_proposal<FeeRuleT: FeeRule + Clone, NoteRef>(
             #[cfg(feature = "orchard")]
             ironwood_active,
         )?;
-        step0.check_transaction_size(&[])?;
         steps.push(step0);
 
         let tr1 =
@@ -1998,7 +1997,6 @@ fn build_proposal<FeeRuleT: FeeRule + Clone, NoteRef>(
             #[cfg(feature = "orchard")]
             ironwood_active,
         )?;
-        step1.check_transaction_size(&steps)?;
         steps.push(step1);
 
         return Proposal::multi_step(
@@ -2009,7 +2007,7 @@ fn build_proposal<FeeRuleT: FeeRule + Clone, NoteRef>(
         );
     }
 
-    let proposal = Proposal::single_step(
+    Proposal::single_step(
         transaction_request,
         payment_pools,
         transparent_inputs,
@@ -2022,9 +2020,7 @@ fn build_proposal<FeeRuleT: FeeRule + Clone, NoteRef>(
         false,
         #[cfg(feature = "orchard")]
         ironwood_active,
-    )?;
-    proposal.steps().first().check_transaction_size(&[])?;
-    Ok(proposal)
+    )
 }
 
 #[cfg(feature = "transparent-inputs")]
@@ -2079,7 +2075,7 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
         )?;
 
         if balance.total() >= shielding_threshold {
-            let proposal = Proposal::single_step(
+            Proposal::single_step(
                 TransactionRequest::empty(),
                 BTreeMap::new(),
                 transparent_inputs,
@@ -2092,9 +2088,8 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
                 true,
                 #[cfg(feature = "orchard")]
                 ironwood_active_at(params, target_height),
-            )?;
-            proposal.steps().first().check_transaction_size(&[])?;
-            Ok(proposal)
+            )
+            .map_err(InputSelectorError::Proposal)
         } else {
             Err(InputSelectorError::InsufficientFunds {
                 available: balance.total(),
@@ -2255,7 +2250,7 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
         // `is_shielding = true` for the legacy "no payment, all value in change"
         // shape produced by `propose_shielding`. From the wallet's perspective
         // this is still a transparent -> shielded transfer of coinbase value.
-        let proposal = Proposal::single_step(
+        Proposal::single_step(
             request,
             payment_pools,
             transparent_inputs,
@@ -2271,9 +2266,8 @@ impl<DbT: InputSource> ShieldingSelector for GreedyInputSelector<DbT> {
             false,
             #[cfg(feature = "orchard")]
             ironwood_active_at(params, target_height),
-        )?;
-        proposal.steps().first().check_transaction_size(&[])?;
-        Ok(proposal)
+        )
+        .map_err(InputSelectorError::Proposal)
     }
 }
 

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -134,12 +134,29 @@ pub enum ProposalError {
     /// transaction was estimated from its inputs, outputs, and change, using conservative
     /// per-element byte costs; the estimate exceeds [`MAX_BLOCK_BYTES`].
     ///
+    /// `MAX_BLOCK_BYTES` is the *block* size limit, not a per-transaction limit: a
+    /// transaction that fits just under it still cannot be mined, because the block must
+    /// also carry its header and coinbase transaction. Passing the gate is therefore
+    /// necessary but not sufficient for mineability near the boundary; the builder is the
+    /// final authority.
+    ///
+    /// Recovery for a caller that receives this error: reduce the number of inputs by
+    /// lowering the payment amount or by consolidating small notes via send-to-self
+    /// transactions before retrying. Each consolidation round must be mined and its note
+    /// commitments anchored before the resulting notes are spendable, so recovery spans
+    /// multiple confirmations. For `propose_send_max` this error is a dead end — there is
+    /// no smaller amount to back off to — and requires a multi-transaction strategy.
+    ///
     /// [`MAX_BLOCK_BYTES`]: zcash_protocol::constants::MAX_BLOCK_BYTES
     TransactionTooLarge {
         /// The conservative upper-bound estimate of the step's serialized byte size.
         estimated_size: usize,
         /// The maximum serialized byte size a Zcash transaction may carry (`MAX_BLOCK_BYTES`).
         limit: usize,
+        /// The total number of shielded inputs (across all shielded pools) the step spends.
+        /// Carried alongside the byte counts so a wallet can explain the situation to a
+        /// user in terms of notes rather than bytes.
+        shielded_input_count: usize,
     },
 }
 
@@ -263,9 +280,10 @@ impl Display for ProposalError {
             ProposalError::TransactionTooLarge {
                 estimated_size,
                 limit,
+                shielded_input_count,
             } => write!(
                 f,
-                "The proposed transaction's estimated serialized size ({estimated_size} bytes) exceeds the maximum transaction size ({limit} bytes)."
+                "The proposed transaction's estimated serialized size ({estimated_size} bytes) exceeds the maximum transaction size ({limit} bytes). It spends {shielded_input_count} shielded inputs; reduce the payment amount or consolidate small notes before retrying."
             ),
         }
     }
@@ -774,6 +792,11 @@ impl<NoteRef> Step<NoteRef> {
             });
         }
 
+        let shielded_input_count = shielded_inputs
+            .iter()
+            .flat_map(|s| s.notes().iter())
+            .count();
+
         let step = Self {
             transaction_request,
             payment_pools,
@@ -794,6 +817,7 @@ impl<NoteRef> Step<NoteRef> {
             return Err(ProposalError::TransactionTooLarge {
                 estimated_size,
                 limit: MAX_BLOCK_BYTES,
+                shielded_input_count,
             });
         }
 
@@ -1154,9 +1178,12 @@ impl<NoteRef> Step<NoteRef> {
     /// The estimate is conservative (it never under-counts), so comparing it against
     /// [`MAX_BLOCK_BYTES`] is a safe size bound: a step whose estimate fits within a
     /// block will fit when built, and a step whose estimate exceeds a block may or may
-    /// not fit (the builder is the final authority), but rejecting the latter at
-    /// proposal time prevents input selection from constructing a transaction that
-    /// can never be mined.
+    /// not fit, but rejecting the latter at proposal time prevents input selection from
+    /// constructing a transaction that can never be mined. Passing the gate is necessary
+    /// but not sufficient for mineability: `MAX_BLOCK_BYTES` is the *block* size limit,
+    /// and a transaction that fits just under it still cannot be mined because the block
+    /// must also carry its header and coinbase transaction. The builder is the final
+    /// authority.
     ///
     /// [`ACTION_SIZE`]: zcash_primitives::transaction::components::orchard::ACTION_SIZE
     /// [`MAX_BLOCK_BYTES`]: zcash_protocol::constants::MAX_BLOCK_BYTES
@@ -1744,7 +1771,10 @@ mod tests {
             Err(ProposalError::TransactionTooLarge {
                 estimated_size,
                 limit,
-            }) if limit == MAX_BLOCK_BYTES && estimated_size > MAX_BLOCK_BYTES
+                shielded_input_count,
+            }) if limit == MAX_BLOCK_BYTES
+                && estimated_size > MAX_BLOCK_BYTES
+                && shielded_input_count == oversize_spend_count
         );
     }
 

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -6,10 +6,17 @@ use std::{
 };
 
 use nonempty::NonEmpty;
-use zcash_primitives::transaction::{TxId, TxVersion};
+#[cfg(feature = "orchard")]
+use zcash_primitives::transaction::components::orchard::ACTION_SIZE as ORCHARD_ACTION_SIZE;
+use zcash_primitives::transaction::{
+    TxId, TxVersion,
+    components::sapling::{OUTPUT_DESCRIPTION_SIZE, SPEND_DESCRIPTION_SIZE},
+    fees::{transparent as transparent_fees, zip317::P2PKH_STANDARD_OUTPUT_SIZE},
+};
 use zcash_protocol::{
     PoolType, ShieldedPool,
     consensus::{BlockHeight, BranchId},
+    constants::MAX_BLOCK_BYTES,
     value::Zatoshis,
 };
 use zip321::{TransactionRequest, Zip321Error};
@@ -122,6 +129,18 @@ pub enum ProposalError {
     /// classification routes Orchard-receiver payments to the Ironwood pool instead.
     #[cfg(feature = "orchard")]
     OrchardPoolPayment(usize),
+    /// The transaction the step describes would exceed the maximum size a Zcash block may
+    /// carry, and so cannot be included in any block. The serialized size of the step's
+    /// transaction was estimated from its inputs, outputs, and change, using conservative
+    /// per-element byte costs; the estimate exceeds [`MAX_BLOCK_BYTES`].
+    ///
+    /// [`MAX_BLOCK_BYTES`]: zcash_protocol::constants::MAX_BLOCK_BYTES
+    TransactionTooLarge {
+        /// The conservative upper-bound estimate of the step's serialized byte size.
+        estimated_size: usize,
+        /// The maximum serialized byte size a Zcash transaction may carry (`MAX_BLOCK_BYTES`).
+        limit: usize,
+    },
 }
 
 impl Display for ProposalError {
@@ -240,6 +259,13 @@ impl Display for ProposalError {
             ProposalError::OrchardReceiverRequiresIronwood(version) => write!(
                 f,
                 "After NU6.3 activation, a payment to an Orchard receiver requires a version 6 (Ironwood) transaction, but version {version:?} was requested."
+            ),
+            ProposalError::TransactionTooLarge {
+                estimated_size,
+                limit,
+            } => write!(
+                f,
+                "The proposed transaction's estimated serialized size ({estimated_size} bytes) exceeds the maximum transaction size ({limit} bytes)."
             ),
         }
     }
@@ -741,23 +767,37 @@ impl<NoteRef> Step<NoteRef> {
             return Err(ProposalError::MissingShieldedAnchor);
         }
 
-        if input_total == output_total {
-            Ok(Self {
-                transaction_request,
-                payment_pools,
-                transparent_inputs,
-                shielded_inputs,
-                anchor_height,
-                prior_step_inputs,
-                balance,
-                is_shielding,
-            })
-        } else {
-            Err(ProposalError::BalanceError {
+        if input_total != output_total {
+            return Err(ProposalError::BalanceError {
                 input_total,
                 output_total,
-            })
+            });
         }
+
+        let step = Self {
+            transaction_request,
+            payment_pools,
+            transparent_inputs,
+            shielded_inputs,
+            anchor_height,
+            prior_step_inputs,
+            balance,
+            is_shielding,
+        };
+
+        // Reject proposals whose estimated serialized size exceeds the maximum a Zcash block
+        // may carry. The estimate is a conservative upper bound (see `estimated_serialized_size`),
+        // so a step that passes this gate may still fail at build time, but a step that fails it
+        // can never be mined and is rejected here rather than wasting the caller's fee budget.
+        let estimated_size = step.estimated_serialized_size();
+        if estimated_size > MAX_BLOCK_BYTES {
+            return Err(ProposalError::TransactionTooLarge {
+                estimated_size,
+                limit: MAX_BLOCK_BYTES,
+            });
+        }
+
+        Ok(step)
     }
 
     /// Returns the transaction request that describes the payments to be made.
@@ -1084,6 +1124,138 @@ impl<NoteRef> Step<NoteRef> {
         bundle_version: ::orchard::bundle::BundleVersion,
     ) -> Result<usize, &'static str> {
         self.orchard_style_action_count(PoolType::IRONWOOD, padding, bundle_version)
+    }
+
+    /// Returns a conservative upper-bound estimate of the serialized byte size of the
+    /// transaction this step describes.
+    ///
+    /// The estimate sums the per-element byte costs of every input, output, and change
+    /// output the step carries, plus a fixed overhead for the transaction header, version,
+    /// lock time, and per-bundle binding signatures. Each per-element cost is an upper bound:
+    /// transparent inputs use their actual known serialized size (so P2SH inputs, which can
+    /// be larger than the P2PKH standard, are not under-counted), with a generous fixed
+    /// upper bound for inputs whose script size is unknown; Sapling uses the v4 serialized
+    /// form, which carries proofs and signatures inline; Orchard uses [`ACTION_SIZE`], which
+    /// excludes the per-action spend authorization signature and proof share, so the
+    /// bundle-level proof and signatures are accounted for in the fixed overhead and padding
+    /// constants. The Orchard and Ironwood action counts use `spends + outputs + 2`, which
+    /// is an upper bound across every bundle type and version: the post-NU6.3
+    /// cross-address-disabled policy charges `spends + outputs` and the pre-NU6.3 policy
+    /// charges `max(spends, outputs)` (no larger), and the default bundle type pads to a
+    /// two-action minimum.
+    ///
+    /// The estimate is conservative (it never under-counts), so comparing it against
+    /// [`MAX_BLOCK_BYTES`] is a safe size bound: a step whose estimate fits within a block
+    /// will fit when built, and a step whose estimate exceeds a block may or may not fit
+    /// (the builder is the final authority), but rejecting the latter at proposal time
+    /// prevents input selection from constructing a transaction that can never be mined.
+    ///
+    /// [`ACTION_SIZE`]: zcash_primitives::transaction::components::orchard::ACTION_SIZE
+    /// [`MAX_BLOCK_BYTES`]: zcash_protocol::constants::MAX_BLOCK_BYTES
+    pub fn estimated_serialized_size(&self) -> usize {
+        // Fixed overhead for the transaction header (version, version_group_id, lock_time,
+        // expiry_height, and the binding-sig field of a v4/v5 transaction) and the
+        // per-bundle authorization data the per-element sizes exclude (Sapling binding
+        // signature, Orchard/Ironwood spend authorization signatures and the bundle proofs).
+        // This is a deliberately coarse upper bound: it needs only to exceed the real
+        // fixed cost, not to match it, since the estimate is used only to reject proposals
+        // that cannot fit in a block.
+        const FIXED_TX_OVERHEAD: usize = 1 << 13; // 8 KiB
+
+        // The maximum padding the default Orchard/Ironwood bundle type applies: the
+        // `Transactional { pad_to_minimum: Some(2) }` default pads to at least two actions.
+        // Added to `spends + outputs` (the post-NU6.3 count, which is >= the pre-NU6.3
+        // `max(spends, outputs)` count) this is an upper bound on the action count across
+        // every bundle type and version.
+        #[cfg(feature = "orchard")]
+        const ORCHARD_PADDING_ACTIONS: usize = 2;
+
+        // Transparent inputs: use each input's actual serialized size where it is known
+        // (P2PKH or P2SH inputs with a known script size), so that P2SH inputs — which can
+        // be larger than the P2PKH standard — are not under-counted. For inputs whose script
+        // size is unknown, fall back to a generous upper bound: the scriptSig of a
+        // transparent input is consensus-limited but in practice rarely exceeds a few hundred
+        // bytes, and 8 KiB is well above any realistic redeem script while still small enough
+        // that a single unknown input cannot by itself trip the block limit.
+        const UNKNOWN_INPUT_SIZE_UPPER_BOUND: usize = 1 << 13; // 8 KiB
+        let transparent_inputs = self
+            .transparent_inputs()
+            .iter()
+            .map(
+                |input| match transparent_fees::InputView::serialized_size(input) {
+                    transparent_fees::InputSize::Known(size) => size,
+                    transparent_fees::InputSize::Unknown(_) => UNKNOWN_INPUT_SIZE_UPPER_BOUND,
+                },
+            )
+            .sum::<usize>();
+
+        // Transparent outputs: each payment to the transparent pool and each transparent
+        // change output costs the standard P2PKH output size.
+        let transparent_payment_outputs =
+            self.output_count_in_pool(PoolType::Transparent) * P2PKH_STANDARD_OUTPUT_SIZE;
+        let transparent_change_outputs =
+            self.change_count_in_pool(PoolType::Transparent) * P2PKH_STANDARD_OUTPUT_SIZE;
+
+        // Sapling spends and outputs. The default Sapling bundle type pads to at least
+        // two outputs when there are any spends or outputs, so the output count is
+        // `max(requested_outputs + change_outputs, 2)` when the bundle is non-empty. The
+        // spend count is `max(requested_spends, 1)` when non-empty. Both are upper-bounded
+        // by adding 2 to the requested count, which covers the padding floor.
+        let sapling_spends = self.input_count_in_pool(PoolType::SAPLING);
+        let sapling_outputs = self.output_count_in_pool(PoolType::SAPLING)
+            + self.change_count_in_pool(PoolType::SAPLING);
+        let sapling_bundle_present = sapling_spends > 0 || sapling_outputs > 0;
+        let sapling_spend_bytes = if sapling_bundle_present {
+            (sapling_spends + 2) * SPEND_DESCRIPTION_SIZE
+        } else {
+            0
+        };
+        let sapling_output_bytes = if sapling_bundle_present {
+            (sapling_outputs + 2) * OUTPUT_DESCRIPTION_SIZE
+        } else {
+            0
+        };
+
+        // Orchard and Ironwood actions. `spends + outputs + ORCHARD_PADDING_ACTIONS` is an
+        // upper bound on the action count across all bundle types and versions (see the
+        // method doc). Each action costs `ACTION_SIZE`; the per-action spend authorization
+        // signature and the bundle proof are accounted for in `FIXED_TX_OVERHEAD`.
+        #[cfg(feature = "orchard")]
+        let orchard_action_bytes = {
+            let orchard_spends = self.input_count_in_pool(PoolType::ORCHARD);
+            let orchard_outputs = self.output_count_in_pool(PoolType::ORCHARD)
+                + self.change_count_in_pool(PoolType::ORCHARD);
+            if orchard_spends + orchard_outputs > 0 {
+                (orchard_spends + orchard_outputs + ORCHARD_PADDING_ACTIONS) * ORCHARD_ACTION_SIZE
+            } else {
+                0
+            }
+        };
+        #[cfg(not(feature = "orchard"))]
+        let orchard_action_bytes: usize = 0;
+
+        #[cfg(feature = "orchard")]
+        let ironwood_action_bytes = {
+            let ironwood_spends = self.input_count_in_pool(PoolType::IRONWOOD);
+            let ironwood_outputs = self.output_count_in_pool(PoolType::IRONWOOD)
+                + self.change_count_in_pool(PoolType::IRONWOOD);
+            if ironwood_spends + ironwood_outputs > 0 {
+                (ironwood_spends + ironwood_outputs + ORCHARD_PADDING_ACTIONS) * ORCHARD_ACTION_SIZE
+            } else {
+                0
+            }
+        };
+        #[cfg(not(feature = "orchard"))]
+        let ironwood_action_bytes: usize = 0;
+
+        FIXED_TX_OVERHEAD
+            + transparent_inputs
+            + transparent_payment_outputs
+            + transparent_change_outputs
+            + sapling_spend_bytes
+            + sapling_output_bytes
+            + orchard_action_bytes
+            + ironwood_action_bytes
     }
 }
 
@@ -1489,6 +1661,69 @@ mod tests {
                 false,
             ),
             Ok(_)
+        );
+    }
+
+    /// A step whose estimated serialized size exceeds the maximum a Zcash block may carry is
+    /// rejected at proposal time, rather than being allowed to reach the builder (where proof
+    /// generation would waste the caller's resources on a transaction that can never be mined).
+    ///
+    /// The estimate is a conservative upper bound, so the boundary it enforces is a safe floor:
+    /// a step that passes may still fail at build time, but a step that fails can never fit. The
+    /// test constructs the smallest step that exceeds the block limit — one more Orchard spend
+    /// than a block can hold — and confirms both the rejection and that the error carries the
+    /// estimate and the limit for diagnostics.
+    #[test]
+    fn step_exceeding_the_block_size_limit_is_rejected() {
+        // One more Orchard spend than fits in a block. Each action costs at least `ACTION_SIZE`
+        // bytes on the wire, so `MAX_BLOCK_BYTES / ACTION_SIZE + 1` spends cannot fit. The
+        // estimate adds a fixed overhead and padding, so the real boundary is a little lower,
+        // but the +1 guarantees the step is over regardless of where that boundary falls.
+        let oversize_spend_count = MAX_BLOCK_BYTES / ACTION_SIZE + 1;
+
+        // The total input value is `oversize_spend_count * 1` zatoshi, and the fee is zero, so
+        // the step is value-balanced (one zatoshi of change per spend) and the rejection is due
+        // to the size, not the balance.
+        let one_zato = Zatoshis::const_from_u64(1);
+        let input_total = (one_zato * oversize_spend_count).unwrap();
+        let change = ChangeValue::shielded(ShieldedPool::Orchard, input_total, None);
+        let balance = TransactionBalance::new(vec![change], Zatoshis::ZERO).unwrap();
+
+        assert_matches!(
+            validated_step(
+                orchard_and_ironwood_notes((oversize_spend_count, 1), (0, 0)),
+                balance,
+                false,
+            ),
+            Err(ProposalError::TransactionTooLarge {
+                estimated_size,
+                limit,
+            }) if limit == MAX_BLOCK_BYTES && estimated_size > MAX_BLOCK_BYTES
+        );
+    }
+
+    /// A step whose estimated size fits within the block limit is accepted. This is the
+    /// negative control for `step_exceeding_the_block_size_limit_is_rejected`: it confirms the
+    /// gate rejects only oversized steps, not every step with a large action count.
+    #[test]
+    fn step_fitting_within_the_block_size_limit_is_accepted() {
+        // A step whose Orchard action count is comfortably below the block ceiling. The
+        // estimate adds a fixed overhead and padding to the per-action cost, so the fitting
+        // count is the floor `MAX_BLOCK_BYTES / ACTION_SIZE` minus a margin for that overhead.
+        let fitting_spend_count = MAX_BLOCK_BYTES / ACTION_SIZE - 16;
+
+        let one_zato = Zatoshis::const_from_u64(1);
+        let input_total = (one_zato * fitting_spend_count).unwrap();
+        let change = ChangeValue::shielded(ShieldedPool::Orchard, input_total, None);
+        let balance = TransactionBalance::new(vec![change], Zatoshis::ZERO).unwrap();
+
+        assert_matches!(
+            validated_step(
+                orchard_and_ironwood_notes((fitting_spend_count, 1), (0, 0)),
+                balance,
+                false,
+            ),
+            Ok(step) if step.estimated_serialized_size() <= MAX_BLOCK_BYTES
         );
     }
 

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -7,11 +7,20 @@ use std::{
 
 use nonempty::NonEmpty;
 #[cfg(feature = "orchard")]
-use zcash_primitives::transaction::components::orchard::ACTION_SIZE as ORCHARD_ACTION_SIZE;
+use zcash_primitives::transaction::components::orchard::{
+    ACTION_SIZE as ORCHARD_ACTION_SIZE, BUNDLE_OVERHEAD as ORCHARD_BUNDLE_OVERHEAD,
+    SPEND_AUTH_SIG_SIZE as ORCHARD_AUTH_SIG_SIZE,
+};
 use zcash_primitives::transaction::{
     TxId, TxVersion,
-    components::sapling::{OUTPUT_DESCRIPTION_SIZE, SPEND_DESCRIPTION_SIZE},
-    fees::{transparent as transparent_fees, zip317::P2PKH_STANDARD_OUTPUT_SIZE},
+    components::sapling::{
+        BUNDLE_OVERHEAD as SAPLING_BUNDLE_OVERHEAD, OUTPUT_DESCRIPTION_SIZE, SPEND_DESCRIPTION_SIZE,
+    },
+    fees::transparent as transparent_fees,
+    fees::zip317::{
+        MAX_TRANSPARENT_INPUT_SIZE, P2PKH_STANDARD_INPUT_SIZE, P2PKH_STANDARD_OUTPUT_SIZE,
+        TRANSPARENT_BUNDLE_OVERHEAD, TX_HEADER_SIZE,
+    },
 };
 use zcash_protocol::{
     PoolType, ShieldedPool,
@@ -151,7 +160,7 @@ pub enum ProposalError {
     TransactionTooLarge {
         /// The conservative upper-bound estimate of the step's serialized byte size.
         estimated_size: usize,
-        /// The maximum serialized byte size a Zcash transaction may carry (`MAX_BLOCK_BYTES`).
+        /// The maximum serialized byte size a Zcash block may carry (`MAX_BLOCK_BYTES`).
         limit: usize,
         /// The total number of shielded inputs (across all shielded pools) the step spends.
         /// Carried alongside the byte counts so a wallet can explain the situation to a
@@ -283,7 +292,7 @@ impl Display for ProposalError {
                 shielded_input_count,
             } => write!(
                 f,
-                "The proposed transaction's estimated serialized size ({estimated_size} bytes) exceeds the maximum transaction size ({limit} bytes). It spends {shielded_input_count} shielded inputs; reduce the payment amount or consolidate small notes before retrying."
+                "The proposed transaction's estimated serialized size ({estimated_size} bytes) exceeds the maximum block size ({limit} bytes). It spends {shielded_input_count} shielded inputs; reduce the payment amount or consolidate small notes before retrying."
             ),
         }
     }
@@ -792,12 +801,7 @@ impl<NoteRef> Step<NoteRef> {
             });
         }
 
-        let shielded_input_count = shielded_inputs
-            .iter()
-            .flat_map(|s| s.notes().iter())
-            .count();
-
-        let step = Self {
+        Ok(Self {
             transaction_request,
             payment_pools,
             transparent_inputs,
@@ -806,22 +810,7 @@ impl<NoteRef> Step<NoteRef> {
             prior_step_inputs,
             balance,
             is_shielding,
-        };
-
-        // Reject proposals whose estimated serialized size exceeds the maximum a Zcash block
-        // may carry. The estimate is a conservative upper bound (see `estimated_serialized_size`),
-        // so a step that passes this gate may still fail at build time, but a step that fails it
-        // can never be mined and is rejected here rather than wasting the caller's fee budget.
-        let estimated_size = step.estimated_serialized_size();
-        if estimated_size > MAX_BLOCK_BYTES {
-            return Err(ProposalError::TransactionTooLarge {
-                estimated_size,
-                limit: MAX_BLOCK_BYTES,
-                shielded_input_count,
-            });
-        }
-
-        Ok(step)
+        })
     }
 
     /// Returns the transaction request that describes the payments to be made.
@@ -1153,19 +1142,24 @@ impl<NoteRef> Step<NoteRef> {
     /// Returns a conservative upper-bound estimate of the serialized byte size of the
     /// transaction this step describes.
     ///
+    /// `prior_steps` is the slice of steps that precede this step in the proposal, as
+    /// passed to [`Step::from_parts`]; it is used to account for inputs that spend
+    /// outputs of prior steps (ZIP-320 / chained-consolidation flows). Pass `&[]` for a
+    /// single-step proposal.
+    ///
     /// The estimate sums the per-element byte costs of every input, output, and change
-    /// output the step carries, plus the per-bundle overhead that each present bundle
-    /// contributes (header fields, binding signatures, and the Orchard/Ironwood bundle
-    /// proof). Each per-element cost is an upper bound:
+    /// output the step carries — including prior-step inputs — plus the per-bundle
+    /// overhead that each present bundle contributes (header fields, binding signatures,
+    /// and the Orchard/Ironwood bundle proof). Each per-element cost is an upper bound:
     /// - Transparent inputs use their actual known serialized size (so P2SH inputs,
-    ///   which can be larger than the P2PKH standard, are not under-counted), with a
-    ///   generous fixed upper bound for inputs whose script size is unknown.
+    ///   which can be larger than the P2PKH standard, are not under-counted), with the
+    ///   consensus-maximum input size for inputs whose script size is unknown.
     /// - Sapling uses the v4 serialized form, which carries proofs and signatures
     ///   inline — a conservative upper bound, since v5 moves these to bundle-level
     ///   fields.
     /// - Orchard and Ironwood use [`ACTION_SIZE`] for each action description, plus
-    ///   the per-action spend authorization signature (64 bytes) and the per-action
-    ///   proof share, computed via [`orchard::Proof::expected_proof_size`].
+    ///   the per-action spend authorization signature and the per-action proof share,
+    ///   computed via [`orchard::Proof::expected_proof_size`].
     ///
     /// The per-bundle overhead is added only when a bundle is present, so a
     /// purely-transparent transaction is not charged for Sapling or Orchard proof
@@ -1187,78 +1181,80 @@ impl<NoteRef> Step<NoteRef> {
     ///
     /// [`ACTION_SIZE`]: zcash_primitives::transaction::components::orchard::ACTION_SIZE
     /// [`MAX_BLOCK_BYTES`]: zcash_protocol::constants::MAX_BLOCK_BYTES
-    pub fn estimated_serialized_size(&self) -> usize {
-        // The fixed transaction header: version (4) + consensus_branch_id (4) +
-        // lock_time (4) + expiry_height (4). The 32-byte constant leaves room for
-        // future header fields (e.g. the zip-233 amount under NU7).
-        const TX_HEADER_SIZE: usize = 32;
-
-        // Per-bundle overhead for a present transparent bundle: two CompactSize
-        // vector-length prefixes (one for vin, one for vout), at most 9 bytes each.
-        const TRANSPARENT_BUNDLE_OVERHEAD: usize = 18;
-
-        // Per-bundle overhead for a present Sapling bundle: value_balance (8) +
-        // binding_sig (64) + CompactSize vector-length prefixes for spends and
-        // outputs (~28). The v4 anchor is per-spend (already in
-        // `SPEND_DESCRIPTION_SIZE`); the v5 per-bundle anchor (32) is covered by
-        // the margin.
-        const SAPLING_BUNDLE_OVERHEAD: usize = 100;
-
-        // Per-action spend authorization signature in an Orchard/Ironwood bundle.
-        #[cfg(feature = "orchard")]
-        const ORCHARD_AUTH_SIG_SIZE: usize = 64;
-
-        // Per-bundle overhead for a present Orchard/Ironwood bundle, excluding the
-        // proof: flags (1) + value_balance (8) + anchor (32) + binding_sig (64) +
-        // CompactSize for the actions vector (~10). The proof is added separately
-        // via `Proof::expected_proof_size`.
-        #[cfg(feature = "orchard")]
-        const ORCHARD_BUNDLE_OVERHEAD: usize = 115;
-
-        // The maximum padding the default Orchard/Ironwood bundle type applies: the
-        // `Transactional { pad_to_minimum: Some(2) }` default pads to at least two
-        // actions. Added to `spends + outputs` (the post-NU6.3 count, which is >=
-        // the pre-NU6.3 `max(spends, outputs)` count) this is an upper bound on the
-        // action count across every bundle type and version.
+    pub fn estimated_serialized_size(&self, prior_steps: &[Step<NoteRef>]) -> usize {
+        // The maximum padding the default Orchard/Ironwood bundle type applies.
         #[cfg(feature = "orchard")]
         const ORCHARD_PADDING_ACTIONS: usize = 2;
 
-        // Transparent inputs: use each input's actual serialized size where it is known
-        // (P2PKH or P2SH inputs with a known script size), so that P2SH inputs — which
-        // can be larger than the P2PKH standard — are not under-counted. For inputs
-        // whose script size is unknown, fall back to a generous upper bound: the
-        // scriptSig of a transparent input is consensus-limited but in practice rarely
-        // exceeds a few hundred bytes, and 8 KiB is well above any realistic redeem
-        // script while still small enough that a single unknown input cannot by itself
-        // trip the block limit.
-        const UNKNOWN_INPUT_SIZE_UPPER_BOUND: usize = 1 << 13; // 8 KiB
-        let transparent_inputs = self
+        // Single-pass tally of shielded inputs by pool, counting both the step's own
+        // shielded inputs and prior-step inputs that spend shielded outputs.
+        let mut sapling_spends = 0usize;
+        let mut orchard_spends = 0usize;
+        let mut ironwood_spends = 0usize;
+
+        if let Some(shielded) = self.shielded_inputs() {
+            for note in shielded.notes().iter() {
+                match note.note().pool() {
+                    ShieldedPool::Sapling => sapling_spends += 1,
+                    ShieldedPool::Orchard => orchard_spends += 1,
+                    ShieldedPool::Ironwood => ironwood_spends += 1,
+                }
+            }
+        }
+
+        // Prior-step inputs: each references an output of a preceding step. Determine
+        // the pool of the referenced output and add its input cost to the relevant
+        // pool's count.
+        let mut prior_transparent_inputs = 0usize;
+        for s_ref in self.prior_step_inputs() {
+            let prior_step = &prior_steps[s_ref.step_index()];
+            let pool = match s_ref.output_index() {
+                StepOutputIndex::Payment(i) => *prior_step
+                    .payment_pools()
+                    .get(&i)
+                    .expect("payment pool exists for referenced payment"),
+                StepOutputIndex::Change(i) => {
+                    prior_step.balance().proposed_change()[i].output_pool()
+                }
+            };
+            match pool {
+                PoolType::Transparent => prior_transparent_inputs += 1,
+                PoolType::SAPLING => sapling_spends += 1,
+                PoolType::ORCHARD => orchard_spends += 1,
+                PoolType::IRONWOOD => ironwood_spends += 1,
+            }
+        }
+
+        // Transparent inputs: use each input's actual serialized size where known, so
+        // that P2SH inputs are not under-counted. For inputs whose script size is
+        // unknown, use the consensus-maximum input size.
+        let transparent_input_bytes = self
             .transparent_inputs()
             .iter()
             .map(
                 |input| match transparent_fees::InputView::serialized_size(input) {
                     transparent_fees::InputSize::Known(size) => size,
-                    transparent_fees::InputSize::Unknown(_) => UNKNOWN_INPUT_SIZE_UPPER_BOUND,
+                    transparent_fees::InputSize::Unknown(_) => MAX_TRANSPARENT_INPUT_SIZE,
                 },
             )
             .sum::<usize>();
+        // Prior-step transparent inputs are wallet-internal outputs with known scripts;
+        // use the P2PKH standard input size as a conservative bound.
+        let prior_transparent_input_bytes = prior_transparent_inputs * P2PKH_STANDARD_INPUT_SIZE;
 
-        // Transparent outputs: each payment to the transparent pool and each transparent
-        // change output costs the standard P2PKH output size.
+        // Transparent outputs.
         let transparent_payment_outputs =
             self.output_count_in_pool(PoolType::Transparent) * P2PKH_STANDARD_OUTPUT_SIZE;
         let transparent_change_outputs =
             self.change_count_in_pool(PoolType::Transparent) * P2PKH_STANDARD_OUTPUT_SIZE;
         let transparent_present = !self.transparent_inputs().is_empty()
+            || prior_transparent_inputs > 0
             || transparent_payment_outputs > 0
             || transparent_change_outputs > 0;
 
-        // Sapling spends and outputs. The default Sapling bundle type pads to at least
-        // two outputs when there are any spends or outputs, so the output count is
-        // `max(requested_outputs + change_outputs, 2)` when the bundle is non-empty. The
-        // spend count is `max(requested_spends, 1)` when non-empty. Both are upper-bounded
-        // by adding 2 to the requested count, which covers the padding floor.
-        let sapling_spends = self.input_count_in_pool(PoolType::SAPLING);
+        // Sapling spends and outputs. The default bundle type pads to at least two
+        // outputs when there are any spends or outputs; adding 2 to each count covers
+        // the padding floor.
         let sapling_outputs = self.output_count_in_pool(PoolType::SAPLING)
             + self.change_count_in_pool(PoolType::SAPLING);
         let sapling_bundle_present = sapling_spends > 0 || sapling_outputs > 0;
@@ -1273,50 +1269,38 @@ impl<NoteRef> Step<NoteRef> {
             0
         };
 
-        // Orchard and Ironwood bundles. Each action costs `ACTION_SIZE` (the action
-        // description) plus `ORCHARD_AUTH_SIG_SIZE` (the per-action spend
-        // authorization signature, written separately from the action description).
-        // The bundle proof is `Proof::expected_proof_size(num_actions)` — a fixed
-        // base plus a per-action share — so it scales with the action count and is
-        // computed via the orchard crate's own `pub const fn` to stay correct if the
-        // circuit changes.
+        // Orchard and Ironwood bundles. Each action costs `ACTION_SIZE` plus the
+        // per-action spend authorization signature; the bundle proof is
+        // `Proof::expected_proof_size(num_actions)` (a fixed base plus a per-action
+        // share), computed via the orchard crate's own `pub const fn`.
         #[cfg(feature = "orchard")]
-        let orchard_bundle_bytes = {
-            let orchard_spends = self.input_count_in_pool(PoolType::ORCHARD);
-            let orchard_outputs = self.output_count_in_pool(PoolType::ORCHARD)
-                + self.change_count_in_pool(PoolType::ORCHARD);
-            let num_actions = orchard_spends + orchard_outputs + ORCHARD_PADDING_ACTIONS;
-            if num_actions > ORCHARD_PADDING_ACTIONS {
-                ORCHARD_BUNDLE_OVERHEAD
-                    + Proof::expected_proof_size(num_actions)
-                    + num_actions * (ORCHARD_ACTION_SIZE + ORCHARD_AUTH_SIG_SIZE)
-            } else {
-                0
-            }
-        };
+        let orchard_bundle_bytes = orchard_style_bundle_bytes(
+            PoolType::ORCHARD,
+            orchard_spends,
+            self.output_count_in_pool(PoolType::ORCHARD)
+                + self.change_count_in_pool(PoolType::ORCHARD),
+            ORCHARD_PADDING_ACTIONS,
+        );
         #[cfg(not(feature = "orchard"))]
         let orchard_bundle_bytes: usize = 0;
+        #[cfg(not(feature = "orchard"))]
+        let _ = (orchard_spends, ironwood_spends);
 
         #[cfg(feature = "orchard")]
-        let ironwood_bundle_bytes = {
-            let ironwood_spends = self.input_count_in_pool(PoolType::IRONWOOD);
-            let ironwood_outputs = self.output_count_in_pool(PoolType::IRONWOOD)
-                + self.change_count_in_pool(PoolType::IRONWOOD);
-            let num_actions = ironwood_spends + ironwood_outputs + ORCHARD_PADDING_ACTIONS;
-            if num_actions > ORCHARD_PADDING_ACTIONS {
-                ORCHARD_BUNDLE_OVERHEAD
-                    + Proof::expected_proof_size(num_actions)
-                    + num_actions * (ORCHARD_ACTION_SIZE + ORCHARD_AUTH_SIG_SIZE)
-            } else {
-                0
-            }
-        };
+        let ironwood_bundle_bytes = orchard_style_bundle_bytes(
+            PoolType::IRONWOOD,
+            ironwood_spends,
+            self.output_count_in_pool(PoolType::IRONWOOD)
+                + self.change_count_in_pool(PoolType::IRONWOOD),
+            ORCHARD_PADDING_ACTIONS,
+        );
         #[cfg(not(feature = "orchard"))]
         let ironwood_bundle_bytes: usize = 0;
 
         TX_HEADER_SIZE
             + (transparent_present as usize) * TRANSPARENT_BUNDLE_OVERHEAD
-            + transparent_inputs
+            + transparent_input_bytes
+            + prior_transparent_input_bytes
             + transparent_payment_outputs
             + transparent_change_outputs
             + (sapling_bundle_present as usize) * SAPLING_BUNDLE_OVERHEAD
@@ -1324,6 +1308,59 @@ impl<NoteRef> Step<NoteRef> {
             + sapling_output_bytes
             + orchard_bundle_bytes
             + ironwood_bundle_bytes
+    }
+
+    /// Checks whether the step's estimated serialized size exceeds the maximum a Zcash
+    /// block may carry, returning [`ProposalError::TransactionTooLarge`] if it does.
+    ///
+    /// This is called by the input-selection paths (`propose_transaction`,
+    /// `propose_send_max`, `propose_shielding`) after a [`Step`] is constructed, so
+    /// that oversized proposals are rejected before they reach the transaction builder.
+    /// It is not called during proposal deserialization (see [`Step::from_parts`]),
+    /// so previously-persisted proposals remain recoverable even if their conservative
+    /// estimate exceeds `MAX_BLOCK_BYTES`.
+    ///
+    /// `prior_steps` is the slice of preceding steps in the proposal, as passed to
+    /// [`Step::from_parts`]; pass `&[]` for a single-step proposal.
+    pub fn check_transaction_size(
+        &self,
+        prior_steps: &[Step<NoteRef>],
+    ) -> Result<(), ProposalError> {
+        let estimated_size = self.estimated_serialized_size(prior_steps);
+        if estimated_size > MAX_BLOCK_BYTES {
+            let shielded_input_count = self
+                .shielded_inputs()
+                .iter()
+                .flat_map(|s| s.notes().iter())
+                .count();
+            return Err(ProposalError::TransactionTooLarge {
+                estimated_size,
+                limit: MAX_BLOCK_BYTES,
+                shielded_input_count,
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Computes the estimated byte size of an Orchard-family bundle (Orchard or Ironwood)
+/// for the given pool, given the number of shielded spends and outputs the step directs
+/// to that pool. Mirrors the `orchard_style_action_count` pattern: both Orchard and
+/// Ironwood share the same per-action and per-bundle costs, differing only in the pool.
+#[cfg(feature = "orchard")]
+fn orchard_style_bundle_bytes(
+    _pool: PoolType,
+    spends: usize,
+    outputs: usize,
+    padding_actions: usize,
+) -> usize {
+    let num_actions = spends + outputs + padding_actions;
+    if num_actions > padding_actions {
+        ORCHARD_BUNDLE_OVERHEAD
+            + Proof::expected_proof_size(num_actions)
+            + num_actions * (ORCHARD_ACTION_SIZE + ORCHARD_AUTH_SIG_SIZE)
+    } else {
+        0
     }
 }
 
@@ -1732,42 +1769,42 @@ mod tests {
         );
     }
 
-    /// A step whose estimated serialized size exceeds the maximum a Zcash block may carry is
-    /// rejected at proposal time, rather than being allowed to reach the builder (where proof
-    /// generation would waste the caller's resources on a transaction that can never be mined).
+    /// A step whose estimated serialized size exceeds the maximum a Zcash block may carry
+    /// is rejected by `check_transaction_size`, rather than being allowed to reach the
+    /// builder (where proof generation would waste the caller's resources on a transaction
+    /// that can never be mined).
     ///
-    /// The estimate is a conservative upper bound, so the boundary it enforces is a safe floor:
-    /// a step that passes may still fail at build time, but a step that fails can never fit. The
-    /// test constructs a step that exceeds the block limit and confirms both the rejection and
-    /// that the error carries the estimate and the limit for diagnostics.
+    /// `Step::from_parts` accepts the step (it no longer enforces the size gate), and
+    /// `check_transaction_size` rejects it — confirming the gate has moved out of the
+    /// constructor so the decode path is not broken.
     #[test]
     fn step_exceeding_the_block_size_limit_is_rejected() {
         // Each Orchard action costs at least `ACTION_SIZE` (the action description) +
         // `ORCHARD_AUTH_SIG_SIZE` (the spend authorization signature) + its share of the
-        // bundle proof (`Proof::expected_proof_size` spreads a per-action cost across all
-        // actions). The full per-action cost is therefore far larger than `ACTION_SIZE`
-        // alone, so the block-fitting boundary is much lower than `MAX_BLOCK_BYTES /
-        // ACTION_SIZE`. Compute it from the real per-action cost so the test stays correct
-        // if the proof circuit changes.
+        // bundle proof (`Proof::expected_proof_size` spreads a per-action cost across
+        // all actions). Compute the boundary from the real per-action cost so the test
+        // stays correct if the proof circuit changes.
         let proof_per_action =
             orchard::Proof::expected_proof_size(2) - orchard::Proof::expected_proof_size(1);
-        let full_action_cost = ACTION_SIZE + 64 + proof_per_action; // action desc + auth sig + proof share
+        let full_action_cost = ACTION_SIZE + 64 + proof_per_action;
         let oversize_spend_count = MAX_BLOCK_BYTES / full_action_cost + 1;
 
-        // The total input value is `oversize_spend_count * 1` zatoshi, and the fee is zero, so
-        // the step is value-balanced (one zatoshi of change per spend) and the rejection is due
-        // to the size, not the balance.
         let one_zato = Zatoshis::const_from_u64(1);
         let input_total = (one_zato * oversize_spend_count).unwrap();
         let change = ChangeValue::shielded(ShieldedPool::Orchard, input_total, None);
         let balance = TransactionBalance::new(vec![change], Zatoshis::ZERO).unwrap();
 
+        // `from_parts` accepts the step (no size gate).
+        let step = validated_step(
+            orchard_and_ironwood_notes((oversize_spend_count, 1), (0, 0)),
+            balance,
+            false,
+        )
+        .expect("from_parts accepts oversized steps");
+
+        // `check_transaction_size` rejects it.
         assert_matches!(
-            validated_step(
-                orchard_and_ironwood_notes((oversize_spend_count, 1), (0, 0)),
-                balance,
-                false,
-            ),
+            step.check_transaction_size(&[]),
             Err(ProposalError::TransactionTooLarge {
                 estimated_size,
                 limit,
@@ -1778,15 +1815,10 @@ mod tests {
         );
     }
 
-    /// A step whose estimated size fits within the block limit is accepted. This is the
-    /// negative control for `step_exceeding_the_block_size_limit_is_rejected`: it confirms the
-    /// gate rejects only oversized steps, not every step with a large action count.
+    /// A step whose estimated size fits within the block limit is accepted by
+    /// `check_transaction_size`.
     #[test]
     fn step_fitting_within_the_block_size_limit_is_accepted() {
-        // A step whose Orchard action count is comfortably below the block ceiling. The
-        // estimate adds per-bundle overhead and padding to the per-action cost, so the
-        // fitting count is the floor `MAX_BLOCK_BYTES / full_action_cost` minus a margin
-        // for that overhead.
         let proof_per_action =
             orchard::Proof::expected_proof_size(2) - orchard::Proof::expected_proof_size(1);
         let full_action_cost = ACTION_SIZE + 64 + proof_per_action;
@@ -1797,14 +1829,14 @@ mod tests {
         let change = ChangeValue::shielded(ShieldedPool::Orchard, input_total, None);
         let balance = TransactionBalance::new(vec![change], Zatoshis::ZERO).unwrap();
 
-        assert_matches!(
-            validated_step(
-                orchard_and_ironwood_notes((fitting_spend_count, 1), (0, 0)),
-                balance,
-                false,
-            ),
-            Ok(step) if step.estimated_serialized_size() <= MAX_BLOCK_BYTES
-        );
+        let step = validated_step(
+            orchard_and_ironwood_notes((fitting_spend_count, 1), (0, 0)),
+            balance,
+            false,
+        )
+        .expect("from_parts accepts steps that fit");
+
+        assert_matches!(step.check_transaction_size(&[]), Ok(()));
     }
 
     #[test]

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -22,7 +22,7 @@ use zcash_protocol::{
 use zip321::{TransactionRequest, Zip321Error};
 #[cfg(feature = "orchard")]
 use {
-    zcash_primitives::transaction::builder::BundlePadding,
+    orchard::Proof, zcash_primitives::transaction::builder::BundlePadding,
     zcash_protocol::zip318::PoolMigrationConstants,
 };
 
@@ -1130,53 +1130,80 @@ impl<NoteRef> Step<NoteRef> {
     /// transaction this step describes.
     ///
     /// The estimate sums the per-element byte costs of every input, output, and change
-    /// output the step carries, plus a fixed overhead for the transaction header, version,
-    /// lock time, and per-bundle binding signatures. Each per-element cost is an upper bound:
-    /// transparent inputs use their actual known serialized size (so P2SH inputs, which can
-    /// be larger than the P2PKH standard, are not under-counted), with a generous fixed
-    /// upper bound for inputs whose script size is unknown; Sapling uses the v4 serialized
-    /// form, which carries proofs and signatures inline; Orchard uses [`ACTION_SIZE`], which
-    /// excludes the per-action spend authorization signature and proof share, so the
-    /// bundle-level proof and signatures are accounted for in the fixed overhead and padding
-    /// constants. The Orchard and Ironwood action counts use `spends + outputs + 2`, which
-    /// is an upper bound across every bundle type and version: the post-NU6.3
-    /// cross-address-disabled policy charges `spends + outputs` and the pre-NU6.3 policy
-    /// charges `max(spends, outputs)` (no larger), and the default bundle type pads to a
-    /// two-action minimum.
+    /// output the step carries, plus the per-bundle overhead that each present bundle
+    /// contributes (header fields, binding signatures, and the Orchard/Ironwood bundle
+    /// proof). Each per-element cost is an upper bound:
+    /// - Transparent inputs use their actual known serialized size (so P2SH inputs,
+    ///   which can be larger than the P2PKH standard, are not under-counted), with a
+    ///   generous fixed upper bound for inputs whose script size is unknown.
+    /// - Sapling uses the v4 serialized form, which carries proofs and signatures
+    ///   inline — a conservative upper bound, since v5 moves these to bundle-level
+    ///   fields.
+    /// - Orchard and Ironwood use [`ACTION_SIZE`] for each action description, plus
+    ///   the per-action spend authorization signature (64 bytes) and the per-action
+    ///   proof share, computed via [`orchard::Proof::expected_proof_size`].
+    ///
+    /// The per-bundle overhead is added only when a bundle is present, so a
+    /// purely-transparent transaction is not charged for Sapling or Orchard proof
+    /// data it does not carry. The Orchard and Ironwood action counts use
+    /// `spends + outputs + 2`, which is an upper bound across every bundle type
+    /// and version: the post-NU6.3 cross-address-disabled policy charges
+    /// `spends + outputs` and the pre-NU6.3 policy charges `max(spends, outputs)`
+    /// (no larger), and the default bundle type pads to a two-action minimum.
     ///
     /// The estimate is conservative (it never under-counts), so comparing it against
-    /// [`MAX_BLOCK_BYTES`] is a safe size bound: a step whose estimate fits within a block
-    /// will fit when built, and a step whose estimate exceeds a block may or may not fit
-    /// (the builder is the final authority), but rejecting the latter at proposal time
-    /// prevents input selection from constructing a transaction that can never be mined.
+    /// [`MAX_BLOCK_BYTES`] is a safe size bound: a step whose estimate fits within a
+    /// block will fit when built, and a step whose estimate exceeds a block may or may
+    /// not fit (the builder is the final authority), but rejecting the latter at
+    /// proposal time prevents input selection from constructing a transaction that
+    /// can never be mined.
     ///
     /// [`ACTION_SIZE`]: zcash_primitives::transaction::components::orchard::ACTION_SIZE
     /// [`MAX_BLOCK_BYTES`]: zcash_protocol::constants::MAX_BLOCK_BYTES
     pub fn estimated_serialized_size(&self) -> usize {
-        // Fixed overhead for the transaction header (version, version_group_id, lock_time,
-        // expiry_height, and the binding-sig field of a v4/v5 transaction) and the
-        // per-bundle authorization data the per-element sizes exclude (Sapling binding
-        // signature, Orchard/Ironwood spend authorization signatures and the bundle proofs).
-        // This is a deliberately coarse upper bound: it needs only to exceed the real
-        // fixed cost, not to match it, since the estimate is used only to reject proposals
-        // that cannot fit in a block.
-        const FIXED_TX_OVERHEAD: usize = 1 << 13; // 8 KiB
+        // The fixed transaction header: version (4) + consensus_branch_id (4) +
+        // lock_time (4) + expiry_height (4). The 32-byte constant leaves room for
+        // future header fields (e.g. the zip-233 amount under NU7).
+        const TX_HEADER_SIZE: usize = 32;
+
+        // Per-bundle overhead for a present transparent bundle: two CompactSize
+        // vector-length prefixes (one for vin, one for vout), at most 9 bytes each.
+        const TRANSPARENT_BUNDLE_OVERHEAD: usize = 18;
+
+        // Per-bundle overhead for a present Sapling bundle: value_balance (8) +
+        // binding_sig (64) + CompactSize vector-length prefixes for spends and
+        // outputs (~28). The v4 anchor is per-spend (already in
+        // `SPEND_DESCRIPTION_SIZE`); the v5 per-bundle anchor (32) is covered by
+        // the margin.
+        const SAPLING_BUNDLE_OVERHEAD: usize = 100;
+
+        // Per-action spend authorization signature in an Orchard/Ironwood bundle.
+        #[cfg(feature = "orchard")]
+        const ORCHARD_AUTH_SIG_SIZE: usize = 64;
+
+        // Per-bundle overhead for a present Orchard/Ironwood bundle, excluding the
+        // proof: flags (1) + value_balance (8) + anchor (32) + binding_sig (64) +
+        // CompactSize for the actions vector (~10). The proof is added separately
+        // via `Proof::expected_proof_size`.
+        #[cfg(feature = "orchard")]
+        const ORCHARD_BUNDLE_OVERHEAD: usize = 115;
 
         // The maximum padding the default Orchard/Ironwood bundle type applies: the
-        // `Transactional { pad_to_minimum: Some(2) }` default pads to at least two actions.
-        // Added to `spends + outputs` (the post-NU6.3 count, which is >= the pre-NU6.3
-        // `max(spends, outputs)` count) this is an upper bound on the action count across
-        // every bundle type and version.
+        // `Transactional { pad_to_minimum: Some(2) }` default pads to at least two
+        // actions. Added to `spends + outputs` (the post-NU6.3 count, which is >=
+        // the pre-NU6.3 `max(spends, outputs)` count) this is an upper bound on the
+        // action count across every bundle type and version.
         #[cfg(feature = "orchard")]
         const ORCHARD_PADDING_ACTIONS: usize = 2;
 
         // Transparent inputs: use each input's actual serialized size where it is known
-        // (P2PKH or P2SH inputs with a known script size), so that P2SH inputs — which can
-        // be larger than the P2PKH standard — are not under-counted. For inputs whose script
-        // size is unknown, fall back to a generous upper bound: the scriptSig of a
-        // transparent input is consensus-limited but in practice rarely exceeds a few hundred
-        // bytes, and 8 KiB is well above any realistic redeem script while still small enough
-        // that a single unknown input cannot by itself trip the block limit.
+        // (P2PKH or P2SH inputs with a known script size), so that P2SH inputs — which
+        // can be larger than the P2PKH standard — are not under-counted. For inputs
+        // whose script size is unknown, fall back to a generous upper bound: the
+        // scriptSig of a transparent input is consensus-limited but in practice rarely
+        // exceeds a few hundred bytes, and 8 KiB is well above any realistic redeem
+        // script while still small enough that a single unknown input cannot by itself
+        // trip the block limit.
         const UNKNOWN_INPUT_SIZE_UPPER_BOUND: usize = 1 << 13; // 8 KiB
         let transparent_inputs = self
             .transparent_inputs()
@@ -1195,6 +1222,9 @@ impl<NoteRef> Step<NoteRef> {
             self.output_count_in_pool(PoolType::Transparent) * P2PKH_STANDARD_OUTPUT_SIZE;
         let transparent_change_outputs =
             self.change_count_in_pool(PoolType::Transparent) * P2PKH_STANDARD_OUTPUT_SIZE;
+        let transparent_present = !self.transparent_inputs().is_empty()
+            || transparent_payment_outputs > 0
+            || transparent_change_outputs > 0;
 
         // Sapling spends and outputs. The default Sapling bundle type pads to at least
         // two outputs when there are any spends or outputs, so the output count is
@@ -1216,46 +1246,57 @@ impl<NoteRef> Step<NoteRef> {
             0
         };
 
-        // Orchard and Ironwood actions. `spends + outputs + ORCHARD_PADDING_ACTIONS` is an
-        // upper bound on the action count across all bundle types and versions (see the
-        // method doc). Each action costs `ACTION_SIZE`; the per-action spend authorization
-        // signature and the bundle proof are accounted for in `FIXED_TX_OVERHEAD`.
+        // Orchard and Ironwood bundles. Each action costs `ACTION_SIZE` (the action
+        // description) plus `ORCHARD_AUTH_SIG_SIZE` (the per-action spend
+        // authorization signature, written separately from the action description).
+        // The bundle proof is `Proof::expected_proof_size(num_actions)` — a fixed
+        // base plus a per-action share — so it scales with the action count and is
+        // computed via the orchard crate's own `pub const fn` to stay correct if the
+        // circuit changes.
         #[cfg(feature = "orchard")]
-        let orchard_action_bytes = {
+        let orchard_bundle_bytes = {
             let orchard_spends = self.input_count_in_pool(PoolType::ORCHARD);
             let orchard_outputs = self.output_count_in_pool(PoolType::ORCHARD)
                 + self.change_count_in_pool(PoolType::ORCHARD);
-            if orchard_spends + orchard_outputs > 0 {
-                (orchard_spends + orchard_outputs + ORCHARD_PADDING_ACTIONS) * ORCHARD_ACTION_SIZE
+            let num_actions = orchard_spends + orchard_outputs + ORCHARD_PADDING_ACTIONS;
+            if num_actions > ORCHARD_PADDING_ACTIONS {
+                ORCHARD_BUNDLE_OVERHEAD
+                    + Proof::expected_proof_size(num_actions)
+                    + num_actions * (ORCHARD_ACTION_SIZE + ORCHARD_AUTH_SIG_SIZE)
             } else {
                 0
             }
         };
         #[cfg(not(feature = "orchard"))]
-        let orchard_action_bytes: usize = 0;
+        let orchard_bundle_bytes: usize = 0;
 
         #[cfg(feature = "orchard")]
-        let ironwood_action_bytes = {
+        let ironwood_bundle_bytes = {
             let ironwood_spends = self.input_count_in_pool(PoolType::IRONWOOD);
             let ironwood_outputs = self.output_count_in_pool(PoolType::IRONWOOD)
                 + self.change_count_in_pool(PoolType::IRONWOOD);
-            if ironwood_spends + ironwood_outputs > 0 {
-                (ironwood_spends + ironwood_outputs + ORCHARD_PADDING_ACTIONS) * ORCHARD_ACTION_SIZE
+            let num_actions = ironwood_spends + ironwood_outputs + ORCHARD_PADDING_ACTIONS;
+            if num_actions > ORCHARD_PADDING_ACTIONS {
+                ORCHARD_BUNDLE_OVERHEAD
+                    + Proof::expected_proof_size(num_actions)
+                    + num_actions * (ORCHARD_ACTION_SIZE + ORCHARD_AUTH_SIG_SIZE)
             } else {
                 0
             }
         };
         #[cfg(not(feature = "orchard"))]
-        let ironwood_action_bytes: usize = 0;
+        let ironwood_bundle_bytes: usize = 0;
 
-        FIXED_TX_OVERHEAD
+        TX_HEADER_SIZE
+            + (transparent_present as usize) * TRANSPARENT_BUNDLE_OVERHEAD
             + transparent_inputs
             + transparent_payment_outputs
             + transparent_change_outputs
+            + (sapling_bundle_present as usize) * SAPLING_BUNDLE_OVERHEAD
             + sapling_spend_bytes
             + sapling_output_bytes
-            + orchard_action_bytes
-            + ironwood_action_bytes
+            + orchard_bundle_bytes
+            + ironwood_bundle_bytes
     }
 }
 
@@ -1670,16 +1711,21 @@ mod tests {
     ///
     /// The estimate is a conservative upper bound, so the boundary it enforces is a safe floor:
     /// a step that passes may still fail at build time, but a step that fails can never fit. The
-    /// test constructs the smallest step that exceeds the block limit — one more Orchard spend
-    /// than a block can hold — and confirms both the rejection and that the error carries the
-    /// estimate and the limit for diagnostics.
+    /// test constructs a step that exceeds the block limit and confirms both the rejection and
+    /// that the error carries the estimate and the limit for diagnostics.
     #[test]
     fn step_exceeding_the_block_size_limit_is_rejected() {
-        // One more Orchard spend than fits in a block. Each action costs at least `ACTION_SIZE`
-        // bytes on the wire, so `MAX_BLOCK_BYTES / ACTION_SIZE + 1` spends cannot fit. The
-        // estimate adds a fixed overhead and padding, so the real boundary is a little lower,
-        // but the +1 guarantees the step is over regardless of where that boundary falls.
-        let oversize_spend_count = MAX_BLOCK_BYTES / ACTION_SIZE + 1;
+        // Each Orchard action costs at least `ACTION_SIZE` (the action description) +
+        // `ORCHARD_AUTH_SIG_SIZE` (the spend authorization signature) + its share of the
+        // bundle proof (`Proof::expected_proof_size` spreads a per-action cost across all
+        // actions). The full per-action cost is therefore far larger than `ACTION_SIZE`
+        // alone, so the block-fitting boundary is much lower than `MAX_BLOCK_BYTES /
+        // ACTION_SIZE`. Compute it from the real per-action cost so the test stays correct
+        // if the proof circuit changes.
+        let proof_per_action =
+            orchard::Proof::expected_proof_size(2) - orchard::Proof::expected_proof_size(1);
+        let full_action_cost = ACTION_SIZE + 64 + proof_per_action; // action desc + auth sig + proof share
+        let oversize_spend_count = MAX_BLOCK_BYTES / full_action_cost + 1;
 
         // The total input value is `oversize_spend_count * 1` zatoshi, and the fee is zero, so
         // the step is value-balanced (one zatoshi of change per spend) and the rejection is due
@@ -1708,9 +1754,13 @@ mod tests {
     #[test]
     fn step_fitting_within_the_block_size_limit_is_accepted() {
         // A step whose Orchard action count is comfortably below the block ceiling. The
-        // estimate adds a fixed overhead and padding to the per-action cost, so the fitting
-        // count is the floor `MAX_BLOCK_BYTES / ACTION_SIZE` minus a margin for that overhead.
-        let fitting_spend_count = MAX_BLOCK_BYTES / ACTION_SIZE - 16;
+        // estimate adds per-bundle overhead and padding to the per-action cost, so the
+        // fitting count is the floor `MAX_BLOCK_BYTES / full_action_cost` minus a margin
+        // for that overhead.
+        let proof_per_action =
+            orchard::Proof::expected_proof_size(2) - orchard::Proof::expected_proof_size(1);
+        let full_action_cost = ACTION_SIZE + 64 + proof_per_action;
+        let fitting_spend_count = MAX_BLOCK_BYTES / full_action_cost - 4;
 
         let one_zato = Zatoshis::const_from_u64(1);
         let input_total = (one_zato * fitting_spend_count).unwrap();

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -524,6 +524,87 @@ impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
             .map(|step| step.input_count_in_pool(pool_type))
             .sum()
     }
+
+    /// Returns a conservative upper-bound estimate of the total serialized byte size
+    /// of all transactions this proposal describes, by summing the per-step estimates
+    /// (see [`Step::estimated_serialized_size`]). Each step is estimated independently,
+    /// so the total is the sum of the per-step serialized sizes, not the size of a
+    /// single transaction.
+    ///
+    /// The estimate is conservative (it never under-counts). See
+    /// [`Step::estimated_serialized_size`] for the per-element costs and the
+    /// mineability caveat.
+    pub fn estimated_serialized_size(&self) -> usize {
+        let steps = self.steps();
+        // Build a resolver closure that maps a prior-step reference to the pool of
+        // the referenced output. The closure captures the proposal's step list, so
+        // `step_index()` always resolves — no panic risk.
+        let resolve_pool = |s_ref: &StepOutput| {
+            let prior = &steps[s_ref.step_index()];
+            match s_ref.output_index() {
+                StepOutputIndex::Payment(i) => *prior
+                    .payment_pools()
+                    .get(&i)
+                    .expect("payment pool exists for referenced payment"),
+                StepOutputIndex::Change(i) => prior.balance().proposed_change()[i].output_pool(),
+            }
+        };
+        steps
+            .iter()
+            .map(|step| step.estimated_serialized_size(&resolve_pool))
+            .sum()
+    }
+
+    /// Checks whether every step's estimated serialized size fits within the maximum
+    /// a Zcash block may carry, returning [`ProposalError::TransactionTooLarge`] for
+    /// the first step that does not.
+    ///
+    /// This is called by the public `propose_transfer` / `propose_shielding` wrappers
+    /// and the `create_proposed_transactions` / `create_pczt_from_proposal` build
+    /// entry points, so it protects all input selectors (including third-party ones)
+    /// and all build paths. It is not called during proposal deserialization, so
+    /// previously-persisted proposals remain recoverable.
+    pub fn check_transaction_size(&self) -> Result<(), ProposalError> {
+        let steps = self.steps();
+        let resolve_pool = |s_ref: &StepOutput| {
+            let prior = &steps[s_ref.step_index()];
+            match s_ref.output_index() {
+                StepOutputIndex::Payment(i) => *prior
+                    .payment_pools()
+                    .get(&i)
+                    .expect("payment pool exists for referenced payment"),
+                StepOutputIndex::Change(i) => prior.balance().proposed_change()[i].output_pool(),
+            }
+        };
+        for step in steps.iter() {
+            let estimated_size = step.estimated_serialized_size(&resolve_pool);
+            if estimated_size > MAX_BLOCK_BYTES {
+                // Count both the step's own shielded inputs and prior-step shielded
+                // inputs, so the count matches what the estimate charged.
+                let shielded_input_count = step
+                    .shielded_inputs()
+                    .iter()
+                    .flat_map(|s| s.notes().iter())
+                    .count()
+                    + step
+                        .prior_step_inputs()
+                        .iter()
+                        .filter(|s_ref| {
+                            matches!(
+                                resolve_pool(s_ref),
+                                PoolType::SAPLING | PoolType::ORCHARD | PoolType::IRONWOOD
+                            )
+                        })
+                        .count();
+                return Err(ProposalError::TransactionTooLarge {
+                    estimated_size,
+                    limit: MAX_BLOCK_BYTES,
+                    shielded_input_count,
+                });
+            }
+        }
+        Ok(())
+    }
 }
 
 impl<FeeRuleT: Debug, NoteRef> Debug for Proposal<FeeRuleT, NoteRef> {
@@ -1142,15 +1223,16 @@ impl<NoteRef> Step<NoteRef> {
     /// Returns a conservative upper-bound estimate of the serialized byte size of the
     /// transaction this step describes.
     ///
-    /// `prior_steps` is the slice of steps that precede this step in the proposal, as
-    /// passed to [`Step::from_parts`]; it is used to account for inputs that spend
-    /// outputs of prior steps (ZIP-320 / chained-consolidation flows). Pass `&[]` for a
-    /// single-step proposal.
+    /// `prior_steps` is the slice of all steps in the proposal (the same slice
+    /// [`Step::from_parts`] receives), used to resolve the pool of each prior-step
+    /// output this step spends. The caller — typically [`Proposal::check_transaction_size`]
+    /// — passes the full proposal's step list so `step_index()` always resolves.
     ///
     /// The estimate sums the per-element byte costs of every input, output, and change
-    /// output the step carries — including prior-step inputs — plus the per-bundle
-    /// overhead that each present bundle contributes (header fields, binding signatures,
-    /// and the Orchard/Ironwood bundle proof). Each per-element cost is an upper bound:
+    /// output the step carries — including prior-step inputs and dummy outputs — plus
+    /// the per-bundle overhead that each present bundle contributes (header fields,
+    /// binding signatures, and the Orchard/Ironwood bundle proof). Each per-element cost
+    /// is an upper bound:
     /// - Transparent inputs use their actual known serialized size (so P2SH inputs,
     ///   which can be larger than the P2PKH standard, are not under-counted), with the
     ///   consensus-maximum input size for inputs whose script size is unknown.
@@ -1163,11 +1245,10 @@ impl<NoteRef> Step<NoteRef> {
     ///
     /// The per-bundle overhead is added only when a bundle is present, so a
     /// purely-transparent transaction is not charged for Sapling or Orchard proof
-    /// data it does not carry. The Orchard and Ironwood action counts use
-    /// `spends + outputs + 2`, which is an upper bound across every bundle type
-    /// and version: the post-NU6.3 cross-address-disabled policy charges
-    /// `spends + outputs` and the pre-NU6.3 policy charges `max(spends, outputs)`
-    /// (no larger), and the default bundle type pads to a two-action minimum.
+    /// data it does not carry. Action counts account for both the default padding floor
+    /// (`spends + outputs + 2`) and any dummy outputs the change strategy recorded via
+    /// [`TransactionBalance::dummy_outputs`], taking the larger so a nonzero dummy count
+    /// is never under-counted.
     ///
     /// The estimate is conservative (it never under-counts), so comparing it against
     /// [`MAX_BLOCK_BYTES`] is a safe size bound: a step whose estimate fits within a
@@ -1181,7 +1262,10 @@ impl<NoteRef> Step<NoteRef> {
     ///
     /// [`ACTION_SIZE`]: zcash_primitives::transaction::components::orchard::ACTION_SIZE
     /// [`MAX_BLOCK_BYTES`]: zcash_protocol::constants::MAX_BLOCK_BYTES
-    pub fn estimated_serialized_size(&self, prior_steps: &[Step<NoteRef>]) -> usize {
+    pub(crate) fn estimated_serialized_size(
+        &self,
+        resolve_prior_pool: &impl Fn(&StepOutput) -> PoolType,
+    ) -> usize {
         // The maximum padding the default Orchard/Ironwood bundle type applies.
         #[cfg(feature = "orchard")]
         const ORCHARD_PADDING_ACTIONS: usize = 2;
@@ -1202,23 +1286,22 @@ impl<NoteRef> Step<NoteRef> {
             }
         }
 
-        // Prior-step inputs: each references an output of a preceding step. Determine
-        // the pool of the referenced output and add its input cost to the relevant
-        // pool's count.
-        let mut prior_transparent_inputs = 0usize;
+        // Prior-step inputs: each references an output of a preceding step. The closure
+        // resolves the pool of the referenced output. For transparent Payment-sourced
+        // prior inputs, use the consensus maximum input size (the recipient could be
+        // P2SH with a large scriptSig); for Change-sourced transparent prior inputs,
+        // use the P2PKH standard (ephemeral change outputs are wallet-internal P2PKH).
+        let mut prior_transparent_input_bytes = 0usize;
         for s_ref in self.prior_step_inputs() {
-            let prior_step = &prior_steps[s_ref.step_index()];
-            let pool = match s_ref.output_index() {
-                StepOutputIndex::Payment(i) => *prior_step
-                    .payment_pools()
-                    .get(&i)
-                    .expect("payment pool exists for referenced payment"),
-                StepOutputIndex::Change(i) => {
-                    prior_step.balance().proposed_change()[i].output_pool()
-                }
-            };
+            let pool = resolve_prior_pool(s_ref);
             match pool {
-                PoolType::Transparent => prior_transparent_inputs += 1,
+                PoolType::Transparent => {
+                    let size = match s_ref.output_index() {
+                        StepOutputIndex::Payment(_) => MAX_TRANSPARENT_INPUT_SIZE,
+                        StepOutputIndex::Change(_) => P2PKH_STANDARD_INPUT_SIZE,
+                    };
+                    prior_transparent_input_bytes += size;
+                }
                 PoolType::SAPLING => sapling_spends += 1,
                 PoolType::ORCHARD => orchard_spends += 1,
                 PoolType::IRONWOOD => ironwood_spends += 1,
@@ -1238,9 +1321,6 @@ impl<NoteRef> Step<NoteRef> {
                 },
             )
             .sum::<usize>();
-        // Prior-step transparent inputs are wallet-internal outputs with known scripts;
-        // use the P2PKH standard input size as a conservative bound.
-        let prior_transparent_input_bytes = prior_transparent_inputs * P2PKH_STANDARD_INPUT_SIZE;
 
         // Transparent outputs.
         let transparent_payment_outputs =
@@ -1248,23 +1328,30 @@ impl<NoteRef> Step<NoteRef> {
         let transparent_change_outputs =
             self.change_count_in_pool(PoolType::Transparent) * P2PKH_STANDARD_OUTPUT_SIZE;
         let transparent_present = !self.transparent_inputs().is_empty()
-            || prior_transparent_inputs > 0
+            || prior_transparent_input_bytes > 0
             || transparent_payment_outputs > 0
             || transparent_change_outputs > 0;
 
+        // Dummy outputs recorded by the change strategy. These pad the shielded bundles
+        // beyond the default `spends + outputs + 2` floor; the estimate must charge for
+        // them so a nonzero dummy count is never under-counted.
+        let dummy = self.balance().dummy_outputs();
+
         // Sapling spends and outputs. The default bundle type pads to at least two
         // outputs when there are any spends or outputs; adding 2 to each count covers
-        // the padding floor.
+        // the padding floor. If the change strategy recorded dummy Sapling outputs,
+        // charge for those too.
         let sapling_outputs = self.output_count_in_pool(PoolType::SAPLING)
             + self.change_count_in_pool(PoolType::SAPLING);
-        let sapling_bundle_present = sapling_spends > 0 || sapling_outputs > 0;
+        let sapling_dummy = dummy.map_or(0, |d| d.sapling());
+        let sapling_bundle_present = sapling_spends > 0 || sapling_outputs > 0 || sapling_dummy > 0;
         let sapling_spend_bytes = if sapling_bundle_present {
             (sapling_spends + 2) * SPEND_DESCRIPTION_SIZE
         } else {
             0
         };
         let sapling_output_bytes = if sapling_bundle_present {
-            (sapling_outputs + 2) * OUTPUT_DESCRIPTION_SIZE
+            (sapling_outputs + 2 + sapling_dummy) * OUTPUT_DESCRIPTION_SIZE
         } else {
             0
         };
@@ -1275,10 +1362,10 @@ impl<NoteRef> Step<NoteRef> {
         // share), computed via the orchard crate's own `pub const fn`.
         #[cfg(feature = "orchard")]
         let orchard_bundle_bytes = orchard_style_bundle_bytes(
-            PoolType::ORCHARD,
             orchard_spends,
             self.output_count_in_pool(PoolType::ORCHARD)
                 + self.change_count_in_pool(PoolType::ORCHARD),
+            dummy.map_or(0, |d| d.orchard()),
             ORCHARD_PADDING_ACTIONS,
         );
         #[cfg(not(feature = "orchard"))]
@@ -1288,10 +1375,10 @@ impl<NoteRef> Step<NoteRef> {
 
         #[cfg(feature = "orchard")]
         let ironwood_bundle_bytes = orchard_style_bundle_bytes(
-            PoolType::IRONWOOD,
             ironwood_spends,
             self.output_count_in_pool(PoolType::IRONWOOD)
                 + self.change_count_in_pool(PoolType::IRONWOOD),
+            dummy.map_or(0, |d| d.ironwood()),
             ORCHARD_PADDING_ACTIONS,
         );
         #[cfg(not(feature = "orchard"))]
@@ -1309,53 +1396,24 @@ impl<NoteRef> Step<NoteRef> {
             + orchard_bundle_bytes
             + ironwood_bundle_bytes
     }
-
-    /// Checks whether the step's estimated serialized size exceeds the maximum a Zcash
-    /// block may carry, returning [`ProposalError::TransactionTooLarge`] if it does.
-    ///
-    /// This is called by the input-selection paths (`propose_transaction`,
-    /// `propose_send_max`, `propose_shielding`) after a [`Step`] is constructed, so
-    /// that oversized proposals are rejected before they reach the transaction builder.
-    /// It is not called during proposal deserialization (see [`Step::from_parts`]),
-    /// so previously-persisted proposals remain recoverable even if their conservative
-    /// estimate exceeds `MAX_BLOCK_BYTES`.
-    ///
-    /// `prior_steps` is the slice of preceding steps in the proposal, as passed to
-    /// [`Step::from_parts`]; pass `&[]` for a single-step proposal.
-    pub fn check_transaction_size(
-        &self,
-        prior_steps: &[Step<NoteRef>],
-    ) -> Result<(), ProposalError> {
-        let estimated_size = self.estimated_serialized_size(prior_steps);
-        if estimated_size > MAX_BLOCK_BYTES {
-            let shielded_input_count = self
-                .shielded_inputs()
-                .iter()
-                .flat_map(|s| s.notes().iter())
-                .count();
-            return Err(ProposalError::TransactionTooLarge {
-                estimated_size,
-                limit: MAX_BLOCK_BYTES,
-                shielded_input_count,
-            });
-        }
-        Ok(())
-    }
 }
 
 /// Computes the estimated byte size of an Orchard-family bundle (Orchard or Ironwood)
-/// for the given pool, given the number of shielded spends and outputs the step directs
-/// to that pool. Mirrors the `orchard_style_action_count` pattern: both Orchard and
-/// Ironwood share the same per-action and per-bundle costs, differing only in the pool.
+/// for the given pool, given the number of shielded spends, real outputs, and dummy
+/// outputs the step directs to that pool. The action count is
+/// `max(spends + outputs + padding, outputs + dummy)`, so a nonzero dummy count is
+/// never under-counted.
 #[cfg(feature = "orchard")]
 fn orchard_style_bundle_bytes(
-    _pool: PoolType,
     spends: usize,
     outputs: usize,
+    dummy_outputs: usize,
     padding_actions: usize,
 ) -> usize {
-    let num_actions = spends + outputs + padding_actions;
-    if num_actions > padding_actions {
+    let default_count = spends + outputs + padding_actions;
+    let dummy_count = outputs + dummy_outputs;
+    let num_actions = default_count.max(dummy_count);
+    if num_actions > 0 {
         ORCHARD_BUNDLE_OVERHEAD
             + Proof::expected_proof_size(num_actions)
             + num_actions * (ORCHARD_ACTION_SIZE + ORCHARD_AUTH_SIG_SIZE)
@@ -1769,21 +1827,15 @@ mod tests {
         );
     }
 
-    /// A step whose estimated serialized size exceeds the maximum a Zcash block may carry
-    /// is rejected by `check_transaction_size`, rather than being allowed to reach the
-    /// builder (where proof generation would waste the caller's resources on a transaction
-    /// that can never be mined).
+    /// A proposal whose estimated serialized size exceeds the maximum a Zcash block may
+    /// carry is rejected by `Proposal::check_transaction_size`, rather than being allowed
+    /// to reach the builder.
     ///
-    /// `Step::from_parts` accepts the step (it no longer enforces the size gate), and
-    /// `check_transaction_size` rejects it — confirming the gate has moved out of the
-    /// constructor so the decode path is not broken.
+    /// `Step::from_parts` accepts the step (it does not enforce the size gate), and
+    /// `Proposal::check_transaction_size` rejects it — confirming the gate is in the
+    /// proposal-level check, not the constructor, so the decode path is not broken.
     #[test]
-    fn step_exceeding_the_block_size_limit_is_rejected() {
-        // Each Orchard action costs at least `ACTION_SIZE` (the action description) +
-        // `ORCHARD_AUTH_SIG_SIZE` (the spend authorization signature) + its share of the
-        // bundle proof (`Proof::expected_proof_size` spreads a per-action cost across
-        // all actions). Compute the boundary from the real per-action cost so the test
-        // stays correct if the proof circuit changes.
+    fn proposal_exceeding_the_block_size_limit_is_rejected() {
         let proof_per_action =
             orchard::Proof::expected_proof_size(2) - orchard::Proof::expected_proof_size(1);
         let full_action_cost = ACTION_SIZE + 64 + proof_per_action;
@@ -1802,9 +1854,17 @@ mod tests {
         )
         .expect("from_parts accepts oversized steps");
 
+        let proposal = Proposal::multi_step(
+            (),
+            TargetHeight::from(100),
+            ConfirmationsPolicy::default(),
+            NonEmpty::singleton(step),
+        )
+        .expect("multi_step accepts a valid step");
+
         // `check_transaction_size` rejects it.
         assert_matches!(
-            step.check_transaction_size(&[]),
+            proposal.check_transaction_size(),
             Err(ProposalError::TransactionTooLarge {
                 estimated_size,
                 limit,
@@ -1815,14 +1875,14 @@ mod tests {
         );
     }
 
-    /// A step whose estimated size fits within the block limit is accepted by
+    /// A proposal whose estimated size fits within the block limit is accepted by
     /// `check_transaction_size`.
     #[test]
-    fn step_fitting_within_the_block_size_limit_is_accepted() {
+    fn proposal_fitting_within_the_block_size_limit_is_accepted() {
         let proof_per_action =
             orchard::Proof::expected_proof_size(2) - orchard::Proof::expected_proof_size(1);
         let full_action_cost = ACTION_SIZE + 64 + proof_per_action;
-        let fitting_spend_count = MAX_BLOCK_BYTES / full_action_cost - 4;
+        let fitting_spend_count = MAX_BLOCK_BYTES / full_action_cost - 8;
 
         let one_zato = Zatoshis::const_from_u64(1);
         let input_total = (one_zato * fitting_spend_count).unwrap();
@@ -1836,7 +1896,15 @@ mod tests {
         )
         .expect("from_parts accepts steps that fit");
 
-        assert_matches!(step.check_transaction_size(&[]), Ok(()));
+        let proposal = Proposal::multi_step(
+            (),
+            TargetHeight::from(100),
+            ConfirmationsPolicy::default(),
+            NonEmpty::singleton(step),
+        )
+        .expect("multi_step accepts a valid step");
+
+        assert_matches!(proposal.check_transaction_size(), Ok(()));
     }
 
     #[test]

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -37,6 +37,16 @@ workspace.
   pool, with `BundlePadding::{DEFAULT, UNPADDED}` matching the corresponding
   `orchard::builder::BundleType` constants. Unlike `BundleType` it cannot
   express a coinbase bundle.
+- `zcash_primitives::transaction::components::sapling::SPEND_DESCRIPTION_SIZE` and
+  `OUTPUT_DESCRIPTION_SIZE`, the sizes in bytes of a Sapling spend description and
+  output description in their v4 (pre-NU5) serialized forms. Each is the full
+  per-element cost on the wire in a version 4 transaction (the v5 form moves
+  proofs and signatures to bundle-level fields), so these are conservative upper
+  bounds: dividing a per-element byte budget by them yields a lower bound on the
+  number of spends or outputs that fit within that budget.
+- `zcash_primitives::transaction::components::sapling::testing::arb_bundle`, now
+  public behind the `test-dependencies` feature, generates a Sapling bundle with
+  arbitrary spends and outputs for cross-crate test strategies.
 
 ### Changed
 - Migrated to `zcash_transparent 0.10.0`.

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -10,6 +10,29 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `zcash_primitives::transaction::components::sapling::SPEND_DESCRIPTION_SIZE` and
+  `OUTPUT_DESCRIPTION_SIZE`, the sizes in bytes of a Sapling spend description and
+  output description in their v4 (pre-NU5) serialized forms. Each is the full
+  per-element cost on the wire in a version 4 transaction (the v5 form moves
+  proofs and signatures to bundle-level fields), so these are conservative upper
+  bounds: dividing a per-element byte budget by them yields a lower bound on the
+  number of spends or outputs that fit within that budget.
+- `zcash_primitives::transaction::components::sapling::testing::arb_bundle`, now
+  public behind the `test-dependencies` feature, generates a Sapling bundle with
+  arbitrary spends and outputs for cross-crate test strategies.
+- `zcash_primitives::transaction::components::orchard::SPEND_AUTH_SIG_SIZE` and
+  `BUNDLE_OVERHEAD`, the per-action spend authorization signature size and the
+  per-bundle overhead (excluding the proof and per-action data) for an
+  Orchard/Ironwood bundle.
+- `zcash_primitives::transaction::components::sapling::BUNDLE_OVERHEAD`, the
+  per-bundle overhead of a Sapling bundle (value balance, binding signature, and
+  CompactSize prefixes).
+- `zcash_primitives::transaction::fees::zip317::MAX_TRANSPARENT_INPUT_SIZE`,
+  `TRANSPARENT_BUNDLE_OVERHEAD`, and `TX_HEADER_SIZE`, the consensus-maximum
+  transparent input size, the transparent bundle overhead, and the fixed
+  transaction header size used in serialized-size estimation.
+
 ## [0.30.0] - 2026-07-23
 
 ### Added
@@ -37,16 +60,6 @@ workspace.
   pool, with `BundlePadding::{DEFAULT, UNPADDED}` matching the corresponding
   `orchard::builder::BundleType` constants. Unlike `BundleType` it cannot
   express a coinbase bundle.
-- `zcash_primitives::transaction::components::sapling::SPEND_DESCRIPTION_SIZE` and
-  `OUTPUT_DESCRIPTION_SIZE`, the sizes in bytes of a Sapling spend description and
-  output description in their v4 (pre-NU5) serialized forms. Each is the full
-  per-element cost on the wire in a version 4 transaction (the v5 form moves
-  proofs and signatures to bundle-level fields), so these are conservative upper
-  bounds: dividing a per-element byte budget by them yields a lower bound on the
-  number of spends or outputs that fit within that budget.
-- `zcash_primitives::transaction::components::sapling::testing::arb_bundle`, now
-  public behind the `test-dependencies` feature, generates a Sapling bundle with
-  arbitrary spends and outputs for cross-crate test strategies.
 
 ### Changed
 - Migrated to `zcash_transparent 0.10.0`.

--- a/zcash_primitives/src/transaction/components/orchard.rs
+++ b/zcash_primitives/src/transaction/components/orchard.rs
@@ -65,6 +65,18 @@ pub const ACTION_SIZE: usize = VALUE_COMMITMENT_BYTE_SIZE
     + ENC_CIPHERTEXT_SIZE
     + OUT_CIPHERTEXT_SIZE;
 
+/// The size in bytes of an Orchard/Ironwood spend authorization signature, as encoded
+/// separately from the action description in the bundle's `vSpendAuthSigs` array.
+pub const SPEND_AUTH_SIG_SIZE: usize = 64;
+
+/// The per-bundle overhead of an Orchard/Ironwood bundle, excluding the proof and the
+/// per-action data: flags (1) + value_balance (8) + anchor (32) + binding_sig (64) +
+/// a CompactSize prefix for the actions vector (at most 9 bytes, budgeted as 10). The
+/// proof is a fixed base plus a per-action share computed via
+/// `orchard::Proof::expected_proof_size`, so it is added at the call site rather than
+/// included here.
+pub const BUNDLE_OVERHEAD: usize = 1 + 8 + 32 + 64 + 10;
+
 pub trait MapAuth<A: Authorization, B: Authorization> {
     fn map_spend_auth(&self, s: A::SpendAuth) -> B::SpendAuth;
     fn map_authorization(&self, a: A) -> B;

--- a/zcash_primitives/src/transaction/components/sapling.rs
+++ b/zcash_primitives/src/transaction/components/sapling.rs
@@ -89,6 +89,13 @@ pub fn zip212_enforcement(params: &impl Parameters, height: BlockHeight) -> Zip2
     }
 }
 
+/// The per-bundle overhead of a Sapling bundle, excluding the per-spend and per-output
+/// data: value_balance (8) + binding_sig (64) + CompactSize vector-length prefixes for
+/// the spends and outputs arrays (at most 9 + 9 = 18, budgeted as 28 for margin). The v4
+/// anchor is per-spend (already in [`SPEND_DESCRIPTION_SIZE`]); the v5 per-bundle anchor
+/// (32) is covered by the margin.
+pub const BUNDLE_OVERHEAD: usize = 8 + 64 + 28;
+
 /// A map from one bundle authorization to another.
 ///
 /// For use with [`TransactionData::map_authorization`].

--- a/zcash_primitives/src/transaction/components/sapling.rs
+++ b/zcash_primitives/src/transaction/components/sapling.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use core::mem::size_of;
 use corez::io::{self, Read, Write};
 use ff::PrimeField;
 
@@ -22,6 +23,55 @@ use zcash_protocol::{
 
 use super::GROTH_PROOF_SIZE;
 use crate::transaction::Transaction;
+
+/// The size in bytes of a Sapling spend description in its v4 (pre-NU5) serialized form, as
+/// written by the internal `write_spend_v4` encoder.
+///
+/// This is the full per-spend cost on the wire in a version 4 transaction: the value
+/// commitment, the anchor, the nullifier, the randomized spending key, the Groth16 proof,
+/// and the spend authorization signature. Version 5 transactions move the proofs and
+/// authorization signatures to bundle-level fields (the v5 spend encoder writes only
+/// `cv` + `nullifier` + `rk`), so this v4 size is the conservative upper bound: dividing a
+/// per-spend byte budget by this constant yields a lower bound on the number of spends
+/// that fit within it.
+pub const SPEND_DESCRIPTION_SIZE: usize = VALUE_COMMITMENT_BYTE_SIZE
+    + ANCHOR_BYTE_SIZE
+    + NULLIFIER_BYTE_SIZE
+    + RK_BYTE_SIZE
+    + GROTH_PROOF_SIZE
+    + SPEND_AUTH_SIG_BYTE_SIZE;
+
+/// The size in bytes of a Sapling output description in its v4 (pre-NU5) serialized form, as
+/// written by the internal `write_output_v4` encoder.
+///
+/// This is the full per-output cost on the wire in a version 4 transaction: the value
+/// commitment, the extracted note commitment, the ephemeral key, the encrypted note
+/// ciphertext, the encrypted outgoing ciphertext, and the Groth16 proof. Version 5
+/// transactions move the proofs to a bundle-level field (the v5 output encoder omits the
+/// `zkproof`), so this v4 size is the conservative upper bound: dividing a per-output byte
+/// budget by this constant yields a lower bound on the number of outputs that fit within it.
+pub const OUTPUT_DESCRIPTION_SIZE: usize = VALUE_COMMITMENT_BYTE_SIZE
+    + CMU_BYTE_SIZE
+    + EPHEMERAL_KEY_BYTE_SIZE
+    + ENC_CIPHERTEXT_SIZE
+    + OUT_CIPHERTEXT_SIZE
+    + GROTH_PROOF_SIZE;
+
+/// The size in bytes of the encoding of a Sapling value commitment (a Jubjub group element).
+const VALUE_COMMITMENT_BYTE_SIZE: usize = 32;
+/// The size in bytes of the encoding of a Sapling nullifier.
+const NULLIFIER_BYTE_SIZE: usize = 32;
+/// The size in bytes of the encoding of a Sapling spend authorization key (a RedJubjub
+/// verification key).
+const RK_BYTE_SIZE: usize = 32;
+/// The size in bytes of the encoding of a Sapling spend authorization signature.
+const SPEND_AUTH_SIG_BYTE_SIZE: usize = 64;
+/// The size in bytes of the encoding of a Sapling anchor (a Jubjub base field element).
+const ANCHOR_BYTE_SIZE: usize = 32;
+/// The size in bytes of the encoding of a Sapling extracted note commitment.
+const CMU_BYTE_SIZE: usize = 32;
+/// The size in bytes of the encoding of a Sapling ephemeral key.
+const EPHEMERAL_KEY_BYTE_SIZE: usize = size_of::<EphemeralKeyBytes>();
 
 /// Returns the enforcement policy for ZIP 212 at the given height.
 pub fn zip212_enforcement(params: &impl Parameters, height: BlockHeight) -> Zip212Enforcement {
@@ -506,7 +556,7 @@ pub mod testing {
     use zcash_protocol::value::{ZatBalance, testing::arb_zat_balance};
 
     prop_compose! {
-        fn arb_bundle()(
+        pub fn arb_bundle()(
             value_balance in arb_zat_balance()
         )(
             bundle in t_sap::arb_bundle(value_balance)
@@ -522,6 +572,115 @@ pub mod testing {
             Strategy::boxed(arb_bundle())
         } else {
             Strategy::boxed(Just(None))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec::Vec;
+
+    use corez::io::{self, Write};
+    use proptest::prelude::*;
+
+    use super::{
+        ANCHOR_BYTE_SIZE, CMU_BYTE_SIZE, EPHEMERAL_KEY_BYTE_SIZE, GROTH_PROOF_SIZE,
+        NULLIFIER_BYTE_SIZE, OUTPUT_DESCRIPTION_SIZE, RK_BYTE_SIZE, SPEND_AUTH_SIG_BYTE_SIZE,
+        SPEND_DESCRIPTION_SIZE, VALUE_COMMITMENT_BYTE_SIZE, testing::arb_bundle, write_output_v4,
+        write_spend_v4,
+    };
+    use ff::PrimeField;
+
+    // Returns the number of bytes `write` emits.
+    fn encoded_len(write: impl FnOnce(&mut Vec<u8>) -> io::Result<()>) -> usize {
+        let mut buf = Vec::new();
+        write(&mut buf).expect("writing to a Vec cannot fail");
+        buf.len()
+    }
+
+    proptest! {
+        /// `SPEND_DESCRIPTION_SIZE` is what callers divide a per-spend byte budget by to bound a
+        /// spend count, so it must equal what the v4 encoder actually writes, not merely what the
+        /// constant's own arithmetic says. Measure a real spend description rather than restating
+        /// the composition, so that a change to any element's encoding fails here.
+        ///
+        /// This is also what keeps the per-element sizes honest while `sapling` exposes none of
+        /// them itself: each is checked against the encoding of the field it describes. The v4
+        /// form is used (rather than v5) because it carries every per-spend byte inline, making it
+        /// the conservative upper bound for size budgeting.
+        #[test]
+        fn spend_description_size_matches_the_encoding(
+            bundle in arb_bundle().prop_filter("bundle has spends", |b| {
+                b.as_ref().is_some_and(|b| !b.shielded_spends().is_empty())
+            }),
+        ) {
+            let bundle = bundle.unwrap();
+            let spend = &bundle.shielded_spends()[0];
+            prop_assert_eq!(
+                encoded_len(|w| write_spend_v4(w, spend)),
+                SPEND_DESCRIPTION_SIZE
+            );
+
+            // Each element, against the constant that names it.
+            prop_assert_eq!(
+                encoded_len(|w| w.write_all(&spend.cv().to_bytes())),
+                VALUE_COMMITMENT_BYTE_SIZE
+            );
+            prop_assert_eq!(
+                encoded_len(|w| w.write_all(spend.anchor().to_repr().as_ref())),
+                ANCHOR_BYTE_SIZE
+            );
+            prop_assert_eq!(
+                encoded_len(|w| w.write_all(&spend.nullifier().0)),
+                NULLIFIER_BYTE_SIZE
+            );
+            prop_assert_eq!(
+                encoded_len(|w| w.write_all(&<[u8; 32]>::from(*spend.rk()))),
+                RK_BYTE_SIZE
+            );
+            prop_assert_eq!(
+                encoded_len(|w| w.write_all(spend.zkproof())),
+                GROTH_PROOF_SIZE
+            );
+            prop_assert_eq!(
+                encoded_len(|w| w.write_all(&<[u8; 64]>::from(*spend.spend_auth_sig()))),
+                SPEND_AUTH_SIG_BYTE_SIZE
+            );
+        }
+
+        /// `OUTPUT_DESCRIPTION_SIZE` is what callers divide a per-output byte budget by to bound an
+        /// output count, so it must equal what the v4 encoder actually writes. See
+        /// `spend_description_size_matches_the_encoding` for the rationale.
+        #[test]
+        fn output_description_size_matches_the_encoding(
+            bundle in arb_bundle().prop_filter("bundle has outputs", |b| {
+                b.as_ref().is_some_and(|b| !b.shielded_outputs().is_empty())
+            }),
+        ) {
+            let bundle = bundle.unwrap();
+            let output = &bundle.shielded_outputs()[0];
+            prop_assert_eq!(
+                encoded_len(|w| write_output_v4(w, output)),
+                OUTPUT_DESCRIPTION_SIZE
+            );
+
+            // Each element, against the constant that names it.
+            prop_assert_eq!(
+                encoded_len(|w| w.write_all(&output.cv().to_bytes())),
+                VALUE_COMMITMENT_BYTE_SIZE
+            );
+            prop_assert_eq!(
+                encoded_len(|w| w.write_all(output.cmu().to_bytes().as_ref())),
+                CMU_BYTE_SIZE
+            );
+            prop_assert_eq!(
+                encoded_len(|w| w.write_all(output.ephemeral_key().as_ref())),
+                EPHEMERAL_KEY_BYTE_SIZE
+            );
+            prop_assert_eq!(
+                encoded_len(|w| w.write_all(output.zkproof())),
+                GROTH_PROOF_SIZE
+            );
         }
     }
 }

--- a/zcash_primitives/src/transaction/components/sapling.rs
+++ b/zcash_primitives/src/transaction/components/sapling.rs
@@ -90,11 +90,9 @@ pub fn zip212_enforcement(params: &impl Parameters, height: BlockHeight) -> Zip2
 }
 
 /// The per-bundle overhead of a Sapling bundle, excluding the per-spend and per-output
-/// data: value_balance (8) + binding_sig (64) + CompactSize vector-length prefixes for
-/// the spends and outputs arrays (at most 9 + 9 = 18, budgeted as 28 for margin). The v4
-/// anchor is per-spend (already in [`SPEND_DESCRIPTION_SIZE`]); the v5 per-bundle anchor
-/// (32) is covered by the margin.
-pub const BUNDLE_OVERHEAD: usize = 8 + 64 + 28;
+/// data: CompactSize prefixes for the spends and outputs arrays (at most 9 + 9) +
+/// value_balance (8) + anchor (32) + binding_sig (64).
+pub const BUNDLE_OVERHEAD: usize = 9 + 9 + 8 + 32 + 64;
 
 /// A map from one bundle authorization to another.
 ///

--- a/zcash_primitives/src/transaction/fees/zip317.rs
+++ b/zcash_primitives/src/transaction/fees/zip317.rs
@@ -33,6 +33,21 @@ pub const P2PKH_STANDARD_INPUT_SIZE: usize = 150;
 /// [ZIP 317]: https//zips.z.cash/zip-0317
 pub const P2PKH_STANDARD_OUTPUT_SIZE: usize = 34;
 
+/// The consensus maximum size of a serialized transparent input: outpoint (36) +
+/// CompactSize prefix for the scriptSig (at most 9) + scriptSig (at most
+/// `MAX_SCRIPT_SIZE = 10_000`) + sequence (4). This is the safe upper bound for a
+/// transparent input whose script size is unknown.
+pub const MAX_TRANSPARENT_INPUT_SIZE: usize = 36 + 9 + 10_000 + 4;
+
+/// The per-bundle overhead of a transparent bundle: two CompactSize vector-length
+/// prefixes (one for `vin`, one for `vout`), at most 9 bytes each.
+pub const TRANSPARENT_BUNDLE_OVERHEAD: usize = 18;
+
+/// The fixed size of a Zcash transaction header: version (4) +
+/// `consensus_branch_id` (4) + `lock_time` (4) + `expiry_height` (4). The constant
+/// leaves room for future header fields (e.g. the `zip233_amount` under NU7).
+pub const TX_HEADER_SIZE: usize = 32;
+
 /// The minimum conventional fee computed from the standard [ZIP 317] constants. Equivalent to
 /// `MARGINAL_FEE * GRACE_ACTIONS`.
 ///


### PR DESCRIPTION
Closes #1569.

The transaction builder never bounded the serialized size of a transaction at input-selection time, so a large spend request consuming many notes could produce a transaction exceeding the block size limit, which can never be mined.

This adds a conservative upper-bound size estimate (`Step::estimated_serialized_size`) and rejects proposals exceeding `MAX_BLOCK_BYTES` in `Step::from_parts` — the trust boundary every input-selection path (propose_transaction, propose_send_max, propose_shielding, and the decode path) flows through.

**Sapling sizing.** Adds `SPEND_DESCRIPTION_SIZE` and `OUTPUT_DESCRIPTION_SIZE` to `zcash_primitives::transaction::components::sapling` — the v4 serialized forms, which carry proofs and signatures inline and so are conservative upper bounds (v5 moves these to bundle-level fields). Proptests verify each constant against the actual encoder output, mirroring the existing Orchard `action_size_matches_the_encoding` pattern.

**Orchard/Ironwood.** Action counts use `spends + outputs + 2`, an upper bound across all bundle types and versions; `ACTION_SIZE` covers the per-action wire cost, and a fixed 8 KiB overhead covers the transaction header, bundle proofs, and binding signatures the per-element sizes exclude.

Re @nullcopy's question on the issue: bounding by serialized bytes against `MAX_BLOCK_BYTES` subsumes the per-action ceiling (each Orchard action costs at least `ACTION_SIZE` bytes), so a separate action-count limit is redundant for the size bound.