### PR TITLE
zcash_pool_migration: let consumers floor the overdue re-spread spacing

### DIFF
--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -21,17 +21,24 @@ and this library adheres to Rust's notion of
   schedule: when the `Prove` or `Broadcast` step it would surface is more than
   `satisfiability::overdue_shift_tolerance` blocks past its scheduled height at
   the served (estimated-tip) target — the tolerance derived from the transfer
-  delay the migration's persisted anchor bucket interval implies — the
-  scheduled height of every not-yet-broadcast transaction is first shifted
-  forward by the overdue amount, and the shifted state is persisted with the
-  call's other writes. After wallet downtime, at most one overdue step is
-  released immediately; the rest keep their drawn inter-broadcast gaps instead
-  of broadcasting as a cluster. A deferred transfer whose proof is still to
-  come also has its anchor boundary redrawn against its shifted schedule
-  (`scheduling::redraw_anchor_boundary`), keeping deferred anchors within the
-  ZIP 318 age distribution; a proved transfer keeps the boundary its proof was
-  built against. The function now takes a `CryptoRng` for those draws — pass
-  the same RNG the other engine entry points use.
+  delay the migration's persisted anchor bucket interval implies — every OTHER
+  not-yet-broadcast transaction's scheduled height is first deferred by the
+  overdue amount, while the triggering step itself is never
+  deferred above the SCANNED target — it lands there when the chain has passed
+  its schedule, and an already-due step keeps its own height — so the release
+  it represents stays executable against the wallet's own chain data in the
+  same session (proving rests on scanned state;
+  a release parked at the estimate could be found overdue and re-deferred by
+  every wake, stalling the run). The re-spread runs at most once per call, and
+  the shifted state is persisted with the call's other writes. After wallet
+  downtime, at most one overdue step is released immediately; the rest keep
+  their drawn inter-broadcast gaps instead of broadcasting as a cluster. A
+  moved transfer whose proof is still to come also has its anchor boundary
+  redrawn against its new schedule (`scheduling::redraw_anchor_boundary`) —
+  the released one against its landing, keeping it provable where it is
+  served — while a proved transfer keeps the boundary its proof was built
+  against. The function now takes a `CryptoRng` for those draws — pass the
+  same RNG the other engine entry points use.
 - `state::AdvanceStep` selection now offers, within each queue, the candidate
   that has been ready longest rather than the first one in storage order: the
   earliest scheduled height for a broadcast or a rebuild, and the earliest

--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -19,26 +19,28 @@ and this library adheres to Rust's notion of
 ### Changed
 - `satisfiability::advance_migration` now re-spreads a missed broadcast
   schedule: when the `Prove` or `Broadcast` step it would surface is more than
-  `satisfiability::overdue_shift_tolerance` blocks past its scheduled height at
-  the served (estimated-tip) target — the tolerance derived from the transfer
-  delay the migration's persisted anchor bucket interval implies — every OTHER
-  not-yet-broadcast transaction's scheduled height is first deferred by the
-  overdue amount, while the triggering step itself is never
+  `satisfiability::overdue_shift_tolerance` blocks past its scheduled height
+  at the served (estimated-tip) target — the tolerance derived from the
+  transfer delay the migration's persisted anchor bucket interval implies —
+  every OTHER not-yet-broadcast transaction's scheduled height is first
+  deferred by the overdue amount, while the triggering step itself is never
   deferred above the SCANNED target — it lands there when the chain has passed
   its schedule, and an already-due step keeps its own height — so the release
   it represents stays executable against the wallet's own chain data in the
-  same session (proving rests on scanned state;
-  a release parked at the estimate could be found overdue and re-deferred by
-  every wake, stalling the run). The re-spread runs at most once per call, and
-  the shifted state is persisted with the call's other writes. After wallet
-  downtime, at most one overdue step is released immediately; the rest keep
-  their drawn inter-broadcast gaps instead of broadcasting as a cluster. A
-  moved transfer whose proof is still to come also has its anchor boundary
-  redrawn against its new schedule (`scheduling::redraw_anchor_boundary`) —
-  the released one against its landing, keeping it provable where it is
-  served — while a proved transfer keeps the boundary its proof was built
-  against. The function now takes a `CryptoRng` for those draws — pass the
-  same RNG the other engine entry points use.
+  same session (proving rests on scanned state; a release parked at the
+  estimate could be found overdue and re-deferred by every wake, stalling the
+  run). The re-spread runs only when more of the schedule is due behind the
+  triggering step (a lone overdue step is served as scheduled), at most once
+  per call, and the shifted state is persisted with the call's other writes.
+  After wallet downtime, at most one overdue step is released immediately; the
+  rest keep their drawn inter-broadcast gaps instead of broadcasting as a
+  cluster. A moved transfer whose proof is still to come also has its anchor
+  boundary redrawn against its new schedule
+  (`scheduling::redraw_anchor_boundary`) — the released one against its
+  landing, keeping it provable where it is served — while a proved transfer
+  keeps the boundary its proof was built against. The function now takes a
+  `CryptoRng` for those draws — pass the same RNG the other engine entry
+  points use.
 - `state::AdvanceStep` selection now offers, within each queue, the candidate
   that has been ready longest rather than the first one in storage order: the
   earliest scheduled height for a broadcast or a rebuild, and the earliest

--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -15,6 +15,23 @@ and this library adheres to Rust's notion of
 - `scheduling::redraw_anchor_boundary`: the recency-weighted anchor draw for a
   transfer whose broadcast schedule has moved, floored at the boundary being
   replaced.
+- `satisfiability::AdvanceConfig::with_compressed_schedule_floors` (with its
+  `overdue_tolerance_floor` and `release_spacing_floor` accessors): two
+  opt-in knobs, each defaulting to zero, for a consumer whose committed
+  schedule is compressed below its own wall-clock privacy buffer — a
+  shortened test-network anchor bucket interval, most often.
+  `overdue_tolerance_floor` floors `satisfiability::advance_migration`'s
+  overdue-shift trigger, so a compressed schedule's tolerance can no longer
+  clamp down near nothing and re-arm the re-spread on every drive.
+  `release_spacing_floor` floors the gap the re-spread's deferral leaves
+  between the served target the drive judges dueness at and the deferred
+  rows scheduled at or after the released step — in particular every
+  `Proved` row, the only state ever served for broadcast — giving such a
+  consumer a post-release window to sync before its next transfer comes
+  due. At the zero default both are no-ops,
+  byte-for-byte — the existing test suite, unmodified, is the proof — so a
+  production mainnet consumer is unaffected. Converting a wall-clock privacy
+  buffer into a block count is left to the caller.
 
 ### Changed
 - `satisfiability::advance_migration` now re-spreads a missed broadcast

--- a/zcash_pool_migration/src/satisfiability.rs
+++ b/zcash_pool_migration/src/satisfiability.rs
@@ -23,7 +23,8 @@ use rand_core::{CryptoRng, RngCore};
 use zcash_protocol::consensus::BlockHeight;
 
 use crate::engine::{
-    MigrationState, MigrationTransferId, MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
+    MigrationState, MigrationTransaction, MigrationTransferId, MigrationTxState, PoolMigrationRead,
+    PoolMigrationWrite,
 };
 use crate::scheduling::{DelayDistribution, SchedulingParams};
 use crate::state::AdvanceStep;
@@ -366,25 +367,109 @@ pub fn overdue_shift_tolerance(transfer_delay: &DelayDistribution) -> u32 {
 }
 
 /// Drive-level policy for [`advance_migration`]: a struct, so future knobs join without signature
-/// churn.
+/// churn — [`Self::with_compressed_schedule_floors`] is exactly such a knob, added after the fact
+/// without touching [`Self::new`].
 #[derive(Clone, Copy, Debug)]
 pub struct AdvanceConfig {
     reorg_settle_depth: ReorgSettleDepth,
+    overdue_tolerance_floor: u32,
+    release_spacing_floor: u32,
 }
 
 impl AdvanceConfig {
-    /// Drive-level policy under the caller's reorg-settlement policy.
+    /// Drive-level policy under the caller's reorg-settlement policy, with both
+    /// compressed-schedule floors ([`Self::with_compressed_schedule_floors`]) at their default of
+    /// zero.
     ///
     /// The settle depth is explicitly required — no `Default` — because the right value tracks the
     /// chain's block spacing, and keeping it current is the caller's responsibility, not this
     /// crate's.
     pub const fn new(reorg_settle_depth: ReorgSettleDepth) -> Self {
-        Self { reorg_settle_depth }
+        Self {
+            reorg_settle_depth,
+            overdue_tolerance_floor: 0,
+            release_spacing_floor: 0,
+        }
     }
 
     /// The caller's reorg-settlement policy; see [`ReorgSettleDepth`].
     pub const fn reorg_settle_depth(&self) -> ReorgSettleDepth {
         self.reorg_settle_depth
+    }
+
+    /// Sets both compressed-schedule floors, replacing the zero defaults [`Self::new`] starts
+    /// from.
+    ///
+    /// ZIP 318's missed-schedule policy draws its numbers from the committed schedule's OWN
+    /// scale: [`overdue_shift_tolerance`] is a quarter of the mean inter-broadcast gap, and the
+    /// deferred gaps the re-spread preserves are whatever that same schedule drew. On a
+    /// mainnet-paced schedule that scale comfortably clears a wallet's wall-clock privacy buffer
+    /// — the stretch after a broadcast during which it would rather not be forced to sync again —
+    /// so the two never compete. Compress the whole schedule, as a shortened test-network anchor
+    /// bucket interval does, and both shrink in proportion while the buffer stays
+    /// wall-clock-fixed: the tolerance can clamp to nearly nothing, re-arming the re-spread on
+    /// every drive, and the preserved gaps can land below the buffer, starving sync for the
+    /// length of the proved backlog.
+    ///
+    /// These floors exist for exactly that consumer — one whose committed schedule is compressed
+    /// below its own privacy buffer — and for no other reason. `overdue_tolerance_floor` is a
+    /// lower bound under [`overdue_shift_tolerance`]'s output at the re-spread's trigger (applied
+    /// in [`advance_migration`]).
+    ///
+    /// `release_spacing_floor` is a lower bound on the deferred set's gap to the SERVED target
+    /// ([`DuenessTargets::effective`]) — the height THIS drive judges dueness at, not the
+    /// release's own landing — GUARANTEED for every deferred row scheduled at or after the
+    /// released candidate: the earliest of them lands at least the floor past the served target,
+    /// handing a compressed-schedule consumer that much wall clock before the next row can come
+    /// due. This in particular covers every [`Proved`](MigrationTxState::Proved) row eligible to
+    /// be the candidate this call: the only state a transaction is ever served for BROADCAST
+    /// from, and the kernel's height-ordered candidate selection always makes an earlier-scheduled
+    /// `Proved` row the candidate itself rather than a deferred sibling — UNLESS that row is
+    /// excluded from candidacy this call (dead-set, set aside, or withheld as expired), in which
+    /// case it defers like any other sibling and sits outside the guarantee; acceptable, since
+    /// none of them can be served for broadcast while so excluded. A row scheduled BEFORE the
+    /// released candidate receives the identical widened delta too, measured from its own —
+    /// earlier — height, short of that bound. Closing that gap unconditionally would need
+    /// non-saturating arithmetic that is nonzero at a floor of zero for precisely such orderings —
+    /// the one trade this crate refuses.
+    ///
+    /// Both floors default to zero, and at zero every path through that arithmetic is
+    /// STRUCTURALLY identical to the floor-free form — not merely tested to agree, but built so
+    /// that subtracting a zero floor always saturates to zero regardless of the surrounding
+    /// heights — so a production mainnet consumer passing zero is unaffected by this method
+    /// existing at all, and the existing test suite is the proof: every test built without this
+    /// method still passes.
+    ///
+    /// Converting a wall-clock privacy buffer into a block count — and any slack or doubling to
+    /// cover a round-trip sync window rather than a single one-way gap — is the CALLER's
+    /// judgment: it rests on the caller's own target block spacing and sync latency, neither of
+    /// which this crate observes. This crate stays a pure mechanism: two numbers in, applied as
+    /// floors, nothing more.
+    pub const fn with_compressed_schedule_floors(
+        mut self,
+        overdue_tolerance_floor: u32,
+        release_spacing_floor: u32,
+    ) -> Self {
+        self.overdue_tolerance_floor = overdue_tolerance_floor;
+        self.release_spacing_floor = release_spacing_floor;
+        self
+    }
+
+    /// The floor under [`overdue_shift_tolerance`]'s output at the re-spread's trigger; see
+    /// [`Self::with_compressed_schedule_floors`]. Zero (the default) applies no floor: the
+    /// trigger fires at exactly [`overdue_shift_tolerance`]'s schedule-derived value, as ZIP 318
+    /// documents.
+    pub const fn overdue_tolerance_floor(&self) -> u32 {
+        self.overdue_tolerance_floor
+    }
+
+    /// The floor under the gap between the SERVED target this drive judges dueness at and the
+    /// deferred rows scheduled at or after the released candidate — see
+    /// [`Self::with_compressed_schedule_floors`] for exactly which rows that guarantee covers.
+    /// Zero (the default) applies no floor: every deferred row lands exactly the overdue amount
+    /// past its original schedule, as ZIP 318 documents.
+    pub const fn release_spacing_floor(&self) -> u32 {
+        self.release_spacing_floor
     }
 }
 
@@ -846,11 +931,15 @@ pub fn advance_migration<St: PoolMigrationWrite, R: RngCore + CryptoRng>(
     // bucket interval is the state's own record of its schedule's scale, and the default ZIP 318
     // ratio recovers the transfer delay it was (absent a hand-override) drawn from. Judging
     // overdueness by the committed scale rather than a caller-supplied current one is what keeps
-    // the tolerance meaningful for a migration committed under different parameters.
+    // the tolerance meaningful for a migration committed under different parameters. Floored at
+    // the caller's `overdue_tolerance_floor` — zero by default, and so a no-op by default — for a
+    // consumer whose schedule is compressed enough that the schedule-derived value alone would
+    // clamp to almost nothing and re-arm the re-spread on every drive.
     let overdue_tolerance = overdue_shift_tolerance(
         &SchedulingParams::new_with_default_distributions(state.anchor_bucket_interval())
             .transfer_delay(),
-    );
+    )
+    .max(config.overdue_tolerance_floor());
 
     // The call's one overdue re-spread, if it runs (see the shift below): at most one, because
     // the released candidate lands at the SCANNED target, which can sit more than the tolerance
@@ -921,6 +1010,28 @@ pub fn advance_migration<St: PoolMigrationWrite, R: RngCore + CryptoRng>(
         // trigger: the rebuild redraws its own transfer's schedule from the target, and sizing a
         // shift by an expired candidate's stale height would overstate it for everything still
         // live.
+        //
+        // A caller whose committed schedule is compressed below its own wall-clock privacy
+        // buffer — a shortened test-network anchor bucket interval is the case this exists for —
+        // may set `AdvanceConfig`'s `release_spacing_floor`. The floor guarantees the spacing for
+        // every deferred row scheduled AT OR AFTER the released one, measured from the served
+        // target this drive judges dueness at rather than the release's own landing: the earliest
+        // such row lands at least the floor past the served target, buying a compressed-schedule
+        // consumer that much wall clock before the next row can come due. This in particular
+        // covers every `Proved` row eligible to be the candidate this call — the ONLY state a
+        // transaction is ever served for BROADCAST from — since this kernel always makes an
+        // earlier-scheduled `Proved` row the candidate itself rather than a deferred sibling
+        // sitting behind the bound, UNLESS that row is excluded from candidacy this call
+        // (dead-set, set aside, or withheld as expired), in which case it defers like any other
+        // sibling and sits outside the guarantee; acceptable, since none of them can be served
+        // for broadcast while so excluded. A row scheduled BEFORE the released one gets the same
+        // widened delta too, measured from its OWN — earlier — height, short of the floor above
+        // the served target. An unconditional bound over every ordering would need non-saturating
+        // arithmetic that is nonzero at a floor of zero for precisely such orderings; this crate
+        // keeps the zero-floor identity instead. At the default of zero the deferral is exactly
+        // the overdue amount, as ZIP 318 documents — a property this arithmetic holds
+        // STRUCTURALLY (subtracting a zero floor always saturates to zero, whatever the
+        // surrounding heights), not merely one the test suite happens to confirm.
         if !shifted
             && matches!(
                 step,
@@ -929,20 +1040,62 @@ pub fn advance_migration<St: PoolMigrationWrite, R: RngCore + CryptoRng>(
         {
             let scheduled = u32::from(tx.scheduled_height());
             let served = u32::from(targets.effective());
+            // The pending set this shift moves when it runs — every OTHER transaction still
+            // `AwaitingSignature`, `Signed`, or `Proved` — EXACTLY the rows `shift_schedule_releasing`
+            // moves (see its match arms). Both the cluster trigger just below and the deferral
+            // floor's `earliest` search need this same predicate, so it is factored out once
+            // rather than risking the two drifting apart.
+            let is_deferred_sibling = |other: &MigrationTransaction| {
+                other.id() != candidate
+                    && matches!(
+                        other.state(),
+                        MigrationTxState::AwaitingSignature
+                            | MigrationTxState::Signed
+                            | MigrationTxState::Proved
+                    )
+            };
             if scheduled.saturating_add(overdue_tolerance) < served
                 && state.transactions().iter().any(|other| {
-                    other.id() != candidate
-                        && matches!(
-                            other.state(),
-                            MigrationTxState::AwaitingSignature
-                                | MigrationTxState::Signed
-                                | MigrationTxState::Proved
-                        )
-                        && u32::from(other.scheduled_height()) <= served
+                    is_deferred_sibling(other) && u32::from(other.scheduled_height()) <= served
                 })
             {
-                let release_at = BlockHeight::from_u32(scheduled.max(u32::from(targets.scanned())));
-                state.shift_schedule_releasing(candidate, release_at, served - scheduled, rng);
+                let release_at = scheduled.max(u32::from(targets.scanned()));
+                let lag = served - scheduled;
+                // The cluster condition just above already found at least one deferred sibling,
+                // so `None` here is unreachable — but a spacing floor with no row to space is
+                // meaningless rather than a panic, so this stays total instead of resting on that
+                // reachability argument.
+                let earliest = state
+                    .transactions()
+                    .iter()
+                    .filter(|other| is_deferred_sibling(other))
+                    .map(|other| u32::from(other.scheduled_height()))
+                    .min();
+                // `extra` is a floor MINUS a gap, both saturating: at the default floor of zero
+                // it is zero on every path — `0.saturating_sub(_)` is always `0`, regardless of
+                // how `earliest` and `scheduled` happen to relate — so a caller passing zero
+                // drives exactly the delta ZIP 318 specifies, byte for byte. (The
+                // equivalent-looking `lag.max(floor + served - earliest)` does NOT have this
+                // property: in odd orderings it can exceed `lag` even at floor zero.)
+                let extra = match earliest {
+                    Some(earliest) => {
+                        // The ORIGINAL drawn gap from the candidate to its nearest deferred
+                        // sibling — equivalently `(earliest + lag).saturating_sub(served)`, since
+                        // `served == scheduled + lag`. Measured directly against `scheduled`
+                        // because dueness — and so the window this floor buys — is judged at
+                        // `served`, not at `release_at`; the two coincide only when the release
+                        // lands exactly on its own schedule.
+                        let gap_now = earliest.saturating_sub(scheduled);
+                        config.release_spacing_floor().saturating_sub(gap_now)
+                    }
+                    None => 0,
+                };
+                state.shift_schedule_releasing(
+                    candidate,
+                    BlockHeight::from_u32(release_at),
+                    lag.saturating_add(extra),
+                    rng,
+                );
                 shifted = true;
                 dirty = true;
                 continue;
@@ -1261,6 +1414,15 @@ mod advance_tests {
 
     fn config() -> AdvanceConfig {
         AdvanceConfig::new(ReorgSettleDepth::new(10))
+    }
+
+    /// [`config`], with both compressed-schedule floors set — for the floor-specific tests alone;
+    /// every other test drives the floor-free default.
+    fn config_with_floors(
+        overdue_tolerance_floor: u32,
+        release_spacing_floor: u32,
+    ) -> AdvanceConfig {
+        config().with_compressed_schedule_floors(overdue_tolerance_floor, release_spacing_floor)
     }
 
     /// A fresh seeded RNG per drive call; only the overdue shift's anchor redraw consumes it, so
@@ -2822,5 +2984,310 @@ mod advance_tests {
             "the sibling that armed the re-spread defers behind the served target too"
         );
         assert_eq!(store.replaced.get(), 1);
+    }
+
+    /// The regression the compressed-schedule floors rest on: a config built through [`config`]
+    /// (no floors set, so both default to zero) must drive the SAME arithmetic every shift test
+    /// above already exercises, producing the SAME numbers. Deliberately a fresh, larger fixture —
+    /// three deferred rows spanning all three pending states
+    /// ([`AwaitingSignature`](MigrationTxState::AwaitingSignature),
+    /// [`Signed`](MigrationTxState::Signed), [`Proved`](MigrationTxState::Proved)) at three
+    /// different original heights — so the new `earliest`/`gap_now`/`extra` computation actually
+    /// runs over a nontrivial set on every call and still comes out to zero every time, rather
+    /// than trivially skipping it.
+    #[test]
+    fn default_config_shifts_the_schedule_by_exactly_the_overdue_lag() {
+        let mut state = state_with_crossings(
+            &[25_000_000, 25_000_000, 25_000_000, 25_000_000],
+            vec![
+                tx(0, prep(0, 0), mined(10)),
+                scheduled_transfer(1, 0, 720, 1_000, MigrationTxState::Proved),
+                scheduled_transfer(2, 1, 720, 1_200, MigrationTxState::AwaitingSignature),
+                scheduled_transfer(3, 2, 720, 1_100, MigrationTxState::Signed),
+                scheduled_transfer(4, 3, 720, 1_300, MigrationTxState::Proved),
+            ],
+        );
+        let mut store = TestStore::new(1_010, []);
+        // Scanned target 1_011; estimated target 2_001: the candidate is 1_001 blocks overdue by
+        // the estimate, well past the 16-block ZIP 318 tolerance, with three other pending rows —
+        // one in each pending state — all due behind it.
+        let targets =
+            DuenessTargets::new(BlockHeight::from_u32(1_011), BlockHeight::from_u32(2_001));
+
+        let step = advance_migration(&mut store, &mut state, targets, &config(), &mut rng())
+            .expect("the store never fails");
+
+        assert_eq!(
+            step,
+            AdvanceStep::Broadcast {
+                id: MigrationTransferId(1)
+            },
+            "the earliest Proved row is still released in this call"
+        );
+        let scheduled: Vec<u32> = state
+            .transactions()
+            .iter()
+            .map(|t| u32::from(t.scheduled_height()))
+            .collect();
+        assert_eq!(
+            scheduled,
+            vec![0, 1_011, 2_201, 2_101, 2_301],
+            "the release lands at max(scheduled, scanned); every deferred row, whichever pending \
+             state it is in, lands at exactly its original height plus the overdue lag — the zero \
+             floors add nothing"
+        );
+        assert_eq!(store.replaced.get(), 1, "the shifted schedule is persisted");
+    }
+
+    /// TOLERANCE FLOOR: a floor set above the schedule-derived tolerance blocks the trigger
+    /// outright, holding the schedule where an unfloored call would shift it. Without the floor
+    /// this exact fixture shifts (the 50-block lag clears the 16-block ZIP 318 tolerance, and a
+    /// sibling is due), so the schedule holding here is solely the floor's doing — the case a
+    /// floored `overdue_tolerance` is meant to prevent: a re-spread re-triggering on every drive
+    /// once a compressed schedule's raw tolerance has clamped down near nothing.
+    #[test]
+    fn tolerance_floor_holds_the_schedule_when_the_lag_is_within_it() {
+        let mut state = state_with_crossings(
+            &[50_000_000, 50_000_000],
+            vec![
+                tx(0, prep(0, 0), mined(10)),
+                scheduled_transfer(1, 0, 720, 1_000, MigrationTxState::Proved),
+                // Due, arming the cluster condition the trigger also needs.
+                scheduled_transfer(2, 1, 720, 1_040, MigrationTxState::Signed),
+            ],
+        );
+        let mut store = TestStore::new(1_050, []);
+        // Lag 50: above the raw 16-block tolerance, at (not above) the 100-block floor.
+        let step = advance_migration(
+            &mut store,
+            &mut state,
+            DuenessTargets::at(BlockHeight::from_u32(1_050)),
+            &config_with_floors(100, 0),
+            &mut rng(),
+        )
+        .expect("the store never fails");
+
+        assert_eq!(
+            step,
+            AdvanceStep::Broadcast {
+                id: MigrationTransferId(1)
+            },
+            "the candidate is served at its own height: the floored tolerance suppresses the shift"
+        );
+        assert_eq!(
+            u32::from(state.transactions()[1].scheduled_height()),
+            1_000,
+            "unchanged"
+        );
+        assert_eq!(
+            u32::from(state.transactions()[2].scheduled_height()),
+            1_040,
+            "unchanged"
+        );
+        assert_eq!(
+            store.replaced.get(),
+            0,
+            "nothing is written: there was nothing to shift"
+        );
+    }
+
+    /// DEFERRAL FLOOR, BINDING: a spacing floor wider than the candidate's ORIGINAL drawn gap to
+    /// its nearest deferred row widens the deferral so that row lands the full floor above the
+    /// SERVED target — the height this drive judges dueness at — while the uniform shift keeps
+    /// every deferred row's PAIRWISE gap to its siblings exactly what it was before the shift,
+    /// since the same widened delta moves all of them.
+    #[test]
+    fn release_spacing_floor_extends_the_deferral_when_it_binds() {
+        let mut state = state_with_crossings(
+            &[40_000_000, 30_000_000, 30_000_000],
+            vec![
+                tx(0, prep(0, 0), mined(10)),
+                scheduled_transfer(1, 0, 720, 1_000, MigrationTxState::Proved),
+                // The nearest deferred row: 10 blocks ahead of the candidate in the ORIGINAL
+                // schedule.
+                scheduled_transfer(2, 1, 720, 1_010, MigrationTxState::Signed),
+                scheduled_transfer(3, 2, 720, 1_030, MigrationTxState::Proved),
+            ],
+        );
+        let mut store = TestStore::new(1_010, []);
+        // Scanned target 1_011; served (effective) target 1_051: lag 51, comfortably past the
+        // 16-block tolerance. The nearest deferred row's ORIGINAL drawn gap to the candidate is
+        // 1_010 - 1_000 = 10 blocks — well below the 80-block floor — so the floor binds and tops
+        // the delta up by 70 (80 - 10), landing that row 121 blocks (51 + 70) past its original
+        // height.
+        let targets =
+            DuenessTargets::new(BlockHeight::from_u32(1_011), BlockHeight::from_u32(1_051));
+        let step = advance_migration(
+            &mut store,
+            &mut state,
+            targets,
+            &config_with_floors(0, 80),
+            &mut rng(),
+        )
+        .expect("the store never fails");
+
+        assert_eq!(
+            step,
+            AdvanceStep::Broadcast {
+                id: MigrationTransferId(1)
+            }
+        );
+        let scheduled: Vec<u32> = state
+            .transactions()
+            .iter()
+            .map(|t| u32::from(t.scheduled_height()))
+            .collect();
+        assert_eq!(
+            scheduled,
+            vec![0, 1_011, 1_131, 1_151],
+            "release at max(scheduled, scanned) = 1_011; both deferred rows carry the same \
+             widened delta of 121 (the 51-block lag plus the 70-block floor top-up)"
+        );
+        assert!(
+            scheduled[2] >= 1_051 + 80,
+            "the earliest deferred landing sits at least the floor above the served target \
+             (1_051) — the guarantee this floor actually makes, since dueness is judged there, \
+             not at the release landing"
+        );
+        assert_eq!(
+            scheduled[3] - scheduled[2],
+            1_030 - 1_010,
+            "the pairwise gap between the deferred rows survives the shift unchanged"
+        );
+    }
+
+    /// DEFERRAL FLOOR, ALREADY CLEARED: a spacing floor no wider than the candidate's ORIGINAL
+    /// drawn gap to its nearest deferred row changes nothing — the deferred row lands at exactly
+    /// its original height plus the lag, same as an unfloored shift — proving the floor is inert
+    /// once the schedule's own spacing already satisfies it, with no dependence on the estimate
+    /// that sizes the lag. The mirror image of the binding case above.
+    #[test]
+    fn release_spacing_floor_adds_nothing_once_the_gap_already_clears_it() {
+        let mut state = state_with_crossings(
+            &[50_000_000, 50_000_000],
+            vec![
+                tx(0, prep(0, 0), mined(10)),
+                scheduled_transfer(1, 0, 720, 1_000, MigrationTxState::Proved),
+                scheduled_transfer(2, 1, 720, 1_010, MigrationTxState::Signed),
+            ],
+        );
+        let mut store = TestStore::new(1_010, []);
+        // The same 51-block lag as the binding case above, but here the nearest deferred row's
+        // ORIGINAL drawn gap to the candidate (1_010 - 1_000 = 10) already clears an 8-block
+        // floor — measured purely from the committed schedule, with no estimate involved.
+        let targets =
+            DuenessTargets::new(BlockHeight::from_u32(1_011), BlockHeight::from_u32(1_051));
+        let step = advance_migration(
+            &mut store,
+            &mut state,
+            targets,
+            &config_with_floors(0, 8),
+            &mut rng(),
+        )
+        .expect("the store never fails");
+
+        assert_eq!(
+            step,
+            AdvanceStep::Broadcast {
+                id: MigrationTransferId(1)
+            }
+        );
+        assert_eq!(
+            u32::from(state.transactions()[1].scheduled_height()),
+            1_011,
+            "released at max(scheduled, scanned)"
+        );
+        assert_eq!(
+            u32::from(state.transactions()[2].scheduled_height()),
+            1_061,
+            "deferred by exactly the 51-block lag: 1_010 + 51 — the 8-block floor, already \
+             cleared by the schedule's own 10-block gap, contributes nothing"
+        );
+    }
+
+    /// THE SCOPED GUARANTEE'S BOUNDARY: a `Proved` candidate at 1_000 with an EARLIER-scheduled
+    /// `AwaitingSignature` sibling at 970 — reachable only because the prove and broadcast queues
+    /// are independent, so a due broadcast can be named ahead of an earlier-scheduled row still
+    /// waiting to be proved. Here `earliest` (970) sits BELOW `scheduled` (1_000), the candidate's
+    /// own original height: `gap_now` — the ORIGINAL drawn gap — saturates to zero, so a binding
+    /// floor is added in FULL rather than topped up from a natural gap, landing the sibling short
+    /// of the served target plus the floor (1_020 + 50 = 1_070) — exactly the case
+    /// `with_compressed_schedule_floors`'s doc now scopes the guarantee around: rows scheduled
+    /// BEFORE the released candidate, not a silent gap in it. A `Proved` sibling can never sit on
+    /// this side of the bound while eligible for candidacy: the kernel's height-ordered selection
+    /// would have made it the candidate instead.
+    ///
+    /// The floor-zero drive pins the other half: this is also the one ordering that would tell
+    /// the forbidden `lag.max(floor + served - earliest)` rewrite apart from the saturating
+    /// form actually used. The forbidden form computes `20.max(0 + 1_020 - 970) == 50` here — a
+    /// nonzero top-up at floor zero — while the saturating form's `extra` is zero unconditionally,
+    /// landing the sibling at exactly `970 + 20 == 990`, the untouched overdue lag.
+    #[test]
+    fn release_spacing_floor_is_short_of_the_guarantee_when_a_sibling_precedes_the_candidate() {
+        let make = || {
+            state_with_crossings(
+                &[50_000_000, 50_000_000],
+                vec![
+                    tx(0, prep(0, 0), mined(10)),
+                    scheduled_transfer(1, 0, 720, 1_000, MigrationTxState::Proved),
+                    scheduled_transfer(2, 1, 720, 970, MigrationTxState::AwaitingSignature),
+                ],
+            )
+        };
+        // Scanned target 1_000 (so the release lands in place at `max(1_000, 1_000)`); served
+        // (effective) target 1_020: lag 20, past the 16-block ZIP 318 tolerance, with the earlier
+        // sibling due (970 <= 1_020) arming the cluster condition.
+        let targets =
+            DuenessTargets::new(BlockHeight::from_u32(1_000), BlockHeight::from_u32(1_020));
+
+        // Floor 50: binds (gap_now saturates to 0), added in full — short of the served target
+        // plus the floor.
+        let mut state = make();
+        let mut store = TestStore::new(999, []);
+        let step = advance_migration(
+            &mut store,
+            &mut state,
+            targets,
+            &config_with_floors(0, 50),
+            &mut rng(),
+        )
+        .expect("the store never fails");
+        assert_eq!(
+            step,
+            AdvanceStep::Broadcast {
+                id: MigrationTransferId(1)
+            }
+        );
+        assert_eq!(
+            u32::from(state.transactions()[1].scheduled_height()),
+            1_000,
+            "released in place: max(scheduled, scanned) moves nothing here"
+        );
+        assert_eq!(
+            u32::from(state.transactions()[2].scheduled_height()),
+            1_040,
+            "970 + 20 (lag) + 50 (floor, added in full since gap_now saturated to zero) — short \
+             of the served target plus the floor (1_020 + 50 = 1_070): the guarantee is scoped \
+             to rows scheduled at or after the candidate, and this sibling precedes it"
+        );
+
+        // Floor 0: the zero-identity holds even in this ordering — precisely where the forbidden
+        // non-saturating rewrite would have disagreed.
+        let mut state = make();
+        let mut store = TestStore::new(999, []);
+        let step = advance_migration(&mut store, &mut state, targets, &config(), &mut rng())
+            .expect("the store never fails");
+        assert_eq!(
+            step,
+            AdvanceStep::Broadcast {
+                id: MigrationTransferId(1)
+            }
+        );
+        assert_eq!(
+            u32::from(state.transactions()[2].scheduled_height()),
+            990,
+            "exactly the overdue lag (970 + 20), not the 1_020 the forbidden \
+             lag.max(floor + served - earliest) form would have produced"
+        );
     }
 }

--- a/zcash_pool_migration/src/satisfiability.rs
+++ b/zcash_pool_migration/src/satisfiability.rs
@@ -344,10 +344,11 @@ pub fn classify_input_observations(
 /// A lag within the tolerance is ordinary wake-up slop (an OS timer delivered late, a block or
 /// two of estimation error), and the step is served as scheduled. A larger lag means the wallet
 /// slept through part of its broadcast schedule, and serving the backlog as-is would cluster
-/// broadcasts the drawn delays exist to spread apart — so every pending transaction but the
-/// released one is deferred by the overdue amount instead, the release itself landing no higher
-/// than the scanned target (see the overdue-shift step in the flow [`advance_migration`]
-/// documents).
+/// broadcasts the drawn delays exist to spread apart — so, when more of the schedule is due
+/// behind it, every pending transaction but the released one is deferred by the overdue amount
+/// instead — the release is never deferred above the scanned target; an already-due step keeps
+/// its own height (see the overdue-shift step in the flow [`advance_migration`] documents). A
+/// lone overdue step is served as scheduled.
 ///
 /// The tolerance is a FUNCTION of the schedule's own scale rather than a constant, because
 /// "late" only means anything relative to the gaps the schedule draws: a lag that is noise
@@ -417,7 +418,7 @@ impl AdvanceConfig {
 /// | schedule dueness in the prove and broadcast queues | expiry as a DECISION: the kernel's dead set, [`MigrationState::expired_transactions`] and [`AdvanceStep::Rebuild`] eligibility, the drain-time [`Replan`](crate::state::AdvanceStep::Replan) gate |
 /// | the doomed-broadcast withhold — a transfer whose expiry has probably passed is not offered, and [`transaction_statuses`](MigrationState::transaction_statuses) reports [`Blocker::ExpiryImminent`](crate::state::Blocker::ExpiryImminent); protective and reversible, since the scanned path still owns the verdict | the dependency closure of [`MigrationState::record_satisfiability`], which writes `Inherited` marks into the store |
 /// | the prove-side expiry skip: proving a transfer that has probably lapsed is wasted work, and skipping it is reversible | anchor-boundary settledness, since an estimate cannot conjure a commitment-tree checkpoint |
-/// | the overdue re-spread's TRIGGER, and the deferral of the rest ([`overdue_shift_tolerance`]): a step lagging the served target by more than the tolerance defers every other pending schedule by the lag. The deferral PERSISTS, but it persists a schedule for steps NOT being served, never a verdict, so an overshooting estimate can only push deferred work later | the overdue re-spread's RELEASE: the triggering step is never deferred above the scanned target — it lands there when the chain has passed its schedule, and an already-due step keeps its own height — because release means EXECUTABLE — proving rests on scanned chain data, and a release parked at the estimate would be found overdue and re-deferred by every wake; the estimate must never manufacture dueness the wallet cannot act on. Also the [`Expired`](crate::state::Blocker::Expired) blocker in `transaction_statuses`, a rendered determination |
+/// | the overdue re-spread's TRIGGER, and the deferral of the rest ([`overdue_shift_tolerance`]): a step lagging the served target by more than the tolerance — with more of the schedule due behind it — defers every other pending schedule by the lag. The deferral PERSISTS, but it persists a schedule for steps NOT being served, never a verdict, so an overshooting estimate can only push deferred work later | the overdue re-spread's RELEASE: the triggering step is never deferred above the scanned target — it lands there when the chain has passed its schedule, and an already-due step keeps its own height — because release means EXECUTABLE — proving rests on scanned chain data, and a release parked at the estimate would be found overdue and re-deferred by every wake; the estimate must never manufacture dueness the wallet cannot act on. Also the [`Expired`](crate::state::Blocker::Expired) blocker in `transaction_statuses`, a rendered determination |
 ///
 /// The clamp in [`new`](Self::new) guarantees `effective >= scanned`, so the transposition
 /// hazard — an estimate reaching a destructive check — is unrepresentable by construction rather
@@ -487,28 +488,29 @@ impl DuenessTargets {
 /// 1. It asks the planning kernel what to do next, decided purely from the persisted state.
 /// 2. A named `Prove` or `Broadcast` candidate whose scheduled height lags the SERVED target
 ///    ([`DuenessTargets::effective`]) by more than the schedule-scaled tolerance
-///    ([`overdue_shift_tolerance`], sized from the transfer delay the migration's persisted
-///    anchor bucket interval implies) means the wallet slept through part of its broadcast
-///    schedule, and the whole pending schedule re-spreads before anything else happens — at
-///    most once per call: every OTHER not-yet-broadcast transaction defers by the lag with its
-///    drawn gaps intact, instead of the missed steps broadcasting as a cluster, while the
-///    candidate itself lands at the SCANNED target when the chain has passed its schedule (else
-///    it keeps its own, already-due height). The candidate is therefore still due — so it is
-///    still released in this call, which is ZIP 318's "at most one overdue transfer is released
-///    immediately" — and the release is EXECUTABLE where it lands: proving rests on scanned
-///    chain data, so a release parked at the estimate would be a step no wallet could act on,
-///    found overdue and re-deferred by every subsequent wake. A moved transfer whose PROOF is
-///    still to come also has its anchor boundary redrawn against its new schedule — the
-///    released one against its landing —
-///    ([`redraw_anchor_boundary`](crate::scheduling::redraw_anchor_boundary)): its stored
-///    boundary was in-distribution for the original broadcast height, and broadcasting it late
-///    — with every deferred sibling late by the SAME amount — would carry an anchor age no
-///    honest draw produces, a linkable fingerprint. (A `Proved` transfer's proof pins its
-///    anchor, so its boundary is kept; a preparation draws none.) The anchor redraw is why this
-///    function takes a [`CryptoRng`]: the drawn boundaries are privacy-relevant observables. A
-///    `Rebuild` candidate never triggers the shift: the rebuild itself redraws its transfer's
-///    schedule from the target, and an expired candidate's stale height would overstate the
-///    shift for the still-live remainder.
+///    ([`overdue_shift_tolerance`], sized from the transfer delay the migration's persisted anchor
+///    bucket interval implies) means the wallet slept through part of its broadcast schedule; when
+///    more of the schedule is due behind it (a lone overdue step is simply served as scheduled —
+///    there is no cluster to prevent), the whole pending schedule re-spreads before anything else
+///    happens — at most once per call: every OTHER not-yet-broadcast transaction defers by the lag
+///    with its drawn gaps intact, instead of the missed steps broadcasting as a cluster, while the
+///    candidate itself lands at the SCANNED target when the chain has passed its schedule (else it
+///    keeps its own, already-due height). The candidate therefore stays due — its release survives
+///    this call, served in it or the pass after (a boundary redraw can reorder the prove queue) —
+///    which is ZIP 318's "at most one overdue transfer is released immediately" — and the release
+///    is EXECUTABLE where it lands: proving rests on scanned chain data, so a release parked at the
+///    estimate would be a step no wallet could act on, found overdue and re-deferred by every
+///    subsequent wake. A moved transfer whose PROOF is still to come also has its anchor boundary
+///    redrawn against its new schedule — the released one against its landing —
+///    ([`redraw_anchor_boundary`](crate::scheduling::redraw_anchor_boundary)): its stored boundary
+///    was in-distribution for the original broadcast height, and broadcasting it late — with every
+///    deferred sibling late by the SAME amount — would carry an anchor age no honest draw produces,
+///    a linkable fingerprint. (A `Proved` transfer's proof pins its anchor, so its boundary is
+///    kept; a preparation draws none.) The anchor redraw is why this function takes a
+///    [`CryptoRng`]: the drawn boundaries are privacy-relevant observables. A `Rebuild` candidate
+///    never triggers the shift: the rebuild itself redraws its transfer's schedule from the target,
+///    and an expired candidate's stale height would overstate the shift for the still-live
+///    remainder.
 /// 3. It puts the transaction the kernel names to the store's satisfiability oracle
 ///    ([`PoolMigrationRead::check_step_satisfiability`]) — the wallet's live view of whether that
 ///    pre-signed artifact can still execute.
@@ -898,11 +900,19 @@ pub fn advance_migration<St: PoolMigrationWrite, R: RngCore + CryptoRng>(
         // EXECUTABLE: proving rests on scanned chain data, so a release parked at the estimate
         // is a step no wallet can act on — each wake would find it overdue again and re-defer
         // it, and the run would stall forever behind a schedule that outruns the scan. The next
-        // planning pass names the candidate again, still due, so it is released in this call. A
-        // moved not-yet-proved transfer's anchor boundary is redrawn against its new schedule —
+        // planning pass finds it still due — served in this call, or the next when a boundary
+        // redraw reorders the prove queue. A moved not-yet-proved transfer's anchor boundary is
+        // redrawn against its new schedule —
         // the released one's against its landing, keeping the release provable where it is
         // served (see `shift_schedule_releasing`) — so deferral never broadcasts an anchor whose
         // age is out of the ZIP 318 draw's distribution.
+        //
+        // The re-spread fires only when a CLUSTER is possible: some OTHER pending transaction
+        // is itself due at the served target. A lone overdue step broadcasts nothing early by
+        // being served as scheduled — there is no backlog behind it to spread — and once a
+        // release is pinned at the scanned target awaiting execution, this is what keeps later
+        // calls from re-deferring the rest by the full estimate lag on every drive (the trigger
+        // would otherwise stay armed until the release executes).
         //
         // The trigger and the deferral are judged and sized at the ESTIMATE
         // (`targets.effective()`), which is what lets a wall-clock-woken wallet re-spread a
@@ -919,7 +929,18 @@ pub fn advance_migration<St: PoolMigrationWrite, R: RngCore + CryptoRng>(
         {
             let scheduled = u32::from(tx.scheduled_height());
             let served = u32::from(targets.effective());
-            if scheduled.saturating_add(overdue_tolerance) < served {
+            if scheduled.saturating_add(overdue_tolerance) < served
+                && state.transactions().iter().any(|other| {
+                    other.id() != candidate
+                        && matches!(
+                            other.state(),
+                            MigrationTxState::AwaitingSignature
+                                | MigrationTxState::Signed
+                                | MigrationTxState::Proved
+                        )
+                        && u32::from(other.scheduled_height()) <= served
+                })
+            {
                 let release_at = BlockHeight::from_u32(scheduled.max(u32::from(targets.scanned())));
                 state.shift_schedule_releasing(candidate, release_at, served - scheduled, rng);
                 shifted = true;
@@ -2379,14 +2400,13 @@ mod advance_tests {
         );
     }
 
-    /// A step overdue by more than the schedule-scaled tolerance ([`overdue_shift_tolerance`])
-    /// shifts the WHOLE pending schedule
-    /// forward by the overdue amount before it is surfaced: the trigger comes due exactly at the
-    /// served target — ZIP 318's one immediately-released overdue transfer — every other pending
-    /// transaction keeps its drawn gap behind it, served schedules stay put, and the shifted
-    /// state is persisted by the time the step is returned. The trigger and the deferral are
-    /// judged at the ESTIMATE; the released trigger itself lands at the SCANNED target — the
-    /// executable one.
+    /// A step overdue by more than the schedule-scaled tolerance ([`overdue_shift_tolerance`]),
+    /// with more of the schedule due behind it, defers every OTHER pending transaction by the
+    /// overdue amount before it is surfaced and itself lands at the SCANNED target — ZIP 318's one
+    /// immediately-released overdue transfer — drawn gaps kept behind it, served schedules staying
+    /// put, and the shifted state persisted by the time the step is returned. The trigger and the
+    /// deferral are judged at the ESTIMATE; the released trigger itself lands at the SCANNED
+    /// target — the executable one.
     #[test]
     fn overdue_step_shifts_the_pending_schedule() {
         let mut state = state_with_crossings(
@@ -2476,6 +2496,9 @@ mod advance_tests {
     /// This test also proves the one-shift-per-call latch: without it, the released landing —
     /// more than the tolerance below the effective target here — re-arms the trigger and the
     /// first call never terminates.
+    ///
+    /// The second call also pins the cluster condition: with the rest deferred beyond even the
+    /// fresh estimate, nothing re-spreads.
     #[test]
     fn released_overdue_step_lands_on_scanned_chain_data() {
         use crate::state::NextAction;
@@ -2523,8 +2546,8 @@ mod advance_tests {
             .expect("the head has a status");
         assert!(head_status.ready(), "prove-ready at the scanned frame");
         assert_eq!(head_status.action(), Some(NextAction::Prove));
-        // A later wake, scan unmoved, estimate further ahead: the release must NOT re-defer —
-        // the rest does (the backlog is still being missed), the release holds its ground.
+        // A later wake, scan unmoved, estimate further ahead: the release must NOT re-defer, and
+        // the rest — no longer due itself — holds too: no cluster, no re-spread.
         let step = advance_migration(
             &mut store,
             &mut state,
@@ -2544,8 +2567,8 @@ mod advance_tests {
         );
         assert_eq!(
             state.transactions()[2].scheduled_height(),
-            BlockHeight::from_u32(4_151),
-            "an unexecuted release re-defers the rest behind each fresh estimate"
+            BlockHeight::from_u32(2_701),
+            "a rest that is not itself due is never re-deferred: the re-spread fires only when a cluster is possible"
         );
     }
 
@@ -2616,10 +2639,13 @@ mod advance_tests {
     #[test]
     fn released_transfer_boundary_lands_provable() {
         let mut state = state_with_crossings(
-            &[100_000_000],
+            &[50_000_000, 50_000_000],
             vec![
                 tx(0, prep(0, 0), mined(10)),
                 scheduled_transfer(1, 0, 720, 1_000, MigrationTxState::Signed),
+                // Due at the estimate (arms the re-spread) but outside the prove queue: its boundary is
+                // unsettled at the scan.
+                scheduled_transfer(2, 1, 1_440, 1_900, MigrationTxState::Signed),
             ],
         );
         let mut store = TestStore::new(1_050, []);
@@ -2645,13 +2671,18 @@ mod advance_tests {
             "boundary {boundary} sits below the scanned target: provable where served"
         );
         assert_eq!(boundary % 144, 0, "and on the grid");
+        assert_eq!(
+            state.transactions()[2].scheduled_height(),
+            BlockHeight::from_u32(2_901),
+            "the due sibling that armed the re-spread defers behind the estimate"
+        );
     }
 
     /// The tolerance boundary: a step at most [`overdue_shift_tolerance`] blocks past its
     /// schedule is ordinary wake-up slop, served as scheduled with nothing rescheduled or
-    /// written; one block further and the whole pending schedule moves. The fixture's committed
-    /// interval is the ZIP 318 one, so the tolerance under test is the mainnet value the drive
-    /// call derives from the persisted state.
+    /// written; one block further — with more of the schedule due behind it — the whole pending
+    /// schedule moves. The fixture's committed interval is the ZIP 318 one, so the tolerance
+    /// under test is the mainnet value the drive call derives from the persisted state.
     #[test]
     fn overdue_shift_tolerance_boundary() {
         // A quarter of the ZIP 318 mean of 66: the value `advance_migration` derives from the
@@ -2664,7 +2695,8 @@ mod advance_tests {
                 vec![
                     tx(0, prep(0, 0), mined(10)),
                     scheduled_transfer(1, 0, 720, 1_000, MigrationTxState::Proved),
-                    scheduled_transfer(2, 1, 720, 1_050, MigrationTxState::Signed),
+                    // Due behind the trigger, arming the cluster condition either side of the boundary.
+                    scheduled_transfer(2, 1, 720, 1_010, MigrationTxState::Signed),
                 ],
             )
         };
@@ -2717,7 +2749,7 @@ mod advance_tests {
         );
         assert_eq!(
             u32::from(state.transactions()[2].scheduled_height()),
-            1_050 + tolerance + 1,
+            1_010 + tolerance + 1,
         );
         assert_eq!(store.replaced.get(), 1);
     }
@@ -2755,10 +2787,13 @@ mod advance_tests {
     #[test]
     fn overdue_prove_shifts_the_pending_schedule() {
         let mut state = state_with_crossings(
-            &[100_000_000],
+            &[50_000_000, 50_000_000],
             vec![
                 tx(0, prep(0, 0), mined(10)),
                 scheduled_transfer(1, 0, 720, 1_000, MigrationTxState::Signed),
+                // Same boundary, so id breaks the prove-readiness tie in the trigger's favor;
+                // due by the served target, so it arms the cluster condition.
+                scheduled_transfer(2, 1, 720, 1_900, MigrationTxState::Signed),
             ],
         );
         let mut store = TestStore::new(2_000, []);
@@ -2780,6 +2815,11 @@ mod advance_tests {
             u32::from(state.transactions()[1].scheduled_height()),
             2_001,
             "its broadcast window re-spread to the served target"
+        );
+        assert_eq!(
+            u32::from(state.transactions()[2].scheduled_height()),
+            2_901,
+            "the sibling that armed the re-spread defers behind the served target too"
         );
         assert_eq!(store.replaced.get(), 1);
     }

--- a/zcash_pool_migration/src/satisfiability.rs
+++ b/zcash_pool_migration/src/satisfiability.rs
@@ -417,7 +417,7 @@ impl AdvanceConfig {
 /// | schedule dueness in the prove and broadcast queues | expiry as a DECISION: the kernel's dead set, [`MigrationState::expired_transactions`] and [`AdvanceStep::Rebuild`] eligibility, the drain-time [`Replan`](crate::state::AdvanceStep::Replan) gate |
 /// | the doomed-broadcast withhold — a transfer whose expiry has probably passed is not offered, and [`transaction_statuses`](MigrationState::transaction_statuses) reports [`Blocker::ExpiryImminent`](crate::state::Blocker::ExpiryImminent); protective and reversible, since the scanned path still owns the verdict | the dependency closure of [`MigrationState::record_satisfiability`], which writes `Inherited` marks into the store |
 /// | the prove-side expiry skip: proving a transfer that has probably lapsed is wasted work, and skipping it is reversible | anchor-boundary settledness, since an estimate cannot conjure a commitment-tree checkpoint |
-/// | the overdue re-spread's TRIGGER, and the deferral of the rest ([`overdue_shift_tolerance`]): a step lagging the served target by more than the tolerance defers every other pending schedule by the lag. The deferral PERSISTS, but it persists a schedule for steps NOT being served, never a verdict, so an overshooting estimate can only push deferred work later | the overdue re-spread's RELEASE: the triggering step lands no higher than the scanned target, because release means EXECUTABLE — proving rests on scanned chain data, and a release parked at the estimate would be found overdue and re-deferred by every wake; the estimate must never manufacture dueness the wallet cannot act on. Also the [`Expired`](crate::state::Blocker::Expired) blocker in `transaction_statuses`, a rendered determination |
+/// | the overdue re-spread's TRIGGER, and the deferral of the rest ([`overdue_shift_tolerance`]): a step lagging the served target by more than the tolerance defers every other pending schedule by the lag. The deferral PERSISTS, but it persists a schedule for steps NOT being served, never a verdict, so an overshooting estimate can only push deferred work later | the overdue re-spread's RELEASE: the triggering step is never deferred above the scanned target — it lands there when the chain has passed its schedule, and an already-due step keeps its own height — because release means EXECUTABLE — proving rests on scanned chain data, and a release parked at the estimate would be found overdue and re-deferred by every wake; the estimate must never manufacture dueness the wallet cannot act on. Also the [`Expired`](crate::state::Blocker::Expired) blocker in `transaction_statuses`, a rendered determination |
 ///
 /// The clamp in [`new`](Self::new) guarantees `effective >= scanned`, so the transposition
 /// hazard — an estimate reaching a destructive check — is unrepresentable by construction rather
@@ -920,8 +920,7 @@ pub fn advance_migration<St: PoolMigrationWrite, R: RngCore + CryptoRng>(
             let scheduled = u32::from(tx.scheduled_height());
             let served = u32::from(targets.effective());
             if scheduled.saturating_add(overdue_tolerance) < served {
-                let release_at =
-                    BlockHeight::from_u32(scheduled.max(u32::from(targets.scanned())));
+                let release_at = BlockHeight::from_u32(scheduled.max(u32::from(targets.scanned())));
                 state.shift_schedule_releasing(candidate, release_at, served - scheduled, rng);
                 shifted = true;
                 dirty = true;

--- a/zcash_pool_migration/src/satisfiability.rs
+++ b/zcash_pool_migration/src/satisfiability.rs
@@ -344,9 +344,10 @@ pub fn classify_input_observations(
 /// A lag within the tolerance is ordinary wake-up slop (an OS timer delivered late, a block or
 /// two of estimation error), and the step is served as scheduled. A larger lag means the wallet
 /// slept through part of its broadcast schedule, and serving the backlog as-is would cluster
-/// broadcasts the drawn delays exist to spread apart — so the whole pending schedule is shifted
-/// forward by the overdue amount instead (see the overdue-shift step in the flow
-/// [`advance_migration`] documents).
+/// broadcasts the drawn delays exist to spread apart — so every pending transaction but the
+/// released one is deferred by the overdue amount instead, the release itself landing no higher
+/// than the scanned target (see the overdue-shift step in the flow [`advance_migration`]
+/// documents).
 ///
 /// The tolerance is a FUNCTION of the schedule's own scale rather than a constant, because
 /// "late" only means anything relative to the gaps the schedule draws: a lag that is noise
@@ -416,7 +417,7 @@ impl AdvanceConfig {
 /// | schedule dueness in the prove and broadcast queues | expiry as a DECISION: the kernel's dead set, [`MigrationState::expired_transactions`] and [`AdvanceStep::Rebuild`] eligibility, the drain-time [`Replan`](crate::state::AdvanceStep::Replan) gate |
 /// | the doomed-broadcast withhold — a transfer whose expiry has probably passed is not offered, and [`transaction_statuses`](MigrationState::transaction_statuses) reports [`Blocker::ExpiryImminent`](crate::state::Blocker::ExpiryImminent); protective and reversible, since the scanned path still owns the verdict | the dependency closure of [`MigrationState::record_satisfiability`], which writes `Inherited` marks into the store |
 /// | the prove-side expiry skip: proving a transfer that has probably lapsed is wasted work, and skipping it is reversible | anchor-boundary settledness, since an estimate cannot conjure a commitment-tree checkpoint |
-/// | the overdue re-spread ([`overdue_shift_tolerance`]): a step lagging the served target by more than the tolerance shifts the whole pending schedule forward by the lag. The shift PERSISTS, but what it persists is a schedule, never a verdict: it re-times the service of steps and records no determination, so an overshooting estimate can only delay broadcasts, not condemn work | the [`Expired`](crate::state::Blocker::Expired) blocker in `transaction_statuses`, a rendered determination |
+/// | the overdue re-spread's TRIGGER, and the deferral of the rest ([`overdue_shift_tolerance`]): a step lagging the served target by more than the tolerance defers every other pending schedule by the lag. The deferral PERSISTS, but it persists a schedule for steps NOT being served, never a verdict, so an overshooting estimate can only push deferred work later | the overdue re-spread's RELEASE: the triggering step lands no higher than the scanned target, because release means EXECUTABLE — proving rests on scanned chain data, and a release parked at the estimate would be found overdue and re-deferred by every wake; the estimate must never manufacture dueness the wallet cannot act on. Also the [`Expired`](crate::state::Blocker::Expired) blocker in `transaction_statuses`, a rendered determination |
 ///
 /// The clamp in [`new`](Self::new) guarantees `effective >= scanned`, so the transposition
 /// hazard — an estimate reaching a destructive check — is unrepresentable by construction rather
@@ -487,23 +488,27 @@ impl DuenessTargets {
 /// 2. A named `Prove` or `Broadcast` candidate whose scheduled height lags the SERVED target
 ///    ([`DuenessTargets::effective`]) by more than the schedule-scaled tolerance
 ///    ([`overdue_shift_tolerance`], sized from the transfer delay the migration's persisted
-///    anchor bucket interval implies) means the wallet
-///    slept through part of its broadcast schedule, and the whole pending schedule is shifted
-///    forward by the lag before anything else happens: the
-///    candidate comes due exactly at the served target — so it is still released in this call,
-///    which is ZIP 318's "at most one overdue transfer is released immediately" — while every
-///    other not-yet-broadcast transaction re-spreads behind it with its drawn gaps intact,
-///    instead of the missed steps broadcasting as a cluster. A shifted transfer whose PROOF is
-///    still to come also has its anchor boundary redrawn against the shifted schedule
+///    anchor bucket interval implies) means the wallet slept through part of its broadcast
+///    schedule, and the whole pending schedule re-spreads before anything else happens — at
+///    most once per call: every OTHER not-yet-broadcast transaction defers by the lag with its
+///    drawn gaps intact, instead of the missed steps broadcasting as a cluster, while the
+///    candidate itself lands at the SCANNED target when the chain has passed its schedule (else
+///    it keeps its own, already-due height). The candidate is therefore still due — so it is
+///    still released in this call, which is ZIP 318's "at most one overdue transfer is released
+///    immediately" — and the release is EXECUTABLE where it lands: proving rests on scanned
+///    chain data, so a release parked at the estimate would be a step no wallet could act on,
+///    found overdue and re-deferred by every subsequent wake. A moved transfer whose PROOF is
+///    still to come also has its anchor boundary redrawn against its new schedule — the
+///    released one against its landing —
 ///    ([`redraw_anchor_boundary`](crate::scheduling::redraw_anchor_boundary)): its stored
-///    boundary was in-distribution for the original broadcast height, and broadcasting it
-///    `delta` blocks late — with every deferred sibling late by the SAME `delta` — would carry
-///    an anchor age no honest draw produces, a linkable fingerprint. (A `Proved` transfer's
-///    proof pins its anchor, so its boundary is kept; a preparation draws none.) The anchor
-///    redraw is why this function takes a [`CryptoRng`]: the drawn boundaries are
-///    privacy-relevant observables. A `Rebuild` candidate never triggers the shift: the rebuild
-///    itself redraws its transfer's schedule from the target, and an expired candidate's stale
-///    height would overstate the shift for the still-live remainder.
+///    boundary was in-distribution for the original broadcast height, and broadcasting it late
+///    — with every deferred sibling late by the SAME amount — would carry an anchor age no
+///    honest draw produces, a linkable fingerprint. (A `Proved` transfer's proof pins its
+///    anchor, so its boundary is kept; a preparation draws none.) The anchor redraw is why this
+///    function takes a [`CryptoRng`]: the drawn boundaries are privacy-relevant observables. A
+///    `Rebuild` candidate never triggers the shift: the rebuild itself redraws its transfer's
+///    schedule from the target, and an expired candidate's stale height would overstate the
+///    shift for the still-live remainder.
 /// 3. It puts the transaction the kernel names to the store's satisfiability oracle
 ///    ([`PoolMigrationRead::check_step_satisfiability`]) — the wallet's live view of whether that
 ///    pre-signed artifact can still execute.
@@ -845,13 +850,20 @@ pub fn advance_migration<St: PoolMigrationWrite, R: RngCore + CryptoRng>(
             .transfer_delay(),
     );
 
+    // The call's one overdue re-spread, if it runs (see the shift below): at most one, because
+    // the released candidate lands at the SCANNED target, which can sit more than the tolerance
+    // below the effective target whenever the estimate leads the scan by more than the
+    // tolerance — a re-armed trigger would then re-defer the rest forever without ever moving
+    // the release. One shift per call is also all the policy needs: a call releases at most one
+    // step, so only one release needs placing.
+    let mut shifted = false;
+
     // Plan, verify, record, plan again. Every iteration either breaks, grows `set_aside`,
     // strictly grows the marked set — strictly, because the kernel never names an already-marked
-    // transaction (they are in its dead set), so a recorded discovery marks at least the candidate
-    // that produced it — or shifts the schedule. The first two are bounded by the transaction
-    // count; each shift raises every pending scheduled height by more than the overdue-shift
-    // tolerance toward the fixed served target, above which no shift triggers, so shifts are
-    // bounded too and the loop terminates.
+    // transaction (they are in its dead set), so a recorded discovery marks at least the
+    // candidate that produced it — or performs the call's one re-spread (`shifted`). The first
+    // two are bounded by the transaction count and the third by its latch, so the loop
+    // terminates.
     let step = loop {
         let step = state.next_step(targets, &set_aside);
         let candidate = match step {
@@ -877,31 +889,41 @@ pub fn advance_migration<St: PoolMigrationWrite, R: RngCore + CryptoRng>(
         };
         // THE OVERDUE SHIFT: ZIP 318's missed-schedule policy ("at most one overdue transfer is
         // released immediately; the rest are re-spread"). A candidate more than the
-        // schedule-scaled tolerance past its scheduled height means the wallet slept through
-        // part of the schedule, and serving the backlog as-is would cluster broadcasts the
-        // drawn delays exist to spread apart. Shifting EVERY pending transaction forward by
-        // the lag moves this candidate's schedule to exactly the served target — the next
-        // planning pass names it again, still due, so it is released in this call — while the
-        // rest re-spread behind it with their inter-broadcast gaps intact. The shift also
-        // redraws the anchor boundary of every deferred not-yet-proved transfer against its new
-        // schedule (see `shift_schedule`), so deferral never broadcasts an anchor whose age is
-        // out of the ZIP 318 draw's distribution.
+        // schedule-scaled tolerance past its scheduled height at the served (estimated-tip)
+        // target means the wallet slept through part of the schedule, and serving the backlog
+        // as-is would cluster broadcasts the drawn delays exist to spread apart. Every OTHER
+        // pending transaction defers by the full lag with its drawn inter-broadcast gaps intact;
+        // the candidate itself is the release, and it lands at the SCANNED target when the chain
+        // has passed its schedule (else it keeps its own, already-due height). Release means
+        // EXECUTABLE: proving rests on scanned chain data, so a release parked at the estimate
+        // is a step no wallet can act on — each wake would find it overdue again and re-defer
+        // it, and the run would stall forever behind a schedule that outruns the scan. The next
+        // planning pass names the candidate again, still due, so it is released in this call. A
+        // moved not-yet-proved transfer's anchor boundary is redrawn against its new schedule —
+        // the released one's against its landing, keeping the release provable where it is
+        // served (see `shift_schedule_releasing`) — so deferral never broadcasts an anchor whose
+        // age is out of the ZIP 318 draw's distribution.
         //
-        // Judged and sized at the ESTIMATE (`targets.effective()`), which is what lets a
-        // wall-clock-woken wallet re-spread without syncing first; legal there because the shift
-        // persists a SCHEDULE, never a verdict — it re-times service, records no determination,
-        // and destroys no work (see the `DuenessTargets` classification). `Rebuild` is
-        // deliberately not a trigger: the rebuild redraws its own transfer's schedule from the
-        // target, and sizing a shift by an expired candidate's stale height would overstate it
-        // for everything still live.
-        if matches!(
-            step,
-            AdvanceStep::Prove { .. } | AdvanceStep::Broadcast { .. }
-        ) {
+        // The trigger and the deferral are judged and sized at the ESTIMATE
+        // (`targets.effective()`), which is what lets a wall-clock-woken wallet re-spread a
+        // backlog of already-proved transfers without syncing first; the RELEASE lands on chain
+        // data. At most one shift per call (`shifted`, above). `Rebuild` is deliberately not a
+        // trigger: the rebuild redraws its own transfer's schedule from the target, and sizing a
+        // shift by an expired candidate's stale height would overstate it for everything still
+        // live.
+        if !shifted
+            && matches!(
+                step,
+                AdvanceStep::Prove { .. } | AdvanceStep::Broadcast { .. }
+            )
+        {
             let scheduled = u32::from(tx.scheduled_height());
             let served = u32::from(targets.effective());
             if scheduled.saturating_add(overdue_tolerance) < served {
-                state.shift_schedule(served - scheduled, rng);
+                let release_at =
+                    BlockHeight::from_u32(scheduled.max(u32::from(targets.scanned())));
+                state.shift_schedule_releasing(candidate, release_at, served - scheduled, rng);
+                shifted = true;
                 dirty = true;
                 continue;
             }
@@ -2363,8 +2385,9 @@ mod advance_tests {
     /// forward by the overdue amount before it is surfaced: the trigger comes due exactly at the
     /// served target — ZIP 318's one immediately-released overdue transfer — every other pending
     /// transaction keeps its drawn gap behind it, served schedules stay put, and the shifted
-    /// state is persisted by the time the step is returned. Judged at the ESTIMATE, so the
-    /// re-spread happens in a broadcast-only session, without syncing first.
+    /// state is persisted by the time the step is returned. The trigger and the deferral are
+    /// judged at the ESTIMATE; the released trigger itself lands at the SCANNED target — the
+    /// executable one.
     #[test]
     fn overdue_step_shifts_the_pending_schedule() {
         let mut state = state_with_crossings(
@@ -2403,8 +2426,8 @@ mod advance_tests {
             .collect();
         assert_eq!(
             scheduled,
-            vec![0, 2_001, 2_067, 900],
-            "pending schedules shift by the overdue amount (gaps intact); served ones stay put"
+            vec![0, 1_011, 2_067, 900],
+            "the release lands at the scanned target; the rest defers by the overdue amount (gaps intact); served ones stay put"
         );
         assert_eq!(store.replaced.get(), 1, "the shifted schedule is persisted");
         let stored: Vec<u32> = store
@@ -2442,6 +2465,187 @@ mod advance_tests {
             boundary >= most_recent - 4 * 144 && boundary < most_recent,
             "boundary {boundary} is in-distribution for schedule {new_schedule}"
         );
+    }
+
+    /// THE LIVELOCK REGRESSION: a released overdue step must land ON CHAIN DATA. Landed at the
+    /// effective (estimated-tip) target instead — the pre-fix behavior — the release sits past
+    /// every scanned-frame executor (proving rests on scanned tree state), so a short-session
+    /// wallet can never act on it before sleeping; its next wake finds the step overdue again
+    /// and re-defers it, forever, and the whole run stalls behind a schedule that outruns the
+    /// scan. The head shape mirrors the wallet this was observed on: a Signed PREPARATION.
+    ///
+    /// This test also proves the one-shift-per-call latch: without it, the released landing —
+    /// more than the tolerance below the effective target here — re-arms the trigger and the
+    /// first call never terminates.
+    #[test]
+    fn released_overdue_step_lands_on_scanned_chain_data() {
+        use crate::state::NextAction;
+
+        let mut head = tx(1, prep(1, 0), MigrationTxState::Signed);
+        head.scheduled_height = BlockHeight::from_u32(1_000);
+        head.depends_on = vec![MigrationTransferId(0)];
+        let mut state = state_with_crossings(
+            &[50_000_000, 50_000_000],
+            vec![
+                tx(0, prep(0, 0), mined(10)),
+                head,
+                // An unsettled boundary (1_440 > scanned) keeps this transfer out of the prove
+                // queue, so the preparation is the named candidate.
+                scheduled_transfer(2, 0, 1_440, 1_700, MigrationTxState::Signed),
+            ],
+        );
+        let mut store = TestStore::new(1_050, []);
+        // Scanned to 1_050 (target 1_051), estimate at 2_000 (target 2_001): the head is 51
+        // blocks past its schedule by the chain and 1_001 by the estimate — both beyond the
+        // 16-block ZIP 318 tolerance.
+        let targets =
+            DuenessTargets::new(BlockHeight::from_u32(1_051), BlockHeight::from_u32(2_001));
+        let step = advance_migration(&mut store, &mut state, targets, &config(), &mut rng())
+            .expect("the store never fails");
+        assert!(
+            matches!(step, AdvanceStep::Prove { id, .. } if id == MigrationTransferId(1)),
+            "the overdue step is still released in this call, got {step:?}"
+        );
+        assert_eq!(
+            state.transactions()[1].scheduled_height(),
+            BlockHeight::from_u32(1_051),
+            "the release lands at the SCANNED target, not the estimate"
+        );
+        assert_eq!(
+            state.transactions()[2].scheduled_height(),
+            BlockHeight::from_u32(2_701),
+            "the rest defer by the full estimate-sized lag"
+        );
+        // The property the landing exists for: a scanned-frame executor can act NOW.
+        let head_status = state
+            .transaction_statuses(DuenessTargets::at(BlockHeight::from_u32(1_051)))
+            .into_iter()
+            .find(|s| s.id() == MigrationTransferId(1))
+            .expect("the head has a status");
+        assert!(head_status.ready(), "prove-ready at the scanned frame");
+        assert_eq!(head_status.action(), Some(NextAction::Prove));
+        // A later wake, scan unmoved, estimate further ahead: the release must NOT re-defer —
+        // the rest does (the backlog is still being missed), the release holds its ground.
+        let step = advance_migration(
+            &mut store,
+            &mut state,
+            DuenessTargets::new(BlockHeight::from_u32(1_051), BlockHeight::from_u32(2_501)),
+            &config(),
+            &mut rng(),
+        )
+        .expect("the store never fails");
+        assert!(
+            matches!(step, AdvanceStep::Prove { id, .. } if id == MigrationTransferId(1)),
+            "still the same release, got {step:?}"
+        );
+        assert_eq!(
+            state.transactions()[1].scheduled_height(),
+            BlockHeight::from_u32(1_051),
+            "the release is stable across wakes: its schedule never outruns the scan again"
+        );
+        assert_eq!(
+            state.transactions()[2].scheduled_height(),
+            BlockHeight::from_u32(4_151),
+            "an unexecuted release re-defers the rest behind each fresh estimate"
+        );
+    }
+
+    /// The broadcast-only wake ZIP 318 carves out: scan stale, wall-clock estimate far ahead, a
+    /// PROVED backlog due only by the estimate. Broadcast needs no scanned state, so the head is
+    /// released IN PLACE — its own schedule already stands at or above everything the chain
+    /// supports, and the scanned landing never moves a release backward — and only the rest
+    /// defers behind the estimate: one release, no cluster, no sync first.
+    #[test]
+    fn estimate_only_backlog_releases_in_place_and_defers_the_rest() {
+        let mut state = state_with_crossings(
+            &[50_000_000, 50_000_000],
+            vec![
+                tx(0, prep(0, 0), mined(10)),
+                scheduled_transfer(1, 0, 720, 1_600, MigrationTxState::Proved),
+                scheduled_transfer(2, 1, 720, 1_666, MigrationTxState::Proved),
+            ],
+        );
+        let mut store = TestStore::new(1_010, []);
+        // Scanned target 1_011; estimated target 2_001: both transfers are due only by the
+        // estimate, and the head lags it by 401 blocks — past the tolerance, so the backlog
+        // re-spreads.
+        let step = advance_migration(
+            &mut store,
+            &mut state,
+            DuenessTargets::new(BlockHeight::from_u32(1_011), BlockHeight::from_u32(2_001)),
+            &config(),
+            &mut rng(),
+        )
+        .expect("the store never fails");
+        assert_eq!(
+            step,
+            AdvanceStep::Broadcast {
+                id: MigrationTransferId(1)
+            },
+            "the head of the estimate-frame backlog is released without syncing"
+        );
+        assert_eq!(
+            state.transactions()[1].scheduled_height(),
+            BlockHeight::from_u32(1_600),
+            "released in place: max(own schedule, scanned target) moves nothing here"
+        );
+        assert_eq!(
+            state.transactions()[2].scheduled_height(),
+            BlockHeight::from_u32(2_067),
+            "the rest defers behind the estimate with its gaps intact"
+        );
+        // After the release goes out, nothing else is due: the cluster is gone.
+        state.mark_broadcast(MigrationTransferId(1));
+        assert_eq!(
+            advance_migration(
+                &mut store,
+                &mut state,
+                DuenessTargets::new(BlockHeight::from_u32(1_011), BlockHeight::from_u32(2_001)),
+                &config(),
+                &mut rng(),
+            )
+            .expect("the store never fails"),
+            AdvanceStep::Waiting,
+            "the deferred rest is beyond the estimate: at most one release per backlog"
+        );
+    }
+
+    /// A released Signed TRANSFER's boundary redraws against its scanned-frame landing, so the
+    /// release is immediately provable — not against the heights the deferred rest re-spread to
+    /// (the pre-fix redraw left the released boundary itself above the scan, unprovable: the
+    /// boundary-climb face of the livelock).
+    #[test]
+    fn released_transfer_boundary_lands_provable() {
+        let mut state = state_with_crossings(
+            &[100_000_000],
+            vec![
+                tx(0, prep(0, 0), mined(10)),
+                scheduled_transfer(1, 0, 720, 1_000, MigrationTxState::Signed),
+            ],
+        );
+        let mut store = TestStore::new(1_050, []);
+        let step = advance_migration(
+            &mut store,
+            &mut state,
+            DuenessTargets::new(BlockHeight::from_u32(1_051), BlockHeight::from_u32(2_001)),
+            &config(),
+            &mut rng(),
+        )
+        .expect("the store never fails");
+        assert!(
+            matches!(step, AdvanceStep::Prove { id, .. } if id == MigrationTransferId(1)),
+            "released, got {step:?}"
+        );
+        let boundary = u32::from(
+            state.transactions()[1]
+                .anchor_boundary()
+                .expect("a transfer keeps carrying a boundary"),
+        );
+        assert!(
+            boundary < 1_051,
+            "boundary {boundary} sits below the scanned target: provable where served"
+        );
+        assert_eq!(boundary % 144, 0, "and on the grid");
     }
 
     /// The tolerance boundary: a step at most [`overdue_shift_tolerance`] blocks past its

--- a/zcash_pool_migration/src/scheduling.rs
+++ b/zcash_pool_migration/src/scheduling.rs
@@ -65,10 +65,9 @@
 //!   re-spread). That requires the persisted schedule and wall-clock state the engine owns; the
 //!   drive API implements it as the overdue shift (see
 //!   [`advance_migration`](crate::satisfiability::advance_migration) and
-//!   [`overdue_shift_tolerance`](crate::satisfiability::overdue_shift_tolerance)), which
-//!   defers every pending transaction but the released one by the overdue amount rather
-//!   than redrawing the schedule, the release landing where the wallet's own chain data
-//!   can serve it.
+//!   [`overdue_shift_tolerance`](crate::satisfiability::overdue_shift_tolerance)), which defers
+//!   every pending transaction but the released one by the overdue amount rather than redrawing the
+//!   schedule, the release never deferred above what the wallet's own chain data can serve.
 //!
 //! This module supplies the heights and anchors those policies act on; it does not enact them.
 //!
@@ -788,13 +787,12 @@ pub fn draw_anchor_boundary<R: RngCore + CryptoRng>(
 
 /// Select a REPLACEMENT boundary for a transfer whose broadcast schedule has moved out from under
 /// its drawn anchor — the overdue shift
-/// ([`advance_migration`](crate::satisfiability::advance_migration)) defers the pending
-/// broadcasts a resuming wallet slept past, and a boundary that was in-distribution for
-/// the ORIGINAL schedule sits too old against the shifted one. With
-/// [`ANCHOR_AGE_CAP`] at 4 buckets, even a modest shift leaves an anchor age no honest draw
-/// produces, and every deferred transfer of one wallet would carry the SAME excess age — a
-/// linkable fingerprint. Redrawing against the new schedule restores the age distribution the
-/// anchor cohorts rely on.
+/// ([`advance_migration`](crate::satisfiability::advance_migration)) defers the pending broadcasts
+/// a resuming wallet slept past, and a boundary that was in-distribution for the ORIGINAL schedule
+/// sits too old against the shifted one. With [`ANCHOR_AGE_CAP`] at 4 buckets, even a modest shift
+/// leaves an anchor age no honest draw produces, and every deferred transfer of one wallet would
+/// carry the SAME excess age — a linkable fingerprint. Redrawing against the new schedule restores
+/// the age distribution the anchor cohorts rely on.
 ///
 /// The draw is [`draw_anchor_boundary`]'s recency-weighted draw against the NEW
 /// `broadcast_height`, with the candidate set floored at `prior_boundary` — the boundary being

--- a/zcash_pool_migration/src/scheduling.rs
+++ b/zcash_pool_migration/src/scheduling.rs
@@ -65,8 +65,10 @@
 //!   re-spread). That requires the persisted schedule and wall-clock state the engine owns; the
 //!   drive API implements it as the overdue shift (see
 //!   [`advance_migration`](crate::satisfiability::advance_migration) and
-//!   [`overdue_shift_tolerance`](crate::satisfiability::overdue_shift_tolerance)), which moves the
-//!   whole pending schedule forward by the overdue amount rather than redrawing it.
+//!   [`overdue_shift_tolerance`](crate::satisfiability::overdue_shift_tolerance)), which
+//!   defers every pending transaction but the released one by the overdue amount rather
+//!   than redrawing the schedule, the release landing where the wallet's own chain data
+//!   can serve it.
 //!
 //! This module supplies the heights and anchors those policies act on; it does not enact them.
 //!
@@ -786,9 +788,9 @@ pub fn draw_anchor_boundary<R: RngCore + CryptoRng>(
 
 /// Select a REPLACEMENT boundary for a transfer whose broadcast schedule has moved out from under
 /// its drawn anchor — the overdue shift
-/// ([`advance_migration`](crate::satisfiability::advance_migration)) defers every pending
-/// broadcast when a wallet resumes after downtime, and a boundary that was in-distribution for
-/// the ORIGINAL schedule sits `delta` blocks too old against the shifted one. With
+/// ([`advance_migration`](crate::satisfiability::advance_migration)) defers the pending
+/// broadcasts a resuming wallet slept past, and a boundary that was in-distribution for
+/// the ORIGINAL schedule sits too old against the shifted one. With
 /// [`ANCHOR_AGE_CAP`] at 4 buckets, even a modest shift leaves an anchor age no honest draw
 /// produces, and every deferred transfer of one wallet would carry the SAME excess age — a
 /// linkable fingerprint. Redrawing against the new schedule restores the age distribution the

--- a/zcash_pool_migration/src/state.rs
+++ b/zcash_pool_migration/src/state.rs
@@ -718,68 +718,6 @@ impl MigrationState {
         self.recompute_status();
     }
 
-    /// Shifts the scheduled height of every transaction that has not yet been broadcast forward
-    /// by `delta` blocks, preserving the schedule's inter-broadcast gaps.
-    ///
-    /// This is the RE-SPREAD half of ZIP 318's missed-schedule policy — at most one overdue
-    /// transfer is released immediately; the rest are re-spread — applied by
-    /// [`advance_migration`](crate::satisfiability::advance_migration) when the step it would
-    /// surface lags the served target by more than
-    /// the schedule-scaled tolerance
-    /// ([`overdue_shift_tolerance`](crate::satisfiability::overdue_shift_tolerance)). Shifting
-    /// every pending transaction by the same delta moves the whole remaining schedule forward in
-    /// block-time without redrawing it, so the gaps between broadcasts — the observable the drawn
-    /// exponential delays exist to shape — survive the wallet's absence unchanged, instead of the
-    /// missed steps piling up and broadcasting as a cluster.
-    ///
-    /// Only PENDING transactions shift ([`AwaitingSignature`](MigrationTxState::AwaitingSignature),
-    /// [`Signed`](MigrationTxState::Signed), [`Proved`](MigrationTxState::Proved)): an in-flight
-    /// or mined transaction's schedule has already been served, and moving it would only distort
-    /// the record of when it was due. Expiry heights are untouched — a pre-signed transaction's
-    /// expiry is effecting data under ZIP 203, fixed at signing — so a large enough shift can move
-    /// a pending schedule past its own expiry; such a transaction self-heals through the ordinary
-    /// expiry path (its rebuild redraws both schedule and expiry). Heights saturate rather than
-    /// overflow.
-    ///
-    /// A shifted TRANSFER whose proof is still to come ([`AwaitingSignature`](MigrationTxState::AwaitingSignature)
-    /// or [`Signed`](MigrationTxState::Signed)) also gets its anchor boundary REDRAWN against the
-    /// shifted schedule ([`redraw_anchor_boundary`](crate::scheduling::redraw_anchor_boundary)):
-    /// the stored boundary was drawn to be in-distribution relative to the ORIGINAL broadcast
-    /// height, so keeping it would broadcast an anchor `delta` blocks older than any honest draw —
-    /// and every deferred transfer of this wallet older by the SAME `delta`, a linkable
-    /// fingerprint. The redraw is sound exactly as `prove_transfer`'s proving-time redraw is:
-    /// ZIP 374 defers the anchor and witnesses to proving, so nothing in the stored artifact pins
-    /// the old boundary. A [`Proved`](MigrationTxState::Proved) transfer's proof DOES pin its
-    /// anchor, so its boundary is kept (re-anchoring it would mean discarding the proof), and a
-    /// preparation carries no drawn boundary at all. In the rare case where no candidate exists at
-    /// or above the prior boundary (see [`redraw_anchor_boundary`](crate::scheduling::redraw_anchor_boundary)),
-    /// the prior — still provable — boundary is kept.
-    pub(crate) fn shift_schedule<R: RngCore + CryptoRng>(&mut self, delta: u32, rng: &mut R) {
-        let interval = self.anchor_bucket_interval;
-        for tx in &mut self.transactions {
-            match tx.state {
-                MigrationTxState::Broadcast { .. } | MigrationTxState::Mined { .. } => continue,
-                MigrationTxState::AwaitingSignature | MigrationTxState::Signed => {
-                    tx.scheduled_height = tx.scheduled_height + delta;
-                    if matches!(tx.kind, MigrationTxKind::Transfer { .. })
-                        && let Some(prior) = tx.anchor_boundary
-                        && let Some(fresh) = crate::scheduling::redraw_anchor_boundary(
-                            interval,
-                            prior,
-                            tx.scheduled_height,
-                            rng,
-                        )
-                    {
-                        tx.anchor_boundary = Some(fresh);
-                    }
-                }
-                MigrationTxState::Proved => {
-                    tx.scheduled_height = tx.scheduled_height + delta;
-                }
-            }
-        }
-    }
-
     /// Defers the scheduled height of every not-yet-broadcast transaction EXCEPT `released` by
     /// `delta` blocks — preserving the schedule's inter-broadcast gaps — while `released` itself
     /// lands exactly at `release_at`.
@@ -1295,7 +1233,7 @@ impl MigrationState {
     /// `Prove` and then `Broadcast` for it as soon as it wakes — or `Rebuild`, once the transfer
     /// has expired. The drive layer adds the RE-SPREAD on top:
     /// [`advance_migration`](crate::satisfiability::advance_migration) shifts the whole pending
-    /// schedule forward ([`Self::shift_schedule`]) before serving a step overdue by more than
+    /// schedule forward ([`Self::shift_schedule_releasing`]) before serving a step overdue by more than
     /// [`overdue_shift_tolerance`](crate::satisfiability::overdue_shift_tolerance) allows, so this
     /// kernel judges the shifted schedule and at most one overdue step is ever released at once.
     pub(crate) fn next_step(
@@ -2124,7 +2062,8 @@ mod tests {
         );
     }
 
-    /// `shift_schedule` moves every PENDING schedule forward by the same delta — preserving the
+    /// A uniform `shift_schedule_releasing` (released landing = its own schedule + delta) moves
+    /// every PENDING schedule forward by the same delta — preserving the
     /// inter-broadcast gaps — and leaves served schedules (in-flight and mined rows) and every
     /// expiry height untouched. A deferred transfer whose proof is still to come has its anchor
     /// boundary REDRAWN in-distribution against its shifted schedule; a proved transfer's proof
@@ -2164,7 +2103,13 @@ mod tests {
             s.transactions[i].anchor_boundary = Some(BlockHeight::from_u32(144));
         }
 
-        s.shift_schedule(100_000, &mut ChaCha8Rng::seed_from_u64(7));
+        let landing = s.transactions[1].scheduled_height + 100_000;
+        s.shift_schedule_releasing(
+            MigrationTransferId(1),
+            landing,
+            100_000,
+            &mut ChaCha8Rng::seed_from_u64(7),
+        );
 
         let scheduled: Vec<u32> = s
             .transactions

--- a/zcash_pool_migration/src/state.rs
+++ b/zcash_pool_migration/src/state.rs
@@ -727,12 +727,16 @@ impl MigrationState {
     /// [`advance_migration`](crate::satisfiability::advance_migration) when the step it would
     /// surface lags the served target by more than the schedule-scaled tolerance
     /// ([`overdue_shift_tolerance`](crate::satisfiability::overdue_shift_tolerance)) with more
-    /// of the schedule due behind it. The
-    /// deferred rows move by one shared delta, so the gaps between broadcasts — the observable
-    /// the drawn exponential delays exist to shape — survive the wallet's absence unchanged. The
-    /// RELEASED row is the one being served: it lands where the caller says the wallet can
-    /// actually EXECUTE it. The caller upholds `release_at >= scheduled_height(released)`, so a
-    /// release only ever moves forward or stays.
+    /// of the schedule due behind it. There, `delta` is the overdue amount — extended to the
+    /// caller's spacing floor when one is set (see
+    /// [`AdvanceConfig`](crate::satisfiability::AdvanceConfig)); the default floor of zero
+    /// defers by exactly the overdue amount, as ZIP 318 documents. This function itself takes
+    /// `delta` as given, agnostic to how its caller arrived at it. The deferred rows move by one
+    /// shared delta, so the gaps between broadcasts — the observable the drawn exponential
+    /// delays exist to shape — survive the wallet's absence unchanged. The RELEASED row is the
+    /// one being served: it lands where the caller says the wallet can actually EXECUTE it. The
+    /// caller upholds `release_at >= scheduled_height(released)`, so a release only ever moves
+    /// forward or stays.
     ///
     /// Only PENDING transactions move ([`AwaitingSignature`](MigrationTxState::AwaitingSignature),
     /// [`Signed`](MigrationTxState::Signed), [`Proved`](MigrationTxState::Proved)): an in-flight

--- a/zcash_pool_migration/src/state.rs
+++ b/zcash_pool_migration/src/state.rs
@@ -726,7 +726,8 @@ impl MigrationState {
     /// released immediately; the rest are re-spread — applied by
     /// [`advance_migration`](crate::satisfiability::advance_migration) when the step it would
     /// surface lags the served target by more than the schedule-scaled tolerance
-    /// ([`overdue_shift_tolerance`](crate::satisfiability::overdue_shift_tolerance)). The
+    /// ([`overdue_shift_tolerance`](crate::satisfiability::overdue_shift_tolerance)) with more
+    /// of the schedule due behind it. The
     /// deferred rows move by one shared delta, so the gaps between broadcasts — the observable
     /// the drawn exponential delays exist to shape — survive the wallet's absence unchanged. The
     /// RELEASED row is the one being served: it lands where the caller says the wallet can
@@ -1232,10 +1233,11 @@ impl MigrationState {
     /// slept through a transfer's proving wake-ups and its broadcast height is simply offered
     /// `Prove` and then `Broadcast` for it as soon as it wakes — or `Rebuild`, once the transfer
     /// has expired. The drive layer adds the RE-SPREAD on top:
-    /// [`advance_migration`](crate::satisfiability::advance_migration) shifts the whole pending
-    /// schedule forward ([`Self::shift_schedule_releasing`]) before serving a step overdue by more than
-    /// [`overdue_shift_tolerance`](crate::satisfiability::overdue_shift_tolerance) allows, so this
-    /// kernel judges the shifted schedule and at most one overdue step is ever released at once.
+    /// [`advance_migration`](crate::satisfiability::advance_migration) defers the rest of the
+    /// pending schedule ([`Self::shift_schedule_releasing`]) and lands the served step where the
+    /// wallet can execute it when a step with more of the schedule due behind it lags beyond
+    /// [`overdue_shift_tolerance`](crate::satisfiability::overdue_shift_tolerance), so this kernel
+    /// judges the shifted schedule and at most one overdue step is ever released at once.
     pub(crate) fn next_step(
         &self,
         targets: DuenessTargets,
@@ -2069,7 +2071,7 @@ mod tests {
     /// boundary REDRAWN in-distribution against its shifted schedule; a proved transfer's proof
     /// pins its anchor, and a preparation carries none.
     #[test]
-    fn shift_schedule_moves_only_pending_schedules() {
+    fn shift_schedule_releasing_moves_only_pending_schedules() {
         let mut s = state_with(vec![
             tx(0, prep(0, 0), MigrationTxState::AwaitingSignature),
             tx(1, prep(0, 1), MigrationTxState::Signed),
@@ -2162,8 +2164,7 @@ mod tests {
     /// `shift_schedule_releasing` defers every PENDING schedule by the delta EXCEPT the released
     /// row, which lands exactly at `release_at` — the executable landing `advance_migration`
     /// computes — with served (Broadcast/Mined) schedules untouched either way. A Proved release
-    /// keeps the boundary its proof pinned, and a released row whose landing equals its current
-    /// schedule moves nothing.
+    /// keeps the boundary its proof pinned.
     #[test]
     fn shift_schedule_releasing_exempts_the_released_row() {
         let mut s = state_with(vec![
@@ -2223,6 +2224,40 @@ mod tests {
         assert!(
             (720..1_008).contains(&boundary),
             "boundary {boundary} is in [prior, most_recent)"
+        );
+    }
+
+    /// A released SIGNED transfer whose landing equals its current schedule moves nothing and
+    /// KEEPS its boundary undrawn-anew: the boundary was drawn for exactly the height being
+    /// served, and a redraw against that same height could only move it — reintroducing, for an
+    /// in-place release, the boundary climb the release exemption exists to prevent.
+    #[test]
+    fn shift_schedule_releasing_keeps_an_unmoved_release_untouched() {
+        let mut s = state_with(vec![
+            tx(0, prep(0, 0), mined(10)),
+            scheduled_transfer(1, 0, 720, 1_500, MigrationTxState::Signed),
+            scheduled_transfer(2, 1, 720, 1_566, MigrationTxState::Signed),
+        ]);
+        s.shift_schedule_releasing(
+            MigrationTransferId(1),
+            BlockHeight::from_u32(1_500),
+            401,
+            &mut ChaCha8Rng::seed_from_u64(7),
+        );
+        assert_eq!(
+            u32::from(s.transactions[1].scheduled_height),
+            1_500,
+            "released in place"
+        );
+        assert_eq!(
+            s.transactions[1].anchor_boundary,
+            Some(BlockHeight::from_u32(720)),
+            "an unmoved release keeps the boundary drawn for its height"
+        );
+        assert_eq!(
+            u32::from(s.transactions[2].scheduled_height),
+            1_967,
+            "the rest still defers"
         );
     }
 

--- a/zcash_pool_migration/src/state.rs
+++ b/zcash_pool_migration/src/state.rs
@@ -780,6 +780,87 @@ impl MigrationState {
         }
     }
 
+    /// Defers the scheduled height of every not-yet-broadcast transaction EXCEPT `released` by
+    /// `delta` blocks — preserving the schedule's inter-broadcast gaps — while `released` itself
+    /// lands exactly at `release_at`.
+    ///
+    /// This is the whole missed-schedule policy of ZIP 318 — at most one overdue transfer is
+    /// released immediately; the rest are re-spread — applied by
+    /// [`advance_migration`](crate::satisfiability::advance_migration) when the step it would
+    /// surface lags the served target by more than the schedule-scaled tolerance
+    /// ([`overdue_shift_tolerance`](crate::satisfiability::overdue_shift_tolerance)). The
+    /// deferred rows move by one shared delta, so the gaps between broadcasts — the observable
+    /// the drawn exponential delays exist to shape — survive the wallet's absence unchanged. The
+    /// RELEASED row is the one being served: it lands where the caller says the wallet can
+    /// actually EXECUTE it. The caller upholds `release_at >= scheduled_height(released)`, so a
+    /// release only ever moves forward or stays.
+    ///
+    /// Only PENDING transactions move ([`AwaitingSignature`](MigrationTxState::AwaitingSignature),
+    /// [`Signed`](MigrationTxState::Signed), [`Proved`](MigrationTxState::Proved)): an in-flight
+    /// or mined transaction's schedule has already been served, and moving it would only distort
+    /// the record of when it was due. Expiry heights are untouched — a pre-signed transaction's
+    /// expiry is effecting data under ZIP 203, fixed at signing — so a large enough shift can
+    /// move a pending schedule past its own expiry; such a transaction self-heals through the
+    /// ordinary expiry path (its rebuild redraws both schedule and expiry). Heights saturate
+    /// rather than overflow.
+    ///
+    /// A moved TRANSFER whose proof is still to come
+    /// ([`AwaitingSignature`](MigrationTxState::AwaitingSignature) or
+    /// [`Signed`](MigrationTxState::Signed)) — deferred or released — also gets its anchor
+    /// boundary REDRAWN against its new schedule
+    /// ([`redraw_anchor_boundary`](crate::scheduling::redraw_anchor_boundary)): the stored
+    /// boundary was drawn to be in-distribution relative to the ORIGINAL broadcast height, so
+    /// keeping it would broadcast an anchor older than any honest draw — and every deferred
+    /// transfer of this wallet older by the SAME delta, a linkable fingerprint. For the released
+    /// row the redraw runs against its landing, which under an executable landing leaves the
+    /// fresh boundary below the landing itself: the release stays provable where it is served. A
+    /// [`Proved`](MigrationTxState::Proved) transfer's proof DOES pin its anchor, so its boundary
+    /// is kept (re-anchoring it would mean discarding the proof), and a preparation carries no
+    /// drawn boundary at all. A released row that does not move keeps its boundary too — it was
+    /// drawn for exactly the height being served. In the rare case where no candidate exists at
+    /// or above the prior boundary (see
+    /// [`redraw_anchor_boundary`](crate::scheduling::redraw_anchor_boundary)), the prior —
+    /// still provable — boundary is kept.
+    pub(crate) fn shift_schedule_releasing<R: RngCore + CryptoRng>(
+        &mut self,
+        released: MigrationTransferId,
+        release_at: BlockHeight,
+        delta: u32,
+        rng: &mut R,
+    ) {
+        let interval = self.anchor_bucket_interval;
+        for tx in &mut self.transactions {
+            let new_height = if tx.id == released {
+                release_at
+            } else {
+                tx.scheduled_height + delta
+            };
+            match tx.state {
+                MigrationTxState::Broadcast { .. } | MigrationTxState::Mined { .. } => continue,
+                MigrationTxState::AwaitingSignature | MigrationTxState::Signed => {
+                    if new_height == tx.scheduled_height {
+                        continue;
+                    }
+                    tx.scheduled_height = new_height;
+                    if matches!(tx.kind, MigrationTxKind::Transfer { .. })
+                        && let Some(prior) = tx.anchor_boundary
+                        && let Some(fresh) = crate::scheduling::redraw_anchor_boundary(
+                            interval,
+                            prior,
+                            tx.scheduled_height,
+                            rng,
+                        )
+                    {
+                        tx.anchor_boundary = Some(fresh);
+                    }
+                }
+                MigrationTxState::Proved => {
+                    tx.scheduled_height = new_height;
+                }
+            }
+        }
+    }
+
     /// Records that the transaction `id` was mined under `txid` at `height`, then recomputes the
     /// overall status. This is what lets a later preparation layer or the transfers become
     /// actionable. Recording the txid on `Mined` (rather than dropping it once broadcast is
@@ -2131,6 +2212,73 @@ mod tests {
         // The preparations never carry a boundary, before or after.
         assert_eq!(s.transactions[0].anchor_boundary, None);
         assert_eq!(s.transactions[1].anchor_boundary, None);
+    }
+
+    /// `shift_schedule_releasing` defers every PENDING schedule by the delta EXCEPT the released
+    /// row, which lands exactly at `release_at` — the executable landing `advance_migration`
+    /// computes — with served (Broadcast/Mined) schedules untouched either way. A Proved release
+    /// keeps the boundary its proof pinned, and a released row whose landing equals its current
+    /// schedule moves nothing.
+    #[test]
+    fn shift_schedule_releasing_exempts_the_released_row() {
+        let mut s = state_with(vec![
+            tx(0, prep(0, 0), mined(10)),
+            scheduled_transfer(1, 0, 720, 1_000, MigrationTxState::Proved),
+            scheduled_transfer(2, 1, 720, 1_066, MigrationTxState::Signed),
+        ]);
+        s.shift_schedule_releasing(
+            MigrationTransferId(1),
+            BlockHeight::from_u32(1_051),
+            1_001,
+            &mut ChaCha8Rng::seed_from_u64(7),
+        );
+        let heights: Vec<u32> = s
+            .transactions
+            .iter()
+            .map(|t| u32::from(t.scheduled_height))
+            .collect();
+        assert_eq!(
+            heights,
+            vec![0, 1_051, 2_067],
+            "released lands at release_at; the rest defer by delta; served rows hold"
+        );
+        assert_eq!(
+            s.transactions[1].anchor_boundary,
+            Some(BlockHeight::from_u32(720)),
+            "a Proved release keeps the boundary its proof pinned"
+        );
+    }
+
+    /// A released SIGNED transfer that moves gets its anchor boundary redrawn against its
+    /// LANDING — under an executable (scanned-frame) landing the fresh boundary sits below the
+    /// landing itself, so the release is immediately provable; redrawn against the deferred
+    /// rest's future heights it would not be.
+    #[test]
+    fn shift_schedule_releasing_redraws_the_released_boundary_at_its_landing() {
+        let mut s = state_with(vec![
+            tx(0, prep(0, 0), mined(10)),
+            scheduled_transfer(1, 0, 720, 1_000, MigrationTxState::Signed),
+        ]);
+        s.shift_schedule_releasing(
+            MigrationTransferId(1),
+            BlockHeight::from_u32(1_051),
+            2_000,
+            &mut ChaCha8Rng::seed_from_u64(7),
+        );
+        assert_eq!(u32::from(s.transactions[1].scheduled_height), 1_051);
+        let boundary = u32::from(
+            s.transactions[1]
+                .anchor_boundary
+                .expect("a transfer keeps carrying a boundary"),
+        );
+        // In-distribution against the landing (ZIP 318 grid 144): on-grid, floored at the prior
+        // boundary, strictly below the most recent grid boundary at 1_051 (= 1_008) — and
+        // therefore below the landing itself.
+        assert_eq!(boundary % 144, 0, "the redrawn boundary is on the grid");
+        assert!(
+            (720..1_008).contains(&boundary),
+            "boundary {boundary} is in [prior, most_recent)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #2927 — a single commit on top of `michal/pool-migration-release-executable-respread`; the diff shown here is only that commit.

## Summary

ZIP 318's missed-schedule policy sizes everything from the committed schedule's own scale: the overdue-shift tolerance is a quarter of the mean inter-broadcast gap, and the re-spread defers every pending row by one shared delta, preserving the drawn gaps. On a mainnet-paced schedule those numbers comfortably clear a wallet's wall-clock privacy buffer — the stretch after a broadcast during which it would rather not be forced to sync. Compress the whole schedule, as a shortened test-network anchor bucket interval does (`SchedulingParams::new_with_default_distributions`), and both shrink in proportion while the buffer stays wall-clock-fixed:

- the tolerance clamps toward its 1-block floor, so the re-spread re-arms on every drive; and
- the preserved gaps land at or below the buffer, so after each released broadcast the next transfer is due before the consumer's sync gate may reopen — sync starves for the length of the proved backlog, and nothing ever confirms while it drains.

This adds two **opt-in** floors to `AdvanceConfig` — `with_compressed_schedule_floors(overdue_tolerance_floor, release_spacing_floor)`, joining `reorg_settle_depth` as drive-level policy without touching `new()`:

- `overdue_tolerance_floor` is a lower bound under `overdue_shift_tolerance`'s output at the re-spread trigger, so a buffer-length delay stops reading as "slept through".
- `release_spacing_floor` is a lower bound on the gap the deferral leaves between the released step and the earliest deferred row, measured in the **served-target frame** — the frame dueness is judged in — so it buys a real wall-clock window to sync after the release (`gap_now` is the original drawn gap, `earliest ⊖ scheduled`; the floor tops the shared delta up by `floor ⊖ gap_now`). The guarantee is scoped to rows scheduled at or after the released candidate; a row scheduled earlier (reachable only for rows still awaiting signature or proof, or excluded from candidacy this call) receives the identical widened delta from its own height and cannot come due for broadcast without first passing through proving — the very window the floor protects.

## Observed

Testnet wallet (39 s blocks, 150 s app-side buffer ≈ 4 blocks, drawn gaps ~1–4 blocks), driven by short foreground sessions on the #2927 branch head: every open released exactly one broadcast (the #2927 contract working as designed) and no session ever synced — the next proved transfer was always due before the post-broadcast buffer expired, the tail's ETAs held constant across opens while wall clock advanced (the re-armed trigger translating the schedule), and confirmations arrived only once the proved backlog was fully spent. With the floors (tolerance 7, spacing 12 blocks for that configuration), the tail parks ~8 minutes past the served target after each release and the drain interleaves with sync.

## Mainnet is byte-identical, structurally

Both floors default to zero, and at zero every path through the arithmetic is the floor-free form — `0.saturating_sub(_)` is zero whatever the surrounding heights, deliberately not the equivalent-looking `lag.max(floor + served − earliest)`, which can exceed `lag` at floor zero in odd orderings. The existing test suite runs unmodified as the proof, plus dedicated tests: a zero-floor drive over a nontrivial deferred set reproduces the exact ZIP 318 lag arithmetic; a binding floor lands the earliest deferred row exactly `floor` above the served target with pairwise gaps preserved; a satisfied floor contributes nothing; and the scoped-guarantee boundary (an earlier-scheduled sibling) is pinned in both the floored and zero-floor forms. Converting a wall-clock buffer into blocks — and any slack or doubling for the round-trip sync window — is the caller's judgment; the crate stays a pure mechanism.

The consumer side (Swift SDK) passes `(0, 0)` unconditionally on mainnet and derives testnet floors from its measured seconds-per-block; that wiring rides the branch of zcash/zcash-swift-wallet-sdk#1946.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
