### PR TITLE
zcash_pool_migration: what a large balance and a messy wallet actually plan

### DIFF
--- a/zcash_pool_migration/src/testing/mod.rs
+++ b/zcash_pool_migration/src/testing/mod.rs
@@ -23,7 +23,9 @@
 mod conformance;
 mod scenarios;
 mod strategies;
+mod wallets;
 
 pub use conformance::*;
 pub use scenarios::*;
 pub use strategies::*;
+pub use wallets::*;

--- a/zcash_pool_migration/src/testing/scenarios.rs
+++ b/zcash_pool_migration/src/testing/scenarios.rs
@@ -385,3 +385,184 @@ pub const MULTI_RUN_EVOLUTION: &[MultiRunEvolutionCase] = {
         m(5_000_000, 11, 517, 2399, 32), // ten full runs of 3, then a tail of 2
     ]
 };
+
+// --- what a large balance actually plans, as a function of its NOTE SHAPE ---
+//
+// The two tables above vary the balance and hold the note shape fixed (one note). This one does the
+// opposite: it fixes a single large balance and varies how the wallet holds it. That is the
+// dimension a user actually notices, because the crossing count is set by the balance's
+// {1,2,5}x10^k decomposition (essentially constant here) while the PREPARATION count is set by how
+// many notes must be consolidated, so the plan grows with the note count even though the amount
+// migrated does not.
+//
+// The balance is the one from a user report of an unexpectedly large plan. Plan-only (nothing is
+// built or proved): funding a wallet with thousands of ZEC is out of reach for the regtest
+// proving simulation, which is why these do not live in `MIGRATION_SCENARIOS`.
+
+/// One thousandth of a ZEC, the unit the reported balance is quoted in.
+const MILLI: u64 = COIN / 1_000;
+
+/// The balance from the user report: 5887.842 ZEC, in zatoshi.
+pub const REPORTED_LARGE_BALANCE: u64 = 5_887_842 * MILLI;
+
+/// One row of the large-balance table: a note shape holding [`REPORTED_LARGE_BALANCE`], and the plan
+/// it produces. The whole-migration figures (`expected_runs` and the `expected_total_*` fields) come
+/// from the estimate; the rest describe the FIRST run, which is the one `plan_migration` returns.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LargeBalanceCase {
+    /// A short description of the note shape.
+    pub label: &'static str,
+    /// The wallet's source Orchard note values, in zatoshi. These sum to
+    /// [`REPORTED_LARGE_BALANCE`].
+    pub source_notes: &'static [u64],
+    /// The expected number of migration runs the whole balance takes.
+    pub expected_runs: usize,
+    /// The expected number of crossings (quanta) across all runs.
+    pub expected_total_crossings: usize,
+    /// The expected total Orchard actions to sign across all runs.
+    pub expected_total_actions: u32,
+    /// The expected total Keystone signing rounds, summed per run.
+    pub expected_total_keystone_rounds: usize,
+    /// The expected number of preparation transactions in the first run.
+    pub expected_preparations: usize,
+    /// The expected number of crossings in the first run.
+    pub expected_transfers: usize,
+    /// The expected number of transactions in the first run: preparations plus crossings. This is
+    /// the "how many transactions is this migration" figure a wallet shows.
+    pub expected_transactions: usize,
+    /// The expected Orchard actions in the first run
+    /// (`preparations * 16 + transfers * 3`).
+    pub expected_actions: u32,
+    /// The expected number of Keystone ([`SigningRoundBudget::KEYSTONE`], 96 actions) signing rounds
+    /// for the first run.
+    pub expected_keystone_rounds: usize,
+    /// The expected value the first run migrates, in zatoshi.
+    pub expected_migrated: u64,
+    /// The expected value the first run leaves behind, in zatoshi. A large residual is what forces a
+    /// second run.
+    pub expected_residual: u64,
+}
+
+/// How the plan for [`REPORTED_LARGE_BALANCE`] (5887.842 ZEC) varies with the note shape holding it.
+/// Plan-only (never built or proved). Captured from the canonical planner on the regtest network.
+pub const LARGE_BALANCE_CASES: &[LargeBalanceCase] = {
+    #[allow(clippy::too_many_arguments)]
+    const fn c(
+        label: &'static str,
+        source_notes: &'static [u64],
+        expected_runs: usize,
+        expected_total_crossings: usize,
+        expected_total_actions: u32,
+        expected_total_keystone_rounds: usize,
+        expected_preparations: usize,
+        expected_transfers: usize,
+        expected_keystone_rounds: usize,
+        expected_migrated: u64,
+        expected_residual: u64,
+    ) -> LargeBalanceCase {
+        LargeBalanceCase {
+            label,
+            source_notes,
+            expected_runs,
+            expected_total_crossings,
+            expected_total_actions,
+            expected_total_keystone_rounds,
+            expected_preparations,
+            expected_transfers,
+            expected_transactions: expected_preparations + expected_transfers,
+            expected_actions: (expected_preparations as u32) * PREPARATION_ACTIONS
+                + (expected_transfers as u32) * TRANSFER_ACTIONS,
+            expected_keystone_rounds,
+            expected_migrated,
+            expected_residual,
+        }
+    }
+    // The balance divides exactly by each of these, so every note carries the same value.
+    const ONE_NOTE: &[u64] = &[REPORTED_LARGE_BALANCE];
+    const TWO_NOTES: &[u64] = &[REPORTED_LARGE_BALANCE / 2; 2];
+    const FIVE_NOTES: &[u64] = &[REPORTED_LARGE_BALANCE / 5; 5];
+    const TEN_NOTES: &[u64] = &[REPORTED_LARGE_BALANCE / 10; 10];
+    const HUNDRED_NOTES: &[u64] = &[REPORTED_LARGE_BALANCE / 100; 100];
+    // One hundredth of a ZEC: the minimum denomination, and the unit the migrated totals fall on.
+    const H: u64 = COIN / 100;
+    &[
+        // The balance decomposes into fourteen {1,2,5}x10^k crossings
+        // (5000 + 500 + 200 + 100 + 50 + 20 + 10 + 5 + 2 + 0.5 + 0.2 + 0.1 + 0.02 + 0.01), and a
+        // single source note funds them all from one preparation transaction: 15 transactions, 58
+        // actions, ONE Keystone round.
+        c(
+            "5887.842 ZEC in a single note",
+            ONE_NOTE,
+            1,
+            14,
+            58,
+            1,
+            1,
+            14,
+            1,
+            588_783 * H,
+            910_000,
+        ),
+        // THE DEGENERATE SHAPE. Neither note reaches the leading 5000 ZEC denomination, so funding
+        // that one crossing consumes BOTH notes across two preparation layers, and the run ends
+        // having migrated only the 5000. The remaining ~887.84 ZEC is left as residual for a whole
+        // SECOND run, which is why the same balance costs 90 actions here against 58 above.
+        c(
+            "5887.842 ZEC in two equal notes",
+            TWO_NOTES,
+            2,
+            14,
+            90,
+            2,
+            2,
+            1,
+            1,
+            500_000 * H,
+            88_784_025_000,
+        ),
+        // From three notes upward the leading crossing is fundable within one run again, so the full
+        // fourteen crossings return; only the preparation count (and with it the Keystone rounds)
+        // grows with the note count.
+        c(
+            "5887.842 ZEC in five equal notes",
+            FIVE_NOTES,
+            1,
+            14,
+            106,
+            2,
+            4,
+            14,
+            2,
+            588_783 * H,
+            670_000,
+        ),
+        c(
+            "5887.842 ZEC in ten equal notes",
+            TEN_NOTES,
+            1,
+            14,
+            122,
+            2,
+            5,
+            14,
+            2,
+            588_783 * H,
+            590_000,
+        ),
+        // A hundred notes cost thirteen preparation transactions, so preparation now dominates:
+        // 247 actions, of which only 39 are the crossings themselves.
+        c(
+            "5887.842 ZEC in one hundred equal notes",
+            HUNDRED_NOTES,
+            1,
+            13,
+            247,
+            3,
+            13,
+            13,
+            3,
+            588_782 * H,
+            965_000,
+        ),
+    ]
+};

--- a/zcash_pool_migration/src/testing/wallets.rs
+++ b/zcash_pool_migration/src/testing/wallets.rs
@@ -1,0 +1,213 @@
+//! Generators for MESSY source-note sets: the wallet shapes that stress note preparation.
+//!
+//! The scenarios in [`scenarios`](super::scenarios) are hand-written note shapes with hand-checked
+//! outcomes, which is the right tool for pinning a specific plan. They are the wrong tool for asking
+//! how the preparation planner BEHAVES on the wallets that actually hurt it: hundreds or thousands
+//! of notes, most of them below the minimum denomination, accumulated over years of change outputs
+//! and mining payouts. Those cannot be written out by hand, and their exact plans are not
+//! interesting individually; what matters is how the cost SCALES.
+//!
+//! So this module generates them. A [`WalletShape`] names a value distribution,
+//! [`generate_notes`] draws `note_count` notes from it, and the caller plans a migration over the
+//! result. Generation is deterministic in the RNG, so a seed reproduces a case exactly.
+//!
+//! The distributions are anchored on the protocol's own denomination bounds rather than invented
+//! magnitudes: [`MIN_DENOMINATION`] is the smallest value a crossing may carry, and a note below it
+//! is SUB-QUANTUM (too small to fund a crossing on its own, so it can only reach the migration by
+//! being consolidated with others). Sub-quantum notes are what force consolidation layers, and
+//! consolidation is what makes a large-note-count plan expensive.
+
+use alloc::vec::Vec;
+
+use rand_core::RngCore;
+
+use zcash_protocol::value::COIN;
+
+/// The minimum denomination, in zatoshi: a note worth less than this is SUB-QUANTUM and cannot fund
+/// a crossing on its own.
+///
+/// This is [`MAX_RESIDUAL_VALUE`](zcash_protocol::zip318::MAX_RESIDUAL_VALUE) as a plain `u64`,
+/// spelled out because `Zatoshis::into_u64` is not `const`; `min_denomination_matches_the_protocol`
+/// pins the two together.
+pub const MIN_DENOMINATION: u64 = COIN / 100;
+
+/// The largest note any generated wallet holds, in zatoshi: the largest value a single crossing may
+/// carry, so no generated note is unrepresentable as one denomination.
+///
+/// This is [`DENOM_CAP`](zcash_protocol::zip318::DENOM_CAP) as a plain `u64`, for the same reason as
+/// [`MIN_DENOMINATION`].
+pub const MAX_GENERATED_NOTE: u64 = 10_000 * COIN;
+
+/// The value distribution a generated wallet's notes follow. Each is a shape a real wallet reaches,
+/// chosen for what it does to PREPARATION rather than for realism alone.
+///
+/// Every shape draws ARBITRARY zatoshi amounts. A real wallet's notes are change outputs, payments
+/// received, and mining payouts; none of those land on a denomination boundary, so a generator that
+/// emitted multiples of the minimum denomination would be testing a wallet that does not exist, and
+/// would hide exactly the remainder-handling the planner has to do.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WalletShape {
+    /// Log-uniform over `[1, 3] * MIN_DENOMINATION`: many notes, each just large enough to fund a
+    /// crossing on its own but none a round multiple of one. Isolates the cost of the note COUNT
+    /// from the cost of consolidating sub-quantum value.
+    NearMinimum,
+    /// Log-uniform from a tenth of the minimum denomination up to 1000 ZEC: equal weight per decade,
+    /// the heavy-tailed shape a long-lived wallet accumulates. A minority of notes are sub-quantum.
+    LogUniform,
+    /// Four notes in five are sub-quantum, the rest ordinary. The consolidation-dominated regime:
+    /// most of the note count carries almost none of the value.
+    SubQuantumHeavy,
+    /// A few whales carrying nearly all of the value, over a long sub-quantum tail. The shape a
+    /// wallet reaches after one large receive and years of small change.
+    WhaleOverDust,
+}
+
+impl WalletShape {
+    /// Every shape, for a caller sweeping all of them.
+    pub const ALL: &'static [WalletShape] = &[
+        WalletShape::NearMinimum,
+        WalletShape::LogUniform,
+        WalletShape::SubQuantumHeavy,
+        WalletShape::WhaleOverDust,
+    ];
+
+    /// A short label for assertion and report messages.
+    pub const fn label(self) -> &'static str {
+        match self {
+            WalletShape::NearMinimum => "near-minimum",
+            WalletShape::LogUniform => "log-uniform",
+            WalletShape::SubQuantumHeavy => "sub-quantum-heavy",
+            WalletShape::WhaleOverDust => "whale-over-dust",
+        }
+    }
+}
+
+/// Draw a value log-uniformly from `[min, max]` (equal probability per decade, so the small
+/// magnitudes are not swamped by the large ones the way a uniform draw would swamp them).
+fn log_uniform<R>(rng: &mut R, min: u64, max: u64) -> u64
+where
+    R: RngCore,
+{
+    debug_assert!(0 < min && min <= max);
+    // Work in the log domain over a fixed-point fraction of the span, so no float RNG is needed.
+    let ln_min = libm::log(min as f64);
+    let ln_max = libm::log(max as f64);
+    // 53 bits keeps the fraction exact in an f64.
+    const FRACTION_BITS: u32 = 53;
+    let fraction =
+        (rng.next_u64() >> (u64::BITS - FRACTION_BITS)) as f64 / (1u64 << FRACTION_BITS) as f64;
+    let value = libm::exp(ln_min + (ln_max - ln_min) * fraction) as u64;
+    value.clamp(min, max)
+}
+
+/// Generate `note_count` source-note values (in zatoshi) drawn from `shape`.
+///
+/// The balance is whatever the draws sum to; that is deliberate, because a real wallet's balance is
+/// a consequence of its note history rather than a target. Every note is at least
+/// `MIN_DENOMINATION / 100`, so nothing generated is below the fee floor by construction, and no
+/// note exceeds [`MAX_GENERATED_NOTE`].
+pub fn generate_notes<R>(shape: WalletShape, note_count: usize, rng: &mut R) -> Vec<u64>
+where
+    R: RngCore,
+{
+    // The floor on any generated note: well below the minimum denomination (so sub-quantum notes are
+    // genuinely sub-quantum) but comfortably above a transaction fee, so no note is unspendable
+    // dust that the planner would simply abandon.
+    const NOTE_FLOOR: u64 = MIN_DENOMINATION / 100;
+    // The ceiling on an "ordinary" (non-whale) note.
+    const ORDINARY_CEILING: u64 = 1_000 * COIN;
+    // The floor on a whale note.
+    const WHALE_FLOOR: u64 = 100 * COIN;
+    // In the whale shape, one note in this many is a whale.
+    const WHALE_PERIOD: usize = 200;
+    // In the sub-quantum-heavy shape, this many notes in five are sub-quantum.
+    const SUB_QUANTUM_IN_FIVE: usize = 4;
+    // The ceiling on a `NearMinimum` note: a small multiple of the minimum denomination, so the
+    // notes cluster just above the quantum without ever landing on it.
+    const NEAR_MINIMUM_CEILING: u64 = 3 * MIN_DENOMINATION;
+
+    (0..note_count)
+        .map(|i| match shape {
+            WalletShape::NearMinimum => log_uniform(rng, MIN_DENOMINATION, NEAR_MINIMUM_CEILING),
+            WalletShape::LogUniform => log_uniform(rng, MIN_DENOMINATION / 10, ORDINARY_CEILING),
+            WalletShape::SubQuantumHeavy => {
+                if i % 5 < SUB_QUANTUM_IN_FIVE {
+                    log_uniform(rng, NOTE_FLOOR, MIN_DENOMINATION - 1)
+                } else {
+                    log_uniform(rng, MIN_DENOMINATION, ORDINARY_CEILING)
+                }
+            }
+            WalletShape::WhaleOverDust => {
+                if i % WHALE_PERIOD == 0 {
+                    log_uniform(rng, WHALE_FLOOR, MAX_GENERATED_NOTE)
+                } else {
+                    log_uniform(rng, NOTE_FLOOR, MIN_DENOMINATION - 1)
+                }
+            }
+        })
+        .collect()
+}
+
+/// How many of `notes` are SUB-QUANTUM (below [`MIN_DENOMINATION`], so unable to fund a crossing on
+/// their own and reachable only through consolidation).
+pub fn sub_quantum_count(notes: &[u64]) -> usize {
+    notes.iter().filter(|&&v| v < MIN_DENOMINATION).count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use rand_chacha::ChaCha8Rng;
+    use rand_core::SeedableRng;
+    use zcash_protocol::zip318::{DENOM_CAP, MAX_RESIDUAL_VALUE};
+
+    /// The spelled-out bounds track the protocol constants they stand in for.
+    #[test]
+    fn min_denomination_matches_the_protocol() {
+        assert_eq!(MIN_DENOMINATION, MAX_RESIDUAL_VALUE.into_u64());
+        assert_eq!(MAX_GENERATED_NOTE, DENOM_CAP.into_u64());
+    }
+
+    /// Every shape generates the requested count, within the documented bounds, and reproduces
+    /// exactly from a seed.
+    #[test]
+    fn generation_is_bounded_and_reproducible() {
+        for &shape in WalletShape::ALL {
+            let notes = generate_notes(shape, 500, &mut ChaCha8Rng::seed_from_u64(11));
+            assert_eq!(notes.len(), 500, "{}", shape.label());
+            assert!(
+                notes.iter().all(|&v| v > 0 && v <= MAX_GENERATED_NOTE),
+                "{}: a note left the generated range",
+                shape.label()
+            );
+            let again = generate_notes(shape, 500, &mut ChaCha8Rng::seed_from_u64(11));
+            assert_eq!(
+                notes,
+                again,
+                "{}: generation is seed-reproducible",
+                shape.label()
+            );
+        }
+    }
+
+    /// Each shape actually produces the sub-quantum mix its documentation claims, so a sweep over
+    /// the shapes really does span the consolidation regimes.
+    #[test]
+    fn shapes_have_the_documented_sub_quantum_mix() {
+        let n = 1_000;
+        let mix = |shape| {
+            let notes = generate_notes(shape, n, &mut ChaCha8Rng::seed_from_u64(23));
+            sub_quantum_count(&notes)
+        };
+        assert_eq!(mix(WalletShape::NearMinimum), 0);
+        // Log-uniform over [min/10, 1000 ZEC] spans 6 decades, one of them sub-quantum.
+        let log_uniform = mix(WalletShape::LogUniform);
+        assert!(
+            (1..n / 2).contains(&log_uniform),
+            "log-uniform should be a sub-quantum minority, got {log_uniform}"
+        );
+        assert_eq!(mix(WalletShape::SubQuantumHeavy), n / 5 * 4);
+        assert_eq!(mix(WalletShape::WhaleOverDust), n - n / 200);
+    }
+}

--- a/zcash_pool_migration/tests/preparation_scaling.rs
+++ b/zcash_pool_migration/tests/preparation_scaling.rs
@@ -1,0 +1,332 @@
+//! How note PREPARATION scales on messy wallets: hundreds to thousands of source notes.
+//!
+//! The other end-to-end tests plan hand-written note shapes and pin the exact plan. This one plans
+//! RANDOM wallets drawn from [`WalletShape`] across a range of note counts, and asserts the scaling
+//! LAWS the preparation planner should obey rather than any individual plan. That is the right
+//! shape of assertion here for two reasons: the exact plan for a thousand random notes is not
+//! meaningful to a reader, and the reason to look at this regime at all is that the cost is driven
+//! by the note count rather than by the balance.
+//!
+//! The quantities that matter, and why:
+//!
+//! - TRANSACTIONS. Every wallet note the migration SPENDS must be consumed by some preparation
+//!   transaction, and a transaction consumes at most [`CONSOLIDATION_INPUTS_PER_TX`] notes (the ZIP
+//!   318 action budget less its one output). So `ceil(spent / 15)` is a hard floor GIVEN the
+//!   selection, and the ratio of the plan to it is what the layering strategy costs on top.
+//! - SELECTION. That floor is conditional, not absolute: a migration only has to fund its crossings,
+//!   so the notes it must spend are the ones needed to COVER that value, not the whole wallet.
+//!   `selection_floor` is the smallest number of notes that could cover it (the largest notes
+//!   first), and the gap between it and `spent` is the part of the cost that is a choice rather than
+//!   a constraint.
+//! - LAYERS. Layers are sequential: each waits for the previous to mine, so they set the
+//!   preparation phase's wall-clock. Consolidating `n` notes at a fan-in of 15 per transaction is a
+//!   15-ary tree, so `ceil(log_15 n)` is the floor.
+//! - SIGNING ROUNDS. Preparation costs 16 actions per transaction against a transfer's 3, so on
+//!   these wallets it is the preparation, not the migration itself, that the user signs.
+//!
+//! Run with `--nocapture --test-threads=1` to see the measured tables alongside the assertions (the
+//! tests interleave their output otherwise). The heavy end of the sweep (thousands of notes) is
+//! `#[ignore]`d: the cost there is building the mock backend's notes, not planning, and it runs in
+//! minutes rather than seconds.
+
+#![cfg(all(feature = "orchard", feature = "test-dependencies"))]
+
+use std::time::{Duration, Instant};
+
+use rand_chacha::ChaCha8Rng;
+use rand_core::SeedableRng;
+
+use zcash_pool_migration::{
+    engine::{MigrationPlan, plan_migration},
+    preparation::{CONSOLIDATION_INPUTS_PER_TX, PrepInput},
+    signing_rounds::{PREPARATION_ACTIONS, SigningRoundBudget},
+    testing::{WalletShape, generate_notes, sub_quantum_count},
+};
+use zcash_pool_migration_memory::{CommitMock, regtest_network};
+
+/// The note counts the fast sweep covers: hundreds, where a messy wallet already costs an order of
+/// magnitude more preparation than a tidy one.
+const NOTE_COUNTS: &[usize] = &[100, 250, 500, 1_000];
+
+/// The note counts the `#[ignore]`d heavy sweep adds: thousands.
+const HEAVY_NOTE_COUNTS: &[usize] = &[2_000, 5_000];
+
+/// The seeds each (shape, note count) cell is measured at. Several draws per cell keep a single
+/// lucky or unlucky wallet from deciding whether a scaling law holds.
+const SEEDS: &[u64] = &[1, 2];
+
+/// What one generated wallet's plan cost.
+struct Measurement {
+    /// The generated source notes.
+    notes: Vec<u64>,
+    /// How many of them are sub-quantum.
+    sub_quantum: usize,
+    /// The wallet notes the preparation actually spends.
+    spent: usize,
+    /// The preparation transactions the plan builds.
+    preparations: usize,
+    /// The sequential preparation layers.
+    layers: usize,
+    /// The pool crossings (one transfer transaction each).
+    crossings: usize,
+    /// The Orchard actions a signer processes for the whole run.
+    actions: u32,
+    /// The Keystone (96-action) signing rounds the run takes.
+    keystone_rounds: usize,
+    /// The value the run migrates, in zatoshi.
+    migrated: u64,
+    /// How long `plan_migration` took. Planning is pure arithmetic with no I/O and no cryptography,
+    /// so anything but instant here is the planner's own complexity in the note count.
+    planning: Duration,
+}
+
+impl Measurement {
+    /// The hard floor on preparation transactions GIVEN the notes the plan chose to spend: each must
+    /// be consumed, and one transaction consumes at most `CONSOLIDATION_INPUTS_PER_TX` of them.
+    fn transaction_floor(&self) -> usize {
+        self.spent.div_ceil(CONSOLIDATION_INPUTS_PER_TX)
+    }
+
+    /// The smallest number of wallet notes that could cover the migrated value, taking the largest
+    /// notes first. A migration must fund its crossings; it does not have to drain the wallet, so
+    /// this is the floor on how many notes NEED spending, against which
+    /// [`spent`](Self::spent) is the planner's actual choice.
+    fn selection_floor(&self) -> usize {
+        let mut values: Vec<u64> = self.notes.clone();
+        values.sort_unstable_by(|a, b| b.cmp(a));
+        let mut covered = 0u64;
+        for (taken, value) in values.into_iter().enumerate() {
+            if covered >= self.migrated {
+                return taken;
+            }
+            covered = covered.saturating_add(value);
+        }
+        self.notes.len()
+    }
+
+    /// The hard floor on layers: consolidating `spent` notes at a fan-in of
+    /// `CONSOLIDATION_INPUTS_PER_TX` per transaction is a 15-ary tree of that depth.
+    fn layer_floor(&self) -> usize {
+        let mut reachable = CONSOLIDATION_INPUTS_PER_TX;
+        let mut depth = 1;
+        while reachable < self.spent {
+            reachable = reachable.saturating_mul(CONSOLIDATION_INPUTS_PER_TX);
+            depth += 1;
+        }
+        depth
+    }
+
+    /// The share of the signing workload that is preparation rather than migration.
+    fn preparation_share(&self) -> f64 {
+        f64::from(self.preparations as u32 * PREPARATION_ACTIONS) / f64::from(self.actions)
+    }
+}
+
+/// Generate a wallet and measure the plan it produces.
+fn measure(shape: WalletShape, note_count: usize, seed: u64) -> Measurement {
+    let mut gen_rng = ChaCha8Rng::seed_from_u64(seed);
+    let notes = generate_notes(shape, note_count, &mut gen_rng);
+
+    let backend = CommitMock::new(seed, &notes);
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let started = Instant::now();
+    let plan: MigrationPlan = plan_migration(&regtest_network(true), &backend, &mut rng)
+        .expect("a generated wallet is fundable");
+    let planning = started.elapsed();
+
+    Measurement {
+        sub_quantum: sub_quantum_count(&notes),
+        spent: spent_wallet_notes(&plan),
+        preparations: plan.preparation_tx_count(),
+        layers: plan.preparation_layer_count(),
+        crossings: plan.transfer_tx_count(),
+        actions: plan.total_actions(),
+        keystone_rounds: plan.signing_round_count(SigningRoundBudget::KEYSTONE),
+        migrated: plan.value_migrated().into_u64(),
+        planning,
+        notes,
+    }
+}
+
+/// How many distinct WALLET notes (as opposed to notes an earlier layer produced) the preparation
+/// spends, plus the notes used directly as funding notes with no preparation at all.
+fn spent_wallet_notes(plan: &MigrationPlan) -> usize {
+    let mut indices: Vec<usize> = plan
+        .preparation()
+        .layers()
+        .iter()
+        .flatten()
+        .flat_map(|tx| tx.inputs())
+        .filter_map(|input| match input {
+            PrepInput::Wallet { index, .. } => Some(*index),
+            PrepInput::Prior { .. } => None,
+        })
+        .chain(
+            plan.preparation()
+                .direct_funding_notes()
+                .iter()
+                .map(|&(index, _)| index),
+        )
+        .collect();
+    indices.sort_unstable();
+    indices.dedup();
+    indices.len()
+}
+
+/// Print one measured row of the sweep table.
+fn report(shape: WalletShape, m: &Measurement) {
+    println!(
+        "{:<18} {:>6} {:>7} {:>6} {:>5} {:>6} {:>5} {:>6} {:>5} {:>6} {:>6} {:>5} {:>4.0}% {:>8.0}",
+        shape.label(),
+        m.notes.len(),
+        m.sub_quantum,
+        m.spent,
+        m.selection_floor(),
+        m.preparations,
+        m.transaction_floor(),
+        m.layers,
+        m.layer_floor(),
+        m.crossings,
+        m.actions,
+        m.keystone_rounds,
+        m.preparation_share() * 100.0,
+        m.planning.as_secs_f64() * 1000.0,
+    );
+}
+
+/// Print the sweep table's header.
+fn report_header() {
+    println!(
+        "{:<18} {:>6} {:>7} {:>6} {:>5} {:>6} {:>5} {:>6} {:>5} {:>6} {:>6} {:>5} {:>5} {:>8}",
+        "shape",
+        "notes",
+        "sub-qtm",
+        "spent",
+        "sfloor",
+        "preps",
+        "tfloor",
+        "layers",
+        "lfloor",
+        "cross",
+        "acts",
+        "ks",
+        "prep%",
+        "plan ms",
+    );
+}
+
+/// Assert the scaling laws on one measured wallet.
+fn assert_scaling_laws(shape: WalletShape, note_count: usize, seed: u64, m: &Measurement) {
+    let case = format!("{} / {note_count} notes / seed {seed}", shape.label());
+
+    // The floors are floors: no plan may beat them.
+    assert!(
+        m.preparations >= m.transaction_floor(),
+        "{case}: {} preparations beats the {} floor for {} spent notes",
+        m.preparations,
+        m.transaction_floor(),
+        m.spent,
+    );
+    assert!(
+        m.layers >= m.layer_floor(),
+        "{case}: {} layers beats the {} floor for {} spent notes",
+        m.layers,
+        m.layer_floor(),
+        m.spent,
+    );
+
+    // A migration always migrates something, and it cannot spend a note the wallet does not have.
+    assert!(m.crossings >= 1, "{case}: nothing migrated");
+    assert!(
+        m.spent <= m.notes.len(),
+        "{case}: spent more notes than held"
+    );
+
+    // Preparation, not migration, is the signing workload here: a preparation is 16 actions to a
+    // transfer's 3, and these wallets need far more preparations than crossings.
+    assert!(
+        m.preparation_share() > 0.5,
+        "{case}: preparation is {:.0}% of the signing workload, expected the majority",
+        m.preparation_share() * 100.0,
+    );
+
+    // Planning is pure arithmetic; it must not become the bottleneck at these note counts.
+    assert!(
+        m.planning < Duration::from_secs(1),
+        "{case}: planning took {:?}",
+        m.planning,
+    );
+}
+
+/// PREPARATION SCALING on messy wallets of a few hundred to a thousand notes.
+#[test]
+fn preparation_scales_with_the_note_count() {
+    report_header();
+    for &shape in WalletShape::ALL {
+        for &note_count in NOTE_COUNTS {
+            for &seed in SEEDS {
+                let m = measure(shape, note_count, seed);
+                if seed == SEEDS[0] {
+                    report(shape, &m);
+                }
+                assert_scaling_laws(shape, note_count, seed, &m);
+            }
+        }
+    }
+}
+
+/// The same sweep at thousands of notes. Ignored by default: generating the mock backend's notes
+/// dominates, so this runs in minutes.
+#[test]
+#[ignore = "minutes: dominated by mock-backend note setup, not by planning"]
+fn preparation_scales_into_the_thousands() {
+    report_header();
+    for &shape in WalletShape::ALL {
+        for &note_count in HEAVY_NOTE_COUNTS {
+            let seed = SEEDS[0];
+            let m = measure(shape, note_count, seed);
+            report(shape, &m);
+            assert_scaling_laws(shape, note_count, seed, &m);
+        }
+    }
+}
+
+/// The planner spends the WHOLE wallet, not the notes the migration needs.
+///
+/// A run only has to fund its crossings, so on a heavy-tailed wallet the largest handful of notes
+/// already covers the migrated value and the rest could be left for a later run. The planner instead
+/// consolidates everything, and since preparation transactions are the dominant signing cost, that
+/// choice is what makes a thousand-note wallet expensive. This test records the gap rather than
+/// asserting it away: it is the measurement an input-selection change would move.
+#[test]
+fn preparation_spends_the_whole_wallet_not_the_notes_it_needs() {
+    println!(
+        "{:<18} {:>6} {:>6} {:>7} {:>7} {:>7}",
+        "shape", "notes", "spent", "needed", "preps", "min-tx",
+    );
+    for &shape in WalletShape::ALL {
+        for &note_count in NOTE_COUNTS {
+            let m = measure(shape, note_count, SEEDS[0]);
+            let needed = m.selection_floor();
+            println!(
+                "{:<18} {:>6} {:>6} {:>7} {:>7} {:>7}",
+                shape.label(),
+                m.notes.len(),
+                m.spent,
+                needed,
+                m.preparations,
+                needed.div_ceil(CONSOLIDATION_INPUTS_PER_TX).max(1),
+            );
+
+            // Covering the migrated value cannot need more notes than the plan actually spent: the
+            // spent notes are, by construction, enough to fund the crossings.
+            assert!(
+                needed <= m.spent,
+                "{} / {note_count}: covering {} zatoshi needs {needed} notes but only {} were spent",
+                shape.label(),
+                m.migrated,
+                m.spent,
+            );
+        }
+    }
+}

--- a/zcash_pool_migration/tests/signing_rounds_e2e.rs
+++ b/zcash_pool_migration/tests/signing_rounds_e2e.rs
@@ -28,7 +28,10 @@ use zcash_protocol::{consensus::BlockHeight, value::COIN};
 #[cfg(feature = "test-dependencies")]
 use zcash_pool_migration::{
     denomination::MIGRATION_MAX_PREPARED_NOTES_PER_RUN,
-    testing::{MIGRATION_SCENARIOS, MULTI_RUN_EVOLUTION, SIGNING_ROUND_EVOLUTION},
+    testing::{
+        LARGE_BALANCE_CASES, MIGRATION_SCENARIOS, MULTI_RUN_EVOLUTION, REPORTED_LARGE_BALANCE,
+        SIGNING_ROUND_EVOLUTION,
+    },
 };
 use zcash_pool_migration::{
     engine::{
@@ -407,5 +410,136 @@ fn keystone_rounds_evolve_with_actions() {
     for pair in SIGNING_ROUND_EVOLUTION.windows(2) {
         assert!(pair[0].expected_actions <= pair[1].expected_actions);
         assert!(pair[0].expected_keystone_rounds <= pair[1].expected_keystone_rounds);
+    }
+}
+
+/// What a LARGE balance actually plans, and how much of that is the balance versus the NOTE SHAPE
+/// holding it. One balance (5887.842 ZEC, from a user report of an unexpectedly large plan) is
+/// planned from five different note shapes, and every headline figure a wallet shows is asserted:
+/// the crossings, the preparation transactions, the transaction total, the actions, the Keystone
+/// (96-action) rounds, and the value migrated. Reuses the plan-only `LARGE_BALANCE_CASES` table.
+///
+/// The shape, not the balance, is what moves the numbers: the crossings are pinned by the balance's
+/// `{1,2,5}x10^k` decomposition (fourteen of them, near-constant across the table), while the
+/// preparations scale with the note count, taking one shape to three Keystone rounds where another
+/// needs one. The two-note shape is the outlier: no note reaches the leading 5000 ZEC denomination,
+/// so its first run migrates that single crossing and defers the rest to a second run.
+#[cfg(feature = "test-dependencies")]
+#[test]
+fn large_balance_plans_by_note_shape() {
+    let seed = 7;
+
+    for case in LARGE_BALANCE_CASES {
+        // Every shape holds the SAME balance, so any difference below is the shape's doing.
+        assert_eq!(
+            case.source_notes.iter().sum::<u64>(),
+            REPORTED_LARGE_BALANCE,
+            "{}: source notes sum to the reported balance",
+            case.label
+        );
+
+        // The whole-migration estimate: what the user is committing to in total.
+        let backend = CommitMock::new(seed, case.source_notes);
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let est = estimate_migration_runs(&regtest_network(true), &backend, &mut rng)
+            .expect("estimates the large-balance migration");
+        assert_eq!(est.run_count(), case.expected_runs, "{}: runs", case.label);
+        assert_eq!(
+            est.total_crossings(),
+            case.expected_total_crossings,
+            "{}: total quanta",
+            case.label
+        );
+        assert_eq!(
+            est.total_actions(),
+            case.expected_total_actions,
+            "{}: total actions to sign",
+            case.label
+        );
+        assert_eq!(
+            est.total_signing_rounds(SigningRoundBudget::KEYSTONE),
+            case.expected_total_keystone_rounds,
+            "{}: total Keystone rounds",
+            case.label
+        );
+
+        // The first run: the plan `plan_migration` hands back, and the transactions a wallet lists.
+        let (_backend, plan) = plan_notes(seed, case.source_notes);
+        assert_eq!(
+            plan.preparation_tx_count(),
+            case.expected_preparations,
+            "{}: preparation transactions",
+            case.label
+        );
+        assert_eq!(
+            plan.transfer_tx_count(),
+            case.expected_transfers,
+            "{}: quanta (crossings)",
+            case.label
+        );
+        assert_eq!(
+            plan.total_transactions(),
+            case.expected_transactions,
+            "{}: transactions in the first run",
+            case.label
+        );
+        assert_eq!(
+            plan.total_actions(),
+            case.expected_actions,
+            "{}: actions in the first run",
+            case.label
+        );
+        assert_eq!(
+            u64::from(plan.value_migrated()),
+            case.expected_migrated,
+            "{}: value migrated by the first run",
+            case.label
+        );
+        assert_eq!(
+            u64::from(plan.residual()),
+            case.expected_residual,
+            "{}: value the first run leaves behind",
+            case.label
+        );
+
+        // The Keystone signing rounds: what the user physically confirms on the device.
+        assert_eq!(
+            plan.signing_round_count(SigningRoundBudget::KEYSTONE),
+            case.expected_keystone_rounds,
+            "{}: Keystone signing rounds",
+            case.label
+        );
+        // The preview a consent screen renders, and its budget invariant.
+        let preview = plan.signing_rounds(SigningRoundBudget::KEYSTONE);
+        assert_eq!(preview.len(), case.expected_keystone_rounds);
+        let mut previewed = 0;
+        for round in &preview {
+            assert!(
+                round.total_actions() <= SigningRoundBudget::KEYSTONE.max_actions(),
+                "{}: a round exceeds the Keystone budget",
+                case.label
+            );
+            previewed += round.len();
+        }
+        assert_eq!(
+            previewed, case.expected_transactions,
+            "{}: the rounds cover every planned transaction",
+            case.label
+        );
+        // Even the widest of these runs signs in one default-budget (software signer) round.
+        assert_eq!(
+            plan.signing_round_count(SigningRoundBudget::DEFAULT),
+            1,
+            "{}: one default-budget round",
+            case.label
+        );
+
+        // A run that leaves a large residual is exactly a run that needs a successor.
+        assert_eq!(
+            case.expected_runs > 1,
+            u64::from(plan.residual()) >= u64::from(zcash_protocol::zip318::MAX_RESIDUAL_VALUE),
+            "{}: a migratable residual is what forces a second run",
+            case.label
+        );
     }
 }


### PR DESCRIPTION
A user reported an unexpectedly large migration plan for a balance of
5887.842 ZEC. This adds the fixtures to investigate that, and the answer turns
out to be about the note shape rather than the balance.

## What is here

**`LARGE_BALANCE_CASES` + `large_balance_plans_by_note_shape`.** The existing
plan-only tables vary the balance and hold the note shape fixed at one note.
This one does the opposite: it fixes the reported balance and varies how the
wallet holds it, asserting every headline figure a wallet shows (runs,
crossings, preparation transactions, transaction total, actions, Keystone
rounds, value migrated, residual).

| shape | runs | preps | crossings | txs | actions | Keystone rounds |
| --- | --- | --- | --- | --- | --- | --- |
| 1 note | 1 | 1 | 14 | 15 | 58 | 1 |
| 2 equal notes | 2 | 3 | 14 | 17 | 90 | 2 |
| 5 equal notes | 1 | 4 | 14 | 18 | 106 | 2 |
| 10 equal notes | 1 | 5 | 14 | 19 | 122 | 2 |
| 100 equal notes | 1 | 13 | 13 | 26 | 247 | 3 |

The crossings are pinned by the balance's `{1,2,5}x10^k` decomposition and stay
at fourteen; only the preparation count moves.

The two-note shape is an outlier worth a look: neither note reaches the leading
5000 ZEC denomination, so funding that one crossing consumes both notes across
two preparation layers and the run ends having migrated only the 5000, deferring
the remaining ~887.84 ZEC to a second run. It is a threshold on the LARGEST
note, not on the note count: a 10/90 split (largest note 5299 ZEC) plans all
fourteen crossings in one run, a 20/80 split (4710 ZEC) does not. The test pins
this as an invariant (`expected_runs > 1` iff the first run's residual is at
least `MAX_RESIDUAL_VALUE`) rather than as a bare number.

**`testing::wallets` + `preparation_scaling.rs`.** Since the note count is what
drives the cost, generate the wallets that stress it: four `WalletShape` value
distributions (near-minimum, log-uniform, sub-quantum-heavy, whale-over-dust)
drawn log-uniformly at arbitrary zatoshi amounts. Real notes are change outputs,
payments, and mining payouts, none of which land on a denomination boundary, so
generating multiples of the minimum denomination would test a wallet that does
not exist and would hide the remainder handling the planner has to do.

`preparation_scaling.rs` plans those from a hundred to a thousand notes
(thousands behind `#[ignore]`, where building the mock backend's notes
dominates) and asserts scaling LAWS rather than individual plans: the
transaction floor of `ceil(spent / 15)` given the notes spent, the layer floor
of `ceil(log_15 spent)`, that preparation is the majority of the signing
workload, and that planning stays well under a second.

## What the measurements say

| shape | notes | spent | preps | floor | layers | Keystone | prep share |
| --- | --- | --- | --- | --- | --- | --- | --- |
| near-minimum | 100 | 100 | 26 | 7 | 5 | 5 | 90% |
| near-minimum | 250 | 250 | 26 | 17 | 5 | 5 | 95% |
| near-minimum | 1000 | 1000 | 79 | 67 | 5 | 14 | 99% |
| log-uniform | 1000 | 1000 | 80 | 67 | 5 | 14 | 97% |
| whale-over-dust | 1000 | 1000 | 75 | 67 | 4 | 13 | 97% |
| log-uniform | 5000 | 5000 | 380 | 334 | 6 | 65 | 98% |

- The layering greedy is already close to optimal: 10 to 15 percent above the
  consolidation floor above 250 notes, with layers at 4 to 6 against a floor of
  2 to 4. There is little to win by improving the layering itself.
- The cost is that the run migrates the whole balance, so preparation spends
  essentially every note held. On the skewed shapes a quarter to a third of
  those notes are not needed to cover the migrated value. A third test records
  that gap; it is the measurement an input-selection change would move.
- Preparation is 83 to 100 percent of what the user signs, so a thousand-note
  wallet is 14 Keystone confirmations and a five-thousand-note wallet is 65.
- `near-minimum` at 100 notes looks like a real inefficiency rather than a
  floor: 26 preparations against a floor of 7, and the same 26 as at 250 notes
  before jumping to 44 at 500. The cost is non-monotonic in the note count
  there.

Planning time itself is not a problem (66ms at 5000 notes).

## Notes for review

Draft, because the point of these fixtures is to decide what to change in the
preparation planner; nothing here changes planner behaviour, and the numbers are
captured from the current planner rather than argued to be correct.

Tests, `cargo fmt --check`, and clippy are clean, and `zcash_client_sqlite`
still builds. No changelog entry: this is test-only.
