### PR TITLE
zcash_pool_migration: return the outlook alongside each advance step

### DIFF
--- a/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
+++ b/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
@@ -366,6 +366,7 @@ impl Run {
         let mut rng = ChaCha8Rng::seed_from_u64(0x318);
         satisfiability::advance_migration(&mut store, state, targets, &ADVANCE, &mut rng)
             .expect("the store and its satisfiability oracle answer")
+            .step()
     }
 
     /// Mine one empty block and scan it, so the chain reaches the migration's next scheduled

--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -26,8 +26,19 @@ and this library adheres to Rust's notion of
 - `scheduling::redraw_anchor_boundary`: the recency-weighted anchor draw for a
   transfer whose broadcast schedule has moved, floored at the boundary being
   replaced.
+- `satisfiability::Advance`: what one `satisfiability::advance_migration` call
+  returns — the verified `state::AdvanceStep` to perform now, plus the outlook:
+  the subsequent step's kind and the earliest target height at which it becomes
+  serviceable, assuming the returned step is executed.
+- `state::StepKind` and `state::AdvanceStep::kind`: an `AdvanceStep`'s variant
+  without its payload.
 
 ### Changed
+- `satisfiability::advance_migration` now returns `satisfiability::Advance`
+  rather than a bare `state::AdvanceStep`: read the step to perform via
+  `Advance::step`, and the outlook — when the migration next has work, and of
+  what kind — via `Advance::next`, which replaces deriving the next wake-up
+  from each transaction's scheduled height by hand.
 - `engine::MigrationStatus` has added variant `Cancelled`: a terminal status
   recording that the user abandoned the migration, distinct from `Failed` so
   that a deliberate abandonment is distinguishable from a migration that broke. 

--- a/zcash_pool_migration/src/satisfiability.rs
+++ b/zcash_pool_migration/src/satisfiability.rs
@@ -26,7 +26,7 @@ use crate::engine::{
     MigrationState, MigrationTransferId, MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
 };
 use crate::scheduling::{DelayDistribution, SchedulingParams};
-use crate::state::AdvanceStep;
+use crate::state::{AdvanceStep, StepKind};
 
 /// The share of planned transfer value (an integer percent) above which a migration with
 /// unsatisfiable transfers should be re-planned IMMEDIATELY rather than after satisfiable work
@@ -468,10 +468,54 @@ impl DuenessTargets {
     }
 }
 
+/// What one [`advance_migration`] call decides: the verified step to perform NOW, and the
+/// OUTLOOK — when the migration will next have work, and of what kind, assuming the returned
+/// step is executed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Advance {
+    step: AdvanceStep,
+    next: Option<(BlockHeight, StepKind)>,
+}
+
+impl Advance {
+    /// The step to perform now, verified against the store's satisfiability oracle exactly as
+    /// [`advance_migration`] documents.
+    pub const fn step(&self) -> AdvanceStep {
+        self.step
+    }
+
+    /// The SUBSEQUENT step, assuming [`step`](Self::step) is executed and recorded: the kind of
+    /// work it will be, and the earliest target height (this crate's `chain_tip + 1` convention,
+    /// directly comparable with the caller's [`DuenessTargets`]) at which it becomes
+    /// serviceable. A height at or below the caller's current target means more work is
+    /// serviceable in this same session; a later height is the wake-up to register, with the
+    /// kind saying what session to plan (a [`Broadcast`](StepKind::Broadcast) needs no sync, a
+    /// [`Prove`](StepKind::Prove) is sync-bound — the ZIP 318 session separation
+    /// [`advance_migration`] documents).
+    ///
+    /// The outlook is ADVISORY, the kernel's unverified plan: the height is a floor, not an
+    /// appointment (dependencies still have to mine, and the wake-up's own [`advance_migration`]
+    /// call verifies — and may displace — the step and names the transaction it applies to), and
+    /// it holds only as of the state this call returned, so the next call's outlook supersedes
+    /// it. `None` means nothing is height-schedulable: what follows is chain-driven (an
+    /// in-flight transaction mining, a dependency the scan must observe) or user-driven (a
+    /// signature, a replan, the sync a [`Reevaluate`](AdvanceStep::Reevaluate) asks for), or the
+    /// migration is terminal. In particular, a step whose own execution decides what comes next
+    /// — a [`Rebuild`](AdvanceStep::Rebuild), whose fresh schedule is drawn at rebuild time; a
+    /// [`Replan`](AdvanceStep::Replan) or [`Reevaluate`](AdvanceStep::Reevaluate), whose outcome
+    /// supersedes or re-decides the plan — carries `None`, and the call that follows the
+    /// execution reports the fresh outlook.
+    pub const fn next(&self) -> Option<(BlockHeight, StepKind)> {
+        self.next
+    }
+}
+
 /// Decide the next step to advance a committed migration and VERIFY it against the store before
 /// surfacing it: the entry point a consuming application drives a migration with, against the
 /// caller's [`DuenessTargets`] — its scanned frontier and its estimate of where the chain tip has
-/// reached, both as targets (`height + 1`).
+/// reached, both as targets (`height + 1`). Returns the step paired with the OUTLOOK — the
+/// subsequent step's kind and earliest serviceable height, assuming the returned step is
+/// executed ([`Advance::next`] defines its semantics).
 ///
 /// A single call plans, verifies, records, and persists:
 ///
@@ -552,10 +596,11 @@ impl DuenessTargets {
 ///   [`Complete`](AdvanceStep::Complete), and unconditionally: a rejection means another observer
 ///   saw chain state this wallet has not, and same-seed activity invalidates the whole store
 ///   view rather than one transaction's answer.
-/// - [`AdvanceStep::Waiting`]: nothing is actionable at this height. Consult
-///   [`MigrationState::transaction_statuses`] for what each transaction is blocked on, and register
-///   the heights at which to wake and re-check: [`MigrationState::sync_wakeup_schedule`] for the
-///   proving wake-ups, plus each transaction's own scheduled broadcast height.
+/// - [`AdvanceStep::Waiting`]: nothing is actionable at this height. The returned
+///   [`Advance::next`] carries the earliest height at which that changes, and the kind of work it
+///   will be; consult [`MigrationState::transaction_statuses`] for what each transaction is
+///   blocked on, and [`MigrationState::sync_wakeup_schedule`] for the full proving wake-up
+///   schedule a background-constrained wallet registers with its OS.
 /// - [`AdvanceStep::Complete`]: the migration is terminal (every transaction mined, or the
 ///   migration failed/cancelled); nothing will ever be actionable again, so stop polling.
 ///
@@ -667,7 +712,7 @@ pub fn advance_migration<St: PoolMigrationWrite, R: RngCore + CryptoRng>(
     targets: DuenessTargets,
     config: &AdvanceConfig,
     rng: &mut R,
-) -> Result<AdvanceStep, St::Error> {
+) -> Result<Advance, St::Error> {
     // Whether any determination has been recorded, and so whether the state must be written back
     // before a step is surfaced.
     let mut dirty = false;
@@ -828,11 +873,16 @@ pub fn advance_migration<St: PoolMigrationWrite, R: RngCore + CryptoRng>(
     if reevaluation_pending {
         // Unconditional: a rejection means some other observer saw chain state this wallet has
         // not, and same-seed activity invalidates the whole store view rather than one
-        // transaction's answer. Whatever was adjudicated above is still persisted first.
+        // transaction's answer. Whatever was adjudicated above is still persisted first. No
+        // outlook: what follows depends on how the adjudication falls, which is exactly what the
+        // requested sync exists to decide.
         if dirty {
             store.replace_migration(state)?;
         }
-        return Ok(AdvanceStep::Reevaluate);
+        return Ok(Advance {
+            step: AdvanceStep::Reevaluate,
+            next: None,
+        });
     }
 
     // The overdue-shift tolerance, sized to the schedule AS COMMITTED: the persisted anchor
@@ -938,7 +988,50 @@ pub fn advance_migration<St: PoolMigrationWrite, R: RngCore + CryptoRng>(
     if dirty {
         store.replace_migration(state)?;
     }
-    Ok(step)
+    Ok(Advance {
+        step,
+        next: upcoming_after(state, step, targets, &set_aside),
+    })
+}
+
+/// The OUTLOOK behind [`Advance::next`]: the subsequent step's kind and earliest serviceable
+/// height, computed on the state as it will stand once `step` is executed and recorded.
+///
+/// The hypothetical is applied to a CLONE of the state — a `Prove` completes to `Proved`, a
+/// `Broadcast` is recorded, `Waiting` changes nothing — and the kernel's
+/// [`upcoming_step`](MigrationState::upcoming_step) is asked of the result, with this call's
+/// `set_aside` carried through so a candidate deferred as "not yet satisfiable" (chain-gated, not
+/// height-gated) cannot resurface as a schedulable outlook the drive loop just declined to
+/// serve. The steps whose execution DECIDES what comes next carry no outlook at all, per
+/// [`Advance::next`]: a `Rebuild` draws its transfer's fresh schedule at rebuild time, a
+/// `Replan` supersedes the plan, a `Reevaluate` re-decides it, and after `Complete` nothing
+/// follows. The clone is the cost of asking "and then?" without disturbing the state the caller
+/// holds; it is paid only when a step is actually surfaced, never per transaction.
+fn upcoming_after(
+    state: &MigrationState,
+    step: AdvanceStep,
+    targets: DuenessTargets,
+    set_aside: &[MigrationTransferId],
+) -> Option<(BlockHeight, StepKind)> {
+    match step {
+        AdvanceStep::Complete
+        | AdvanceStep::Replan
+        | AdvanceStep::Reevaluate
+        | AdvanceStep::Rebuild { .. } => None,
+        AdvanceStep::Waiting => state.upcoming_step(targets, set_aside),
+        AdvanceStep::Prove { id, .. } => {
+            let mut post = state.clone();
+            if let Some(t) = post.transactions.iter_mut().find(|t| t.id == id) {
+                t.state = MigrationTxState::Proved;
+            }
+            post.upcoming_step(targets, set_aside)
+        }
+        AdvanceStep::Broadcast { id } => {
+            let mut post = state.clone();
+            post.mark_broadcast(id);
+            post.upcoming_step(targets, set_aside)
+        }
+    }
 }
 
 /// Whether a satisfiability answer is a DISCOVERY for [`advance_migration`] to record and broaden
@@ -1366,7 +1459,8 @@ mod advance_tests {
             &config(),
             &mut rng(),
         )
-        .expect("the store never fails");
+        .expect("the store never fails")
+        .step();
 
         assert!(
             matches!(step, AdvanceStep::Prove { id, .. } if id == MigrationTransferId(2)),
@@ -1429,7 +1523,8 @@ mod advance_tests {
             &config(),
             &mut rng(),
         )
-        .expect("the store never fails");
+        .expect("the store never fails")
+        .step();
 
         assert_eq!(
             step,
@@ -1478,7 +1573,8 @@ mod advance_tests {
             &config(),
             &mut rng(),
         )
-        .expect("the store never fails");
+        .expect("the store never fails")
+        .step();
 
         assert_eq!(
             step,
@@ -1515,7 +1611,8 @@ mod advance_tests {
             &config(),
             &mut rng(),
         )
-        .expect("the store never fails");
+        .expect("the store never fails")
+        .step();
         assert_eq!(
             step,
             AdvanceStep::Broadcast {
@@ -1548,7 +1645,8 @@ mod advance_tests {
             &config(),
             &mut rng(),
         )
-        .expect("the store never fails");
+        .expect("the store never fails")
+        .step();
 
         assert_eq!(
             step,
@@ -1576,7 +1674,8 @@ mod advance_tests {
             &config(),
             &mut rng(),
         )
-        .expect("the store never fails");
+        .expect("the store never fails")
+        .step();
         assert_eq!(step, AdvanceStep::Waiting);
         assert_eq!(store.queries.get(), 0, "a waiting call asks nothing");
         assert_eq!(store.replaced.get(), 0);
@@ -1626,7 +1725,8 @@ mod advance_tests {
             &config(),
             &mut rng(),
         )
-        .expect("the store never fails");
+        .expect("the store never fails")
+        .step();
 
         assert_eq!(
             step,
@@ -1688,7 +1788,8 @@ mod advance_tests {
             &config(),
             &mut rng(),
         )
-        .expect("the store never fails");
+        .expect("the store never fails")
+        .step();
 
         assert_eq!(
             state.transactions()[0].state(),
@@ -1745,7 +1846,8 @@ mod advance_tests {
             &config(),
             &mut rng(),
         )
-        .expect("the store never fails");
+        .expect("the store never fails")
+        .step();
 
         assert_eq!(
             step,
@@ -1781,7 +1883,8 @@ mod advance_tests {
             &config(),
             &mut rng(),
         )
-        .expect("the store never fails");
+        .expect("the store never fails")
+        .step();
 
         assert_eq!(
             store.mined_queries.get(),
@@ -1823,7 +1926,8 @@ mod advance_tests {
             &config(),
             &mut rng(),
         )
-        .expect("the store never fails");
+        .expect("the store never fails")
+        .step();
 
         assert_eq!(
             step,
@@ -1890,7 +1994,8 @@ mod advance_tests {
             &config(),
             &mut rng(),
         )
-        .expect("the store never fails");
+        .expect("the store never fails")
+        .step();
 
         assert_eq!(
             step,
@@ -2018,7 +2123,8 @@ mod advance_tests {
                 &config(),
                 &mut rng()
             )
-            .expect("the store never fails"),
+            .expect("the store never fails")
+            .step(),
             AdvanceStep::Reevaluate,
             "the sibling's due broadcast waits behind the unanswered rejection",
         );
@@ -2054,7 +2160,8 @@ mod advance_tests {
                 &config(),
                 &mut rng()
             )
-            .expect("the store never fails"),
+            .expect("the store never fails")
+            .step(),
             AdvanceStep::Broadcast {
                 id: MigrationTransferId(1)
             },
@@ -2103,7 +2210,8 @@ mod advance_tests {
                 &config(),
                 &mut rng()
             )
-            .expect("the store never fails"),
+            .expect("the store never fails")
+            .step(),
             AdvanceStep::Replan,
         );
 
@@ -2162,7 +2270,8 @@ mod advance_tests {
                 &config(),
                 &mut rng()
             )
-            .expect("the store never fails"),
+            .expect("the store never fails")
+            .step(),
             AdvanceStep::Complete,
         );
         assert_eq!(store.queries.get(), 0);
@@ -2215,7 +2324,8 @@ mod advance_tests {
                 &config(),
                 &mut rng()
             )
-            .expect("the store never fails"),
+            .expect("the store never fails")
+            .step(),
             AdvanceStep::Reevaluate,
         );
         let marked = BlockHeight::from_u32(1600);
@@ -2268,7 +2378,8 @@ mod advance_tests {
                 &config(),
                 &mut rng()
             )
-            .expect("the store never fails"),
+            .expect("the store never fails")
+            .step(),
             AdvanceStep::Reevaluate,
             "one unanswerable rejection still holds the whole loop",
         );
@@ -2323,7 +2434,8 @@ mod advance_tests {
 
         assert_eq!(
             advance_migration(&mut store, &mut state, targets, &config(), &mut rng())
-                .expect("the store never fails"),
+                .expect("the store never fails")
+                .step(),
             AdvanceStep::Broadcast {
                 id: MigrationTransferId(2)
             },
@@ -2351,7 +2463,8 @@ mod advance_tests {
                 &config(),
                 &mut rng(),
             )
-            .expect("the store never fails"),
+            .expect("the store never fails")
+            .step(),
             AdvanceStep::Broadcast {
                 id: MigrationTransferId(1)
             },
@@ -2387,7 +2500,8 @@ mod advance_tests {
             &config(),
             &mut rng(),
         )
-        .expect("the store never fails");
+        .expect("the store never fails")
+        .step();
 
         assert_eq!(
             step,
@@ -2476,7 +2590,8 @@ mod advance_tests {
             &config(),
             &mut rng(),
         )
-        .expect("the store never fails");
+        .expect("the store never fails")
+        .step();
         assert_eq!(
             step,
             AdvanceStep::Broadcast {
@@ -2500,7 +2615,8 @@ mod advance_tests {
             &config(),
             &mut rng(),
         )
-        .expect("the store never fails");
+        .expect("the store never fails")
+        .step();
         assert_eq!(
             step,
             AdvanceStep::Broadcast {
@@ -2567,7 +2683,8 @@ mod advance_tests {
             &config(),
             &mut rng(),
         )
-        .expect("the store never fails");
+        .expect("the store never fails")
+        .step();
 
         assert!(
             matches!(step, AdvanceStep::Prove { id, .. } if id == MigrationTransferId(1)),
@@ -2579,5 +2696,179 @@ mod advance_tests {
             "its broadcast window re-spread to the served target"
         );
         assert_eq!(store.replaced.get(), 1);
+    }
+
+    /// The outlook assumes the returned step is EXECUTED. A due preparation's prove reports its
+    /// own broadcast servable at that same schedule — the same-session signal — while a transfer
+    /// proved early reports its broadcast at its later scheduled height, the wake-up to register
+    /// when the proving session ends.
+    #[test]
+    fn outlook_after_a_prove_is_the_broadcast_that_follows() {
+        let mut prep_tx = tx(1, prep(0, 0), MigrationTxState::Signed);
+        prep_tx.scheduled_height = BlockHeight::from_u32(1_000);
+        let mut state = state_with_crossings(&[100_000_000], vec![prep_tx]);
+        let mut store = TestStore::new(1_000, []);
+        let targets = DuenessTargets::at(BlockHeight::from_u32(1_001));
+
+        let advance = advance_migration(&mut store, &mut state, targets, &config(), &mut rng())
+            .expect("the store never fails");
+        assert!(
+            matches!(advance.step(), AdvanceStep::Prove { id, .. } if id == MigrationTransferId(1)),
+            "the due preparation's prove is the step: {:?}",
+            advance.step()
+        );
+        assert_eq!(
+            advance.next(),
+            Some((BlockHeight::from_u32(1_000), StepKind::Broadcast)),
+            "once proved, its broadcast is servable at its own (already-due) schedule"
+        );
+
+        let mut state = state_with_crossings(
+            &[100_000_000],
+            vec![
+                tx(0, prep(0, 0), mined(10)),
+                scheduled_transfer(1, 0, 720, 1_200, MigrationTxState::Signed),
+            ],
+        );
+        let advance = advance_migration(&mut store, &mut state, targets, &config(), &mut rng())
+            .expect("the store never fails");
+        assert!(
+            matches!(advance.step(), AdvanceStep::Prove { id, .. } if id == MigrationTransferId(1)),
+            "the settled-boundary transfer's prove is the step: {:?}",
+            advance.step()
+        );
+        assert_eq!(
+            advance.next(),
+            Some((BlockHeight::from_u32(1_200), StepKind::Broadcast)),
+            "the proof leaves nothing until the transfer's own broadcast window"
+        );
+    }
+
+    /// A `Waiting` step carries the wake-up: the earliest height-gated floor among the pending
+    /// transactions — here the proved transfer's broadcast window, not the later-boundary
+    /// transfer's proof — and a broadcast step's outlook reports the next due broadcast in the
+    /// same session.
+    #[test]
+    fn outlook_reports_the_earliest_upcoming_floor() {
+        let mut state = state_with_crossings(
+            &[50_000_000, 50_000_000],
+            vec![
+                tx(0, prep(0, 0), mined(10)),
+                scheduled_transfer(1, 0, 720, 1_200, MigrationTxState::Proved),
+                // Boundary 1_300 is unsettled at the target, so its prove floor (1_302) sits
+                // past the broadcast window above.
+                scheduled_transfer(2, 1, 1_300, 1_500, MigrationTxState::Signed),
+            ],
+        );
+        let mut store = TestStore::new(1_000, []);
+        let targets = DuenessTargets::at(BlockHeight::from_u32(1_001));
+
+        let advance = advance_migration(&mut store, &mut state, targets, &config(), &mut rng())
+            .expect("the store never fails");
+        assert_eq!(advance.step(), AdvanceStep::Waiting);
+        assert_eq!(
+            advance.next(),
+            Some((BlockHeight::from_u32(1_200), StepKind::Broadcast)),
+            "the earliest floor wins: the broadcast window, not the later prove"
+        );
+
+        // Both proved and due: the first broadcast's outlook is the second, servable now.
+        let mut state = state_with_crossings(
+            &[50_000_000, 50_000_000],
+            vec![
+                tx(0, prep(0, 0), mined(10)),
+                scheduled_transfer(1, 0, 720, 995, MigrationTxState::Proved),
+                scheduled_transfer(2, 1, 720, 1_000, MigrationTxState::Proved),
+            ],
+        );
+        let advance = advance_migration(&mut store, &mut state, targets, &config(), &mut rng())
+            .expect("the store never fails");
+        assert_eq!(
+            advance.step(),
+            AdvanceStep::Broadcast {
+                id: MigrationTransferId(1)
+            },
+            "the longest-due broadcast is served first"
+        );
+        assert_eq!(
+            advance.next(),
+            Some((BlockHeight::from_u32(1_000), StepKind::Broadcast)),
+            "the other due broadcast follows in the same session (its floor is already reached)"
+        );
+    }
+
+    /// No outlook where none is knowable or schedulable: a candidate deferred as "not yet
+    /// satisfiable" is chain-gated and must not resurface as a wake-up the loop just declined to
+    /// serve; a migration whose every transaction is in flight waits on the chain alone; and a
+    /// rebuild's fresh schedule is drawn at rebuild time, so the call that follows it reports
+    /// the outlook instead.
+    #[test]
+    fn outlook_is_none_when_nothing_is_height_schedulable() {
+        // The only pending transaction's broadcast is due, but the wallet cannot yet vouch for
+        // its inputs: the step defers to Waiting, and the outlook must not name the deferred
+        // candidate's own (already-reached) floor.
+        let mut state = state_with_crossings(
+            &[100_000_000],
+            vec![
+                tx(0, prep(0, 0), mined(10)),
+                scheduled_transfer(1, 0, 720, 1_000, MigrationTxState::Proved),
+            ],
+        );
+        let mut store = TestStore::new(
+            900,
+            [(
+                MigrationTransferId(1),
+                StepSatisfiability::NotYetSatisfiable {
+                    as_of_height: BlockHeight::from_u32(900),
+                },
+            )],
+        );
+        let targets = DuenessTargets::at(BlockHeight::from_u32(1_001));
+        let advance = advance_migration(&mut store, &mut state, targets, &config(), &mut rng())
+            .expect("the store never fails");
+        assert_eq!(advance.step(), AdvanceStep::Waiting);
+        assert_eq!(
+            advance.next(),
+            None,
+            "a set-aside candidate is chain-gated: no height re-serves it"
+        );
+
+        // Everything in flight: mining is chain-derived, so nothing is height-schedulable.
+        let mut state = state_with_crossings(
+            &[100_000_000],
+            vec![
+                tx(0, prep(0, 0), mined(10)),
+                scheduled_transfer(1, 0, 720, 1_000, broadcast()),
+            ],
+        );
+        let mut store = TestStore::new(1_000, []);
+        let advance = advance_migration(&mut store, &mut state, targets, &config(), &mut rng())
+            .expect("the store never fails");
+        assert_eq!(advance.step(), AdvanceStep::Waiting);
+        assert_eq!(
+            advance.next(),
+            None,
+            "in flight: the chain decides what is next"
+        );
+
+        // An expired transfer: the rebuild draws its replacement's schedule when it happens, so
+        // the outlook cannot be stated ahead of it.
+        let mut expired = scheduled_transfer(1, 0, 720, 900, MigrationTxState::Signed);
+        expired.expiry_height = BlockHeight::from_u32(950);
+        let mut state =
+            state_with_crossings(&[100_000_000], vec![tx(0, prep(0, 0), mined(10)), expired]);
+        let advance = advance_migration(&mut store, &mut state, targets, &config(), &mut rng())
+            .expect("the store never fails");
+        assert_eq!(
+            advance.step(),
+            AdvanceStep::Rebuild {
+                id: MigrationTransferId(1)
+            }
+        );
+        assert_eq!(
+            advance.next(),
+            None,
+            "the rebuild reschedules its transfer; the following call reports the fresh outlook"
+        );
     }
 }

--- a/zcash_pool_migration/src/state.rs
+++ b/zcash_pool_migration/src/state.rs
@@ -126,6 +126,45 @@ pub enum AdvanceStep {
     Complete,
 }
 
+/// The kind of work an [`AdvanceStep`] names, shorn of the step's payload: the discriminant a
+/// consumer schedules wake-ups and renders progress by, obtained through [`AdvanceStep::kind`].
+/// The drive API's outlook ([`Advance`](crate::satisfiability::Advance)) pairs one of these with
+/// the earliest target height at which a step of that kind becomes serviceable — the kind alone,
+/// because the outlook is advisory: WHICH transaction the step names is decided by the
+/// [`advance_migration`](crate::satisfiability::advance_migration) call that actually serves it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StepKind {
+    /// An [`AdvanceStep::Prove`].
+    Prove,
+    /// An [`AdvanceStep::Broadcast`].
+    Broadcast,
+    /// An [`AdvanceStep::Rebuild`].
+    Rebuild,
+    /// An [`AdvanceStep::Replan`].
+    Replan,
+    /// An [`AdvanceStep::Reevaluate`].
+    Reevaluate,
+    /// An [`AdvanceStep::Waiting`].
+    Waiting,
+    /// An [`AdvanceStep::Complete`].
+    Complete,
+}
+
+impl AdvanceStep {
+    /// This step's [`StepKind`]: the variant without its payload.
+    pub const fn kind(&self) -> StepKind {
+        match self {
+            AdvanceStep::Prove { .. } => StepKind::Prove,
+            AdvanceStep::Broadcast { .. } => StepKind::Broadcast,
+            AdvanceStep::Rebuild { .. } => StepKind::Rebuild,
+            AdvanceStep::Replan => StepKind::Replan,
+            AdvanceStep::Reevaluate => StepKind::Reevaluate,
+            AdvanceStep::Waiting => StepKind::Waiting,
+            AdvanceStep::Complete => StepKind::Complete,
+        }
+    }
+}
+
 /// The action a wallet takes next on a ready migration transaction.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum NextAction {
@@ -1305,6 +1344,158 @@ impl MigrationState {
             return AdvanceStep::Complete;
         }
         AdvanceStep::Waiting
+    }
+
+    /// The next step that will involve transaction `t`, with the earliest target height at which
+    /// it could be served: the per-transaction FLOOR behind [`Self::upcoming_step`]. `dead` is
+    /// the caller's [`Self::dead_set`].
+    ///
+    /// `None` means no future step involves the transaction: it is mined or in flight (mining is
+    /// chain-derived, not a step), it can never mine — its own mark, or a dead dependency — so
+    /// its value is [`Replan`](AdvanceStep::Replan) territory (a step that names no transaction),
+    /// or it is an expired PREPARATION, whose remediation is a new signing ceremony over its
+    /// dependent subtree rather than any single step.
+    ///
+    /// The height is a floor, not an appointment: each step's serviceability guard is
+    /// upward-closed in the target height, so the least target satisfying it is well-defined —
+    /// but chain-driven guards (dependencies mining, the doomed-window withhold resolving) are
+    /// the caller's to judge. Per step, the floor is the least target at which the guard holds: a
+    /// transfer's proof once its drawn boundary sits strictly below the scanned tip
+    /// (`boundary + 2`), a preparation's proof and any broadcast at the scheduled height, a
+    /// rebuild at the lapse's first observability (`expiry_height + 1`), and a reported
+    /// transaction's reevaluation at the first scanned target resting at its reported tip
+    /// (`reported + 1`). Dispositions are judged in [`Self::transaction_statuses`]' blocker
+    /// precedence (unsatisfiable, then a standing report, then expiry, then the lifecycle), so
+    /// the floor, the status view, and the kernel's queues tell one story. An
+    /// `AwaitingSignature` transaction's next STEP is its proof — signature application is the
+    /// consumer's own flow, not an advance step — matching [`Self::sync_wakeup_schedule`].
+    fn step_floor(
+        &self,
+        t: &MigrationTransaction,
+        targets: DuenessTargets,
+        dead: &BTreeSet<MigrationTransferId>,
+    ) -> Option<(AdvanceStep, BlockHeight)> {
+        // Mined is final: nothing is ever asked of the transaction again.
+        if matches!(t.state, MigrationTxState::Mined { .. }) {
+            return None;
+        }
+        // The unsatisfiable determination, exactly as `transaction_statuses` renders
+        // `Blocker::Unsatisfiable`. Expiry ALONE deliberately does not route here, though it
+        // seeds the dead set: an expired but otherwise-live transfer's next step is its rebuild,
+        // below.
+        if t.unsatisfiable.is_some() || t.depends_on.iter().any(|d| dead.contains(d)) {
+            return None;
+        }
+        // A standing report withholds the transaction until the drive API can adjudicate it,
+        // which needs the wallet's answers resting at or above the reported tip. Ahead of
+        // expiry, as in the status view: being actively withheld on another observer's testimony
+        // is the more specific thing to report.
+        if let Some(reported) = t.broadcast_failure_at {
+            return Some((AdvanceStep::Reevaluate, reported + 1));
+        }
+        // A lapse the wallet's own scan supports: a transfer's remedy is its rebuild; an expired
+        // preparation has no single-transaction step (see `Blocker::Expired`).
+        if Self::is_expired(t, targets.scanned()) {
+            return match t.kind {
+                MigrationTxKind::Transfer { .. } => {
+                    Some((AdvanceStep::Rebuild { id: t.id }, t.expiry_height + 1))
+                }
+                MigrationTxKind::Preparation { .. } => None,
+            };
+        }
+        match t.state {
+            MigrationTxState::Signed | MigrationTxState::AwaitingSignature => Some((
+                AdvanceStep::Prove {
+                    id: t.id,
+                    kind: t.kind,
+                },
+                match t.anchor_boundary {
+                    Some(boundary) => boundary + 2,
+                    None => t.scheduled_height,
+                },
+            )),
+            MigrationTxState::Proved => {
+                Some((AdvanceStep::Broadcast { id: t.id }, t.scheduled_height))
+            }
+            MigrationTxState::Broadcast { .. } | MigrationTxState::Mined { .. } => None,
+        }
+    }
+
+    /// The step that will next become serviceable, as the kind of work it is and the earliest
+    /// target height at which the kernel could name it: the OUTLOOK the drive API returns
+    /// alongside each step ([`Advance`](crate::satisfiability::Advance) documents the consumer
+    /// contract). `set_aside` carries the drive loop's call-local deferrals, exactly as for
+    /// [`Self::next_step`]: a candidate answered "not yet satisfiable" is chain-gated — retry
+    /// after further sync — so it must not resurface as a schedulable outlook either.
+    ///
+    /// When the kernel already has actionable work at these targets, the outlook is that step's
+    /// kind at its own floor ([`Self::step_floor`]; the migration-level
+    /// [`Replan`](AdvanceStep::Replan), which no height gates, is served at the current target).
+    /// When the kernel reports [`Waiting`](AdvanceStep::Waiting), the outlook looks PAST the
+    /// current targets: the earliest per-transaction floor among the transactions whose
+    /// serviceability is HEIGHT-gated — live, dependencies mined, and not withheld in the doomed
+    /// window — with ties broken by the queue order the kernel would serve them in (broadcast,
+    /// prove, rebuild) and then by id. A transaction gated on chain events (dependencies still
+    /// mining, a doomed-window withhold the scan must resolve) contributes nothing: no height
+    /// makes it serviceable, and the consumer's ordinary sync-and-drive loop is what discovers
+    /// it. `None` therefore means nothing is height-schedulable: what follows is chain-driven or
+    /// user-driven, or the migration is terminal.
+    pub(crate) fn upcoming_step(
+        &self,
+        targets: DuenessTargets,
+        set_aside: &[MigrationTransferId],
+    ) -> Option<(BlockHeight, StepKind)> {
+        match self.next_step(targets, set_aside) {
+            AdvanceStep::Complete => None,
+            // The kernel never returns `Reevaluate` (the drive API owns that slot), but it is a
+            // step like any other here, and matching it explicitly keeps that fact from resting
+            // on the absence of an arm.
+            AdvanceStep::Reevaluate => None,
+            // No height gates a replan: it is serviceable the moment it is decided.
+            AdvanceStep::Replan => Some((targets.effective(), StepKind::Replan)),
+            step @ (AdvanceStep::Prove { .. }
+            | AdvanceStep::Broadcast { .. }
+            | AdvanceStep::Rebuild { .. }) => {
+                let id = match step {
+                    AdvanceStep::Prove { id, .. }
+                    | AdvanceStep::Broadcast { id }
+                    | AdvanceStep::Rebuild { id } => id,
+                    _ => unreachable!("matched an actionable step"),
+                };
+                let dead = self.dead_set(targets);
+                self.transactions
+                    .iter()
+                    .find(|t| t.id == id)
+                    .and_then(|t| self.step_floor(t, targets, &dead))
+                    .map(|(step, height)| (height, step.kind()))
+            }
+            AdvanceStep::Waiting => {
+                let dead = self.dead_set(targets);
+                self.transactions
+                    .iter()
+                    .filter(|t| !set_aside.contains(&t.id))
+                    // Chain-gated, not height-gated: no wake-up height serves a transaction
+                    // whose dependencies are still mining, and a doomed-window withhold
+                    // (`scanned <= expiry < effective`) resolves by scan — into either a
+                    // rebuild or a resumed broadcast — not by any target being reached.
+                    .filter(|t| self.deps_mined(&t.depends_on))
+                    .filter(|t| !Self::is_expired(t, targets.effective()))
+                    .filter_map(|t| self.step_floor(t, targets, &dead).map(|f| (t.id, f)))
+                    // The earliest floor; at equal heights, the queue order the kernel serves
+                    // (broadcast, then prove, then rebuild), then id, so the outlook is
+                    // deterministic and agrees with what the wake-up's own call will name.
+                    .min_by_key(|(id, (step, height))| {
+                        let rank = match step {
+                            AdvanceStep::Broadcast { .. } => 0u8,
+                            AdvanceStep::Prove { .. } => 1,
+                            AdvanceStep::Rebuild { .. } => 2,
+                            _ => 3,
+                        };
+                        (*height, rank, *id)
+                    })
+                    .map(|(_, (step, height))| (height, step.kind()))
+            }
+        }
     }
 
     /// Builds the per-transaction status view at the caller's [`DuenessTargets`], so a wallet can

--- a/zcash_pool_migration/tests/engine_commit.rs
+++ b/zcash_pool_migration/tests/engine_commit.rs
@@ -182,6 +182,7 @@ fn commits_a_multi_layer_migration_in_one_pass() {
     let targets = DuenessTargets::at(latest_scheduled(&state));
     match advance_migration(&mut backend, &mut state, targets, &config, &mut rng)
         .expect("the store answers")
+        .step()
     {
         AdvanceStep::Prove { id, .. } | AdvanceStep::Broadcast { id } => {
             assert!(layer0_ids.contains(&id), "layer 0 broadcasts first")
@@ -200,6 +201,7 @@ fn commits_a_multi_layer_migration_in_one_pass() {
     let targets = DuenessTargets::at(latest_scheduled(&state));
     match advance_migration(&mut backend, &mut state, targets, &config, &mut rng)
         .expect("the store answers")
+        .step()
     {
         AdvanceStep::Prove { id, .. } | AdvanceStep::Broadcast { id } => {
             assert!(
@@ -215,6 +217,7 @@ fn commits_a_multi_layer_migration_in_one_pass() {
     let targets = DuenessTargets::at(latest_scheduled(&state));
     match advance_migration(&mut backend, &mut state, targets, &config, &mut rng)
         .expect("the store answers")
+        .step()
     {
         AdvanceStep::Prove { id, .. } | AdvanceStep::Broadcast { id } => {
             let tx = state


### PR DESCRIPTION
satisfiability::advance_migration now returns satisfiability::Advance: the verified AdvanceStep to perform now, plus the outlook — the subsequent step's kind (the new payload-free state::StepKind, derived via AdvanceStep::kind) and the earliest target height at which it becomes serviceable, assuming the returned step is executed. A height at or below the caller's target means more work is servable in the same session; a later one is the wake-up to register, with the kind saying what session to plan (broadcast needs no sync, proving is sync-bound).

The outlook is the kernel's unverified plan, computed on a clone of the state with the returned step hypothetically recorded (a prove completes to Proved, a broadcast is recorded, Waiting changes nothing) and judged in the status view's blocker precedence, with the drive loop's set-aside deferrals carried through so a chain-gated candidate never resurfaces as a schedulable wake-up. Each per-transaction floor is the least target satisfying that step's serviceability guard — well-defined because every height guard is upward-closed — while chain-gated transactions (dependencies mining, the doomed-window withhold) contribute nothing. Steps whose execution decides what follows (Rebuild, Replan, Reevaluate) carry no outlook; the call after their execution reports it fresh.