### PR TITLE
zcash_pool_migration: anchor-depth prove gating and batched Prove steps

### DIFF
--- a/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
+++ b/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
@@ -367,6 +367,7 @@ impl Run {
         satisfiability::advance_migration(&mut store, state, targets, &ADVANCE, &mut rng)
             .expect("the store and its satisfiability oracle answer")
             .step()
+            .clone()
     }
 
     /// Mine one empty block and scan it, so the chain reaches the migration's next scheduled
@@ -498,15 +499,30 @@ impl Run {
         let mut waited = 0u32;
         while unmined_preparation(&committed.state) {
             match self.advance(&mut committed.state) {
-                AdvanceStep::Prove { id, kind } => {
-                    assert!(
-                        matches!(kind, MigrationTxKind::Preparation { .. }),
-                        "no crossing is provable while a preparation it depends on is unmined",
-                    );
-                    assert_eq!(
-                        self.perform_prove(&mut committed.state, id, kind),
-                        ProveStepOutcome::Proved,
-                    );
+                AdvanceStep::Prove { transactions } => {
+                    for target in transactions {
+                        let (id, kind) = (target.id(), target.kind());
+                        if matches!(kind, MigrationTxKind::Transfer { .. }) {
+                            // The batch may carry a crossing alongside the preparations, but
+                            // only once the preparation minting its funding note has mined.
+                            let deps = committed
+                                .state
+                                .transactions()
+                                .iter()
+                                .find(|t| t.id() == id)
+                                .expect("the step names stored transactions")
+                                .depends_on()
+                                .to_vec();
+                            assert!(
+                                committed.state.deps_mined(&deps),
+                                "no crossing is provable while a preparation it depends on is unmined",
+                            );
+                        }
+                        assert_eq!(
+                            self.perform_prove(&mut committed.state, id, kind),
+                            ProveStepOutcome::Proved,
+                        );
+                    }
                 }
                 AdvanceStep::Broadcast { id } => {
                     self.perform_broadcast(&mut committed.state, id);
@@ -536,10 +552,16 @@ impl Run {
         loop {
             self.drive_preparations(committed);
             match self.advance(&mut committed.state) {
-                AdvanceStep::Prove {
-                    id,
-                    kind: MigrationTxKind::Transfer { .. },
-                } => return id,
+                AdvanceStep::Prove { transactions } => {
+                    // `drive_preparations` has just proved and broadcast every due
+                    // preparation, so what the batch carries here is transfers, earliest
+                    // anchor boundary first.
+                    assert!(
+                        matches!(transactions[0].kind(), MigrationTxKind::Transfer { .. }),
+                        "only transfers await proving once the preparations are driven"
+                    );
+                    return transactions[0].id();
+                }
                 AdvanceStep::Waiting => {
                     assert!(
                         waited < MAX_WAITING_BLOCKS,
@@ -566,11 +588,13 @@ impl Run {
         let mut waited = 0u32;
         loop {
             match self.advance(&mut committed.state) {
-                AdvanceStep::Prove { id, kind } => {
-                    assert_eq!(
-                        self.perform_prove(&mut committed.state, id, kind),
-                        ProveStepOutcome::Proved,
-                    );
+                AdvanceStep::Prove { transactions } => {
+                    for target in transactions {
+                        assert_eq!(
+                            self.perform_prove(&mut committed.state, target.id(), target.kind()),
+                            ProveStepOutcome::Proved,
+                        );
+                    }
                 }
                 AdvanceStep::Broadcast { id } => {
                     let kind = committed
@@ -809,20 +833,23 @@ impl Run {
 
         loop {
             match self.advance(&mut committed.state) {
-                AdvanceStep::Prove { id, kind } => {
-                    assert_eq!(
-                        self.perform_prove(&mut committed.state, id, kind),
-                        ProveStepOutcome::Proved,
-                        "{}: proving {id:?}",
-                        scenario.label
-                    );
-                    let proven = committed
-                        .state
-                        .transactions()
-                        .iter()
-                        .find(|t| t.id() == id)
-                        .expect("the proved transaction is present");
-                    assert!(matches!(proven.state(), MigrationTxState::Proved));
+                AdvanceStep::Prove { transactions } => {
+                    for target in transactions {
+                        let (id, kind) = (target.id(), target.kind());
+                        assert_eq!(
+                            self.perform_prove(&mut committed.state, id, kind),
+                            ProveStepOutcome::Proved,
+                            "{}: proving {id:?}",
+                            scenario.label
+                        );
+                        let proven = committed
+                            .state
+                            .transactions()
+                            .iter()
+                            .find(|t| t.id() == id)
+                            .expect("the proved transaction is present");
+                        assert!(matches!(proven.state(), MigrationTxState::Proved));
+                    }
                 }
 
                 AdvanceStep::Broadcast { id } => {
@@ -2401,10 +2428,13 @@ fn a_settled_reorg_below_a_broadcast_crossings_anchor_marks_it() {
     let mut waited = 0u32;
     loop {
         match run.advance(&mut committed.state) {
-            AdvanceStep::Prove { id, kind } => {
-                assert_eq!(id, transfer_id);
+            AdvanceStep::Prove { transactions } => {
                 assert_eq!(
-                    run.perform_prove(&mut committed.state, id, kind),
+                    transactions.iter().map(|t| t.id()).collect::<Vec<_>>(),
+                    vec![transfer_id]
+                );
+                assert_eq!(
+                    run.perform_prove(&mut committed.state, transfer_id, transactions[0].kind()),
                     ProveStepOutcome::Proved,
                 );
                 break;

--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -65,6 +65,17 @@ and this library adheres to Rust's notion of
   `PROVABLE_ANCHOR_DEPTH - 1` blocks later than before; the schedule re-spread
   in `satisfiability::advance_migration` does not count that gate-imposed wait
   as a missed schedule.
+- `state::AdvanceStep::Prove` now carries `transactions: Vec<state::ProveTarget>`
+  — every transaction provable right now, earliest-ready first — in place of a
+  single `id` and its `kind`. Proving is not privacy-relevant, so one synced
+  session proves everything it can rather than being offered one candidate per
+  call. A consumer proves each entry in order; `ProveTarget::kind` selects the
+  engine call and says whether the broadcast follows immediately (a
+  preparation) or in its own later session (a transfer), exactly as the old
+  `kind` field did. A consumer interrupted partway through a batch loses
+  nothing, since the next call re-offers the unproved remainder. Consequently
+  `state::AdvanceStep` and `satisfiability::Advance` are no longer `Copy`, and
+  `satisfiability::Advance::step` returns a reference.
 - `engine::MigrationStatus` has added variant `Cancelled`: a terminal status
   recording that the user abandoned the migration, distinct from `Failed` so
   that a deliberate abandonment is distinguishable from a migration that broke. 

--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -30,6 +30,11 @@ and this library adheres to Rust's notion of
   returns — the verified `state::AdvanceStep` to perform now, plus the outlook:
   the subsequent step's kind and the earliest target height at which it becomes
   serviceable, assuming the returned step is executed.
+- `scheduling::PROVABLE_ANCHOR_DEPTH`: how many blocks below the wallet's
+  fully-scanned tip a transfer's drawn anchor boundary must sit (at least)
+  before the planning kernel offers the transfer's proof.
+  `scheduling::WakeupParams::DEFAULT`'s settle margin is now defined as this
+  constant; its value (10) is unchanged.
 - `state::StepKind` and `state::AdvanceStep::kind`: an `AdvanceStep`'s variant
   without its payload.
 - `preparation::PreparationStrategy`.
@@ -50,6 +55,16 @@ and this library adheres to Rust's notion of
 - `preparation::plan_preparation` now returns the best plan produced by any of
   the strategies the crate ships, rather than the layered greedy's plan. Its
   signature, its errors and the plans it returns are unchanged.
+- A transfer's proof is now offered (`state::AdvanceStep::Prove`, and `ready`
+  with `state::NextAction::Prove` in `state::MigrationState::transaction_statuses`)
+  only once its drawn anchor boundary sits at least
+  `scheduling::PROVABLE_ANCHOR_DEPTH` blocks below the wallet's fully-scanned
+  tip, rather than merely strictly below it, so proofs are never built against
+  a checkpoint a plausible reorg could displace. A consumer that polled for
+  provability immediately after a boundary passed will observe the offer
+  `PROVABLE_ANCHOR_DEPTH - 1` blocks later than before; the schedule re-spread
+  in `satisfiability::advance_migration` does not count that gate-imposed wait
+  as a missed schedule.
 - `engine::MigrationStatus` has added variant `Cancelled`: a terminal status
   recording that the user abandoned the migration, distinct from `Failed` so
   that a deliberate abandonment is distinguishable from a migration that broke. 

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -5483,8 +5483,13 @@ mod commit_tests {
             .max()
             .expect("the committed migration has transactions");
         match state.next_step(DuenessTargets::at(target), &[]) {
-            crate::state::AdvanceStep::Prove { id, .. }
-            | crate::state::AdvanceStep::Broadcast { id } => {
+            crate::state::AdvanceStep::Prove { transactions } => {
+                assert!(
+                    transactions.iter().all(|t| layer0_ids.contains(&t.id())),
+                    "layer 0 proves first"
+                )
+            }
+            crate::state::AdvanceStep::Broadcast { id } => {
                 assert!(layer0_ids.contains(&id), "layer 0 broadcasts first")
             }
             other => panic!("expected a broadcast step, got {other:?}"),
@@ -5499,8 +5504,13 @@ mod commit_tests {
             .map(|t| t.id)
             .collect();
         match state.next_step(DuenessTargets::at(target), &[]) {
-            crate::state::AdvanceStep::Prove { id, .. }
-            | crate::state::AdvanceStep::Broadcast { id } => {
+            crate::state::AdvanceStep::Prove { transactions } => {
+                assert!(
+                    transactions.iter().all(|t| layer1_ids.contains(&t.id())),
+                    "layer 1 proves once layer 0 mines"
+                )
+            }
+            crate::state::AdvanceStep::Broadcast { id } => {
                 assert!(
                     layer1_ids.contains(&id),
                     "layer 1 broadcasts once layer 0 mines"
@@ -5512,8 +5522,13 @@ mod commit_tests {
             state.mark_mined(*id, BlockHeight::from_u32(2_000_020));
         }
         match state.next_step(DuenessTargets::at(target), &[]) {
-            crate::state::AdvanceStep::Prove { id, .. }
-            | crate::state::AdvanceStep::Broadcast { id } => {
+            step @ (crate::state::AdvanceStep::Prove { .. }
+            | crate::state::AdvanceStep::Broadcast { .. }) => {
+                let id = match &step {
+                    crate::state::AdvanceStep::Prove { transactions } => transactions[0].id(),
+                    crate::state::AdvanceStep::Broadcast { id } => *id,
+                    _ => unreachable!(),
+                };
                 let tx = state
                     .transactions
                     .iter()
@@ -5668,8 +5683,20 @@ mod commit_tests {
         for layer in 0..layer_count {
             let ids = layer_ids(&state, layer);
             match state.next_step(DuenessTargets::at(target), &[]) {
-                crate::state::AdvanceStep::Prove { id, .. }
-                | crate::state::AdvanceStep::Broadcast { id } => assert!(
+                // The batch carries EVERYTHING provable: the newly unblocked layer, and any
+                // transfer whose funding producer has already mined. What the dependency walk
+                // guarantees is that no LATER preparation layer proves before its predecessor
+                // mines.
+                crate::state::AdvanceStep::Prove {
+                    transactions: named,
+                } => assert!(
+                    named.iter().all(|t| {
+                        matches!(t.kind(), MigrationTxKind::Transfer { .. })
+                            || ids.contains(&t.id())
+                    }),
+                    "layer {layer} (with any ready transfers) is proved once its predecessor has mined"
+                ),
+                crate::state::AdvanceStep::Broadcast { id } => assert!(
                     ids.contains(&id),
                     "layer {layer} is proved or broadcast once its predecessor has mined"
                 ),
@@ -5698,8 +5725,13 @@ mod commit_tests {
             }
         }
         match state.next_step(DuenessTargets::at(target), &[]) {
-            crate::state::AdvanceStep::Prove { id, .. }
-            | crate::state::AdvanceStep::Broadcast { id } => {
+            step @ (crate::state::AdvanceStep::Prove { .. }
+            | crate::state::AdvanceStep::Broadcast { .. }) => {
+                let id = match &step {
+                    crate::state::AdvanceStep::Prove { transactions } => transactions[0].id(),
+                    crate::state::AdvanceStep::Broadcast { id } => *id,
+                    _ => unreachable!(),
+                };
                 let tx = state.transactions.iter().find(|t| t.id == id).unwrap();
                 assert!(
                     matches!(tx.kind, MigrationTxKind::Transfer { .. }),

--- a/zcash_pool_migration/src/satisfiability.rs
+++ b/zcash_pool_migration/src/satisfiability.rs
@@ -471,7 +471,7 @@ impl DuenessTargets {
 /// What one [`advance_migration`] call decides: the verified step to perform NOW, and the
 /// OUTLOOK — when the migration will next have work, and of what kind, assuming the returned
 /// step is executed.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Advance {
     step: AdvanceStep,
     next: Option<(BlockHeight, StepKind)>,
@@ -480,8 +480,8 @@ pub struct Advance {
 impl Advance {
     /// The step to perform now, verified against the store's satisfiability oracle exactly as
     /// [`advance_migration`] documents.
-    pub const fn step(&self) -> AdvanceStep {
-        self.step
+    pub const fn step(&self) -> &AdvanceStep {
+        &self.step
     }
 
     /// The SUBSEQUENT step, assuming [`step`](Self::step) is executed and recorded: the kind of
@@ -574,14 +574,19 @@ impl Advance {
 /// state, persists it, and calls this again; until the state records the step's completion, the
 /// same step is offered again. The steps map onto the crate's operations as follows:
 ///
-/// - [`AdvanceStep::Prove`]: install the transaction's deferred anchor and witnesses —
-///   [`prove_transfer`] / [`prove_preparation`] — and hand the returned proof to
+/// - [`AdvanceStep::Prove`]: for EACH named transaction in order, install its deferred anchor
+///   and witnesses — [`prove_transfer`] / [`prove_preparation`], chosen by the
+///   [`kind`](crate::state::ProveTarget::kind) each batch entry carries — and hand the returned
+///   proof to
 ///   [`PoolMigrationWrite::store_proved_transaction`], which records the `Signed -> Proved`
 ///   transition and persists it (for a wallet-database store, atomically with the wallet's own
-///   record of the now fully-constructed transaction). Proving needs a SYNCED wallet and mutable
-///   access to its commitment trees, but only the account's viewing key. The step carries the
-///   transaction's kind so the consumer can tell, without a lookup, whether the broadcast follows
-///   in the same session (a preparation) or in its own later one (a transfer).
+///   record of the now fully-constructed transaction). The step names the WHOLE currently
+///   provable set at once — proving emits nothing a network observer can see, so unlike
+///   broadcasting there is nothing to space out, and a synced session proves everything it can
+///   (see [`AdvanceStep::Prove`] for the ordering and the mixed-kinds note). Proving needs a
+///   SYNCED wallet and mutable access to its commitment trees, but only the account's viewing
+///   key. A consumer interrupted partway through the batch loses nothing: the next call
+///   re-offers exactly the still-unproved remainder.
 /// - [`AdvanceStep::Broadcast`]: submit the stored proven transaction to the network, then record
 ///   it with [`MigrationState::mark_broadcast`]. Its mining is later detected through the
 ///   consumer's own chain view and recorded with [`MigrationState::mark_mined`], which is what
@@ -665,7 +670,9 @@ impl Advance {
 ///   database query, and it is paid on a set that empties as transactions are broadcast. A store
 ///   that persists each transaction's derived id could answer from there instead; nothing here
 ///   requires the derivation to happen per call;
-/// - one query for the candidate the kernel names — and none at all when the kernel answers
+/// - one query per transaction the step names — a single candidate for `Broadcast` and
+///   `Rebuild`, each member of a `Prove` batch in the call that serves it (each is about to
+///   cost proving work) — and none at all when the kernel answers
 ///   [`Waiting`](AdvanceStep::Waiting), [`Complete`](AdvanceStep::Complete), or
 ///   [`Replan`](AdvanceStep::Replan), which name no transaction.
 ///
@@ -898,19 +905,37 @@ pub fn advance_migration<St: PoolMigrationWrite, R: RngCore + CryptoRng>(
             .transfer_delay(),
     );
 
-    // Plan, verify, record, plan again. Every iteration either breaks, grows `set_aside`,
-    // strictly grows the marked set — strictly, because the kernel never names an already-marked
-    // transaction (they are in its dead set), so a recorded discovery marks at least the candidate
-    // that produced it — or shifts the schedule. The first two are bounded by the transaction
-    // count; each shift raises every pending scheduled height by more than the overdue-shift
-    // tolerance toward the fixed served target, above which no shift triggers, so shifts are
-    // bounded too and the loop terminates.
-    let step = loop {
+    // Plan, verify, record, plan again: ask the kernel for a step, and put every transaction
+    // the step names — its CANDIDATES: the members of a `Prove` batch, or the single
+    // transaction of a `Broadcast` or `Rebuild` — to the store's satisfiability oracle before
+    // the step is surfaced.
+    //
+    // The loop terminates because each iteration does exactly one of:
+    // - BREAK, surfacing a step: one naming no transaction, or one whose every candidate the
+    //   oracle vouched for.
+    // - Grow `set_aside`, the call-local list of candidates deferred as "not yet satisfiable".
+    //   Ids are never removed and the kernel never re-names a set-aside id, so this happens at
+    //   most once per transaction.
+    // - Record at least one new UNSATISFIABILITY MARK — the durable
+    //   `MigrationTransaction::unsatisfiable_at` stamp, written through
+    //   `MigrationState::record_satisfiability` when the oracle reports a candidate's inputs
+    //   spent or its anchor invalidated. At least one, because the kernel never names an
+    //   already-marked transaction (marked transactions are in its dead set), so a discovery
+    //   always stamps a previously unmarked one; bounded by the transaction count.
+    // - Shift the schedule. The trigger compares pending scheduled heights against
+    //   `targets.effective()` — the height the schedule is SERVED at, a constant of this call —
+    //   and fires only on a candidate lagging it by more than `overdue_tolerance`; the shift
+    //   then raises every pending scheduled height by more than that tolerance. The minimum
+    //   pending height therefore climbs by more than the tolerance per shift while the served
+    //   height stands still, so after finitely many shifts no candidate lags far enough to
+    //   trigger, and shifts stop.
+    let step = 'plan: loop {
         let step = state.next_step(targets, &set_aside);
-        let candidate = match step {
-            AdvanceStep::Prove { id, .. }
-            | AdvanceStep::Broadcast { id }
-            | AdvanceStep::Rebuild { id } => id,
+        // The candidates the step names, in the order the step carries them: a `Prove`'s whole
+        // batch, or the single transaction of a `Broadcast` or `Rebuild`.
+        let candidates: Vec<MigrationTransferId> = match &step {
+            AdvanceStep::Prove { transactions } => transactions.iter().map(|t| t.id()).collect(),
+            AdvanceStep::Broadcast { id } | AdvanceStep::Rebuild { id } => vec![*id],
             // These name no transaction, so there is nothing to verify. `Reevaluate` is decided
             // above, by this function, and the kernel never returns it — but it is a step like
             // any other here, and matching it explicitly keeps that fact from resting on the
@@ -920,14 +945,24 @@ pub fn advance_migration<St: PoolMigrationWrite, R: RngCore + CryptoRng>(
             | AdvanceStep::Replan
             | AdvanceStep::Reevaluate => break step,
         };
-        let Some(tx) = state.transactions().iter().find(|t| t.id() == candidate) else {
-            // The kernel names its candidates out of `state.transactions()`, so an id that is not
-            // there means the state is corrupt. Nothing can be verified about it and nothing may
-            // be surfaced unverified, so the call reports `Waiting` — the safe degradation, and a
-            // BREAK rather than another iteration, which leaves no way for a corrupt state to
-            // spin the loop. Anything already recorded is still persisted below.
-            break AdvanceStep::Waiting;
-        };
+        // Each candidate's schedule data, copied out so no borrow of `state` outlives the
+        // mutations below. The kernel names its candidates out of `state.transactions()`, so an
+        // id that is not there means the state is corrupt: nothing can be verified about it and
+        // nothing may be surfaced unverified, so the call reports `Waiting` — the safe
+        // degradation, and a BREAK rather than another iteration, which leaves no way for a
+        // corrupt state to spin the loop. Anything already recorded is still persisted below.
+        let mut schedule_data: Vec<(MigrationTransferId, u32, Option<u32>)> =
+            Vec::with_capacity(candidates.len());
+        for id in &candidates {
+            let Some(tx) = state.transactions().iter().find(|t| t.id() == *id) else {
+                break 'plan AdvanceStep::Waiting;
+            };
+            schedule_data.push((
+                *id,
+                u32::from(tx.scheduled_height()),
+                tx.anchor_boundary().map(u32::from),
+            ));
+        }
         // THE OVERDUE SHIFT: ZIP 318's missed-schedule policy ("at most one overdue transfer is
         // released immediately; the rest are re-spread"). A candidate more than the
         // schedule-scaled tolerance past its scheduled height means the wallet slept through
@@ -961,43 +996,90 @@ pub fn advance_migration<St: PoolMigrationWrite, R: RngCore + CryptoRng>(
             step,
             AdvanceStep::Prove { .. } | AdvanceStep::Broadcast { .. }
         ) {
-            let scheduled = u32::from(tx.scheduled_height());
-            let overdue_from = match (&step, tx.anchor_boundary()) {
-                (AdvanceStep::Prove { .. }, Some(boundary)) => {
-                    scheduled.max(u32::from(boundary) + PROVABLE_ANCHOR_DEPTH + 1)
+            // For a batch, the MOST overdue member — the least `overdue_from` — is the trigger,
+            // and the shift is sized by that member's schedule, exactly as when it is the sole
+            // candidate.
+            let most_overdue = schedule_data
+                .iter()
+                .map(|(_, scheduled, boundary)| {
+                    let overdue_from = match (&step, boundary) {
+                        (AdvanceStep::Prove { .. }, Some(boundary)) => {
+                            (*scheduled).max(boundary + PROVABLE_ANCHOR_DEPTH + 1)
+                        }
+                        _ => *scheduled,
+                    };
+                    (overdue_from, *scheduled)
+                })
+                .min();
+            if let Some((overdue_from, scheduled)) = most_overdue {
+                let served = u32::from(targets.effective());
+                if overdue_from.saturating_add(overdue_tolerance) < served {
+                    state.shift_schedule(served - scheduled, rng);
+                    dirty = true;
+                    continue;
                 }
-                _ => scheduled,
-            };
-            let served = u32::from(targets.effective());
-            if overdue_from.saturating_add(overdue_tolerance) < served {
-                state.shift_schedule(served - scheduled, rng);
-                dirty = true;
-                continue;
             }
         }
-        let answer = store.check_step_satisfiability(tx, config.reorg_settle_depth())?;
-        match answer {
-            StepSatisfiability::Satisfiable { .. } => break step,
-            // Not an obstruction: the wallet cannot yet vouch for the inputs (their source is
-            // unmined, or mined but unscanned). Take the candidate out of this call's queues so
-            // the migration's other work still surfaces, and leave no mark — a false mark would
-            // strand live value behind an observation only a reorg can clear.
-            StepSatisfiability::NotYetSatisfiable { .. } => set_aside.push(candidate),
-            answer @ StepSatisfiability::Unsatisfiable { .. } => {
-                if !records_a_determination(&answer) {
-                    // `Expired`: never overrides the kernel, which derives expiry itself from the
-                    // same `expiry_height`. The two can disagree only under caller/store height
-                    // skew, and there the kernel's scanned target governs, so the step stands
-                    // exactly as planned (for a transfer, the rebuild that is expiry's remedy).
-                    break step;
+        // VERIFY every candidate the step names. The single-candidate steps pay the same one
+        // query as ever; a `Prove` batch pays one query per member in the call that serves it,
+        // because every member is about to cost proving work.
+        let mut kept: Vec<MigrationTransferId> = Vec::new();
+        let mut deferred: Vec<MigrationTransferId> = Vec::new();
+        let mut discoveries: Vec<(MigrationTransferId, StepSatisfiability)> = Vec::new();
+        for (id, _, _) in &schedule_data {
+            let Some(tx) = state.transactions().iter().find(|t| t.id() == *id) else {
+                break 'plan AdvanceStep::Waiting;
+            };
+            let answer = store.check_step_satisfiability(tx, config.reorg_settle_depth())?;
+            match answer {
+                StepSatisfiability::Satisfiable { .. } => kept.push(*id),
+                // Not an obstruction: the wallet cannot yet vouch for the inputs (their source
+                // is unmined, or mined but unscanned). Take the candidate out of this call's
+                // queues so the migration's other work still surfaces, and leave no mark — a
+                // false mark would strand live value behind an observation only a reorg can
+                // clear.
+                StepSatisfiability::NotYetSatisfiable { .. } => deferred.push(*id),
+                answer @ StepSatisfiability::Unsatisfiable { .. } => {
+                    if records_a_determination(&answer) {
+                        discoveries.push((*id, answer));
+                    } else {
+                        // `Expired`: never overrides the kernel, which derives expiry itself
+                        // from the same `expiry_height`. The two can disagree only under
+                        // caller/store height skew, and there the kernel's scanned target
+                        // governs, so the member stands exactly as planned (for a transfer, the
+                        // rebuild that is expiry's remedy).
+                        kept.push(*id);
+                    }
                 }
-                // A DISCOVERY, so BROADEN, then record as ONE batch so the durable closure runs
-                // once over the whole discovery.
-                let mut batch = vec![(candidate, answer)];
-                broaden_after_discovery(store, state, &mut batch, config.reorg_settle_depth())?;
-                state.record_satisfiability(targets, &batch);
-                dirty = true;
             }
+        }
+        set_aside.extend(deferred.iter().copied());
+        if !discoveries.is_empty() {
+            // A DISCOVERY, so BROADEN, then record as ONE batch so the durable closure runs
+            // once over the whole discovery, and plan again with the marks in force.
+            broaden_after_discovery(store, state, &mut discoveries, config.reorg_settle_depth())?;
+            state.record_satisfiability(targets, &discoveries);
+            dirty = true;
+            continue;
+        }
+        if deferred.is_empty() {
+            // Every named candidate verified: the step stands exactly as planned.
+            break step;
+        }
+        // Some members deferred, none died. The survivors are exactly what the next planning
+        // pass would name again — the kernel is pure, no marks changed, and the deferrals are
+        // now set aside — so a surviving `Prove` batch is served directly rather than re-buying
+        // each member's oracle answer; a fully deferred step re-plans.
+        if !kept.is_empty()
+            && let AdvanceStep::Prove { transactions } = &step
+        {
+            break AdvanceStep::Prove {
+                transactions: transactions
+                    .iter()
+                    .filter(|t| kept.contains(&t.id()))
+                    .copied()
+                    .collect(),
+            };
         }
     };
 
@@ -1007,10 +1089,8 @@ pub fn advance_migration<St: PoolMigrationWrite, R: RngCore + CryptoRng>(
     if dirty {
         store.replace_migration(state)?;
     }
-    Ok(Advance {
-        step,
-        next: upcoming_after(state, step, targets, &set_aside),
-    })
+    let next = upcoming_after(state, &step, targets, &set_aside);
+    Ok(Advance { step, next })
 }
 
 /// The OUTLOOK behind [`Advance::next`]: the subsequent step's kind and earliest serviceable
@@ -1028,7 +1108,7 @@ pub fn advance_migration<St: PoolMigrationWrite, R: RngCore + CryptoRng>(
 /// holds; it is paid only when a step is actually surfaced, never per transaction.
 fn upcoming_after(
     state: &MigrationState,
-    step: AdvanceStep,
+    step: &AdvanceStep,
     targets: DuenessTargets,
     set_aside: &[MigrationTransferId],
 ) -> Option<(BlockHeight, StepKind)> {
@@ -1038,16 +1118,20 @@ fn upcoming_after(
         | AdvanceStep::Reevaluate
         | AdvanceStep::Rebuild { .. } => None,
         AdvanceStep::Waiting => state.upcoming_step(targets, set_aside),
-        AdvanceStep::Prove { id, .. } => {
+        AdvanceStep::Prove { transactions } => {
             let mut post = state.clone();
-            if let Some(t) = post.transactions.iter_mut().find(|t| t.id == id) {
+            for t in post
+                .transactions
+                .iter_mut()
+                .filter(|t| transactions.iter().any(|pt| pt.id() == t.id))
+            {
                 t.state = MigrationTxState::Proved;
             }
             post.upcoming_step(targets, set_aside)
         }
         AdvanceStep::Broadcast { id } => {
             let mut post = state.clone();
-            post.mark_broadcast(id);
+            post.mark_broadcast(*id);
             post.upcoming_step(targets, set_aside)
         }
     }
@@ -1123,6 +1207,7 @@ mod advance_tests {
     use crate::denomination::DenominationPlan;
     use crate::engine::{MigrationStatus, MigrationTransaction, MigrationTxKind};
     use crate::preparation::PreparationPlan;
+    use crate::state::ProveTarget;
 
     /// A store that answers satisfiability from a fixed table — anything absent is satisfiable at
     /// `as_of_height`, the healthy default — and counts what the drive loop asks of it.
@@ -1262,6 +1347,14 @@ mod advance_tests {
 
     fn transfer(crossing: usize) -> MigrationTxKind {
         MigrationTxKind::Transfer { crossing }
+    }
+
+    // One member of an expected `Prove` batch.
+    fn pt(id: u32, kind: MigrationTxKind) -> ProveTarget {
+        ProveTarget {
+            id: MigrationTransferId(id),
+            kind,
+        }
     }
 
     fn mined(height: u32) -> MigrationTxState {
@@ -1479,10 +1572,11 @@ mod advance_tests {
             &mut rng(),
         )
         .expect("the store never fails")
-        .step();
+        .step()
+        .clone();
 
         assert!(
-            matches!(step, AdvanceStep::Prove { id, .. } if id == MigrationTransferId(2)),
+            matches!(&step, AdvanceStep::Prove { transactions } if *transactions == [pt(2, transfer(1))]),
             "the live transfer's prove is surfaced, not the dead transfer's broadcast: {step:?}"
         );
         let marked = BlockHeight::from_u32(1600);
@@ -1543,7 +1637,8 @@ mod advance_tests {
             &mut rng(),
         )
         .expect("the store never fails")
-        .step();
+        .step()
+        .clone();
 
         assert_eq!(
             step,
@@ -1593,7 +1688,8 @@ mod advance_tests {
             &mut rng(),
         )
         .expect("the store never fails")
-        .step();
+        .step()
+        .clone();
 
         assert_eq!(
             step,
@@ -1631,7 +1727,8 @@ mod advance_tests {
             &mut rng(),
         )
         .expect("the store never fails")
-        .step();
+        .step()
+        .clone();
         assert_eq!(
             step,
             AdvanceStep::Broadcast {
@@ -1665,7 +1762,8 @@ mod advance_tests {
             &mut rng(),
         )
         .expect("the store never fails")
-        .step();
+        .step()
+        .clone();
 
         assert_eq!(
             step,
@@ -1694,7 +1792,8 @@ mod advance_tests {
             &mut rng(),
         )
         .expect("the store never fails")
-        .step();
+        .step()
+        .clone();
         assert_eq!(step, AdvanceStep::Waiting);
         assert_eq!(store.queries.get(), 0, "a waiting call asks nothing");
         assert_eq!(store.replaced.get(), 0);
@@ -1745,7 +1844,8 @@ mod advance_tests {
             &mut rng(),
         )
         .expect("the store never fails")
-        .step();
+        .step()
+        .clone();
 
         assert_eq!(
             step,
@@ -1808,7 +1908,8 @@ mod advance_tests {
             &mut rng(),
         )
         .expect("the store never fails")
-        .step();
+        .step()
+        .clone();
 
         assert_eq!(
             state.transactions()[0].state(),
@@ -1866,7 +1967,8 @@ mod advance_tests {
             &mut rng(),
         )
         .expect("the store never fails")
-        .step();
+        .step()
+        .clone();
 
         assert_eq!(
             step,
@@ -1902,8 +2004,7 @@ mod advance_tests {
             &config(),
             &mut rng(),
         )
-        .expect("the store never fails")
-        .step();
+        .expect("the store never fails");
 
         assert_eq!(
             store.mined_queries.get(),
@@ -1946,7 +2047,8 @@ mod advance_tests {
             &mut rng(),
         )
         .expect("the store never fails")
-        .step();
+        .step()
+        .clone();
 
         assert_eq!(
             step,
@@ -2014,7 +2116,8 @@ mod advance_tests {
             &mut rng(),
         )
         .expect("the store never fails")
-        .step();
+        .step()
+        .clone();
 
         assert_eq!(
             step,
@@ -2143,7 +2246,8 @@ mod advance_tests {
                 &mut rng()
             )
             .expect("the store never fails")
-            .step(),
+            .step()
+            .clone(),
             AdvanceStep::Reevaluate,
             "the sibling's due broadcast waits behind the unanswered rejection",
         );
@@ -2180,7 +2284,8 @@ mod advance_tests {
                 &mut rng()
             )
             .expect("the store never fails")
-            .step(),
+            .step()
+            .clone(),
             AdvanceStep::Broadcast {
                 id: MigrationTransferId(1)
             },
@@ -2230,7 +2335,8 @@ mod advance_tests {
                 &mut rng()
             )
             .expect("the store never fails")
-            .step(),
+            .step()
+            .clone(),
             AdvanceStep::Replan,
         );
 
@@ -2290,7 +2396,8 @@ mod advance_tests {
                 &mut rng()
             )
             .expect("the store never fails")
-            .step(),
+            .step()
+            .clone(),
             AdvanceStep::Complete,
         );
         assert_eq!(store.queries.get(), 0);
@@ -2344,7 +2451,8 @@ mod advance_tests {
                 &mut rng()
             )
             .expect("the store never fails")
-            .step(),
+            .step()
+            .clone(),
             AdvanceStep::Reevaluate,
         );
         let marked = BlockHeight::from_u32(1600);
@@ -2398,7 +2506,8 @@ mod advance_tests {
                 &mut rng()
             )
             .expect("the store never fails")
-            .step(),
+            .step()
+            .clone(),
             AdvanceStep::Reevaluate,
             "one unanswerable rejection still holds the whole loop",
         );
@@ -2454,7 +2563,8 @@ mod advance_tests {
         assert_eq!(
             advance_migration(&mut store, &mut state, targets, &config(), &mut rng())
                 .expect("the store never fails")
-                .step(),
+                .step()
+                .clone(),
             AdvanceStep::Broadcast {
                 id: MigrationTransferId(2)
             },
@@ -2483,7 +2593,8 @@ mod advance_tests {
                 &mut rng(),
             )
             .expect("the store never fails")
-            .step(),
+            .step()
+            .clone(),
             AdvanceStep::Broadcast {
                 id: MigrationTransferId(1)
             },
@@ -2520,7 +2631,8 @@ mod advance_tests {
             &mut rng(),
         )
         .expect("the store never fails")
-        .step();
+        .step()
+        .clone();
 
         assert_eq!(
             step,
@@ -2610,7 +2722,8 @@ mod advance_tests {
             &mut rng(),
         )
         .expect("the store never fails")
-        .step();
+        .step()
+        .clone();
         assert_eq!(
             step,
             AdvanceStep::Broadcast {
@@ -2635,7 +2748,8 @@ mod advance_tests {
             &mut rng(),
         )
         .expect("the store never fails")
-        .step();
+        .step()
+        .clone();
         assert_eq!(
             step,
             AdvanceStep::Broadcast {
@@ -2703,10 +2817,11 @@ mod advance_tests {
             &mut rng(),
         )
         .expect("the store never fails")
-        .step();
+        .step()
+        .clone();
 
         assert!(
-            matches!(step, AdvanceStep::Prove { id, .. } if id == MigrationTransferId(1)),
+            matches!(&step, AdvanceStep::Prove { transactions } if *transactions == [pt(1, transfer(0))]),
             "the prove is still surfaced in the shifting call: {step:?}"
         );
         assert_eq!(
@@ -2732,7 +2847,7 @@ mod advance_tests {
         let advance = advance_migration(&mut store, &mut state, targets, &config(), &mut rng())
             .expect("the store never fails");
         assert!(
-            matches!(advance.step(), AdvanceStep::Prove { id, .. } if id == MigrationTransferId(1)),
+            matches!(advance.step(), AdvanceStep::Prove { transactions } if *transactions == [pt(1, prep(0, 0))]),
             "the due preparation's prove is the step: {:?}",
             advance.step()
         );
@@ -2752,7 +2867,7 @@ mod advance_tests {
         let advance = advance_migration(&mut store, &mut state, targets, &config(), &mut rng())
             .expect("the store never fails");
         assert!(
-            matches!(advance.step(), AdvanceStep::Prove { id, .. } if id == MigrationTransferId(1)),
+            matches!(advance.step(), AdvanceStep::Prove { transactions } if *transactions == [pt(1, transfer(0))]),
             "the settled-boundary transfer's prove is the step: {:?}",
             advance.step()
         );
@@ -2784,7 +2899,7 @@ mod advance_tests {
 
         let advance = advance_migration(&mut store, &mut state, targets, &config(), &mut rng())
             .expect("the store never fails");
-        assert_eq!(advance.step(), AdvanceStep::Waiting);
+        assert_eq!(advance.step(), &AdvanceStep::Waiting);
         assert_eq!(
             advance.next(),
             Some((BlockHeight::from_u32(1_200), StepKind::Broadcast)),
@@ -2804,7 +2919,7 @@ mod advance_tests {
             .expect("the store never fails");
         assert_eq!(
             advance.step(),
-            AdvanceStep::Broadcast {
+            &AdvanceStep::Broadcast {
                 id: MigrationTransferId(1)
             },
             "the longest-due broadcast is served first"
@@ -2845,7 +2960,7 @@ mod advance_tests {
         let targets = DuenessTargets::at(BlockHeight::from_u32(1_001));
         let advance = advance_migration(&mut store, &mut state, targets, &config(), &mut rng())
             .expect("the store never fails");
-        assert_eq!(advance.step(), AdvanceStep::Waiting);
+        assert_eq!(advance.step(), &AdvanceStep::Waiting);
         assert_eq!(
             advance.next(),
             None,
@@ -2863,7 +2978,7 @@ mod advance_tests {
         let mut store = TestStore::new(1_000, []);
         let advance = advance_migration(&mut store, &mut state, targets, &config(), &mut rng())
             .expect("the store never fails");
-        assert_eq!(advance.step(), AdvanceStep::Waiting);
+        assert_eq!(advance.step(), &AdvanceStep::Waiting);
         assert_eq!(
             advance.next(),
             None,
@@ -2880,7 +2995,7 @@ mod advance_tests {
             .expect("the store never fails");
         assert_eq!(
             advance.step(),
-            AdvanceStep::Rebuild {
+            &AdvanceStep::Rebuild {
                 id: MigrationTransferId(1)
             }
         );
@@ -2888,6 +3003,53 @@ mod advance_tests {
             advance.next(),
             None,
             "the rebuild reschedules its transfer; the following call reports the fresh outlook"
+        );
+    }
+
+    /// A `Prove` batch member the wallet cannot yet vouch for is set aside without costing the
+    /// rest of the batch: the survivors are served directly — each member having paid exactly
+    /// one oracle query, with no re-planning re-buy — and the outlook assumes the surviving
+    /// batch proved, with the set-aside member contributing no wake-up (it is chain-gated).
+    #[test]
+    fn prove_batch_serves_survivors_when_a_member_defers() {
+        let mut state = state_with_crossings(
+            &[50_000_000, 50_000_000],
+            vec![
+                tx(0, prep(0, 0), mined(10)),
+                scheduled_transfer(1, 0, 720, 1_400, MigrationTxState::Signed),
+                scheduled_transfer(2, 1, 730, 1_500, MigrationTxState::Signed),
+            ],
+        );
+        let mut store = TestStore::new(
+            900,
+            [(
+                MigrationTransferId(1),
+                StepSatisfiability::NotYetSatisfiable {
+                    as_of_height: BlockHeight::from_u32(900),
+                },
+            )],
+        );
+        let targets = DuenessTargets::at(BlockHeight::from_u32(1_001));
+
+        let advance = advance_migration(&mut store, &mut state, targets, &config(), &mut rng())
+            .expect("the store never fails");
+        assert_eq!(
+            advance.step(),
+            &AdvanceStep::Prove {
+                transactions: vec![pt(2, transfer(1))],
+            },
+            "the deferred member is dropped; the survivor is served"
+        );
+        assert_eq!(
+            store.queries.get(),
+            2,
+            "each batch member paid exactly one oracle query"
+        );
+        assert_eq!(store.replaced.get(), 0, "a deferral records nothing");
+        assert_eq!(
+            advance.next(),
+            Some((BlockHeight::from_u32(1_500), StepKind::Broadcast)),
+            "the outlook assumes the survivor proved and skips the set-aside member"
         );
     }
 }

--- a/zcash_pool_migration/src/satisfiability.rs
+++ b/zcash_pool_migration/src/satisfiability.rs
@@ -25,7 +25,7 @@ use zcash_protocol::consensus::BlockHeight;
 use crate::engine::{
     MigrationState, MigrationTransferId, MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
 };
-use crate::scheduling::{DelayDistribution, SchedulingParams};
+use crate::scheduling::{DelayDistribution, PROVABLE_ANCHOR_DEPTH, SchedulingParams};
 use crate::state::{AdvanceStep, StepKind};
 
 /// The share of planned transfer value (an integer percent) above which a migration with
@@ -533,7 +533,10 @@ impl Advance {
 ///    ([`overdue_shift_tolerance`], sized from the transfer delay the migration's persisted
 ///    anchor bucket interval implies) means the wallet
 ///    slept through part of its broadcast schedule, and the whole pending schedule is shifted
-///    forward by the lag before anything else happens: the
+///    forward by the lag before anything else happens (for a transfer's `Prove` the overdueness
+///    clock starts no earlier than the anchor-depth gate's own floor,
+///    `boundary + `[`PROVABLE_ANCHOR_DEPTH`]` + 1`, so a proof the gate itself held back never
+///    reads as wallet sleep): the
 ///    candidate comes due exactly at the served target — so it is still released in this call,
 ///    which is ZIP 318's "at most one overdue transfer is released immediately" — while every
 ///    other not-yet-broadcast transaction re-spreads behind it with its drawn gaps intact,
@@ -944,13 +947,29 @@ pub fn advance_migration<St: PoolMigrationWrite, R: RngCore + CryptoRng>(
         // deliberately not a trigger: the rebuild redraws its own transfer's schedule from the
         // target, and sizing a shift by an expired candidate's stale height would overstate it
         // for everything still live.
+        //
+        // For a TRANSFER'S PROVE the overdueness clock starts at the height its proof could
+        // first have been offered — `boundary + PROVABLE_ANCHOR_DEPTH + 1`, the anchor-depth
+        // gate's own floor — when that is later than its scheduled height. A schedule that
+        // placed a broadcast inside its own anchor's settling window (compressed test-network
+        // intervals, or a boundary redrawn near the tip) makes the proof lag the schedule as a
+        // matter of ENGINE TIMING, not wallet sleep, and re-spreading on it would shift the
+        // whole plan — and redraw boundaries near the new schedule — every time the gate was
+        // waited out, chasing its own tail. The shift's SIZE still moves the candidate's
+        // schedule to the served target, exactly as for a genuinely slept-through window.
         if matches!(
             step,
             AdvanceStep::Prove { .. } | AdvanceStep::Broadcast { .. }
         ) {
             let scheduled = u32::from(tx.scheduled_height());
+            let overdue_from = match (&step, tx.anchor_boundary()) {
+                (AdvanceStep::Prove { .. }, Some(boundary)) => {
+                    scheduled.max(u32::from(boundary) + PROVABLE_ANCHOR_DEPTH + 1)
+                }
+                _ => scheduled,
+            };
             let served = u32::from(targets.effective());
-            if scheduled.saturating_add(overdue_tolerance) < served {
+            if overdue_from.saturating_add(overdue_tolerance) < served {
                 state.shift_schedule(served - scheduled, rng);
                 dirty = true;
                 continue;

--- a/zcash_pool_migration/src/scheduling.rs
+++ b/zcash_pool_migration/src/scheduling.rs
@@ -277,6 +277,24 @@ impl Default for SchedulingParams {
     }
 }
 
+/// How deep below the wallet's fully-scanned tip a transfer's drawn anchor boundary must sit —
+/// AT LEAST this many blocks — before the planning kernel offers the transfer's proof: about
+/// 12.5 minutes of reorg stability at the target block spacing, so the boundary checkpoint
+/// proved against is one a reorg can no longer plausibly displace. This is the same settling
+/// judgment [`WakeupParams::DEFAULT`] expresses as a wake-up margin — that margin IS this
+/// constant, so a zero-jitter wake-up landing exactly on its scheduled height syncs to the
+/// first tip at which the kernel offers the proofs the wake-up exists to produce — and it
+/// matches the conventional [`ReorgSettleDepth`](crate::satisfiability::ReorgSettleDepth).
+/// Not specified by ZIP 318; provisional.
+///
+/// Proving a shallower boundary would cost correctness nothing — the satisfiability oracle
+/// detects an anchor a settled reorg invalidated, and the proof is simply redone — but it
+/// spends the proving work exactly when a reorg is most plausible, so the kernel holds the
+/// proof until the boundary is this deep. The gate is judged only against the SCANNED target
+/// ([`DuenessTargets::scanned`](crate::satisfiability::DuenessTargets::scanned)): an estimate
+/// cannot conjure the checkpoint, nor its depth.
+pub const PROVABLE_ANCHOR_DEPTH: u32 = 10;
+
 /// Parameters shaping the sync/proving wake-up schedule ([`schedule_sync_wakeups`]): how many
 /// blocks past an anchor boundary a wake-up waits for that boundary to settle, and how much random
 /// jitter spreads independent wallets' wake-ups apart as a thundering-herd defense. These values
@@ -288,9 +306,11 @@ pub struct WakeupParams {
 }
 
 impl WakeupParams {
-    /// The provisional defaults: a 10-block settle margin (about 12.5 minutes at the target block
-    /// spacing, so the synced boundary is one a reorg can no longer plausibly displace) and a
-    /// 12-block jitter cap (about 15 minutes).
+    /// The provisional defaults: a settle margin of [`PROVABLE_ANCHOR_DEPTH`] blocks (10 —
+    /// about 12.5 minutes at the target block spacing; the kernel's provability gate and this
+    /// margin are the SAME depth, so a zero-jitter wake-up syncs to the first tip at which the
+    /// kernel offers the proofs the wake-up exists to produce) and a 12-block jitter cap (about
+    /// 15 minutes).
     ///
     /// The jitter cap exists as a THUNDERING-HERD defense, and for nothing else: anchor
     /// boundaries sit on a GLOBAL grid shared by every migrating wallet, so un-jittered wake-ups
@@ -307,7 +327,7 @@ impl WakeupParams {
     /// same-height wallets WITHIN a block, so the jitter only needs to spread wallets ACROSS
     /// blocks.
     pub const DEFAULT: Self = Self {
-        settle_margin: 10,
+        settle_margin: PROVABLE_ANCHOR_DEPTH,
         jitter_cap: 12,
     };
 

--- a/zcash_pool_migration/src/state.rs
+++ b/zcash_pool_migration/src/state.rs
@@ -40,17 +40,36 @@ use crate::scheduling::{self, SyncWakeup, WakeupParams, WakeupScheduleError};
 /// [`MigrationState::mark_broadcast`] / [`MigrationState::mark_mined`]), then calls
 /// [`advance_migration`](crate::satisfiability::advance_migration) again, which documents the work each
 /// step names.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AdvanceStep {
-    /// Prove this pre-signed transaction (install its deferred Orchard anchor and spend witnesses
-    /// and store the proof through the store's
-    /// `PoolMigrationWrite::store_proved_transaction`), WITHOUT broadcasting: its dependencies
-    /// are mined and, for a transfer, its drawn anchor boundary has settled (the boundary block
-    /// sits at least [`PROVABLE_ANCHOR_DEPTH`](crate::scheduling::PROVABLE_ANCHOR_DEPTH) blocks
-    /// below the scanned chain tip, so the checkpoint proved against exists in the wallet's
-    /// commitment tree and is reorg-stable). Broadcast is a separate later step; whether it
-    /// belongs in the same waking session depends on the transaction's `kind` (see that field,
-    /// and [`advance_migration`](crate::satisfiability::advance_migration)).
+    /// Prove EVERY one of these pre-signed transactions (install each one's deferred Orchard
+    /// anchor and spend witnesses and store the proof through the store's
+    /// `PoolMigrationWrite::store_proved_transaction`, one transaction at a time), WITHOUT
+    /// broadcasting: each has its dependencies mined and, for a transfer, its drawn anchor
+    /// boundary settled (the boundary block sits at least
+    /// [`PROVABLE_ANCHOR_DEPTH`](crate::scheduling::PROVABLE_ANCHOR_DEPTH) blocks below the
+    /// scanned chain tip, so the checkpoint proved against exists in the wallet's commitment
+    /// tree and is reorg-stable).
+    ///
+    /// The step carries the WHOLE provable set rather than one candidate, because proving —
+    /// unlike broadcasting — has no privacy implications to space out: it emits nothing a
+    /// network observer can see, so there is no reason to leave provable work on the table when
+    /// a synced session is already open, and a wallet that proves everything offered here needs
+    /// no further sync wake-up for transfers whose boundaries have already settled. Broadcast
+    /// remains a separate later step, surfaced one transaction at a time on the privacy
+    /// schedule.
+    ///
+    /// The set orders earliest-ready first (a transfer by its anchor boundary, a due
+    /// preparation by its scheduled height, ties by id) and can MIX the two kinds: a due
+    /// preparation — provable only once its broadcast schedule is due, and ready to broadcast
+    /// the moment it is proved — may sit alongside transfers whose settled boundaries make them
+    /// provable well before their broadcast windows. Each entry is a [`ProveTarget`], carrying
+    /// the transaction's [`kind`](ProveTarget::kind) beside its id so the consumer can act on
+    /// the distinction — which engine call proves it, and whether its broadcast follows
+    /// immediately — without a lookup; the outlook returned alongside this step
+    /// ([`Advance::next`](crate::satisfiability::Advance::next)) says what the session holds
+    /// once the proofs land — a due preparation's own broadcast, or nothing until a later
+    /// window.
     ///
     /// Proving is not time-critical: the wallet durably retains the boundary checkpoints its
     /// committed transfers anchor to (they are exempt from ordinary checkpoint pruning; see
@@ -59,16 +78,8 @@ pub enum AdvanceStep {
     /// Proving EARLY — at a sync wake-up well before the broadcast height — is what keeps the
     /// sync-heavy work out of the broadcast session.
     Prove {
-        /// The transaction to prove.
-        id: MigrationTransferId,
-        /// What the transaction is, surfaced because the two kinds want different session
-        /// handling. A PREPARATION becomes provable only once its broadcast schedule is due, so
-        /// when it is surfaced here it is by construction ready to broadcast the moment it is
-        /// proved: prove it against a fresh checkpoint at the tip and broadcast it at the same
-        /// wake-up, like an ordinary transaction. A TRANSFER is surfaced as soon as its drawn
-        /// anchor boundary settles, typically well before its scheduled broadcast height: prove it
-        /// now and leave the broadcast to its own (later) session.
-        kind: MigrationTxKind,
+        /// The transactions to prove, earliest-ready first; never empty, and each id distinct.
+        transactions: Vec<ProveTarget>,
     },
     /// Broadcast this already-proven transaction: it is `Proved`, its dependencies are mined, and its
     /// scheduled broadcast height has arrived.
@@ -125,6 +136,24 @@ pub enum AdvanceStep {
     /// reached a terminal status (complete, failed/cancelled, or superseded by a re-plan — see
     /// [`MigrationState::is_terminal`]), so a driver can stop polling it.
     Complete,
+}
+
+/// One transaction of a [`Prove`](AdvanceStep::Prove) batch: the transaction to prove, with the
+/// [`kind`](Self::kind) that decides how the consumer acts on it. The kind rides along so no
+/// lookup stands between the step and that decision: it selects the engine call
+/// ([`prove_preparation`](crate::engine::prove_preparation) against a fresh checkpoint at the
+/// tip, or [`prove_transfer`](crate::engine::prove_transfer) against the drawn boundary), and it
+/// carries the session handling — a PREPARATION is provable only once its broadcast schedule is
+/// due, so it is by construction ready to broadcast the moment it is proved, while a TRANSFER's
+/// broadcast waits for its own later session.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, CopyGetters)]
+pub struct ProveTarget {
+    /// The transaction to prove.
+    #[getset(get_copy = "pub")]
+    pub(crate) id: MigrationTransferId,
+    /// What the transaction is: the preparation/transfer distinction described on the type.
+    #[getset(get_copy = "pub")]
+    pub(crate) kind: MigrationTxKind,
 }
 
 /// The kind of work an [`AdvanceStep`] names, shorn of the step's payload: the discriminant a
@@ -515,29 +544,29 @@ impl MigrationState {
         }
     }
 
-    /// The next pre-signed transaction ready to PROVE (move `Signed -> Proved`): its anchor is
-    /// resolvable now. Proving is decoupled from broadcasting so a transfer can be proved at a
+    /// EVERY pre-signed transaction ready to PROVE (move `Signed -> Proved`): each one's anchor
+    /// is resolvable now. Proving is decoupled from broadcasting so a transfer can be proved at a
     /// sync wake-up well before its scheduled broadcast height, keeping the sync work and the
-    /// broadcast in separate waking sessions. The whole transaction is returned, not just its id,
-    /// so [`Self::next_step`] can also surface its kind.
+    /// broadcast in separate waking sessions — and the whole ready set is surfaced as ONE
+    /// [`AdvanceStep::Prove`], because proving emits nothing a network observer can see, so
+    /// nothing about it wants the one-at-a-time spacing the broadcast queue exists to provide.
     ///
-    /// Among the ready candidates the one that became ready EARLIEST is returned: a transfer's
-    /// anchor boundary, a preparation's scheduled height (it carries no boundary), ties broken by
-    /// id. Everything ready is proved before the loop reports `Waiting`, so this only orders the
-    /// work within a session — longest-waiting first, which is also oldest-anchor first, retiring
-    /// the checkpoints the wallet has been retaining longest.
+    /// Ordered earliest-ready first: a transfer by its anchor boundary, a preparation by its
+    /// scheduled height (it carries no boundary), ties broken by id — oldest-anchor first, so a
+    /// consumer proving in order retires the checkpoints the wallet has been retaining longest.
     ///
     /// Transactions in `dead` — the ids judged unable to ever mine, at the SCANNED target — and in
     /// `set_aside` — the drive loop's call-local exclusions — are never offered;
     /// [`Self::next_step`] supplies both. Readiness itself splits the pair as
     /// [`Self::prove_ready`] describes.
-    fn next_provable_tx(
+    fn provable_targets(
         &self,
         targets: DuenessTargets,
         dead: &BTreeSet<MigrationTransferId>,
         set_aside: &[MigrationTransferId],
-    ) -> Option<&MigrationTransaction> {
-        self.transactions
+    ) -> Vec<ProveTarget> {
+        let mut ready: Vec<&MigrationTransaction> = self
+            .transactions
             .iter()
             .filter(|t| {
                 matches!(t.state, MigrationTxState::Signed)
@@ -545,9 +574,17 @@ impl MigrationState {
                     && !set_aside.contains(&t.id)
                     && self.prove_ready(t, targets)
             })
-            // The height each became provable at: a transfer's drawn boundary, a preparation's
-            // schedule.
-            .min_by_key(|t| (t.anchor_boundary.unwrap_or(t.scheduled_height), t.id))
+            .collect();
+        // The height each became provable at: a transfer's drawn boundary, a preparation's
+        // schedule.
+        ready.sort_by_key(|t| (t.anchor_boundary.unwrap_or(t.scheduled_height), t.id));
+        ready
+            .into_iter()
+            .map(|t| ProveTarget {
+                id: t.id,
+                kind: t.kind,
+            })
+            .collect()
     }
 
     /// The id of the next transaction ready to BROADCAST: already `Proved`, its dependencies mined,
@@ -1202,11 +1239,15 @@ impl MigrationState {
     /// the committed threshold is exceeded, then PROVE, then REBUILD, then REPLAN once dead
     /// value is all that remains.
     ///
-    /// Within each queue the longest-READY candidate is offered first, ties broken by id — never
-    /// the first by position in [`transactions`](MigrationState::transactions). Readiness is what
-    /// each queue itself waits on: the scheduled height for a broadcast or a rebuild, the anchor
-    /// boundary (a preparation: its scheduled height) for a proof. The whole queue is drained
-    /// before the next one is consulted, so this orders work within a session, not across them.
+    /// Within the broadcast and rebuild queues the longest-READY candidate is offered first,
+    /// ties broken by id — never the first by position in
+    /// [`transactions`](MigrationState::transactions) — and the whole queue is drained, one
+    /// candidate per call, before the next queue is consulted. Readiness is what each queue
+    /// itself waits on: the scheduled height for a broadcast or a rebuild, the anchor boundary
+    /// (a preparation: its scheduled height) for a proof. The PROVE queue is instead served
+    /// WHOLE: one [`Prove`](AdvanceStep::Prove) step carries every ready candidate,
+    /// earliest-ready first, because proving emits nothing observable and so has no reason to be
+    /// doled out call by call. Either way this orders work within a session, not across them.
     ///
     /// [`Reevaluate`](AdvanceStep::Reevaluate) is NOT among the steps decided here: adjudicating
     /// a broadcast-failure report needs the oracle, so the drive API owns that slot. What this
@@ -1308,13 +1349,13 @@ impl MigrationState {
             return AdvanceStep::Replan;
         }
         // A wallet should not broadcast and sync in the same waking session unless necessary.
-        // At this point we know we're not broadcasting, so we can sync and prove. The kind rides
-        // along because it decides the session handling: a preparation is broadcast as soon as it
-        // is proved, a transfer's broadcast waits for its own (later) session.
-        if let Some(t) = self.next_provable_tx(targets, &dead, set_aside) {
+        // At this point we know we're not broadcasting, so we can sync and prove — and prove
+        // EVERYTHING that is ready: proving emits nothing observable, so the whole provable set
+        // is served as one step rather than being doled out call by call.
+        let provable = self.provable_targets(targets, &dead, set_aside);
+        if !provable.is_empty() {
             return AdvanceStep::Prove {
-                id: t.id,
-                kind: t.kind,
+                transactions: provable,
             };
         }
         // If we have not been able to make progress on still-valid transactions, then surface any
@@ -1355,9 +1396,9 @@ impl MigrationState {
         AdvanceStep::Waiting
     }
 
-    /// The next step that will involve transaction `t`, with the earliest target height at which
-    /// it could be served: the per-transaction FLOOR behind [`Self::upcoming_step`]. `dead` is
-    /// the caller's [`Self::dead_set`].
+    /// The KIND of the next step that will involve transaction `t`, with the earliest target
+    /// height at which it could be served: the per-transaction FLOOR behind
+    /// [`Self::upcoming_step`]. `dead` is the caller's [`Self::dead_set`].
     ///
     /// `None` means no future step involves the transaction: it is mined or in flight (mining is
     /// chain-derived, not a step), it can never mine — its own mark, or a dead dependency — so
@@ -1385,7 +1426,7 @@ impl MigrationState {
         t: &MigrationTransaction,
         targets: DuenessTargets,
         dead: &BTreeSet<MigrationTransferId>,
-    ) -> Option<(AdvanceStep, BlockHeight)> {
+    ) -> Option<(StepKind, BlockHeight)> {
         // Mined is final: nothing is ever asked of the transaction again.
         if matches!(t.state, MigrationTxState::Mined { .. }) {
             return None;
@@ -1402,32 +1443,25 @@ impl MigrationState {
         // expiry, as in the status view: being actively withheld on another observer's testimony
         // is the more specific thing to report.
         if let Some(reported) = t.broadcast_failure_at {
-            return Some((AdvanceStep::Reevaluate, reported + 1));
+            return Some((StepKind::Reevaluate, reported + 1));
         }
         // A lapse the wallet's own scan supports: a transfer's remedy is its rebuild; an expired
         // preparation has no single-transaction step (see `Blocker::Expired`).
         if Self::is_expired(t, targets.scanned()) {
             return match t.kind {
-                MigrationTxKind::Transfer { .. } => {
-                    Some((AdvanceStep::Rebuild { id: t.id }, t.expiry_height + 1))
-                }
+                MigrationTxKind::Transfer { .. } => Some((StepKind::Rebuild, t.expiry_height + 1)),
                 MigrationTxKind::Preparation { .. } => None,
             };
         }
         match t.state {
             MigrationTxState::Signed | MigrationTxState::AwaitingSignature => Some((
-                AdvanceStep::Prove {
-                    id: t.id,
-                    kind: t.kind,
-                },
+                StepKind::Prove,
                 match t.anchor_boundary {
                     Some(boundary) => boundary + (scheduling::PROVABLE_ANCHOR_DEPTH + 1),
                     None => t.scheduled_height,
                 },
             )),
-            MigrationTxState::Proved => {
-                Some((AdvanceStep::Broadcast { id: t.id }, t.scheduled_height))
-            }
+            MigrationTxState::Proved => Some((StepKind::Broadcast, t.scheduled_height)),
             MigrationTxState::Broadcast { .. } | MigrationTxState::Mined { .. } => None,
         }
     }
@@ -1467,10 +1501,11 @@ impl MigrationState {
             step @ (AdvanceStep::Prove { .. }
             | AdvanceStep::Broadcast { .. }
             | AdvanceStep::Rebuild { .. }) => {
-                let id = match step {
-                    AdvanceStep::Prove { id, .. }
-                    | AdvanceStep::Broadcast { id }
-                    | AdvanceStep::Rebuild { id } => id,
+                let id = match &step {
+                    // The set orders earliest-ready first, and readiness order is floor order,
+                    // so the first member carries the step's own floor.
+                    AdvanceStep::Prove { transactions } => transactions.first()?.id,
+                    AdvanceStep::Broadcast { id } | AdvanceStep::Rebuild { id } => *id,
                     _ => unreachable!("matched an actionable step"),
                 };
                 let dead = self.dead_set(targets);
@@ -1478,7 +1513,7 @@ impl MigrationState {
                     .iter()
                     .find(|t| t.id == id)
                     .and_then(|t| self.step_floor(t, targets, &dead))
-                    .map(|(step, height)| (height, step.kind()))
+                    .map(|(kind, height)| (height, kind))
             }
             AdvanceStep::Waiting => {
                 let dead = self.dead_set(targets);
@@ -1495,16 +1530,16 @@ impl MigrationState {
                     // The earliest floor; at equal heights, the queue order the kernel serves
                     // (broadcast, then prove, then rebuild), then id, so the outlook is
                     // deterministic and agrees with what the wake-up's own call will name.
-                    .min_by_key(|(id, (step, height))| {
-                        let rank = match step {
-                            AdvanceStep::Broadcast { .. } => 0u8,
-                            AdvanceStep::Prove { .. } => 1,
-                            AdvanceStep::Rebuild { .. } => 2,
+                    .min_by_key(|(id, (kind, height))| {
+                        let rank = match kind {
+                            StepKind::Broadcast => 0u8,
+                            StepKind::Prove => 1,
+                            StepKind::Rebuild => 2,
                             _ => 3,
                         };
                         (*height, rank, *id)
                     })
-                    .map(|(_, (step, height))| (height, step.kind()))
+                    .map(|(_, (kind, height))| (height, kind))
             }
         }
     }
@@ -1723,6 +1758,14 @@ mod tests {
 
     fn transfer(crossing: usize) -> MigrationTxKind {
         MigrationTxKind::Transfer { crossing }
+    }
+
+    // One member of an expected `Prove` batch.
+    fn pt(id: u32, kind: MigrationTxKind) -> ProveTarget {
+        ProveTarget {
+            id: MigrationTransferId(id),
+            kind,
+        }
     }
 
     // A state wrapping the given transactions; the plan pieces are empty (unused by state logic).
@@ -2032,17 +2075,17 @@ mod tests {
             Some(MigrationTransferId(0))
         );
 
-        // Prove: provable longest, so by ANCHOR BOUNDARY (transfer 0) — the opposite order.
+        // Prove: the whole ready set at once, ordered by ANCHOR BOUNDARY (transfer 0 first) —
+        // the opposite order.
         s.transactions[0].state = MigrationTxState::Signed;
         s.transactions[1].state = MigrationTxState::Signed;
         assert_eq!(
-            s.next_provable_tx(due, &BTreeSet::new(), &[]).map(|t| t.id),
-            Some(MigrationTransferId(0))
+            s.provable_targets(due, &BTreeSet::new(), &[]),
+            vec![pt(0, transfer(0)), pt(1, transfer(1))]
         );
         assert_eq!(
-            s.next_provable_tx(due, &BTreeSet::new(), &[MigrationTransferId(0)])
-                .map(|t| t.id),
-            Some(MigrationTransferId(1))
+            s.provable_targets(due, &BTreeSet::new(), &[MigrationTransferId(0)]),
+            vec![pt(1, transfer(1))]
         );
 
         // Rebuild: expired longest, so by schedule again. Give both an expiry the target passed.
@@ -2176,8 +2219,7 @@ mod tests {
         assert_eq!(
             s.next_step(DuenessTargets::at(BlockHeight::from_u32(100)), &[]),
             AdvanceStep::Prove {
-                id: MigrationTransferId(0),
-                kind: prep(0, 0),
+                transactions: vec![pt(0, prep(0, 0))],
             }
         );
         s.transactions[0].state = MigrationTxState::Proved;
@@ -2202,8 +2244,7 @@ mod tests {
         assert_eq!(
             s.next_step(DuenessTargets::at(BlockHeight::from_u32(100)), &[]),
             AdvanceStep::Prove {
-                id: MigrationTransferId(1),
-                kind: prep(1, 0),
+                transactions: vec![pt(1, prep(1, 0))],
             }
         );
         s.transactions[1].state = MigrationTxState::Proved;
@@ -2219,8 +2260,7 @@ mod tests {
         assert_eq!(
             s.next_step(DuenessTargets::at(BlockHeight::from_u32(100)), &[]),
             AdvanceStep::Prove {
-                id: MigrationTransferId(2),
-                kind: transfer(0),
+                transactions: vec![pt(2, transfer(0))],
             }
         );
         s.transactions[2].state = MigrationTxState::Proved;
@@ -2254,8 +2294,7 @@ mod tests {
         assert_eq!(
             s.next_step(DuenessTargets::at(BlockHeight::from_u32(50)), &[]),
             AdvanceStep::Prove {
-                id: MigrationTransferId(1),
-                kind: transfer(0),
+                transactions: vec![pt(1, transfer(0))],
             }
         );
     }
@@ -2561,8 +2600,7 @@ mod tests {
         assert_eq!(
             s.next_step(DuenessTargets::at(BlockHeight::from_u32(51)), &[]),
             AdvanceStep::Prove {
-                id: MigrationTransferId(1),
-                kind: transfer(0),
+                transactions: vec![pt(1, transfer(0))],
             }
         );
 
@@ -2645,13 +2683,12 @@ mod tests {
         // The same holds for a still-`Signed` (unproved) expired transfer: it is not provable either.
         s.transactions[1].state = MigrationTxState::Signed;
         assert_eq!(
-            s.next_provable_tx(
+            s.provable_targets(
                 DuenessTargets::at(BlockHeight::from_u32(51)),
                 &BTreeSet::new(),
                 &[],
-            )
-            .map(|t| t.id),
-            None
+            ),
+            Vec::new()
         );
         assert_eq!(
             s.next_step(DuenessTargets::at(BlockHeight::from_u32(51)), &[]),
@@ -2704,8 +2741,7 @@ mod tests {
         assert_eq!(
             s.next_step(DuenessTargets::at(BlockHeight::from_u32(51)), &[]),
             AdvanceStep::Prove {
-                id: MigrationTransferId(1),
-                kind: transfer(0),
+                transactions: vec![pt(1, transfer(0))],
             }
         );
         // Once the valid transfer is proved and broadcast, the expired one is surfaced for rebuild.
@@ -3163,15 +3199,21 @@ mod tests {
             tx(0, prep(0, 0), MigrationTxState::Signed),
             tx(1, prep(0, 1), MigrationTxState::Signed),
         ]);
-        let AdvanceStep::Prove { id: first_id, .. } =
-            s.next_step(DuenessTargets::at(BlockHeight::from_u32(100)), &[])
-        else {
-            panic!("expected Prove");
-        };
-        match s.next_step(DuenessTargets::at(BlockHeight::from_u32(100)), &[first_id]) {
-            AdvanceStep::Prove { id, .. } => assert_ne!(id, first_id),
-            other => panic!("expected the sibling, got {other:?}"),
-        }
+        assert_eq!(
+            s.next_step(DuenessTargets::at(BlockHeight::from_u32(100)), &[]),
+            AdvanceStep::Prove {
+                transactions: vec![pt(0, prep(0, 0)), pt(1, prep(0, 1))],
+            }
+        );
+        assert_eq!(
+            s.next_step(
+                DuenessTargets::at(BlockHeight::from_u32(100)),
+                &[MigrationTransferId(0)]
+            ),
+            AdvanceStep::Prove {
+                transactions: vec![pt(1, prep(0, 1))],
+            }
+        );
         assert_eq!(
             s.next_step(
                 DuenessTargets::at(BlockHeight::from_u32(100)),
@@ -4203,8 +4245,7 @@ mod tests {
         assert_eq!(
             live.next_step(targets, &[]),
             AdvanceStep::Prove {
-                id: MigrationTransferId(1),
-                kind: transfer(0),
+                transactions: vec![pt(1, transfer(0))],
             }
         );
     }
@@ -4240,8 +4281,7 @@ mod tests {
                 &[],
             ),
             AdvanceStep::Prove {
-                id: MigrationTransferId(1),
-                kind: transfer(0),
+                transactions: vec![pt(1, transfer(0))],
             }
         );
     }

--- a/zcash_pool_migration/src/state.rs
+++ b/zcash_pool_migration/src/state.rs
@@ -46,10 +46,11 @@ pub enum AdvanceStep {
     /// and store the proof through the store's
     /// `PoolMigrationWrite::store_proved_transaction`), WITHOUT broadcasting: its dependencies
     /// are mined and, for a transfer, its drawn anchor boundary has settled (the boundary block
-    /// is strictly below the chain tip, so its checkpoint exists in the wallet's commitment
-    /// tree). Broadcast is a separate later step; whether it belongs in the same waking session
-    /// depends on the transaction's `kind` (see that field, and
-    /// [`advance_migration`](crate::satisfiability::advance_migration)).
+    /// sits at least [`PROVABLE_ANCHOR_DEPTH`](crate::scheduling::PROVABLE_ANCHOR_DEPTH) blocks
+    /// below the scanned chain tip, so the checkpoint proved against exists in the wallet's
+    /// commitment tree and is reorg-stable). Broadcast is a separate later step; whether it
+    /// belongs in the same waking session depends on the transaction's `kind` (see that field,
+    /// and [`advance_migration`](crate::satisfiability::advance_migration)).
     ///
     /// Proving is not time-critical: the wallet durably retains the boundary checkpoints its
     /// committed transfers anchor to (they are exempt from ordinary checkpoint pruning; see
@@ -468,14 +469,17 @@ impl MigrationState {
     /// is resolvable from the wallet's commitment tree right now.
     ///
     /// A TRANSFER anchors to a drawn boundary ([`anchor_boundary`](MigrationTransaction::anchor_boundary)),
-    /// which must have SETTLED: the boundary block must be strictly below the chain tip so its
-    /// checkpoint exists in the tree. Proving becomes available as soon as that holds, decoupled
-    /// from the (later) broadcast schedule: the wallet durably retains the boundary checkpoint, so
-    /// nothing forces the proof to happen promptly, but making it available early lets the
-    /// sync-heavy proving work happen at a sync wake-up in a different waking session from the
-    /// broadcast (see [`Self::next_step`]). A PREPARATION carries no drawn boundary and anchors to
-    /// a fresh checkpoint at the tip when proved, so it is prove-ready once its dependencies are
-    /// mined and its scheduled height has arrived.
+    /// which must have SETTLED: the boundary block must sit at least
+    /// [`PROVABLE_ANCHOR_DEPTH`](crate::scheduling::PROVABLE_ANCHOR_DEPTH) blocks below the
+    /// scanned chain tip, so its checkpoint exists in the tree AND is deep enough that a reorg
+    /// can no longer plausibly displace it.
+    /// Proving becomes available as soon as that holds, decoupled from the (later) broadcast
+    /// schedule: the wallet durably retains the boundary checkpoint, so nothing forces the proof
+    /// to happen promptly, but making it available early lets the sync-heavy proving work happen
+    /// at a sync wake-up in a different waking session from the broadcast (see
+    /// [`Self::next_step`]). A PREPARATION carries no drawn boundary and anchors to a fresh
+    /// checkpoint at the tip when proved, so it is prove-ready once its dependencies are mined
+    /// and its scheduled height has arrived.
     ///
     /// The two targets divide here exactly as [`DuenessTargets`] describes. Boundary settledness is
     /// judged at [`scanned`](DuenessTargets::scanned): the checkpoint either exists in the wallet's
@@ -497,11 +501,16 @@ impl MigrationState {
             return false;
         }
         match t.anchor_boundary {
-            // A transfer: the boundary must be strictly below the SCANNED tip, so the wallet
-            // actually holds the checkpoint. The scanned target is `tip + 1`, so `boundary < tip`
-            // is `boundary + 1 < scanned`.
-            Some(boundary) => u32::from(boundary) + 1 < u32::from(targets.scanned()),
-            // A preparation: prove-ready once its schedule is due, at the served target.
+            // A transfer: the boundary must sit AT LEAST `PROVABLE_ANCHOR_DEPTH` blocks below
+            // the SCANNED tip — deep enough that the checkpoint proved against is reorg-stable
+            // (see the constant). The scanned target is `tip + 1`, so `tip - boundary >= DEPTH`
+            // is `boundary + DEPTH < scanned`.
+            Some(boundary) => {
+                u32::from(boundary) + scheduling::PROVABLE_ANCHOR_DEPTH
+                    < u32::from(targets.scanned())
+            }
+            // A preparation: prove-ready once its schedule is due, at the served target. It
+            // anchors to a fresh checkpoint at the tip when proved, so no boundary depth applies.
             None => t.scheduled_height <= targets.effective(),
         }
     }
@@ -1360,8 +1369,10 @@ impl MigrationState {
     /// upward-closed in the target height, so the least target satisfying it is well-defined —
     /// but chain-driven guards (dependencies mining, the doomed-window withhold resolving) are
     /// the caller's to judge. Per step, the floor is the least target at which the guard holds: a
-    /// transfer's proof once its drawn boundary sits strictly below the scanned tip
-    /// (`boundary + 2`), a preparation's proof and any broadcast at the scheduled height, a
+    /// transfer's proof once its drawn boundary sits at least
+    /// [`PROVABLE_ANCHOR_DEPTH`](crate::scheduling::PROVABLE_ANCHOR_DEPTH) blocks below the
+    /// scanned tip (`boundary + PROVABLE_ANCHOR_DEPTH + 1`), a preparation's proof and any
+    /// broadcast at the scheduled height, a
     /// rebuild at the lapse's first observability (`expiry_height + 1`), and a reported
     /// transaction's reevaluation at the first scanned target resting at its reported tip
     /// (`reported + 1`). Dispositions are judged in [`Self::transaction_statuses`]' blocker
@@ -1410,7 +1421,7 @@ impl MigrationState {
                     kind: t.kind,
                 },
                 match t.anchor_boundary {
-                    Some(boundary) => boundary + 2,
+                    Some(boundary) => boundary + (scheduling::PROVABLE_ANCHOR_DEPTH + 1),
                     None => t.scheduled_height,
                 },
             )),
@@ -2521,28 +2532,34 @@ mod tests {
 
     #[test]
     fn transfer_prove_ready_waits_for_its_anchor_boundary() {
-        // A transfer anchors to a drawn boundary; it is not provable until the boundary block is
-        // strictly below the tip (its checkpoint has settled), decoupled from the broadcast schedule.
+        // A transfer anchors to a drawn boundary; it is not provable until the boundary block
+        // sits at least `PROVABLE_ANCHOR_DEPTH` blocks below the tip (its checkpoint has
+        // settled to reorg stability), decoupled from the broadcast schedule.
         let mut xfer = tx(1, transfer(0), MigrationTxState::Signed);
         xfer.depends_on = vec![MigrationTransferId(0)];
         xfer.anchor_boundary = Some(BlockHeight::from_u32(40));
         xfer.scheduled_height = BlockHeight::from_u32(60);
         let mut s = state_with(vec![tx(0, prep(0, 0), mined(10)), xfer]);
 
-        // `target_height` is `tip + 1`. At tip 40 (target 41) the boundary is not yet strictly below
-        // the tip -> not provable, blocked on the anchor boundary.
+        // `target_height` is `tip + 1`. At tip 49 (target 50) the boundary is only 9 blocks
+        // below the tip -> not yet provable, blocked on the anchor boundary.
         assert_eq!(
-            s.next_step(DuenessTargets::at(BlockHeight::from_u32(41)), &[]),
+            s.next_step(DuenessTargets::at(BlockHeight::from_u32(50)), &[]),
             AdvanceStep::Waiting
         );
-        let v = s.transaction_statuses(DuenessTargets::at(BlockHeight::from_u32(41)));
+        let v = s.transaction_statuses(DuenessTargets::at(BlockHeight::from_u32(50)));
         assert!(!v[1].ready);
         assert_eq!(v[1].blocked_on, Some(Blocker::AnchorBoundary));
 
-        // At tip 41 (target 42) boundary 40 is strictly below the tip -> provable now, even though
-        // the broadcast schedule (60) has not arrived.
+        // At tip 50 (target 51) boundary 40 sits exactly `PROVABLE_ANCHOR_DEPTH` blocks below
+        // the tip -> provable now, even though the broadcast schedule (60) has not arrived.
         assert_eq!(
-            s.next_step(DuenessTargets::at(BlockHeight::from_u32(42)), &[]),
+            u32::from(BlockHeight::from_u32(40)) + crate::scheduling::PROVABLE_ANCHOR_DEPTH,
+            50,
+            "the settling target below tracks the constant"
+        );
+        assert_eq!(
+            s.next_step(DuenessTargets::at(BlockHeight::from_u32(51)), &[]),
             AdvanceStep::Prove {
                 id: MigrationTransferId(1),
                 kind: transfer(0),
@@ -4198,28 +4215,28 @@ mod tests {
     /// still reported as waiting on its boundary.
     #[test]
     fn an_estimate_does_not_conjure_a_settled_anchor_boundary() {
-        // Boundary 1_500 settles at target 1_502 (`boundary + 1 < target`), so a scan at 1_501
-        // has not reached it while an estimate at 1_700 has.
+        // Boundary 1_500 settles at target 1_511 (`boundary + PROVABLE_ANCHOR_DEPTH < target`),
+        // so a scan at 1_510 has not reached it while an estimate at 1_700 has.
         let s = state_with(vec![
             tx(0, prep(0, 0), mined(10)),
             scheduled_transfer(1, 0, 1_500, 1_400, MigrationTxState::Signed),
         ]);
         let targets =
-            DuenessTargets::new(BlockHeight::from_u32(1_501), BlockHeight::from_u32(1_700));
+            DuenessTargets::new(BlockHeight::from_u32(1_510), BlockHeight::from_u32(1_700));
 
         assert!(
             !s.prove_ready(&s.transactions[1], targets),
-            "the checkpoint the transfer anchors to has not been scanned"
+            "the boundary has not settled to the provability depth in the wallet's own scan"
         );
         assert_eq!(s.next_step(targets, &[]), AdvanceStep::Waiting);
         assert_eq!(
             s.transaction_statuses(targets)[1].blocked_on,
             Some(Blocker::AnchorBoundary)
         );
-        // One more scanned block and the checkpoint exists, whatever the estimate says.
+        // One more scanned block and the boundary is deep enough, whatever the estimate says.
         assert_eq!(
             s.next_step(
-                DuenessTargets::new(BlockHeight::from_u32(1_502), BlockHeight::from_u32(1_700)),
+                DuenessTargets::new(BlockHeight::from_u32(1_511), BlockHeight::from_u32(1_700)),
                 &[],
             ),
             AdvanceStep::Prove {

--- a/zcash_pool_migration/tests/engine_commit.rs
+++ b/zcash_pool_migration/tests/engine_commit.rs
@@ -183,8 +183,15 @@ fn commits_a_multi_layer_migration_in_one_pass() {
     match advance_migration(&mut backend, &mut state, targets, &config, &mut rng)
         .expect("the store answers")
         .step()
+        .clone()
     {
-        AdvanceStep::Prove { id, .. } | AdvanceStep::Broadcast { id } => {
+        AdvanceStep::Prove { transactions } => {
+            assert!(
+                transactions.iter().all(|t| layer0_ids.contains(&t.id())),
+                "layer 0 proves first"
+            )
+        }
+        AdvanceStep::Broadcast { id } => {
             assert!(layer0_ids.contains(&id), "layer 0 broadcasts first")
         }
         other => panic!("expected a broadcast step, got {other:?}"),
@@ -202,8 +209,15 @@ fn commits_a_multi_layer_migration_in_one_pass() {
     match advance_migration(&mut backend, &mut state, targets, &config, &mut rng)
         .expect("the store answers")
         .step()
+        .clone()
     {
-        AdvanceStep::Prove { id, .. } | AdvanceStep::Broadcast { id } => {
+        AdvanceStep::Prove { transactions } => {
+            assert!(
+                transactions.iter().all(|t| layer1_ids.contains(&t.id())),
+                "layer 1 proves once layer 0 mines"
+            )
+        }
+        AdvanceStep::Broadcast { id } => {
             assert!(
                 layer1_ids.contains(&id),
                 "layer 1 broadcasts once layer 0 mines"
@@ -218,8 +232,14 @@ fn commits_a_multi_layer_migration_in_one_pass() {
     match advance_migration(&mut backend, &mut state, targets, &config, &mut rng)
         .expect("the store answers")
         .step()
+        .clone()
     {
-        AdvanceStep::Prove { id, .. } | AdvanceStep::Broadcast { id } => {
+        step @ (AdvanceStep::Prove { .. } | AdvanceStep::Broadcast { .. }) => {
+            let id = match &step {
+                AdvanceStep::Prove { transactions } => transactions[0].id(),
+                AdvanceStep::Broadcast { id } => *id,
+                _ => unreachable!(),
+            };
             let tx = state
                 .transactions()
                 .iter()


### PR DESCRIPTION
Building on the `Advance` outlook from #2936, two changes to how the pool-migration planner serves proving work:

**Gate transfer proofs on a reorg-stable anchor depth.** A transfer's proof is now offered only once its drawn anchor boundary sits at least `scheduling::PROVABLE_ANCHOR_DEPTH` blocks below the wallet's fully-scanned tip, rather than merely strictly below it, so the kernel never offers a proof against a checkpoint a plausible reorg could still displace. The depth (10 blocks) is the same reorg-stability judgment the sync wake-up schedule already waited out as `WakeupParams::DEFAULT`'s settle margin — that margin is now defined as the constant, its value unchanged, so a zero-jitter wake-up syncs to the first tip at which the kernel offers the proofs the wake-up exists to produce. The overdue re-spread in `advance_migration` starts a prove candidate's overdueness clock no earlier than the gate's own floor, so a proof the gate held back never reads as wallet sleep (without this, a schedule that places a broadcast inside its anchor's settling window — compressed test-network intervals, or a boundary redrawn near the tip — would re-spread and redraw boundaries every time the gate was waited out, chasing its own tail).

**Serve the whole provable set as one `Prove` step.** `state::AdvanceStep::Prove` now carries `transactions: Vec<state::ProveTarget>` — every transaction provable at the caller's targets, earliest-ready first — in place of a single candidate. Proving emits nothing a network observer can see, so unlike broadcasting there is nothing to space out: a synced session proves everything it can, and needs no further sync wake-up for transfers whose boundaries have already settled. Each `ProveTarget` carries the transaction's `kind` beside its `id`, so a consumer still tells without a lookup which engine call proves the entry and whether its broadcast follows immediately (a due preparation) or in its own later session (a transfer). The drive loop verifies every batch member against the satisfiability oracle in the serving call, records marking discoveries as one broadened batch, and sets aside members answering "not yet satisfiable" while serving the surviving batch directly (the kernel is pure, so the survivors need no second oracle query). A consumer interrupted partway through a batch loses nothing, since the next call re-offers the unproved remainder.

Notes for review:

- A `Prove` batch can never mix preparation layers: `prove_ready` requires `deps_mined`, which demands the `Mined` state, so a later layer's preparations only become provable after the wallet's scan sees the previous layer mine. The deep-migration commit test asserts this per layer (a batch may legitimately carry a transfer whose funding producer has already mined alongside the newly-unblocked layer).
- `AdvanceStep` and `satisfiability::Advance` lose `Copy` (the batch carries a `Vec`), and `Advance::step` now returns a reference.
- The batched step's overdue-shift trigger is the most overdue member, and the shift is sized by that member's schedule, preserving the single-candidate semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Gsndy5ri9eYvtH31DnHTQ
