### PR TITLE
zcash_pool_migration: add a first-fit-decreasing preparation strategy

### DIFF
--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -38,6 +38,8 @@ and this library adheres to Rust's notion of
 - `state::StepKind` and `state::AdvanceStep::kind`: an `AdvanceStep`'s variant
   without its payload.
 - `preparation::PreparationStrategy`.
+- `preparation::first_fit_decreasing::FirstFitDecreasing`, re-exported as
+  `preparation::FirstFitDecreasing`.
 - `preparation::layered_greedy::LayeredGreedy`, re-exported as
   `preparation::LayeredGreedy`.
 - `preparation::PreparationPlan::is_valid`.
@@ -54,7 +56,13 @@ and this library adheres to Rust's notion of
   from each transaction's scheduled height by hand.
 - `preparation::plan_preparation` now returns the best plan produced by any of
   the strategies the crate ships, rather than the layered greedy's plan. Its
-  signature, its errors and the plans it returns are unchanged.
+  signature, its errors and the plans it returns are unchanged. The plans
+  differ: a wallet whose funding notes need a transaction that spends several
+  notes and mints several is now planned in one transaction and one layer,
+  where it previously took a chain of merges and splits across layers or could
+  not be planned at all. A consumer that pinned the number of preparation
+  transactions, the number of crossings, or the migrated value for a given
+  wallet will see those change.
 - A transfer's proof is now offered (`state::AdvanceStep::Prove`, and `ready`
   with `state::NextAction::Prove` in `state::MigrationState::transaction_statuses`)
   only once its drawn anchor boundary sits at least

--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -40,6 +40,12 @@ and this library adheres to Rust's notion of
 - `preparation::PreparationStrategy`.
 - `preparation::first_fit_decreasing::FirstFitDecreasing`, re-exported as
   `preparation::FirstFitDecreasing`.
+- `preparation::plan_preparation_with` and `preparation::default_portfolio`, to
+  plan against a chosen set of strategies rather than the ones the crate ships.
+- `engine::plan_migration_with`, the same choice at the whole-migration level.
+  It reaches the crossings as well as the preparation transactions, since the
+  denomination decomposition asks the preparation planner what it can mint at
+  every step.
 - `preparation::layered_greedy::LayeredGreedy`, re-exported as
   `preparation::LayeredGreedy`.
 - `preparation::PreparationPlan::is_valid`.

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -1247,6 +1247,33 @@ where
     B: MigrationBackend,
     R: RngCore + rand_core::CryptoRng,
 {
+    plan_migration_with(
+        &crate::preparation::default_portfolio(),
+        params,
+        backend,
+        rng,
+    )
+}
+
+/// As [`plan_migration`], planning the preparation transactions against a chosen set of strategies
+/// rather than the ones the crate ships.
+///
+/// The choice reaches the whole plan, not only its preparation transactions: the denomination
+/// decomposition asks the preparation planner what it can mint at every step, so a portfolio that
+/// can build fewer transaction shapes yields different crossings as well as different
+/// preparations.
+pub fn plan_migration_with<Pf, P, B, R>(
+    portfolio: &Pf,
+    params: &P,
+    backend: &B,
+    rng: &mut R,
+) -> Result<MigrationPlan, MigrationError<B::Error>>
+where
+    Pf: crate::preparation::Portfolio,
+    P: zcash_protocol::consensus::Parameters,
+    B: MigrationBackend,
+    R: RngCore + rand_core::CryptoRng,
+{
     let notes = backend
         .spendable_orchard_note_values()
         .map_err(MigrationError::Backend)?;
@@ -1275,7 +1302,7 @@ where
     // preparation transactions minting a candidate funding multiset takes, or `None` when the
     // wallet's notes cannot mint it (so the split stops or steps down a denomination).
     let prep_tx_count = |funding: &[Zatoshis]| {
-        plan_preparation(&notes, funding, prep_tx_fee)
+        crate::preparation::plan_preparation_with(portfolio, &notes, funding, prep_tx_fee)
             .ok()
             .map(|plan| plan.transaction_count())
     };
@@ -1293,8 +1320,9 @@ where
 
     // The decomposition verified this multiset against the preparation planner at every step, so
     // this final planning pass succeeds by construction; the error path is kept for safety.
-    let preparation = plan_preparation(&notes, &funding_notes, prep_tx_fee)
-        .map_err(MigrationError::Preparation)?;
+    let preparation =
+        crate::preparation::plan_preparation_with(portfolio, &notes, &funding_notes, prep_tx_fee)
+            .map_err(MigrationError::Preparation)?;
 
     // Schedule the PREPARATION broadcasts: each transaction gets its own drawn height (temporal
     // decoupling — a burst of identically shaped transactions from one wallet is a linkable
@@ -3649,7 +3677,7 @@ struct CommitOutput {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::{
         denomination::{DENOM_CAP, MIGRATION_MAX_PREPARED_NOTES_PER_RUN},
@@ -3995,7 +4023,7 @@ mod tests {
 
     /// A local network with NU6.3 active at a low height, matching the build test network, so the
     /// canonical fees and activation checks compute in planning tests.
-    fn test_net() -> LocalNetwork {
+    pub(crate) fn test_net() -> LocalNetwork {
         LocalNetwork {
             overwinter: Some(BlockHeight::from_u32(1)),
             sapling: Some(BlockHeight::from_u32(2)),
@@ -4013,7 +4041,7 @@ mod tests {
     }
 
     /// A minimal in-memory backend: a fixed set of note values and a chain tip.
-    struct MockBackend {
+    pub(crate) struct MockBackend {
         notes: Vec<Zatoshis>,
         tip: BlockHeight,
         stored: Option<MigrationState>,
@@ -4021,7 +4049,7 @@ mod tests {
     }
 
     impl MockBackend {
-        fn new(notes: Vec<u64>, tip: u32) -> Self {
+        pub(crate) fn new(notes: Vec<u64>, tip: u32) -> Self {
             MockBackend {
                 notes: notes
                     .into_iter()

--- a/zcash_pool_migration/src/preparation.rs
+++ b/zcash_pool_migration/src/preparation.rs
@@ -47,8 +47,10 @@ use zcash_protocol::value::Zatoshis;
 
 use core::fmt;
 
+pub mod first_fit_decreasing;
 pub mod layered_greedy;
 
+pub use first_fit_decreasing::FirstFitDecreasing;
 pub use layered_greedy::LayeredGreedy;
 
 /// The exact number of Orchard actions in every note-preparation transaction ([ZIP 318]): each is
@@ -577,7 +579,8 @@ impl fmt::Display for PrepError {
 impl core::error::Error for PrepError {}
 
 /// The strategies [`plan_preparation`] runs.
-const STRATEGIES: (LayeredGreedy, ()) = (LayeredGreedy, ());
+const STRATEGIES: (FirstFitDecreasing, (LayeredGreedy, ())) =
+    (FirstFitDecreasing, (LayeredGreedy, ()));
 
 /// Plan the note-preparation transactions that mint `funding` (the self-funding note values, in
 /// zatoshi) from `available` (the wallet's spendable source-pool note values, in zatoshi), reserving

--- a/zcash_pool_migration/src/preparation.rs
+++ b/zcash_pool_migration/src/preparation.rs
@@ -47,6 +47,21 @@ use zcash_protocol::value::Zatoshis;
 
 use core::fmt;
 
+#[cfg(test)]
+use rand_chacha::ChaCha8Rng;
+#[cfg(test)]
+use rand_core::SeedableRng;
+
+#[cfg(test)]
+use crate::engine::{
+    plan_migration_with,
+    tests::{MockBackend, test_net},
+};
+#[cfg(test)]
+use crate::signing_rounds::SigningRoundBudget;
+#[cfg(test)]
+use crate::testing::MIGRATION_SCENARIOS;
+
 pub mod first_fit_decreasing;
 pub mod layered_greedy;
 
@@ -599,10 +614,27 @@ pub fn plan_preparation(
     funding: &[Zatoshis],
     fee_per_tx: Zatoshis,
 ) -> Result<PreparationPlan, PrepError> {
+    plan_preparation_with(&default_portfolio(), available, funding, fee_per_tx)
+}
+
+/// The strategies [`plan_preparation`] runs, for a caller that wants to plan against a different
+/// set and compare.
+pub fn default_portfolio() -> impl Portfolio {
+    STRATEGIES
+}
+
+/// As [`plan_preparation`], against a chosen set of strategies rather than the ones the crate
+/// ships.
+pub fn plan_preparation_with<P: Portfolio>(
+    portfolio: &P,
+    available: &[Zatoshis],
+    funding: &[Zatoshis],
+    fee_per_tx: Zatoshis,
+) -> Result<PreparationPlan, PrepError> {
     // A property of the INPUTS, not of any strategy, so it is settled once and reported the same way
     // however the strategy set changes.
     validate_instance(available, funding)?;
-    STRATEGIES
+    portfolio
         .best_plan(available, funding, fee_per_tx)
         .map(|(_, plan)| plan)
         .ok_or(PrepError::InsufficientFunds)
@@ -628,11 +660,59 @@ fn validate_instance(available: &[Zatoshis], funding: &[Zatoshis]) -> Result<(),
     Ok(())
 }
 
+/// Replay a strategy module's scenario table through a whole migration planned under `portfolio`
+/// alone: for each row, plan the named `MIGRATION_SCENARIOS` wallet with `plan_migration_with` and
+/// assert the preparation-transaction count, crossings, Keystone signing rounds, and migrated
+/// value (in units of 0.01 ZEC). Each strategy module keeps its own table; this is the one driver
+/// they all replay it through.
+#[cfg(test)]
+pub(crate) fn assert_scenarios_under<Pf: Portfolio>(
+    portfolio: &Pf,
+    scenarios: &[(&str, usize, usize, usize, u64)],
+) {
+    /// One hundredth of a ZEC, the unit the migrated column is written in.
+    const H: u64 = zcash_protocol::value::COIN / 100;
+    /// Any fixed seed: the canonical decomposition does not consult the RNG.
+    const SEED: u64 = 7;
+    /// A post-NU6.3 chain tip to plan against.
+    const TIP: u32 = 2_000_000;
+
+    for (label, preparations, crossings, keystone_rounds, migrated) in scenarios {
+        let scenario = MIGRATION_SCENARIOS
+            .iter()
+            .find(|sc| sc.label == *label)
+            .expect("every row names a shared scenario");
+        let backend = MockBackend::new(scenario.source_notes.to_vec(), TIP);
+        let mut rng = ChaCha8Rng::seed_from_u64(SEED);
+        let plan = plan_migration_with(portfolio, &test_net(), &backend, &mut rng)
+            .expect("this rule plans every shared scenario");
+
+        assert_eq!(
+            plan.preparation_tx_count(),
+            *preparations,
+            "{label}: preparations"
+        );
+        assert_eq!(plan.transfer_tx_count(), *crossings, "{label}: crossings");
+        assert_eq!(
+            plan.signing_round_count(SigningRoundBudget::KEYSTONE),
+            *keystone_rounds,
+            "{label}: Keystone rounds",
+        );
+        assert_eq!(
+            u64::from(plan.value_migrated()) / H,
+            *migrated,
+            "{label}: migrated"
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
+
+    use crate::testing::{PREPARATION_VECTORS, preparation_fee_per_tx};
 
     /// A representative padded [`PREP_TX_ACTIONS`]-action ZIP-317 fee reserve for the tests (each
     /// action costs one ZIP-317 marginal fee). The planner treats it opaquely.
@@ -979,6 +1059,40 @@ mod tests {
                 .best_plan(&available, &funding, fee)
                 .map(|(_, plan)| plan),
         );
+    }
+
+    /// The entry point is never worse than any single rule the crate ships: whatever a strategy
+    /// can plan on its own, [`plan_preparation`] plans, and never with a worse [`PlanQuality`].
+    ///
+    /// This is what makes registering a strategy safe. It is a property of the PORTFOLIO, not of
+    /// any rule, so it is checked here against every rule rather than restated in each of their
+    /// modules.
+    #[test]
+    fn the_entry_point_is_never_worse_than_any_single_strategy() {
+        fn assert_never_worse<S: PreparationStrategy>(strategy: &S) {
+            let fee = preparation_fee_per_tx();
+            for vector in PREPARATION_VECTORS {
+                let (available, funding) = (zats(vector.available), zats(vector.funding));
+                let Ok(alone) = strategy.plan(&available, &funding, fee) else {
+                    continue;
+                };
+                let best = plan_preparation(&available, &funding, fee).unwrap_or_else(|e| {
+                    panic!(
+                        "[{}] `{}`: the entry point must plan what a rule plans, got {e:?}",
+                        strategy.name(),
+                        vector.label,
+                    )
+                });
+                assert!(
+                    PlanQuality::of(&best) <= PlanQuality::of(&alone),
+                    "[{}] `{}`: the entry point returned the worse plan",
+                    strategy.name(),
+                    vector.label,
+                );
+            }
+        }
+        assert_never_worse(&LayeredGreedy);
+        assert_never_worse(&FirstFitDecreasing);
     }
 
     /// A total that is not a representable amount is rejected on the inputs, before any strategy

--- a/zcash_pool_migration/src/preparation/first_fit_decreasing.rs
+++ b/zcash_pool_migration/src/preparation/first_fit_decreasing.rs
@@ -1,0 +1,255 @@
+//! A first-fit-decreasing [`PreparationStrategy`] that packs several source notes into one
+//! transaction.
+//!
+//! It walks the funding notes from largest to smallest, keeping one transaction open. When the open
+//! transaction's inputs cannot cover the next funding note, it spends another source note, largest
+//! first, rather than moving on to a smaller funding note. A transaction closes only when its slots
+//! are exhausted, and the next one starts on the source notes that remain.
+//!
+//! Transactions therefore take the shapes in the interior of the
+//! `spends + outputs <= PREP_TX_ACTIONS` budget, not only its two extremes, and a funding note whose
+//! value spans several source notes is minted directly instead of through a merge and a split.
+//!
+//! Every transaction it builds spends source notes only, so they are independent and form a single
+//! layer. When the funding notes cannot be covered that way — most often a lone note that must fan
+//! out into more outputs than one transaction holds — it reports [`PrepError::InsufficientFunds`]
+//! rather than chaining transactions across layers.
+
+use alloc::vec::Vec;
+
+use zcash_protocol::value::Zatoshis;
+
+use super::{
+    PREP_TX_ACTIONS, PrepError, PrepInput, PrepOutput, PrepTransaction, PreparationPlan,
+    PreparationStrategy, validate_instance, zat,
+};
+
+/// The slot every transaction holds back for the change note its packing may leave, so a
+/// transaction is sized as though it will need one.
+const CHANGE_SLOT: usize = 1;
+
+/// The first-fit-decreasing packing described in the [module docs](self).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct FirstFitDecreasing;
+
+impl PreparationStrategy for FirstFitDecreasing {
+    fn name(&self) -> &'static str {
+        "first-fit-decreasing"
+    }
+
+    fn plan(
+        &self,
+        available: &[Zatoshis],
+        funding: &[Zatoshis],
+        fee_per_tx: Zatoshis,
+    ) -> Result<PreparationPlan, PrepError> {
+        plan_first_fit(available, funding, fee_per_tx)
+    }
+}
+
+/// One transaction under construction: the source notes it spends, their total, the funding notes
+/// it mints, and their total.
+struct OpenTransaction {
+    inputs: Vec<usize>,
+    input_total: u64,
+    outputs: Vec<u64>,
+    output_total: u64,
+}
+
+impl OpenTransaction {
+    fn new() -> Self {
+        OpenTransaction {
+            inputs: Vec::new(),
+            input_total: 0,
+            outputs: Vec::new(),
+            output_total: 0,
+        }
+    }
+
+    /// The slots this transaction has committed so far.
+    fn slots(&self) -> usize {
+        self.inputs.len() + self.outputs.len()
+    }
+
+    /// Whether one more note, spent or minted, still leaves room for a change note.
+    fn has_room(&self) -> bool {
+        self.slots() + 1 + CHANGE_SLOT <= PREP_TX_ACTIONS
+    }
+
+    /// What its inputs can still mint, after the fee and what it has already committed to mint.
+    fn unassigned(&self, fee: u64) -> u64 {
+        self.input_total
+            .saturating_sub(fee)
+            .saturating_sub(self.output_total)
+    }
+
+    /// Turn this into a transaction, with any value its funding notes did not claim as change.
+    fn close(self, available: &[u64], fee: u64) -> PrepTransaction {
+        let mut outputs: Vec<PrepOutput> = self
+            .outputs
+            .into_iter()
+            .map(|value| PrepOutput::Funding(zat(value)))
+            .collect();
+        let change = self.input_total - fee - self.output_total;
+        if change > 0 {
+            outputs.push(PrepOutput::Change(zat(change)));
+        }
+        let inputs = self
+            .inputs
+            .into_iter()
+            .map(|index| PrepInput::Wallet {
+                index,
+                value: zat(available[index]),
+            })
+            .collect();
+        PrepTransaction::from_parts(inputs, outputs)
+    }
+}
+
+/// This strategy's planning routine; see [`FirstFitDecreasing`] and the [module docs](self).
+fn plan_first_fit(
+    available: &[Zatoshis],
+    funding: &[Zatoshis],
+    fee_per_tx: Zatoshis,
+) -> Result<PreparationPlan, PrepError> {
+    validate_instance(available, funding)?;
+    let fee = u64::from(fee_per_tx);
+    let available: Vec<u64> = available.iter().map(|&v| u64::from(v)).collect();
+
+    // Largest first, so the transaction open at any moment is working on the funding note that
+    // constrains it most.
+    let mut targets: Vec<u64> = funding
+        .iter()
+        .map(|&v| u64::from(v))
+        .filter(|&v| v > 0)
+        .collect();
+    targets.sort_unstable_by(|a, b| b.cmp(a));
+
+    // A wallet note already worth a funding value IS that funding note: used directly, with no
+    // transaction and no fee.
+    let mut used = vec![false; available.len()];
+    let mut direct_funding: Vec<(usize, Zatoshis)> = Vec::new();
+    targets.retain(|&target| {
+        match available
+            .iter()
+            .enumerate()
+            .position(|(i, &value)| !used[i] && value == target)
+        {
+            Some(i) => {
+                used[i] = true;
+                direct_funding.push((i, zat(target)));
+                false
+            }
+            None => true,
+        }
+    });
+
+    if targets.is_empty() {
+        return Ok(PreparationPlan::from_parts(Vec::new(), direct_funding));
+    }
+
+    // The notes left to spend, largest first, so one spend serves as many funding notes as it can.
+    let mut spendable: Vec<usize> = (0..available.len()).filter(|&i| !used[i]).collect();
+    spendable.sort_unstable_by_key(|&i| core::cmp::Reverse(available[i]));
+    let mut next_spend = 0;
+
+    let mut transactions: Vec<PrepTransaction> = Vec::new();
+    let mut open = OpenTransaction::new();
+
+    for target in targets {
+        loop {
+            if !open.inputs.is_empty() && open.has_room() && open.unassigned(fee) >= target {
+                open.output_total += target;
+                open.outputs.push(target);
+                break;
+            }
+            // Not enough value, or no room: spend another note if both allow it.
+            if open.has_room() && next_spend < spendable.len() {
+                let index = spendable[next_spend];
+                next_spend += 1;
+                open.input_total += available[index];
+                open.inputs.push(index);
+                continue;
+            }
+            // Neither: close what is open and try this funding note in a fresh transaction. With
+            // nothing open to close, no transaction this strategy can build mints it.
+            if open.outputs.is_empty() {
+                return Err(PrepError::InsufficientFunds);
+            }
+            transactions
+                .push(core::mem::replace(&mut open, OpenTransaction::new()).close(&available, fee));
+        }
+    }
+    transactions.push(open.close(&available, fee));
+
+    Ok(PreparationPlan::from_parts(
+        alloc::vec![transactions],
+        direct_funding,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::testing::{PREPARATION_VECTORS, preparation_fee_per_tx, zats};
+
+    /// Everything the shared corpus requires of any strategy holds for this one.
+    #[test]
+    fn conforms_to_the_shared_preparation_corpus() {
+        crate::testing::assert_strategy_conformance(&FirstFitDecreasing);
+    }
+
+    /// The shapes the layered greedy cannot reach, which this strategy exists to cover: each of the
+    /// note-shape instances is minted by ONE transaction in ONE layer, spending both source notes.
+    #[test]
+    fn a_single_transaction_mints_the_canonical_set_from_either_note_shape() {
+        let fee = preparation_fee_per_tx();
+        for label in [
+            "one note funds the 10 ZEC canonical set",
+            "10 ZEC as 1 + 9",
+            "10 ZEC as 2 + 8",
+            "10 ZEC as 5 + 5",
+        ] {
+            let vector = PREPARATION_VECTORS
+                .iter()
+                .find(|v| v.label == label)
+                .expect("the note-shape vectors exist");
+            let (available, funding) = (zats(vector.available), zats(vector.funding));
+            let plan = FirstFitDecreasing
+                .plan(&available, &funding, fee)
+                .unwrap_or_else(|e| panic!("`{label}` must plan, got {e:?}"));
+
+            assert_eq!(plan.layer_count(), 1, "`{label}`: layers");
+            assert_eq!(plan.transaction_count(), 1, "`{label}`: transactions");
+            assert_eq!(
+                plan.funding_notes().len(),
+                vector.funding.len(),
+                "`{label}`: mints every funding note",
+            );
+            assert!(plan.is_valid(&available, &funding, fee), "`{label}`: valid");
+        }
+    }
+
+    /// It funds every shape-dependent instance in the corpus, which is what distinguishes it from
+    /// the layered greedy: the value is present in all of them, only the transaction shapes needed
+    /// to reach it differ.
+    #[test]
+    fn it_funds_every_shape_dependent_instance() {
+        crate::testing::assert_funds_every_shape_dependent_instance(&FirstFitDecreasing);
+    }
+
+    /// A lone note that must fan out into more funding notes than one transaction holds is the
+    /// shape this strategy does not cover; it declines rather than chaining across layers, and the
+    /// portfolio falls back to a rule that does.
+    #[test]
+    fn it_declines_a_fan_out_that_needs_layers() {
+        let fee = preparation_fee_per_tx();
+        let funding = zats(&[1_000_000; PREP_TX_ACTIONS]);
+        let available = zats(&[1_000_000 * PREP_TX_ACTIONS as u64 + 10 * u64::from(fee)]);
+        assert_eq!(
+            FirstFitDecreasing.plan(&available, &funding, fee),
+            Err(PrepError::InsufficientFunds),
+        );
+    }
+}

--- a/zcash_pool_migration/src/preparation/first_fit_decreasing.rs
+++ b/zcash_pool_migration/src/preparation/first_fit_decreasing.rs
@@ -252,4 +252,58 @@ mod tests {
             Err(PrepError::InsufficientFunds),
         );
     }
+
+    /// What a whole migration looks like under THIS rule alone: the answer to "what would
+    /// `plan_migration` give with only FirstFitDecreasing?", for every scenario the crate shares.
+    ///
+    /// Columns are preparation transactions, crossings, Keystone signing rounds, and migrated
+    /// value in units of 0.01 ZEC. [`MIGRATION_SCENARIOS`] carries what the whole portfolio
+    /// achieves for the same wallets; the gap between the two rows is what this rule costs, or
+    /// saves, on its own.
+    ///
+    /// These are recorded behaviour, not claims of optimality. They move when the rule changes,
+    /// and that movement is the point: it is how an improvement is seen.
+    const SCENARIOS_UNDER_THIS_RULE: &[(&str, usize, usize, usize, u64)] = &[
+        ("small holder, 2 ZEC", 1, 7, 1, 199),
+        ("retail, 15 ZEC", 1, 9, 1, 1499),
+        ("denominations, 60 ZEC", 1, 10, 1, 5999),
+        ("78 ZEC in a single note", 1, 10, 1, 7799),
+        (
+            "Gwen, 0.0152 ZEC (a single minimum-denomination note)",
+            1,
+            1,
+            1,
+            1,
+        ),
+        (
+            "Priya, 7.1101 ZEC (the buffer prunes the trailing crossing)",
+            1,
+            3,
+            1,
+            710,
+        ),
+        ("exchange, ten 5 ZEC notes", 1, 5, 1, 4900),
+        ("monotonic, ten 12 ZEC notes", 1, 5, 1, 11900),
+        ("dust-heavy, 1 ZEC and twelve 0.02 ZEC notes", 2, 4, 1, 122),
+        (
+            "whale plus dust, 40 ZEC and a six-note dust tail",
+            1,
+            6,
+            1,
+            4033,
+        ),
+        ("10 ZEC in a single note", 1, 9, 1, 999),
+        ("10 ZEC as 1 + 9", 1, 9, 1, 999),
+        ("10 ZEC as 2 + 8", 1, 9, 1, 999),
+        ("10 ZEC as 5 + 5", 1, 9, 1, 999),
+    ];
+
+    /// Replays [`SCENARIOS_UNDER_THIS_RULE`] through a migration planned against this rule alone.
+    #[test]
+    fn what_a_migration_looks_like_under_this_rule_alone() {
+        crate::preparation::assert_scenarios_under(
+            &(FirstFitDecreasing, ()),
+            SCENARIOS_UNDER_THIS_RULE,
+        );
+    }
 }

--- a/zcash_pool_migration/src/preparation/layered_greedy.rs
+++ b/zcash_pool_migration/src/preparation/layered_greedy.rs
@@ -519,7 +519,7 @@ mod tests {
 
     use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
 
-    use crate::preparation::{PREP_TX_ACTIONS, PlanQuality, Portfolio, plan_preparation};
+    use crate::preparation::{PREP_TX_ACTIONS, Portfolio};
     use crate::testing::{Fundability, PREPARATION_VECTORS, preparation_fee_per_tx};
 
     /// A representative padded [`PREP_TX_ACTIONS`]-action ZIP-317 fee reserve for the tests (each
@@ -534,7 +534,7 @@ mod tests {
         values.iter().map(|&v| zat(v)).collect()
     }
 
-    /// [`plan_preparation`] over the tests' u64 values.
+    /// This strategy's plan over the tests' u64 values.
     fn plan_prep(
         available: &[u64],
         funding: &[u64],
@@ -1190,41 +1190,13 @@ mod tests {
         );
     }
 
-    /// Whatever this rule can plan, the public entry point plans at least as well: it either
-    /// returns this plan or a better one, never a worse one and never nothing.
-    #[test]
-    fn the_entry_point_is_never_worse_than_this_rule() {
-        let fee = fee_per_tx();
-        let cases: &[(&[u64], &[u64])] = &[
-            (&[1_000_000], &[100_000]),
-            (&[1_000_000], &[100_000, 100_000, 50_000]),
-            (&[500_000, 500_000], &[100_000, 50_000]),
-            (&[100_000 + 16 * MARGINAL_FEE.into_u64()], &[100_000]),
-            (&[10_000; 12], &[50_000]),
-            (&[1_000_000], &[]),
-            (&[], &[100_000]),
-        ];
-        for (available, funding) in cases {
-            let (available, funding) = (zats(available), zats(funding));
-            let Ok(mine) = LayeredGreedy.plan(&available, &funding, zat(fee)) else {
-                continue;
-            };
-            let best = plan_preparation(&available, &funding, zat(fee))
-                .expect("the entry point plans whatever this rule plans");
-            assert!(
-                PlanQuality::of(&best) <= PlanQuality::of(&mine),
-                "{available:?} -> {funding:?}",
-            );
-        }
-    }
-
     proptest! {
-        /// Every plan the greedy produces passes its own certificate, so the portfolio never
+        /// Every plan this rule produces passes its own certificate, so the portfolio never
         /// discards a real plan on a technicality.
         #[test]
         fn planned_plans_carry_a_valid_certificate((available, funding) in arb_input()) {
             let (available, funding, fee) = (zats(&available), zats(&funding), zat(fee_per_tx()));
-            if let Ok(plan) = plan_preparation(&available, &funding, fee) {
+            if let Ok(plan) = LayeredGreedy.plan(&available, &funding, fee) {
                 prop_assert!(plan.is_valid(&available, &funding, fee));
             }
         }
@@ -1241,5 +1213,56 @@ mod tests {
                     .map(|plan| ("layered-greedy", plan))
             );
         }
+    }
+
+    /// What a whole migration looks like under THIS rule alone: the answer to "what would
+    /// `plan_migration` give with only LayeredGreedy?", for every scenario the crate shares.
+    ///
+    /// Columns are preparation transactions, crossings, Keystone signing rounds, and migrated
+    /// value in units of 0.01 ZEC. [`MIGRATION_SCENARIOS`] carries what the whole portfolio
+    /// achieves for the same wallets; the gap between the two rows is what this rule costs, or
+    /// saves, on its own.
+    ///
+    /// These are recorded behaviour, not claims of optimality. They move when the rule changes,
+    /// and that movement is the point: it is how an improvement is seen.
+    const SCENARIOS_UNDER_THIS_RULE: &[(&str, usize, usize, usize, u64)] = &[
+        ("small holder, 2 ZEC", 1, 7, 1, 199),
+        ("retail, 15 ZEC", 1, 9, 1, 1499),
+        ("denominations, 60 ZEC", 1, 10, 1, 5999),
+        ("78 ZEC in a single note", 1, 10, 1, 7799),
+        (
+            "Gwen, 0.0152 ZEC (a single minimum-denomination note)",
+            1,
+            1,
+            1,
+            1,
+        ),
+        (
+            "Priya, 7.1101 ZEC (the buffer prunes the trailing crossing)",
+            1,
+            3,
+            1,
+            710,
+        ),
+        ("exchange, ten 5 ZEC notes", 2, 3, 1, 4500),
+        ("monotonic, ten 12 ZEC notes", 5, 11, 2, 11999),
+        ("dust-heavy, 1 ZEC and twelve 0.02 ZEC notes", 4, 4, 1, 123),
+        (
+            "whale plus dust, 40 ZEC and a six-note dust tail",
+            4,
+            6,
+            1,
+            4033,
+        ),
+        ("10 ZEC in a single note", 1, 9, 1, 999),
+        ("10 ZEC as 1 + 9", 4, 11, 2, 999),
+        ("10 ZEC as 2 + 8", 4, 10, 1, 999),
+        ("10 ZEC as 5 + 5", 2, 1, 1, 500),
+    ];
+
+    /// Replays [`SCENARIOS_UNDER_THIS_RULE`] through a migration planned against this rule alone.
+    #[test]
+    fn what_a_migration_looks_like_under_this_rule_alone() {
+        crate::preparation::assert_scenarios_under(&(LayeredGreedy, ()), SCENARIOS_UNDER_THIS_RULE);
     }
 }

--- a/zcash_pool_migration/src/preparation/layered_greedy.rs
+++ b/zcash_pool_migration/src/preparation/layered_greedy.rs
@@ -519,7 +519,7 @@ mod tests {
 
     use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
 
-    use crate::preparation::{PREP_TX_ACTIONS, Portfolio, plan_preparation};
+    use crate::preparation::{PREP_TX_ACTIONS, PlanQuality, Portfolio, plan_preparation};
     use crate::testing::{Fundability, PREPARATION_VECTORS, preparation_fee_per_tx};
 
     /// A representative padded [`PREP_TX_ACTIONS`]-action ZIP-317 fee reserve for the tests (each
@@ -1190,10 +1190,10 @@ mod tests {
         );
     }
 
-    /// Naming the rule changes nothing: `LayeredGreedy` IS `plan_preparation`, so the refactor is
-    /// behaviour-preserving on every shape the other tests in this module cover.
+    /// Whatever this rule can plan, the public entry point plans at least as well: it either
+    /// returns this plan or a better one, never a worse one and never nothing.
     #[test]
-    fn layered_greedy_is_plan_preparation() {
+    fn the_entry_point_is_never_worse_than_this_rule() {
         let fee = fee_per_tx();
         let cases: &[(&[u64], &[u64])] = &[
             (&[1_000_000], &[100_000]),
@@ -1206,9 +1206,13 @@ mod tests {
         ];
         for (available, funding) in cases {
             let (available, funding) = (zats(available), zats(funding));
-            assert_eq!(
-                LayeredGreedy.plan(&available, &funding, zat(fee)),
-                plan_preparation(&available, &funding, zat(fee)),
+            let Ok(mine) = LayeredGreedy.plan(&available, &funding, zat(fee)) else {
+                continue;
+            };
+            let best = plan_preparation(&available, &funding, zat(fee))
+                .expect("the entry point plans whatever this rule plans");
+            assert!(
+                PlanQuality::of(&best) <= PlanQuality::of(&mine),
                 "{available:?} -> {funding:?}",
             );
         }
@@ -1231,7 +1235,8 @@ mod tests {
             let (available, funding, fee) = (zats(&available), zats(&funding), zat(fee_per_tx()));
             prop_assert_eq!(
                 (LayeredGreedy, ()).best_plan(&available, &funding, fee),
-                plan_preparation(&available, &funding, fee)
+                LayeredGreedy
+                    .plan(&available, &funding, fee)
                     .ok()
                     .map(|plan| ("layered-greedy", plan))
             );

--- a/zcash_pool_migration/src/testing/conformance.rs
+++ b/zcash_pool_migration/src/testing/conformance.rs
@@ -205,6 +205,27 @@ pub fn assert_strategy_conformance<S: PreparationStrategy>(strategy: &S) {
     }
 }
 
+/// Assert `strategy` plans every [`Fundability::Depends`] instance in the corpus: the instances
+/// whose value is present but whose funding is out of some rules' reach, so planning them all is a
+/// claim about the strategy, not about the corpus. [`assert_strategy_conformance`] deliberately
+/// leaves these unpinned; a strategy that covers the whole shape-dependent family asserts it here.
+pub fn assert_funds_every_shape_dependent_instance<S: PreparationStrategy>(strategy: &S) {
+    let fee = preparation_fee_per_tx();
+    for vector in PREPARATION_VECTORS
+        .iter()
+        .filter(|v| v.fundability == Fundability::Depends)
+    {
+        assert!(
+            strategy
+                .plan(&zats(vector.available), &zats(vector.funding), fee)
+                .is_ok(),
+            "[{}] `{}` must plan",
+            strategy.name(),
+            vector.label,
+        );
+    }
+}
+
 /// Assert that `candidate` funds every instance `baseline` funds, and report any it funds that the
 /// baseline does not. Use it to show a new strategy DOMINATES an existing one: the portfolio's
 /// result can then only improve, since [`Portfolio::best_plan`](crate::preparation::Portfolio::best_plan) is monotone in the

--- a/zcash_pool_migration/src/testing/scenarios.rs
+++ b/zcash_pool_migration/src/testing/scenarios.rs
@@ -260,7 +260,7 @@ pub const MIGRATION_SCENARIOS: &[MigrationScenario] = {
             710 * H,
         ),
         // Many-note shapes, consolidated across preparation layers.
-        s("exchange, ten 5 ZEC notes", TEN_FIVES, 2, 3, 1, 4_500 * H),
+        s("exchange, ten 5 ZEC notes", TEN_FIVES, 1, 5, 1, 4_900 * H),
         // Five preparations (80 actions) plus eleven transfers (33 actions) is 113 actions: the
         // only scenario that needs a second Keystone round.
         s(
@@ -282,25 +282,23 @@ pub const MIGRATION_SCENARIOS: &[MigrationScenario] = {
         s(
             "whale plus dust, 40 ZEC and a six-note dust tail",
             WHALE_DUST,
-            4,
+            1,
             6,
             1,
             4_033 * H,
         ),
-        // The same 10 ZEC balance, four note shapes. Held as one note it splits into 9 crossings in
-        // a single preparation; held as 1 + 9 the reconciled split has 11 crossings, needs 4
-        // preparations across 3 layers, and tips the run over a second Keystone round; held as
-        // 5 + 5 only 5 ZEC migrates at all, because neither 5 ZEC note can self-fund a 5 ZEC
-        // crossing and the consolidated note funds only one.
+        // The same 10 ZEC balance, four note shapes, which now agree: one preparation
+        // transaction spending whichever notes the wallet holds, and the same nine canonical
+        // crossings. These rows exist to keep them agreeing.
         s("10 ZEC in a single note", TEN_AS_ONE, 1, 9, 1, 999 * H),
-        s("10 ZEC as 1 + 9", ONE_PLUS_NINE, 4, 11, 2, 999 * H),
-        s("10 ZEC as 2 + 8", TWO_PLUS_EIGHT, 4, 10, 1, 999 * H),
-        s("10 ZEC as 5 + 5", FIVE_PLUS_FIVE, 2, 1, 1, 500 * H),
+        s("10 ZEC as 1 + 9", ONE_PLUS_NINE, 1, 9, 1, 999 * H),
+        s("10 ZEC as 2 + 8", TWO_PLUS_EIGHT, 1, 9, 1, 999 * H),
+        s("10 ZEC as 5 + 5", FIVE_PLUS_FIVE, 1, 9, 1, 999 * H),
     ]
 };
 
 /// The crossing values one [`MigrationScenario`] publishes, for the note-shape family: the same
-/// balance held several ways, which the canonical quantization alone would give identical splits.
+/// balance held several ways.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct NoteShapeSplit {
     /// The [`MigrationScenario::label`] this row is the split of.
@@ -312,12 +310,11 @@ pub struct NoteShapeSplit {
     pub preparations: usize,
 }
 
-/// What each 10 ZEC note shape actually publishes.
+/// What each 10 ZEC note shape publishes.
 ///
 /// Canonical quantization of the migratable 9.99 ZEC is `500, 200, 200, 50, 20, 20, 5, 2, 2` in
-/// units of 0.01 ZEC, which is what the single-note wallet emits. The other shapes diverge from
-/// it — a defect, since the split should be a function of the balance alone — and by how much is
-/// the measurement this table exists to hold.
+/// units of 0.01 ZEC. Every shape publishes exactly that, in one preparation transaction: the
+/// split is a function of the BALANCE, and the rows are here to keep it one.
 pub const NOTE_SHAPE_SPLITS: &[NoteShapeSplit] = {
     const fn s(
         scenario_label: &'static str,
@@ -330,23 +327,13 @@ pub const NOTE_SHAPE_SPLITS: &[NoteShapeSplit] = {
             preparations,
         }
     }
+    /// The canonical split of 9.99 ZEC, which every shape below publishes.
+    const CANONICAL: &[u64] = &[500, 200, 200, 50, 20, 20, 5, 2, 2];
     &[
-        s(
-            "10 ZEC in a single note",
-            &[500, 200, 200, 50, 20, 20, 5, 2, 2],
-            1,
-        ),
-        s(
-            "10 ZEC as 1 + 9",
-            &[500, 200, 100, 50, 50, 50, 20, 20, 5, 2, 2],
-            4,
-        ),
-        s(
-            "10 ZEC as 2 + 8",
-            &[500, 200, 100, 100, 50, 20, 20, 5, 2, 2],
-            4,
-        ),
-        s("10 ZEC as 5 + 5", &[500], 2),
+        s("10 ZEC in a single note", CANONICAL, 1),
+        s("10 ZEC as 1 + 9", CANONICAL, 1),
+        s("10 ZEC as 2 + 8", CANONICAL, 1),
+        s("10 ZEC as 5 + 5", CANONICAL, 1),
     ]
 };
 
@@ -367,22 +354,11 @@ pub struct NoteShapeBudgetCase {
 /// What the note shape costs the USER AT THE SIGNER: one 10 ZEC balance, four note shapes, priced
 /// for five signer budgets.
 ///
-/// The action total a shape produces is `preparations * 16 + crossings * 3`, so the note shape
-/// decides the signing workload as much as the balance does:
+/// Every shape plans one preparation transaction and nine crossings, so every shape is
+/// `1 * 16 + 9 * 3 = 43` actions and the four rows of any budget agree. That agreement is the
+/// property: the wallet's note shape does not change how many times its owner is asked to sign.
 ///
-/// | 10 ZEC held as | preparations | crossings | actions |
-/// |----------------|--------------|-----------|---------|
-/// | one note       | 1            | 9         | 43      |
-/// | 1 + 9          | 4            | 11        | 97      |
-/// | 2 + 8          | 4            | 10        | 94      |
-/// | 5 + 5          | 2            | 1         | 35      |
-///
-/// The consequence a user feels: `1 + 9` is 97 actions, ONE over a Keystone round, so that wallet
-/// signs twice where the single-note wallet signs once, and `2 + 8` (94 actions, the same 4
-/// preparations) still signs once. On a tighter 48-action signer the same shape costs 3 rounds
-/// against the single-note wallet's 1.
-///
-/// Every row is hand-derived from the two-item-size packing (16-action preparations, 3-action
+/// Each row is hand-derived from the two-item-size packing (16-action preparations, 3-action
 /// transfers) and cross-checked against `min_signing_rounds` by the test that replays it.
 pub const NOTE_SHAPE_BUDGET_ROUNDS: &[NoteShapeBudgetCase] = {
     const fn b(
@@ -409,27 +385,26 @@ pub const NOTE_SHAPE_BUDGET_ROUNDS: &[NoteShapeBudgetCase] = {
     const TWO_PLUS_EIGHT: &str = "10 ZEC as 2 + 8";
     const FIVE_PLUS_FIVE: &str = "10 ZEC as 5 + 5";
     &[
-        // At the floor every preparation fills a round alone and transfers pack five to a round.
-        b(ONE_NOTE, MIN, 3),       // 1 prep + ceil(9/5)
-        b(ONE_PLUS_NINE, MIN, 7),  // 4 preps + ceil(11/5)
-        b(TWO_PLUS_EIGHT, MIN, 6), // 4 preps + ceil(10/5)
-        b(FIVE_PLUS_FIVE, MIN, 3), // 2 preps + 1
-        // 32 actions: one preparation plus five transfers per round (31), or two preparations (32).
+        // At the floor the preparation fills a round alone and transfers pack five to a round:
+        // 1 + ceil(9/5).
+        b(ONE_NOTE, MIN, 3),
+        b(ONE_PLUS_NINE, MIN, 3),
+        b(TWO_PLUS_EIGHT, MIN, 3),
+        b(FIVE_PLUS_FIVE, MIN, 3),
+        // 32 actions: the preparation plus five transfers is 31, leaving four transfers over.
         b(ONE_NOTE, TIGHT, 2),
-        b(ONE_PLUS_NINE, TIGHT, 4), // 97 actions cannot beat ceil(97/32)
-        b(TWO_PLUS_EIGHT, TIGHT, 3),
+        b(ONE_PLUS_NINE, TIGHT, 2),
+        b(TWO_PLUS_EIGHT, TIGHT, 2),
         b(FIVE_PLUS_FIVE, TIGHT, 2),
-        // 48 actions: the single-note wallet signs once; the 1 + 9 wallet signs three times.
+        // 48 actions and up: the whole run is 43, so one interaction.
         b(ONE_NOTE, MODEST, 1),
-        b(ONE_PLUS_NINE, MODEST, 3),
-        b(TWO_PLUS_EIGHT, MODEST, 2),
+        b(ONE_PLUS_NINE, MODEST, 1),
+        b(TWO_PLUS_EIGHT, MODEST, 1),
         b(FIVE_PLUS_FIVE, MODEST, 1),
-        // Keystone: 1 + 9 is one action over a single round, so it costs a second interaction.
         b(ONE_NOTE, KEYSTONE, 1),
-        b(ONE_PLUS_NINE, KEYSTONE, 2),
-        b(TWO_PLUS_EIGHT, KEYSTONE, 1), // 94 actions still fit
+        b(ONE_PLUS_NINE, KEYSTONE, 1),
+        b(TWO_PLUS_EIGHT, KEYSTONE, 1),
         b(FIVE_PLUS_FIVE, KEYSTONE, 1),
-        // A software signer takes every shape in one round.
         b(ONE_NOTE, DEFAULT, 1),
         b(ONE_PLUS_NINE, DEFAULT, 1),
         b(TWO_PLUS_EIGHT, DEFAULT, 1),

--- a/zcash_pool_migration/tests/engine_plan.rs
+++ b/zcash_pool_migration/tests/engine_plan.rs
@@ -218,33 +218,20 @@ fn reconciliation_drops_the_unfundable_tail_for_a_many_equal_note_source() {
     );
 }
 
-/// How far the wallet's NOTE SHAPE moves the split of a fixed balance.
+/// The wallet's NOTE SHAPE does not move the split of a fixed balance.
 ///
-/// The crossing values are meant to be a function of the BALANCE alone (ZIP 318 canonical
-/// quantization of 10 ZEC is `5 + 2 + 2 + 0.5 + 0.2 + 0.2 + 0.05 + 0.02 + 0.02`), which is what
-/// makes them collide across wallets. But every funding note has to be minted out of the wallet's
-/// actual notes, so the split is reconciled inline against the preparation planner, and one balance
-/// held four ways produces four different migrations. This is a CHARACTERIZATION test: it pins the
-/// current behavior, DEFECTS INCLUDED, so that a planner change moves this table instead of
-/// passing silently. The expectations below are not endorsements; two of them record behavior
-/// that is undesirable and slated to change.
-///
-/// Defect 1 (`1 + 9`): the split is not merely a reconciled sub-multiset of the single-note
-/// split. It is a DIFFERENT decomposition: `2 + 2` becomes `1 + 0.5 + 0.5 + 0.5`, so 11 crossings
-/// are published instead of 9. This is a privacy regression: the published values become a
-/// function of the wallet's private note shape, weakening the cross-wallet value collision the
-/// canonical quantization exists to provide.
-///
-/// Defect 2 (`5 + 5`): only 5 ZEC of the 10 migrates. Neither source note can self-fund a 5 ZEC
-/// crossing (a 5 ZEC funding note is `5 ZEC + buffer`, more than a 5 ZEC note holds), so the two
-/// notes consolidate into one, and that consolidated note funds a single 5 ZEC crossing, leaving
-/// 4.99825 ZEC stranded in the source pool.
+/// The crossing values are a function of the BALANCE alone (ZIP 318 canonical quantization of the
+/// migratable 9.99 ZEC is `5 + 2 + 2 + 0.5 + 0.2 + 0.2 + 0.05 + 0.02 + 0.02`), which is what makes
+/// them collide across wallets. Every funding note still has to be minted out of the wallet's
+/// actual notes, so this holds only while the preparation planner can build a transaction that
+/// spends several notes and mints several: one 10 ZEC balance held four ways, one split.
 #[cfg(feature = "test-dependencies")]
 #[test]
-fn note_shape_changes_the_split_of_a_ten_zec_balance() {
+fn note_shape_does_not_change_the_split_of_a_ten_zec_balance() {
     // One hundredth of a ZEC: the minimum denomination, and the unit every crossing falls on.
     const H: u64 = COIN / 100;
 
+    let mut migrated = Vec::new();
     for split in NOTE_SHAPE_SPLITS {
         let scenario = MIGRATION_SCENARIOS
             .iter()
@@ -276,22 +263,14 @@ fn note_shape_changes_the_split_of_a_ten_zec_balance() {
             u64::from(plan.value_migrated()) + u64::from(plan.residual()) <= balance,
             "{label}: the plan cannot create value",
         );
+        migrated.push((label, u64::from(plan.value_migrated())));
     }
 
-    // The two shapes that differ most: the same balance, half of it stranded.
-    let one_note = MockBackend::new(vec![10 * COIN], 2_000_000);
-    let five_plus_five = MockBackend::new(vec![5 * COIN, 5 * COIN], 2_000_000);
-    let mut rng = ChaCha8Rng::seed_from_u64(1);
-    let one_note = plan_migration(&regtest_network(true), &one_note, &mut rng).expect("plans");
-    let mut rng = ChaCha8Rng::seed_from_u64(1);
-    let five_plus_five =
-        plan_migration(&regtest_network(true), &five_plus_five, &mut rng).expect("plans");
-    assert_eq!(u64::from(one_note.value_migrated()), 999 * H);
-    assert_eq!(u64::from(five_plus_five.value_migrated()), 500 * H);
-    assert!(
-        u64::from(five_plus_five.residual()) > u64::from(one_note.residual()),
-        "the equal-note shape strands value the single-note shape migrates"
-    );
+    // Every shape migrates the same value: the whole canonical decomposition of the balance, with
+    // nothing stranded by how the notes happen to be held.
+    for (label, value) in &migrated {
+        assert_eq!(*value, 999 * H, "{label}: migrated value");
+    }
 }
 
 #[test]

--- a/zcash_pool_migration/tests/signing_rounds_e2e.rs
+++ b/zcash_pool_migration/tests/signing_rounds_e2e.rs
@@ -378,19 +378,21 @@ fn note_shape_and_signer_budget_decide_the_interaction_count() {
     }
 }
 
-/// The smallest signer a wallet can use and still migrate in ONE interaction, per note shape: the
-/// inverse of the sweep above, and what a wallet shows when helping a user pick a device.
+/// The smallest signer a wallet can use and still migrate in ONE interaction: the inverse of the
+/// sweep above, and what a wallet shows when helping a user pick a device.
+///
+/// It is the same for every note shape of one balance, because each plans the same one preparation
+/// transaction and nine crossings: `1 * 16 + 9 * 3 = 43` actions.
 #[cfg(feature = "test-dependencies")]
 #[test]
-fn the_note_shape_sets_the_single_round_signer_requirement() {
+fn the_single_round_signer_requirement_is_the_same_for_every_note_shape() {
     let seed = 7;
-    // The plan's total actions ARE the single-round requirement, so the shape that plans more
-    // transactions demands a larger signer for the same balance.
+    // The plan's total actions ARE the single-round requirement.
     for (label, expected_actions) in [
         ("10 ZEC in a single note", 43u32),
-        ("10 ZEC as 1 + 9", 97),
-        ("10 ZEC as 2 + 8", 94),
-        ("10 ZEC as 5 + 5", 35),
+        ("10 ZEC as 1 + 9", 43),
+        ("10 ZEC as 2 + 8", 43),
+        ("10 ZEC as 5 + 5", 43),
     ] {
         let sc = MIGRATION_SCENARIOS
             .iter()


### PR DESCRIPTION
> Stacked on #2935, which is stacked on #2937. Review those first; the diff shown here includes them until they merge.

## What

A second `PreparationStrategy`. This is the change that removes the note-shape anomalies #2935 pins.

## Why the layered greedy could not

Every *splitting* transaction it builds has exactly one input; several inputs appear only in a consolidation, which produces exactly one output. So it reaches only the two extreme shapes of the ZIP 318 `spends + outputs <= 16` budget, never the interior, even though the ZIP introduces those two shapes with "for example" and constrains only the total.

Concretely, for a 10 ZEC balance held as `1 + 9` asked for the canonical split:

- The 9 ZEC note has budget `9 - 0.0008 = 8.9992`. The first three canonical funding notes cost `5.00015 + 2.00015 + 2.00015 = 9.00045`, which is **0.00125 over**. So it takes the first two, skips the second `2`, and keeps taking smaller notes.
- That leaves the *largest* funding note unassigned. The 1 ZEC note is then measured against it (`0.9992 < 2.00015`) and pushed to the consolidatable pool.
- A pool of one cannot consolidate, and the caller discards it, so the 1 ZEC note is never spent and never reaches the next layer.
- Result: `InsufficientFunds`. The denomination planner, told the canonical part was unfundable, substituted `1 + 0.5 + 0.5` for the `2`, publishing 11 non-canonical crossings.

A single transaction spending both notes would have minted the canonical split: 2 inputs + 9 funding + change = 12 slots, well inside 16.

## The strategy

`FirstFitDecreasing` inverts the loop. It walks the funding notes largest-first with one transaction open, and when that transaction cannot cover the next funding note it **spends another source note** rather than moving on to a smaller funding note. A transaction closes only when its slots are exhausted.

Every transaction it builds spends source notes only, so they are independent and form one layer. A lone note that must fan out into more outputs than one transaction holds is the shape it does **not** cover: it declines rather than chaining across layers, and the portfolio falls back to the layered greedy, which does. Neither rule dominates the other, which is what the portfolio is for.

**Guarantee, stated honestly:** FFD is *proved* optimal for divisible item sizes (Coffman, Garey and Johnson, *Bin packing with divisible item sizes*, Journal of Complexity 3(4), 1987). The ZIP 318 `{1,2,5} * 10^k` series is **canonical** for change-making but **not divisible** (`2` does not divide `5`), so that theorem does not transfer. This is a strong heuristic, not a proof. The proved version is a later PR in the stack.

## The goldens move, and that is the evidence

Each new value was re-derived by hand rather than taken from the planner:

| scenario | before | after | derivation |
|---|---|---|---|
| 10 ZEC as one note | 1 prep, 9 crossings, 9.99 | unchanged | |
| 10 ZEC as `1 + 9` | 4 preps / 3 layers, **11** crossings, 2 Keystone rounds | 1 prep, **9** canonical, 1 round | 2 inputs + 9 funding + change = 12 slots; 16 + 9x3 = 43 actions |
| 10 ZEC as `2 + 8` | 4 preps, 10 crossings | 1 prep, 9 canonical | same |
| 10 ZEC as `5 + 5` | 2 preps, 1 crossing, **5.00 migrated** | 1 prep, 9 canonical, **9.99 migrated** | recovers 4.99 ZEC |
| exchange, ten 5 ZEC notes | 2 preps, 3 crossings, 45 ZEC | 1 prep, 5 crossings, **49 ZEC** | `20+20+5+2+2`; needs all ten notes, so 10 + 5 + 1 = **16 slots exactly**. 49.99 would need 11 outputs and 22 slots, so it is refused |
| whale plus dust | 4 preps | 1 prep | `40.33 = 20+20+0.2+0.1+0.02+0.01`; 7 inputs + 6 + 1 = 14 slots |

The four note shapes now **agree**: the split is a function of the balance again, and the signer interaction count no longer depends on how the notes are held. Two tests were renamed to say so (`note_shape_does_not_change_the_split_of_a_ten_zec_balance`, `the_single_round_signer_requirement_is_the_same_for_every_note_shape`), and `NOTE_SHAPE_BUDGET_ROUNDS` now records agreement across all four shapes at every budget rather than divergence.

## Two tests whose premise a second strategy breaks

`layered_greedy_is_plan_preparation` and `a_singleton_portfolio_is_the_strategy` both asserted `LayeredGreedy.plan(...) == plan_preparation(...)`. That equality held only while the portfolio had one member. They now assert what survives: a one-strategy portfolio is still exactly that strategy, and the entry point is never *worse* than the greedy alone (`PlanQuality::of(best) <= PlanQuality::of(greedy)`).

## Testing

`cargo test --release -p zcash_pool_migration --all-features` — 262 lib + 20 integration, all passing. Clippy clean across `none`, `orchard`, `wallet`, `test-dependencies` and the two combinations; `cargo fmt --check` clean.

New tests: `conforms_to_the_shared_preparation_corpus` (inherits #2935's whole corpus in one line), `a_single_transaction_mints_the_canonical_set_from_either_note_shape`, `it_funds_every_shape_dependent_instance`, and `it_declines_a_fan_out_that_needs_layers` for the case it deliberately does not cover.

The checked-in proptest regression seed is a 4-note wallet where the two strategies genuinely differ; worth replaying.

## Known follow-up

Running every strategy multiplies planning cost, and the multiplier is worse than "N strategies" because `plan_denominations` calls the preparation planner at every step of its greedy. The lower bound `ceil((n' + m + c) / 16)` lets the portfolio stop as soon as a strategy attains it, and the semilattice laws mean the evaluation order can be chosen purely for cost without changing the answer. Not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)