### PR TITLE
Add `WalletWrite::import_standalone_transparent_address`

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -10,6 +10,13 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `zcash_client_backend::data_api::WalletWrite::import_standalone_transparent_address`
+  (requires the `transparent-key-import` feature): imports a transparent
+  address into an account as watch-only, without any associated key material.
+- `zcash_client_backend::wallet::TransparentAddressSource::StandaloneAddress`
+- `zcash_client_backend::wallet::TransparentAddressMetadata::standalone_address`
+
 ### Changed
 - The `orchard` feature is now enabled by default. Consumers that require a
   smaller feature set should disable default features and enable only the
@@ -18,6 +25,12 @@ workspace.
   idempotent: storing a transaction the wallet has already recorded must
   replace that record rather than fail. An implementation that inserts its
   sent-output records must upsert them instead.
+- `zcash_client_backend::wallet::TransparentAddressSource` has a new
+  `StandaloneAddress` variant (under the `transparent-key-import` feature);
+  exhaustive matches on this enum must add an arm for it. Inputs whose address
+  has this source cannot be spent:
+  `zcash_client_backend::data_api::wallet::create_proposed_transactions`
+  returns `Error::KeyNotAvailable` when a proposal includes one.
 
 ## [0.24.0-rc.7] - 2026-08-03
 

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -3686,6 +3686,32 @@ pub trait WalletWrite:
         account: <Self as WalletRead>::AccountId,
     ) -> Result<(), <Self as WalletRead>::Error>;
 
+    /// Imports the given transparent address into the account as a watch-only address, without
+    /// any associated key material.
+    ///
+    /// The imported address will contribute to the balance of the account, but the wallet holds
+    /// neither the public key (P2PKH) nor the redeem script (P2SH) from which the address was
+    /// derived, so funds received by it cannot be spent — its outputs are excluded from spendable
+    /// input selection, and it must not be included in the addresses passed to
+    /// [`propose_shielding`]. Subsequently importing the corresponding key material with
+    /// [`import_standalone_transparent_pubkey`] or [`import_standalone_transparent_script`]
+    /// upgrades the address in place, after which the spending limitations of those methods
+    /// apply instead.
+    ///
+    /// [`import_standalone_transparent_pubkey`]: Self::import_standalone_transparent_pubkey
+    /// [`import_standalone_transparent_script`]: Self::import_standalone_transparent_script
+    /// [`propose_shielding`]: crate::data_api::wallet::propose_shielding
+    #[cfg(feature = "transparent-key-import")]
+    fn import_standalone_transparent_address(
+        &mut self,
+        _account: <Self as WalletRead>::AccountId,
+        _address: TransparentAddress,
+    ) -> Result<(), <Self as WalletRead>::Error> {
+        unimplemented!(
+            "WalletWrite::import_standalone_transparent_address must be overridden for wallets to use the `transparent-key-import` feature"
+        )
+    }
+
     /// Imports the given pubkey into the account without key derivation information, and adds the
     /// associated transparent p2pkh address.
     ///

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -1209,6 +1209,282 @@ fn build_test_redeem_script() -> (script::Redeem, secp256k1::SecretKey) {
     (redeem_script, secret_key)
 }
 
+/// Tests that importing standalone transparent addresses without key material succeeds and
+/// the addresses appear in `get_transparent_receivers` with the
+/// [`TransparentAddressSource::StandaloneAddress`] source.
+#[cfg(feature = "transparent-key-import")]
+pub fn import_standalone_transparent_address<DSF>(dsf: DSF)
+where
+    DSF: DataStoreFactory,
+{
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(dsf)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let account_id = st.test_account().unwrap().id();
+
+    // A P2PKH address, imported without its pubkey.
+    let secp = Secp256k1::new();
+    let secret_key = SecretKey::from_slice(&[1u8; 32]).expect("valid secret key");
+    let p2pkh_addr = TransparentAddress::from_pubkey(&secret_key.public_key(&secp));
+    assert_matches!(
+        st.wallet_mut()
+            .import_standalone_transparent_address(account_id, p2pkh_addr),
+        Ok(_)
+    );
+
+    // A P2SH address, imported without its redeem script.
+    let (redeem_script, _) = build_test_redeem_script();
+    let p2sh_addr =
+        TransparentAddress::from_script_pubkey(&sh(&redeem_script)).expect("valid P2SH address");
+    assert_matches!(
+        st.wallet_mut()
+            .import_standalone_transparent_address(account_id, p2sh_addr),
+        Ok(_)
+    );
+
+    let receivers = st
+        .wallet()
+        .get_transparent_receivers(account_id, false, true)
+        .unwrap();
+    for addr in [p2pkh_addr, p2sh_addr] {
+        let metadata = receivers.get(&addr).expect("address should be present");
+        assert!(matches!(
+            metadata.source(),
+            TransparentAddressSource::StandaloneAddress
+        ));
+    }
+}
+
+/// Tests that importing the same standalone address twice to the same account is idempotent.
+#[cfg(feature = "transparent-key-import")]
+pub fn import_standalone_transparent_address_idempotent<DSF>(dsf: DSF)
+where
+    DSF: DataStoreFactory,
+{
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(dsf)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let account_id = st.test_account().unwrap().id();
+
+    let secp = Secp256k1::new();
+    let secret_key = SecretKey::from_slice(&[1u8; 32]).expect("valid secret key");
+    let taddr = TransparentAddress::from_pubkey(&secret_key.public_key(&secp));
+
+    assert_matches!(
+        st.wallet_mut()
+            .import_standalone_transparent_address(account_id, taddr),
+        Ok(_)
+    );
+
+    let receivers_before = st
+        .wallet()
+        .get_transparent_receivers(account_id, false, true)
+        .unwrap();
+
+    // Second import to the same account should also succeed (idempotent).
+    assert_matches!(
+        st.wallet_mut()
+            .import_standalone_transparent_address(account_id, taddr),
+        Ok(_)
+    );
+
+    let receivers_after = st
+        .wallet()
+        .get_transparent_receivers(account_id, false, true)
+        .unwrap();
+    assert_eq!(receivers_before.len(), receivers_after.len());
+}
+
+/// Tests that importing the same standalone address to a different account fails.
+#[cfg(feature = "transparent-key-import")]
+pub fn import_standalone_transparent_address_conflict<DSF>(dsf: DSF)
+where
+    DSF: DataStoreFactory,
+{
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(dsf)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let account1_id = st.test_account().unwrap().id();
+
+    let secp = Secp256k1::new();
+    let secret_key = SecretKey::from_slice(&[1u8; 32]).expect("valid secret key");
+    let taddr = TransparentAddress::from_pubkey(&secret_key.public_key(&secp));
+
+    assert_matches!(
+        st.wallet_mut()
+            .import_standalone_transparent_address(account1_id, taddr),
+        Ok(_)
+    );
+
+    // Create a second account
+    let birthday = AccountBirthday::from_parts(
+        ChainState::empty(
+            st.network()
+                .activation_height(NetworkUpgrade::Sapling)
+                .unwrap()
+                - 1,
+            BlockHash([0; 32]),
+        ),
+        None,
+    );
+    let seed2 = Secret::new(vec![42u8; 32]);
+    let (account2_id, _) = st
+        .wallet_mut()
+        .create_account("account2", &seed2, &birthday, None)
+        .unwrap();
+
+    // Import of the same address to the second account should fail
+    assert_matches!(
+        st.wallet_mut()
+            .import_standalone_transparent_address(account2_id, taddr),
+        Err(_)
+    );
+}
+
+/// Tests that a UTXO received at an address imported without key material is reflected in the
+/// wallet balance, but is not offered as a spendable output.
+#[cfg(feature = "transparent-key-import")]
+pub fn import_standalone_transparent_address_balance<DSF>(dsf: DSF)
+where
+    DSF: DataStoreFactory,
+    <<DSF as DataStoreFactory>::DataStore as WalletWrite>::UtxoRef: std::fmt::Debug,
+{
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(dsf)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let account_id = st.test_account().unwrap().id();
+    let birthday = st.test_account().unwrap().birthday().height();
+
+    let secp = Secp256k1::new();
+    let secret_key = SecretKey::from_slice(&[1u8; 32]).expect("valid secret key");
+    let taddr = TransparentAddress::from_pubkey(&secret_key.public_key(&secp));
+
+    // Import the address without its pubkey.
+    st.wallet_mut()
+        .import_standalone_transparent_address(account_id, taddr)
+        .unwrap();
+
+    let height = birthday + 1000;
+    st.wallet_mut().update_chain_tip(height).unwrap();
+
+    // Create a fake UTXO at the address.
+    let value = Zatoshis::const_from_u64(50_000);
+    let outpoint = OutPoint::fake();
+    let txout = TxOut::new(value, taddr.script().into());
+    let utxo = WalletTransparentOutput::from_parts(
+        outpoint,
+        txout,
+        Some(height),
+        Some(account_id),
+        None,
+        None,
+    )
+    .unwrap();
+    st.wallet_mut()
+        .put_received_transparent_utxo(&utxo)
+        .unwrap();
+
+    // Verify the balance is reflected via get_transparent_balances.
+    let target_height = TargetHeight::from(height + 1);
+    let balances = st
+        .wallet()
+        .get_transparent_balances(account_id, target_height, ConfirmationsPolicy::MIN)
+        .unwrap();
+    assert_eq!(balances.get(&taddr).map(|(_, b)| b.total()), Some(value),);
+
+    // The output must not be offered for spending: the wallet holds no key material with
+    // which a spend could be constructed.
+    let utxos = st
+        .wallet()
+        .get_spendable_transparent_outputs(
+            &taddr,
+            target_height,
+            ConfirmationsPolicy::MIN,
+            CoinbaseFilter::AllTransparentOutputs,
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
+        )
+        .unwrap();
+    assert_eq!(utxos, vec![]);
+}
+
+/// Tests that importing key material for a previously address-only import upgrades the
+/// address in place: the pubkey (P2PKH) or redeem script (P2SH) becomes the address's
+/// source, without a duplicate receiver appearing.
+#[cfg(feature = "transparent-key-import")]
+pub fn import_standalone_transparent_address_upgrade<DSF>(dsf: DSF)
+where
+    DSF: DataStoreFactory,
+{
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(dsf)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let account_id = st.test_account().unwrap().id();
+
+    let secp = Secp256k1::new();
+    let secret_key = SecretKey::from_slice(&[1u8; 32]).expect("valid secret key");
+    let pubkey = secret_key.public_key(&secp);
+    let p2pkh_addr = TransparentAddress::from_pubkey(&pubkey);
+
+    let (redeem_script, _) = build_test_redeem_script();
+    let p2sh_addr =
+        TransparentAddress::from_script_pubkey(&sh(&redeem_script)).expect("valid P2SH address");
+
+    // Import both addresses without key material.
+    st.wallet_mut()
+        .import_standalone_transparent_address(account_id, p2pkh_addr)
+        .unwrap();
+    st.wallet_mut()
+        .import_standalone_transparent_address(account_id, p2sh_addr)
+        .unwrap();
+
+    let receivers_before = st
+        .wallet()
+        .get_transparent_receivers(account_id, false, true)
+        .unwrap();
+
+    // Import the key material for each address.
+    st.wallet_mut()
+        .import_standalone_transparent_pubkey(account_id, pubkey)
+        .unwrap();
+    st.wallet_mut()
+        .import_standalone_transparent_script(account_id, redeem_script)
+        .unwrap();
+
+    // The addresses were upgraded in place: no new receivers, and each address's source
+    // now reflects the imported key material.
+    let receivers_after = st
+        .wallet()
+        .get_transparent_receivers(account_id, false, true)
+        .unwrap();
+    assert_eq!(receivers_before.len(), receivers_after.len());
+
+    let p2pkh_metadata = receivers_after
+        .get(&p2pkh_addr)
+        .expect("address should be present");
+    assert!(matches!(
+        p2pkh_metadata.source(),
+        TransparentAddressSource::StandalonePubkey(_)
+    ));
+
+    let p2sh_metadata = receivers_after
+        .get(&p2sh_addr)
+        .expect("address should be present");
+    assert!(matches!(
+        p2sh_metadata.source(),
+        TransparentAddressSource::StandaloneScript(_)
+    ));
+}
+
 /// Tests that importing a standalone transparent public key succeeds.
 #[cfg(feature = "transparent-key-import")]
 pub fn import_standalone_transparent_pubkey<DSF>(dsf: DSF)

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -2083,6 +2083,12 @@ where
                         utxos_spent.push(outpoint.clone());
                         builder.add_transparent_p2sh_input(from_chain, outpoint, txout)?;
                     }
+                    // An address imported without key material cannot construct a spend: the
+                    // wallet holds neither the pubkey nor the redeem script for the input.
+                    #[cfg(feature = "transparent-key-import")]
+                    TransparentAddressSource::StandaloneAddress => {
+                        return Err(Error::KeyNotAvailable(PoolType::Transparent));
+                    }
                 }
 
                 Ok(())
@@ -2615,6 +2621,12 @@ where
                 for key in keys {
                     transparent_signing_set.add_key(*key);
                 }
+            }
+            // Unreachable in practice: inputs from an address imported without key material
+            // are rejected when the proposed transaction is constructed.
+            #[cfg(feature = "transparent-key-import")]
+            TransparentAddressSource::StandaloneAddress => {
+                return Err(Error::AddressNotRecognized(_address));
             }
         }
     }
@@ -3193,7 +3205,8 @@ where
                             } => Some((index, *scope, *address_index)),
                             #[cfg(feature = "transparent-key-import")]
                             TransparentAddressSource::StandalonePubkey(_)
-                            | TransparentAddressSource::StandaloneScript(_) => None,
+                            | TransparentAddressSource::StandaloneScript(_)
+                            | TransparentAddressSource::StandaloneAddress => None,
                         }
                     })
                     .collect::<Vec<_>>();

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -1058,6 +1058,18 @@ impl TransparentAddressMetadata {
         }
     }
 
+    /// Returns a [`TransparentAddressMetadata`] with [`TransparentAddressSource::StandaloneAddress`]
+    /// source information for an imported bare transparent address and the specified exposure
+    /// height.
+    #[cfg(feature = "transparent-key-import")]
+    pub fn standalone_address(exposure: Exposure, next_check_time: Option<SystemTime>) -> Self {
+        Self {
+            source: TransparentAddressSource::StandaloneAddress,
+            exposure,
+            next_check_time,
+        }
+    }
+
     /// Returns the source metadata for the address.
     pub fn source(&self) -> &TransparentAddressSource {
         &self.source
@@ -1136,6 +1148,13 @@ pub enum TransparentAddressSource {
     /// This variant provides the redeem script directly.
     #[cfg(feature = "transparent-key-import")]
     StandaloneScript(script::Redeem),
+
+    /// The address was imported as a bare transparent address, without any associated key
+    /// material. The wallet watches for outputs received by the address, but holds neither
+    /// the public key (P2PKH) nor the redeem script (P2SH) from which it was derived, so
+    /// funds received by it cannot be spent unless that material is subsequently imported.
+    #[cfg(feature = "transparent-key-import")]
+    StandaloneAddress,
 }
 
 #[cfg(feature = "transparent-inputs")]
@@ -1149,6 +1168,8 @@ impl TransparentAddressSource {
             TransparentAddressSource::StandalonePubkey(_) => None,
             #[cfg(feature = "transparent-key-import")]
             TransparentAddressSource::StandaloneScript(_) => None,
+            #[cfg(feature = "transparent-key-import")]
+            TransparentAddressSource::StandaloneAddress => None,
         }
     }
 
@@ -1161,6 +1182,8 @@ impl TransparentAddressSource {
             TransparentAddressSource::StandalonePubkey(_) => None,
             #[cfg(feature = "transparent-key-import")]
             TransparentAddressSource::StandaloneScript(_) => None,
+            #[cfg(feature = "transparent-key-import")]
+            TransparentAddressSource::StandaloneAddress => None,
         }
     }
 
@@ -1174,6 +1197,8 @@ impl TransparentAddressSource {
             TransparentAddressSource::StandalonePubkey(_) => None,
             #[cfg(feature = "transparent-key-import")]
             TransparentAddressSource::StandaloneScript(redeem_script) => Some(redeem_script),
+            #[cfg(feature = "transparent-key-import")]
+            TransparentAddressSource::StandaloneAddress => None,
         }
     }
 }

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -11,6 +11,15 @@ workspace.
 ## [Unreleased]
 
 ### Added
+- Support for `WalletWrite::import_standalone_transparent_address` (under the
+  `transparent-key-import` feature): a watch-only transparent address is
+  stored as a `key_scope = -1` row of the `addresses` table with neither
+  imported-material column set. A schema migration relaxes the `addresses`
+  table constraint to admit this shape. Importing the corresponding pubkey or
+  redeem script with `WalletWrite::import_standalone_transparent_pubkey` /
+  `import_standalone_transparent_script` now upgrades such a row in place.
+  Outputs received by an address imported without key material contribute to
+  the account balance but are excluded from spendable-output selection.
 - The `v_migration_transactions` view: one row per SCHEDULED pool-migration
   transaction (belonging to a non-terminal migration and not yet broadcast),
   with its identity, kind, lifecycle state, scheduled and expiry heights,

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -1762,6 +1762,15 @@ impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL: Clock, R:
     }
 
     #[cfg(feature = "transparent-key-import")]
+    fn import_standalone_transparent_address(
+        &mut self,
+        account: <Self as WalletRead>::AccountId,
+        address: TransparentAddress,
+    ) -> Result<(), <Self as WalletRead>::Error> {
+        self.transactionally(|wdb| wdb.import_standalone_transparent_address(account, address))
+    }
+
+    #[cfg(feature = "transparent-key-import")]
     fn import_standalone_transparent_pubkey(
         &mut self,
         account: <Self as WalletRead>::AccountId,
@@ -2135,6 +2144,16 @@ impl<P: consensus::Parameters, CL: Clock, R: RngCore> WalletWrite
         account_uuid: <Self as WalletRead>::AccountId,
     ) -> Result<(), <Self as WalletRead>::Error> {
         wallet::delete_account(self.conn.0, account_uuid)
+    }
+
+    #[cfg(feature = "transparent-key-import")]
+    fn import_standalone_transparent_address(
+        &mut self,
+        account: <Self as WalletRead>::AccountId,
+        address: TransparentAddress,
+    ) -> Result<(), <Self as WalletRead>::Error> {
+        wallet::import_standalone_transparent_address(self.conn.0, &self.params, account, address)
+            .map(|_inserted| ())
     }
 
     #[cfg(feature = "transparent-key-import")]

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -825,6 +825,114 @@ pub(crate) fn transparent_receiver_address_exists(
         .is_some())
 }
 
+/// Returns the row id of an address-only standalone import of the given receiver address in
+/// the given account — a [`KeyScope::Foreign`] row with neither imported-material column set —
+/// if one exists.
+#[cfg(feature = "transparent-key-import")]
+fn standalone_address_only_row(
+    conn: &rusqlite::Transaction,
+    account_id: AccountRef,
+    addr_str: &str,
+) -> Result<Option<i64>, SqliteClientError> {
+    Ok(conn
+        .query_row(
+            "SELECT id FROM addresses
+             WHERE account_id = :account_id
+             AND cached_transparent_receiver_address = :address
+             AND key_scope = :key_scope
+             AND imported_transparent_receiver_pubkey IS NULL
+             AND imported_transparent_receiver_script IS NULL",
+            named_params![
+                ":account_id": account_id.0,
+                ":address": addr_str,
+                ":key_scope": KeyScope::Foreign.encode(),
+            ],
+            |row| row.get(0),
+        )
+        .optional()?)
+}
+
+/// Imports a standalone transparent receiver into the given account by its address alone,
+/// without any associated key material.
+///
+/// Returns the number of address rows inserted: `1` when a new receiver row was added, or `0`
+/// when nothing was inserted because the receiver address was already present in the wallet.
+#[cfg(feature = "transparent-key-import")]
+pub(crate) fn import_standalone_transparent_address<P: consensus::Parameters>(
+    conn: &rusqlite::Transaction,
+    params: &P,
+    account_uuid: AccountUuid,
+    address: ::transparent::address::TransparentAddress,
+) -> Result<usize, SqliteClientError> {
+    use ::transparent::address::TransparentAddress;
+
+    // Resolve the account up front so an unknown account is reported explicitly, rather than
+    // inferred from a zero-row INSERT below.
+    let account_id = get_account_ref(conn, account_uuid)?;
+
+    let addr_str = Address::Transparent(address).encode(params);
+
+    // The only identity an address-only import carries is the address itself, so the
+    // cross-account conflict check is on the receiver address of existing standalone imports
+    // (of any kind — a standalone import with key material subsumes an address-only one).
+    let existing_import_account = conn
+        .query_row(
+            "SELECT accounts.uuid AS account_uuid
+             FROM addresses
+             JOIN accounts ON accounts.id = addresses.account_id
+             WHERE cached_transparent_receiver_address = :address
+             AND key_scope = :key_scope",
+            named_params![
+                ":address": addr_str,
+                ":key_scope": KeyScope::Foreign.encode(),
+            ],
+            |row| row.get::<_, Uuid>("account_uuid"),
+        )
+        .optional()?;
+
+    if let Some(current) = existing_import_account {
+        if current == account_uuid.expose_uuid() {
+            // The address has already been imported; nothing to do.
+            return Ok(0);
+        } else {
+            return Err(SqliteClientError::StandaloneImportConflict(current));
+        }
+    }
+
+    // If this transparent receiver is already recorded as a derived address, the existing
+    // representation already covers it. See `import_standalone_transparent_pubkey_inner` for
+    // details of this resolution.
+    if transparent_receiver_address_exists(conn, &addr_str)? {
+        return Ok(0);
+    }
+
+    let receiver_flags = match address {
+        TransparentAddress::PublicKeyHash(_) => ReceiverFlags::P2PKH,
+        TransparentAddress::ScriptHash(_) => ReceiverFlags::P2SH,
+    };
+
+    let rows_affected = conn.execute(
+        r#"
+        INSERT INTO addresses (
+          account_id, key_scope, address, cached_transparent_receiver_address, receiver_flags
+        )
+        VALUES (
+          :account_id, :key_scope, :address, :address, :receiver_flags
+        )
+        "#,
+        named_params![
+            ":account_id": account_id.0,
+            ":key_scope": KeyScope::Foreign.encode(),
+            ":address": addr_str,
+            ":receiver_flags": receiver_flags.bits(),
+        ],
+    )?;
+
+    // The account is known (resolved above) and the receiver is not already recorded (checked
+    // above), so exactly one row is inserted.
+    Ok(rows_affected)
+}
+
 /// Imports a standalone transparent P2PKH receiver by its pubkey into the given account.
 ///
 /// Returns the number of address rows inserted: `1` when a new receiver row was added, or `0`
@@ -902,6 +1010,22 @@ fn import_standalone_transparent_pubkey_inner<P: consensus::Parameters>(
     }
 
     let addr_str = Address::Transparent(TransparentAddress::from_pubkey(&pubkey)).encode(params);
+
+    // If the receiver was previously imported into this account by its address alone (a
+    // Foreign-scope row with no key material), upgrade the existing row in place with the
+    // pubkey, preserving the row id and hence any attached outputs and exposure state.
+    if let Some(row_id) = standalone_address_only_row(conn, account_id, &addr_str)? {
+        conn.execute(
+            "UPDATE addresses
+             SET imported_transparent_receiver_pubkey = :imported_transparent_receiver_pubkey
+             WHERE id = :id",
+            named_params![
+                ":imported_transparent_receiver_pubkey": pubkey.serialize(),
+                ":id": row_id,
+            ],
+        )?;
+        return Ok(0);
+    }
 
     // If this transparent receiver is already recorded (for example it was derived as an
     // account receiver, so its row carries a NULL `imported_transparent_receiver_pubkey` and is
@@ -1003,6 +1127,23 @@ pub(crate) fn import_standalone_transparent_script<P: consensus::Parameters>(
     }
 
     let addr_str = Address::Transparent(addr).encode(params);
+
+    // If the receiver was previously imported into this account by its address alone (a
+    // Foreign-scope row with no key material), upgrade the existing row in place with the
+    // redeem script, preserving the row id and hence any attached outputs and exposure state.
+    if let Some(row_id) = standalone_address_only_row(conn, account_id, &addr_str)? {
+        conn.execute(
+            "UPDATE addresses
+             SET imported_transparent_receiver_script = :imported_transparent_receiver_script
+             WHERE id = :id",
+            named_params![
+                ":imported_transparent_receiver_script": &rs_bytes[..],
+                ":id": row_id,
+            ],
+        )?;
+        return Ok(());
+    }
+
     conn.execute(
         r#"
         INSERT INTO addresses (

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -179,14 +179,17 @@ pub(super) const INDEX_ACCOUNTS_P2SH_IVK: &str =
 ///   address. At present, this will ordinarily be populated only for ZIP 320 ephemeral addresses.
 /// - `imported_transparent_receiver_pubkey`: The 33-byte pubkey corresponding to the
 ///   `cached_transparent_receiver_address` value, for imported transparent P2PKH addresses that
-///   were not obtained via derivation from an HD seed associated with the account. In cases that
-///   `cached_transparent_receiver_address` is non-null, either this column, or
-///   `imported_transparent_receiver_script` (for imported P2SH addresses), or
-///   `transparent_child_index` must also be non-null. This is only set for imported addresses
-///   (key_scope = -1).
+///   were not obtained via derivation from an HD seed associated with the account. This is only
+///   set for imported addresses (key_scope = -1).
 /// - `imported_transparent_receiver_script`: The serialized redeem script for an imported
 ///   standalone P2SH address. When present, `cached_transparent_receiver_address` holds the P2SH
 ///   address derived from this script. This is only set for imported addresses (key_scope = -1).
+///
+/// At most one of `imported_transparent_receiver_pubkey` and
+/// `imported_transparent_receiver_script` may be set. An imported row (key_scope = -1) with
+/// neither set is a standalone transparent address imported without key material: the wallet
+/// watches for outputs received by `cached_transparent_receiver_address`, but cannot spend
+/// them unless the corresponding pubkey or redeem script is subsequently imported.
 ///
 /// [`ReceiverFlags`]: crate::wallet::encoding::ReceiverFlags
 pub(super) const TABLE_ADDRESSES: &str = r#"
@@ -210,6 +213,7 @@ CREATE TABLE "addresses" (
     CONSTRAINT ck_addr_transparent_index_consistency CHECK (
         (transparent_child_index IS NULL OR diversifier_index_be < x'0000000F00000000000000')
         AND (
+            -- no transparent receiver: all transparent columns are absent
             (
                 cached_transparent_receiver_address IS NULL
                 AND transparent_child_index IS NULL
@@ -218,12 +222,18 @@ CREATE TABLE "addresses" (
             )
             OR (
                 cached_transparent_receiver_address IS NOT NULL
+                -- a transparent receiver has a child index iff it was derived
+                AND ((transparent_child_index IS NULL) == (key_scope = -1))
+                -- at most one kind of imported key material
+                AND NOT (
+                    imported_transparent_receiver_pubkey IS NOT NULL
+                    AND imported_transparent_receiver_script IS NOT NULL
+                )
+                -- imported key material appears only on imported (key_scope = -1) rows
                 AND (
-                    (transparent_child_index IS NULL) == (
-                        key_scope = -1 AND (
-                            (imported_transparent_receiver_pubkey IS NULL) !=
-                              (imported_transparent_receiver_script IS NULL)
-                        )
+                    key_scope = -1 OR (
+                        imported_transparent_receiver_pubkey IS NULL
+                        AND imported_transparent_receiver_script IS NULL
                     )
                 )
             )

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -153,6 +153,7 @@ migration_modules!(
     sent_notes_to_internal,
     shardtree_support,
     spend_key_available,
+    standalone_address,
     standalone_p2sh,
     support_legacy_sqlite,
     support_zcashd_wallet_import,
@@ -271,8 +272,8 @@ pub(super) fn all_migrations<
     //                               ivk_item_cache |            /           orchard_note_version
     //                             .----------------'           /                  \
     //                             |  add_transparent_receiver_address_index        \
-    //                             |                                                 \
-    //                             |                                        ironwood_received_notes ----------------
+    //                             |               |                                 \
+    //                             |      standalone_address               ironwood_received_notes ----------------
     //                             |                                        /         |          \                  \
     //                             |                     ironwood_pool_code_views     |      note_locking  fix_bad_ironwood_change_flagging
     //                             |                             |          \         |
@@ -399,6 +400,7 @@ pub(super) fn all_migrations<
         Box::new(orchard_ironwood_broadcast_binding::Migration),
         Box::new(orchard_ironwood_migration_txid_blob::Migration),
         Box::new(v_migration_transactions::Migration),
+        Box::new(standalone_address::Migration),
     ]
 }
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/standalone_address.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/standalone_address.rs
@@ -1,0 +1,310 @@
+//! This migration relaxes the addresses table constraint to allow standalone transparent
+//! addresses imported without any associated key material: `key_scope = -1` rows with
+//! neither an imported transparent receiver pubkey nor an imported receiver script.
+
+use std::collections::HashSet;
+
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+
+use crate::wallet::init::WalletMigrationError;
+
+use super::add_transparent_receiver_address_index;
+
+/// This migration relaxes the addresses table constraint to allow standalone transparent
+/// addresses imported without any associated key material.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xc9a2c15c_5142_44f9_9485_13a6a87829f1);
+
+pub(super) const DEPENDENCIES: &[Uuid] = &[add_transparent_receiver_address_index::MIGRATION_ID];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Relaxes the addresses table constraint to allow standalone transparent addresses imported without key material."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        // Recreate the addresses table with the relaxed constraint. For rows with a cached
+        // transparent receiver address, the previous constraint required a `key_scope = -1`
+        // (Foreign) row to have exactly one of the two imported-material columns set; the
+        // new constraint requires at most one, additionally admitting the address-only
+        // shape in which both are NULL. It also states directly that the imported-material
+        // columns may only be set on Foreign rows, which was previously only implied by
+        // the shapes the writing code produces.
+        transaction.execute_batch(
+            r#"
+            CREATE TABLE addresses_new (
+                id INTEGER NOT NULL PRIMARY KEY,
+                account_id INTEGER NOT NULL
+                    REFERENCES accounts(id) ON DELETE CASCADE,
+                key_scope INTEGER NOT NULL,
+                diversifier_index_be BLOB,
+                address TEXT NOT NULL,
+                transparent_child_index INTEGER,
+                cached_transparent_receiver_address TEXT,
+                exposed_at_height INTEGER,
+                receiver_flags INTEGER NOT NULL,
+                transparent_receiver_next_check_time INTEGER,
+                imported_transparent_receiver_pubkey BLOB,
+                imported_transparent_receiver_script BLOB,
+                UNIQUE (account_id, key_scope, diversifier_index_be),
+                UNIQUE (imported_transparent_receiver_pubkey),
+                UNIQUE (imported_transparent_receiver_script),
+                CONSTRAINT ck_addr_transparent_index_consistency CHECK (
+                    (transparent_child_index IS NULL OR diversifier_index_be < x'0000000F00000000000000')
+                    AND (
+                        -- no transparent receiver: all transparent columns are absent
+                        (
+                            cached_transparent_receiver_address IS NULL
+                            AND transparent_child_index IS NULL
+                            AND imported_transparent_receiver_pubkey IS NULL
+                            AND imported_transparent_receiver_script IS NULL
+                        )
+                        OR (
+                            cached_transparent_receiver_address IS NOT NULL
+                            -- a transparent receiver has a child index iff it was derived
+                            AND ((transparent_child_index IS NULL) == (key_scope = -1))
+                            -- at most one kind of imported key material
+                            AND NOT (
+                                imported_transparent_receiver_pubkey IS NOT NULL
+                                AND imported_transparent_receiver_script IS NOT NULL
+                            )
+                            -- imported key material appears only on imported (key_scope = -1) rows
+                            AND (
+                                key_scope = -1 OR (
+                                    imported_transparent_receiver_pubkey IS NULL
+                                    AND imported_transparent_receiver_script IS NULL
+                                )
+                            )
+                        )
+                    )
+                ),
+                CONSTRAINT ck_addr_foreign_or_diversified CHECK (
+                    (diversifier_index_be IS NULL) == (key_scope = -1)
+                )
+            );
+
+            INSERT INTO addresses_new (
+                id, account_id, key_scope, diversifier_index_be, address,
+                transparent_child_index, cached_transparent_receiver_address,
+                exposed_at_height, receiver_flags, transparent_receiver_next_check_time,
+                imported_transparent_receiver_pubkey, imported_transparent_receiver_script
+            )
+            SELECT
+                id, account_id, key_scope, diversifier_index_be, address,
+                transparent_child_index, cached_transparent_receiver_address,
+                exposed_at_height, receiver_flags, transparent_receiver_next_check_time,
+                imported_transparent_receiver_pubkey, imported_transparent_receiver_script
+            FROM addresses;
+
+            PRAGMA legacy_alter_table = ON;
+
+            DROP TABLE addresses;
+            ALTER TABLE addresses_new RENAME TO addresses;
+
+            PRAGMA legacy_alter_table = OFF;
+
+            -- Recreate the existing indices
+            CREATE INDEX idx_addresses_accounts ON addresses (
+                account_id ASC
+            );
+            CREATE UNIQUE INDEX idx_addresses_cached_transparent_receiver_address ON addresses (
+                cached_transparent_receiver_address ASC
+            );
+            CREATE INDEX idx_addresses_indices ON addresses (
+                diversifier_index_be ASC
+            );
+            CREATE INDEX idx_addresses_pubkeys ON addresses (
+                imported_transparent_receiver_pubkey ASC
+            );
+            CREATE INDEX idx_addresses_t_indices ON addresses (
+                transparent_child_index ASC
+            );
+            "#,
+        )?;
+
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::named_params;
+    use secrecy::Secret;
+    use tempfile::NamedTempFile;
+    use zcash_keys::keys::UnifiedSpendingKey;
+    use zcash_protocol::consensus::Network;
+
+    use crate::{
+        WalletDb,
+        testing::db::{test_clock, test_rng},
+        wallet::init::{WalletMigrator, migrations::tests::test_migrate},
+    };
+
+    use super::{DEPENDENCIES, MIGRATION_ID};
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[MIGRATION_ID]);
+    }
+
+    #[test]
+    fn migrate_preserves_data() {
+        let network = Network::TestNetwork;
+        let data_file = NamedTempFile::new().unwrap();
+        let mut db_data =
+            WalletDb::for_path(data_file.path(), network, test_clock(), test_rng()).unwrap();
+
+        let seed_bytes = vec![0xab; 32];
+
+        // Migrate to database state just prior to this migration.
+        WalletMigrator::new()
+            .with_seed(Secret::new(seed_bytes.clone()))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, DEPENDENCIES)
+            .unwrap();
+
+        // Insert a test account with a valid UFVK so post-migration checks pass.
+        let usk = UnifiedSpendingKey::from_seed(&network, &seed_bytes[..], zip32::AccountId::ZERO)
+            .unwrap();
+        let ufvk = usk.to_unified_full_viewing_key();
+        let ufvk_str = ufvk.encode(&network);
+        let uivk_str = ufvk.to_unified_incoming_viewing_key().encode(&network);
+
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO accounts (uuid, account_kind, hd_seed_fingerprint,
+                 hd_account_index, ufvk, uivk, has_spend_key, birthday_height)
+                 VALUES (X'0000000000000000000000000000AAAA', 0, X'00000000000000000000000000000000000000000000000000000000000000AB',
+                 0, :ufvk, :uivk, 1, 1)",
+                named_params![":ufvk": ufvk_str, ":uivk": uivk_str],
+            )
+            .unwrap();
+
+        let account_id: i64 = db_data
+            .conn
+            .query_row(
+                "SELECT id FROM accounts WHERE uuid = X'0000000000000000000000000000AAAA'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        // Insert the address row shapes that exist in production databases.
+
+        // 1. Derived transparent address (most common row type)
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO addresses (account_id, key_scope, diversifier_index_be, address,
+                 transparent_child_index, cached_transparent_receiver_address, receiver_flags)
+                 VALUES (?1, 0, X'00000000000000000000000000', 'addr_derived', 0, 't_derived', 5)",
+                [account_id],
+            )
+            .unwrap();
+
+        // 2. Shielded-only address (no transparent receiver — all transparent fields NULL)
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO addresses (account_id, key_scope, diversifier_index_be, address,
+                 receiver_flags)
+                 VALUES (?1, 0, X'00000000000000000100000000', 'addr_shielded', 4)",
+                [account_id],
+            )
+            .unwrap();
+
+        // 3. Standalone P2PKH address
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO addresses (account_id, key_scope, address,
+                 cached_transparent_receiver_address, receiver_flags,
+                 imported_transparent_receiver_pubkey)
+                 VALUES (?1, -1, 'ttest_addr', 'ttest_addr', 1, X'0000000000000000000000000000000000000000000000000000000000000001')",
+                [account_id],
+            )
+            .unwrap();
+
+        // 4. Standalone P2SH address
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO addresses (account_id, key_scope, address,
+                 cached_transparent_receiver_address, receiver_flags,
+                 imported_transparent_receiver_script)
+                 VALUES (?1, -1, 't_p2sh', 't_p2sh', 2, X'0102030405')",
+                [account_id],
+            )
+            .unwrap();
+
+        // Run the standalone_address migration.
+        WalletMigrator::new()
+            .with_seed(Secret::new(seed_bytes))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, &[MIGRATION_ID])
+            .unwrap();
+
+        // Verify all 4 rows survived the migration.
+        let count: i64 = db_data
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM addresses WHERE account_id = ?1",
+                [account_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 4);
+
+        // Verify an address-only import (both imported-material columns NULL) succeeds with
+        // the new constraint.
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO addresses (account_id, key_scope, address,
+                 cached_transparent_receiver_address, receiver_flags)
+                 VALUES (?1, -1, 't_addr_only', 't_addr_only', 1)",
+                [account_id],
+            )
+            .unwrap();
+
+        // Verify a row with both imported-material columns set is rejected.
+        let result = db_data.conn.execute(
+            "INSERT INTO addresses (account_id, key_scope, address,
+             cached_transparent_receiver_address, receiver_flags,
+             imported_transparent_receiver_pubkey, imported_transparent_receiver_script)
+             VALUES (?1, -1, 't_both', 't_both', 1,
+             X'0000000000000000000000000000000000000000000000000000000000000002', X'AABBCC')",
+            [account_id],
+        );
+        assert!(result.is_err());
+
+        // Verify a non-foreign row with an imported-material column set is rejected.
+        let result = db_data.conn.execute(
+            "INSERT INTO addresses (account_id, key_scope, diversifier_index_be, address,
+             transparent_child_index, cached_transparent_receiver_address, receiver_flags,
+             imported_transparent_receiver_script)
+             VALUES (?1, 0, X'00000000000000000200000000', 'bad_non_foreign', 1, 'bad_non_foreign', 1, X'AABBCCDD')",
+            [account_id],
+        );
+        assert!(result.is_err());
+    }
+}

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -274,32 +274,30 @@ pub(crate) fn get_transparent_receivers<P: consensus::Parameters>(
             let p2pkh_metadata = || -> Result<TransparentAddressMetadata, SqliteClientError> {
                 match key_scope {
                     #[cfg(feature = "transparent-key-import")]
-                    KeyScope::Foreign => {
-                        let pubkey_bytes = row
-                                .get::<_, Option<Vec<u8>>>(3)?
-                                .ok_or_else(|| {
-                                    SqliteClientError::CorruptedData(
-                                    "Pubkey bytes must be present for all imported transparent P2PKH addresses."
-                                        .to_owned(),
-                                )
-                                })
-                                .and_then(|b| {
-                                    <[u8; 33]>::try_from(&b[..]).map_err(|_| {
-                                        SqliteClientError::CorruptedData(format!(
-                                            "Invalid public key byte length; must be 33 bytes, got {}.",
-                                            b.len()
-                                        ))
-                                    })
-                                })?;
-                        let pubkey = PublicKey::from_bytes(pubkey_bytes).map_err(|e| {
-                            SqliteClientError::CorruptedData(format!("Invalid public key: {e}"))
-                        })?;
-                        Ok(TransparentAddressMetadata::standalone_p2pkh(
-                            pubkey,
+                    KeyScope::Foreign => match row.get::<_, Option<Vec<u8>>>(3)? {
+                        // A Foreign row with neither imported-material column set is an
+                        // address imported without key material.
+                        None => Ok(TransparentAddressMetadata::standalone_address(
                             exposure,
                             next_check_time,
-                        ))
-                    }
+                        )),
+                        Some(b) => {
+                            let pubkey_bytes = <[u8; 33]>::try_from(&b[..]).map_err(|_| {
+                                SqliteClientError::CorruptedData(format!(
+                                    "Invalid public key byte length; must be 33 bytes, got {}.",
+                                    b.len()
+                                ))
+                            })?;
+                            let pubkey = PublicKey::from_bytes(pubkey_bytes).map_err(|e| {
+                                SqliteClientError::CorruptedData(format!("Invalid public key: {e}"))
+                            })?;
+                            Ok(TransparentAddressMetadata::standalone_p2pkh(
+                                pubkey,
+                                exposure,
+                                next_check_time,
+                            ))
+                        }
+                    },
                     derived => {
                         let (scope, address_index) = derived
                             .as_transparent()
@@ -1404,11 +1402,18 @@ fn spendable_transparent_outputs_query(
            -- unknown tx_index defaults to 1 (non-coinbase) to avoid false positives,
            -- so such outputs are excluded by CoinbaseOnly and included by NonCoinbaseOnly
          AND ({lock_eligible_sql}) -- the output is eligible under the lock filter
+         AND NOT (
+             addresses.key_scope = {foreign_scope}
+             AND addresses.imported_transparent_receiver_pubkey IS NULL
+             AND addresses.imported_transparent_receiver_script IS NULL
+         ) -- exclude outputs of addresses imported without key material: no
+           -- key material exists with which a spend could be constructed
          ORDER BY {order_by_sql}",
         tx_unexpired_condition_minconf_0("t"),
         spent_utxos_clause(),
         excluding_wallet_internal_ephemeral_outputs("u", "addresses", "t", "accounts"),
         excluding_immature_coinbase_outputs("t"),
+        foreign_scope = KeyScope::Foreign.encode(),
     )
 }
 
@@ -2568,8 +2573,11 @@ pub(crate) fn get_transparent_address_metadata<P: consensus::Parameters>(
                                         next_check_time,
                                     ))
                                 } else {
-                                    Err(SqliteClientError::CorruptedData(
-                                        "imported_transparent_receiver_pubkey or imported_transparent_receiver_script must be set for \"standalone\" transparent addresses".to_string()
+                                    // A Foreign row with neither imported-material column set
+                                    // is an address imported without key material.
+                                    Ok(TransparentAddressMetadata::standalone_address(
+                                        _standalone_exposure,
+                                        next_check_time,
                                     ))
                                 }
                             }
@@ -4042,6 +4050,46 @@ mod tests {
             result,
             Err(crate::error::SqliteClientError::AccountUnknown)
         ));
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-key-import")]
+    fn test_import_standalone_transparent_address() {
+        zcash_client_backend::data_api::testing::transparent::import_standalone_transparent_address(
+            TestDbFactory::default(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-key-import")]
+    fn test_import_standalone_transparent_address_idempotent() {
+        zcash_client_backend::data_api::testing::transparent::import_standalone_transparent_address_idempotent(
+            TestDbFactory::default(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-key-import")]
+    fn test_import_standalone_transparent_address_conflict() {
+        zcash_client_backend::data_api::testing::transparent::import_standalone_transparent_address_conflict(
+            TestDbFactory::default(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-key-import")]
+    fn test_import_standalone_transparent_address_balance() {
+        zcash_client_backend::data_api::testing::transparent::import_standalone_transparent_address_balance(
+            TestDbFactory::default(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-key-import")]
+    fn test_import_standalone_transparent_address_upgrade() {
+        zcash_client_backend::data_api::testing::transparent::import_standalone_transparent_address_upgrade(
+            TestDbFactory::default(),
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes https://github.com/zcash/librustzcash/issues/2941

Imports a transparent address into an account as watch-only, without any associated key material, closing the gap for zcashd `importaddress`-style watch-only tracking where the caller holds only the address (#2941).

In `zcash_client_sqlite`, the address is stored as a `key_scope = -1` row of `addresses` with neither imported-material column set; a new migration relaxes the addresses-table CHECK constraint from "exactly one" to "at most one" imported-material column for Foreign rows. Discovery and balance paths pick the row up via `cached_transparent_receiver_address` as for other standalone imports, while spendable-output selection excludes its outputs, and `create_proposed_transactions` rejects proposals that would spend them, since no key material exists to construct an input.

Importing the corresponding pubkey or redeem script with the existing `import_standalone_transparent_pubkey` / `import_standalone_transparent_script` methods now upgrades such a row in place, preserving the row id and hence attached outputs and exposure state.


Claude-Session: https://claude.ai/code/session_01XaysA4NLRmfucHSs1gPNZu
[COR-1778](https://linear.app/zodl/issue/COR-1778)