### PR TITLE
zcash_pool_migration: snapshot the spendable notes in the wallet adapter

### DIFF
--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -55,6 +55,12 @@ and this library adheres to Rust's notion of
   `(A, (B, (C, ())))`.
 
 ### Changed
+- `wallet::WalletMigration` now snapshots the account's spendable Orchard
+  notes on its first read and serves every later read from that snapshot, so
+  a plan's note indices always resolve against the selection that produced
+  them and committing a run performs one note selection instead of one per
+  spent note. A consumer that held one adapter across changes to the wallet's
+  spendable notes must construct a fresh adapter to observe them.
 - `satisfiability::advance_migration` now returns `satisfiability::Advance`
   rather than a bare `state::AdvanceStep`: read the step to perform via
   `Advance::step`, and the outlook — when the migration next has work, and of

--- a/zcash_pool_migration/src/wallet.rs
+++ b/zcash_pool_migration/src/wallet.rs
@@ -22,6 +22,7 @@
 
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
+use core::cell::{Ref, RefCell};
 use core::fmt;
 use core::num::NonZeroU32;
 
@@ -129,6 +130,9 @@ where
     /// The inter-arrival delays to schedule under, or `None` to derive them from the wallet's own
     /// anchor bucket interval by the ZIP 318 ratios.
     scheduling_delays: Option<(DelayDistribution, DelayDistribution)>,
+    /// The spendable-note snapshot every read is served from, filled on first use — see
+    /// [`Self::spendable_orchard`].
+    spendable: RefCell<Option<Vec<SpendableNote>>>,
 }
 
 impl<'a, W, St> WalletMigration<'a, W, St>
@@ -157,6 +161,7 @@ where
             usk,
             store,
             scheduling_delays: None,
+            spendable: RefCell::new(None),
         }
     }
 
@@ -190,31 +195,41 @@ where
     }
 
     /// The account's spendable Orchard notes as `(note, tree position, value)`, sorted by tree
-    /// position so the index is stable across calls (the engine maps a value index from
-    /// `spendable_orchard_note_values` back to a note by the same order).
-    fn spendable_orchard(&self) -> Result<Vec<SpendableNote>, AdapterError<W, St>> {
-        let target = self.selection_target()?;
-        let received = self
-            .wallet
-            .select_unspent_notes(
-                self.account,
-                &[ShieldedPool::Orchard],
-                target,
-                &[],
-                LockFilter::Policy(&LockedInputPolicy::Exclude),
-            )
-            .map_err(Error::InputSource)?;
-        let mut notes: Vec<SpendableNote> = received
-            .orchard()
-            .iter()
-            .map(|rn| {
-                let note = *rn.note();
-                let value = note.value().inner();
-                (note, rn.note_commitment_tree_position(), value)
-            })
-            .collect();
-        notes.sort_by_key(|(_, pos, _)| *pos);
-        Ok(notes)
+    /// position and SNAPSHOTTED on the first read: the engine addresses a note by its index into
+    /// this sequence (a plan's `PrepInput::Wallet { index, .. }` names the selection its planning
+    /// call observed), so every read through one adapter must see the same set. The snapshot also
+    /// keeps a commit linear in the plan's inputs — resolving each spent note through a fresh
+    /// selection made signing a large plan quadratic in the wallet's note count.
+    ///
+    /// Wallet changes are observed by constructing a fresh adapter; this one's selection is fixed.
+    fn spendable_orchard(&self) -> Result<Ref<'_, [SpendableNote]>, AdapterError<W, St>> {
+        if self.spendable.borrow().is_none() {
+            let target = self.selection_target()?;
+            let received = self
+                .wallet
+                .select_unspent_notes(
+                    self.account,
+                    &[ShieldedPool::Orchard],
+                    target,
+                    &[],
+                    LockFilter::Policy(&LockedInputPolicy::Exclude),
+                )
+                .map_err(Error::InputSource)?;
+            let mut notes: Vec<SpendableNote> = received
+                .orchard()
+                .iter()
+                .map(|rn| {
+                    let note = *rn.note();
+                    let value = note.value().inner();
+                    (note, rn.note_commitment_tree_position(), value)
+                })
+                .collect();
+            notes.sort_by_key(|(_, pos, _)| *pos);
+            *self.spendable.borrow_mut() = Some(notes);
+        }
+        Ok(Ref::map(self.spendable.borrow(), |cached| {
+            cached.as_deref().expect("filled above")
+        }))
     }
 }
 
@@ -228,9 +243,9 @@ where
 
     fn spendable_orchard_note_values(&self) -> Result<Vec<Zatoshis>, Self::Error> {
         self.spendable_orchard()?
-            .into_iter()
+            .iter()
             .enumerate()
-            .map(|(i, (_, _, value))| {
+            .map(|(i, &(_, _, value))| {
                 Zatoshis::from_u64(value).map_err(|_| Error::InvalidNoteValue(i))
             })
             .collect()


### PR DESCRIPTION
Part of #2630.

## The defect

`WalletMigration::resolve_wallet_note` ran the wallet's full unspent-note selection for every input it resolved, so committing a plan that spends `n` notes performed `n` complete selections of `n` notes each — quadratic in the wallet's note count, inside the single atomic `sign_and_store` call.

**Field evidence** (complex testnet wallet, 1,396 spendable Orchard notes): ~1.9 million note materializations put the confirm spinner at ~25 minutes, during which the mobile SDK's database actor serialized every other wallet operation behind the commit; the process was killed before the commit's one write transaction committed, so the migration store was found empty afterwards — the migration appeared to vanish after being displayed. (Planning itself was measured at under a millisecond for the same wallet; the cost was entirely this resolution loop.)

## The fix

Snapshot the selection in the adapter on first read and serve every later read from it: one selection per adapter, and the commit is linear in the plan's inputs.

The snapshot is also the correctness the plan already assumed. A plan's `PrepInput::Wallet` indices name positions in the selection its planning call observed; the per-call re-selection upheld that only while nothing shifted mid-commit, a drift the `StalePlan` value check detects merely probabilistically. One adapter now means one selection by construction. Wallet changes are observed by constructing a fresh adapter — which every existing caller (including the mobile SDK's FFI, which builds a backend per call) already does per operation.

CHANGELOG entry included for the `WalletMigration` behavior contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
