### PR TITLE
zcash_pool_migration: follow up on the denomination-interface review

### DIFF
--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -70,6 +70,13 @@ and this library adheres to Rust's notion of
   how the wallet's notes happen to hold the balance. A wallet that cannot fund
   the entire canonical split migrates a prefix of it in the current run, with
   the remainder deferred to a later run.
+- `engine::MigrationError` has a new `UnfundableSplit` variant, and
+  `engine::plan_migration` returns it (rather than `NothingToMigrate`) when the
+  balance quantizes to at least one canonical part but the wallet's current
+  notes cannot fund any part of that split. This is deferral, not completion:
+  value above the residual threshold remains, and it can migrate once the
+  spendable balance changes. `NothingToMigrate` now means only that the balance
+  itself has nothing left to quantize.
 - `satisfiability::advance_migration` now returns `satisfiability::Advance`
   rather than a bare `state::AdvanceStep`: read the step to perform via
   `Advance::step`, and the outlook — when the migration next has work, and of

--- a/zcash_pool_migration/src/denomination.rs
+++ b/zcash_pool_migration/src/denomination.rs
@@ -334,3 +334,20 @@ pub fn plan_denominations<R: RngCore + CryptoRng>(
         rng,
     )
 }
+
+/// Whether `total_input` quantizes to at least one canonical part under the recommended strategy —
+/// that is, whether SOME wallet holding this balance could migrate part of it. A pure function of
+/// the balance and fees: reconciliation against a concrete wallet's notes can only truncate the
+/// canonical split, never extend it, so a balance for which this is `false` has nothing to migrate
+/// regardless of note shape, while `true` with an empty reconciled plan means the WALLET's notes —
+/// not the balance — blocked the run (see
+/// [`MigrationError::UnfundableSplit`](crate::engine::MigrationError::UnfundableSplit)).
+pub(crate) fn balance_has_canonical_split(
+    total_input: Zatoshis,
+    transfer_fee_buffer: Zatoshis,
+    prep_tx_fee: Zatoshis,
+) -> bool {
+    !CanonicalOneTwoFive::recommended(transfer_fee_buffer)
+        .unconstrained_split(u64::from(total_input), u64::from(prep_tx_fee))
+        .is_empty()
+}

--- a/zcash_pool_migration/src/denomination/strategies.rs
+++ b/zcash_pool_migration/src/denomination/strategies.rs
@@ -833,8 +833,11 @@ mod tests {
     proptest! {
         /// The note shape can only TRUNCATE the published split, never reshape it: against the real
         /// preparation planner, whatever the wallet's notes, the crossings are a prefix of the
-        /// balance's canonical split (the plan under the optimistic stub). This is the reconciliation
-        /// kernel's contract — dropping from the bottom is the only repair.
+        /// balance's canonical split ([`CanonicalOneTwoFive::unconstrained_split`] itself, NOT the
+        /// plan under the optimistic stub: for a balance of exactly one denomination plus its
+        /// buffer, the split forgoes the fee reserve so an exact note can fund it directly, and a
+        /// stub that charges a fee reconciles that split away). This is the reconciliation kernel's
+        /// contract — dropping from the bottom is the only repair.
         #[test]
         fn the_note_shape_only_truncates_the_canonical_split(
             notes in prop::collection::vec(1u64..2_000_000_000, 1..20),
@@ -851,7 +854,7 @@ mod tests {
             };
             let mut rng = ChaCha8Rng::seed_from_u64(0);
             let constrained = crossings_u64(&s.plan(zat(total), zat(fee), &real, &mut rng));
-            let canonical = crossings_u64(&s.plan(zat(total), zat(fee), &prep_tx_count_stub, &mut rng));
+            let canonical = s.unconstrained_split(total, fee);
 
             prop_assert!(
                 constrained.len() <= canonical.len()
@@ -861,5 +864,108 @@ mod tests {
                 canonical,
             );
         }
+    }
+
+    /// The prefix contract at the corner the proptest's generator cannot reach: a balance of
+    /// exactly one canonical denomination plus its transfer buffer. Its canonical split is that
+    /// single denomination with NO fee reserve (an exact note funds it directly), so a wallet
+    /// holding the balance as the exact note publishes the full split — and a wallet holding it any
+    /// other way can fund no part of it (there is no room for any preparation fee) and publishes
+    /// the empty prefix, deferring the whole balance rather than reshaping the split.
+    #[test]
+    fn an_exact_denomination_balance_migrates_fully_or_not_at_all() {
+        let buffer = zip317_buffer();
+        let fee = 16 * MARGINAL_FEE.into_u64();
+        let total = COIN + buffer;
+        let s = CanonicalOneTwoFive::recommended(zat(buffer));
+        assert_eq!(s.unconstrained_split(total, fee), vec![COIN]);
+
+        let plan_against = |notes: &[u64]| {
+            let available: Vec<Zatoshis> = notes.iter().map(|&v| zat(v)).collect();
+            let real = |funding: &[Zatoshis]| {
+                crate::preparation::plan_preparation(&available, funding, zat(fee))
+                    .ok()
+                    .map(|plan| plan.transaction_count())
+            };
+            let mut rng = ChaCha8Rng::seed_from_u64(0);
+            s.plan(zat(total), zat(fee), &real, &mut rng)
+        };
+
+        // The exact note: the full canonical split, funded directly, nothing reserved.
+        let exact = plan_against(&[total]);
+        assert_eq!(crossings_u64(&exact), vec![COIN]);
+        assert_eq!(exact.prep_fees(), Zatoshis::ZERO);
+
+        // The same balance as two notes: no preparation can mint the funding note (the notes sum to
+        // exactly its value), so the whole split defers and the balance stays as change.
+        let split = plan_against(&[60 * COIN / 100, 40 * COIN / 100 + buffer]);
+        assert_eq!(crossings_u64(&split), Vec::<u64>::new());
+        assert_eq!(split.change(), Some(zat(total)));
+    }
+
+    /// The cap regime: a balance whose canonical split saturates
+    /// [`MIGRATION_MAX_PREPARED_NOTES_PER_RUN`] repeated [`DENOM_CAP`] parts, planned against the
+    /// real preparation planner over more than 50 source notes. The published crossings are the
+    /// full capped split — a prefix of the canonical split by construction — and the excess balance
+    /// waits as change.
+    #[test]
+    fn the_cap_regime_publishes_repeated_denom_cap_parts() {
+        let buffer = zip317_buffer();
+        let fee = 16 * MARGINAL_FEE.into_u64();
+        let cap = DENOM_CAP.into_u64();
+        // 55 wallet notes of one DENOM_CAP each: none is an exact funding note (each lacks the
+        // buffer), so every funding note is minted by consolidation.
+        let notes: Vec<u64> = vec![cap; 55];
+        let total: u64 = notes.iter().sum();
+        let available: Vec<Zatoshis> = notes.iter().map(|&v| zat(v)).collect();
+        let s = CanonicalOneTwoFive::recommended(zat(buffer));
+
+        let canonical = s.unconstrained_split(total, fee);
+        assert_eq!(
+            canonical,
+            vec![cap; MIGRATION_MAX_PREPARED_NOTES_PER_RUN],
+            "the canonical split saturates the per-run cap with repeated DENOM_CAP parts"
+        );
+
+        let real = |funding: &[Zatoshis]| {
+            crate::preparation::plan_preparation(&available, funding, zat(fee))
+                .ok()
+                .map(|plan| plan.transaction_count())
+        };
+        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let plan = s.plan(zat(total), zat(fee), &real, &mut rng);
+        assert_eq!(crossings_u64(&plan), canonical);
+    }
+
+    /// Reconciliation drops a SUFFIX when the wallet's true consolidation costs exceed the
+    /// optimistic reserve: a wallet of hundreds of sub-funding notes pays its extra preparation
+    /// fees by deferring the smallest parts, and what it publishes is still a nonempty strict
+    /// prefix of the balance's canonical split.
+    #[test]
+    fn consolidation_costs_truncate_a_suffix_of_the_split() {
+        let buffer = zip317_buffer();
+        let fee = 16 * MARGINAL_FEE.into_u64();
+        // 300 notes of the minimum denomination: each is below the smallest self-funding note
+        // (which needs the buffer on top), so everything must consolidate, and the ~20+ transaction
+        // fees far exceed the optimistic single-transaction reserve.
+        let notes: Vec<u64> = vec![u64::from(MAX_RESIDUAL_VALUE); 300];
+        let total: u64 = notes.iter().sum();
+        let available: Vec<Zatoshis> = notes.iter().map(|&v| zat(v)).collect();
+        let s = CanonicalOneTwoFive::recommended(zat(buffer));
+
+        let real = |funding: &[Zatoshis]| {
+            crate::preparation::plan_preparation(&available, funding, zat(fee))
+                .ok()
+                .map(|plan| plan.transaction_count())
+        };
+        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let constrained = crossings_u64(&s.plan(zat(total), zat(fee), &real, &mut rng));
+        let canonical = s.unconstrained_split(total, fee);
+
+        assert!(
+            !constrained.is_empty() && constrained.len() < canonical.len(),
+            "the split truncates without emptying: {constrained:?} from {canonical:?}"
+        );
+        assert_eq!(constrained, canonical[..constrained.len()]);
     }
 }

--- a/zcash_pool_migration/src/denomination/strategies.rs
+++ b/zcash_pool_migration/src/denomination/strategies.rs
@@ -80,8 +80,16 @@ impl CanonicalOneTwoFive {
     /// [`FUNDING_OUTPUTS_PER_TX`]-notes preparation model. The exception is a balance containing
     /// exactly one self-funding canonical denomination: that split is retained because an exact
     /// wallet note can fund it directly without a preparation transaction. Whether the wallet
-    /// actually contains that note is decided later during reconciliation.
-    fn unconstrained_split(&self, total_input_zatoshi: u64, prep_tx_fee_zatoshi: u64) -> Vec<u64> {
+    /// actually contains that note is decided later during reconciliation — and a wallet holding
+    /// that balance any OTHER way cannot fund the part at all (the notes sum to exactly the funding
+    /// note, leaving no room for any preparation fee), so reconciliation defers the WHOLE split to
+    /// a later run rather than reshaping it (see
+    /// [`MigrationError::UnfundableSplit`](crate::engine::MigrationError::UnfundableSplit)).
+    pub(crate) fn unconstrained_split(
+        &self,
+        total_input_zatoshi: u64,
+        prep_tx_fee_zatoshi: u64,
+    ) -> Vec<u64> {
         let buffer = self.buffer_zatoshi;
         // Smallest self-funding note: the minimum denomination plus its transfer buffer.
         let min_note = self.min_denomination_zatoshi + buffer;

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -71,7 +71,7 @@ use zcash_primitives::transaction::fees::{FeeRule as _, transparent, zip317};
 #[cfg(feature = "orchard")]
 use crate::satisfiability::{DuenessTargets, UnsatisfiableCause};
 use crate::{
-    denomination::{DenominationPlan, plan_denominations},
+    denomination::{DenominationPlan, balance_has_canonical_split, plan_denominations},
     preparation::{PREP_TX_ACTIONS, PrepError, PrepInput, PreparationPlan, plan_preparation},
     satisfiability::{ReorgSettleDepth, ReplanThreshold, StepSatisfiability, UnsatisfiableKind},
     scheduling::{self, Schedule},
@@ -1154,6 +1154,19 @@ pub enum MigrationError<E> {
     Preparation(PrepError),
     /// The account has no migratable balance.
     NothingToMigrate,
+    /// The balance quantizes to at least one canonical part, but the wallet's current notes cannot
+    /// fund ANY part of that split, so this run defers the whole balance. Reconciliation only ever
+    /// drops parts of the canonical split (never substitutes smaller denominations — see
+    /// [`DenominationStrategy::plan`](crate::denomination::DenominationStrategy::plan)), so a
+    /// wallet whose notes cannot mint even the split's first part has no migratable decomposition
+    /// until its spendable balance changes. The known shapes: a balance of exactly one canonical
+    /// denomination plus its transfer buffer held as anything other than that exact note (the notes
+    /// sum to exactly the funding note, leaving no room for any preparation fee), and a wallet so
+    /// fragmented that consolidating it costs more than the balance can pay. Unlike
+    /// [`NothingToMigrate`](Self::NothingToMigrate), this is NOT completion: value above the
+    /// residual threshold remains, and an application should report it as deferred rather than
+    /// migrated.
+    UnfundableSplit,
     /// The backend's note values do not form a valid balance (their sum exceeds the maximum money
     /// supply).
     InvalidBalance(BalanceError),
@@ -1170,6 +1183,9 @@ impl<E: fmt::Display> fmt::Display for MigrationError<E> {
             MigrationError::Backend(e) => write!(f, "wallet backend error: {e}"),
             MigrationError::Preparation(e) => write!(f, "cannot prepare the migration: {e}"),
             MigrationError::NothingToMigrate => f.write_str("no migratable balance"),
+            MigrationError::UnfundableSplit => f.write_str(
+                "the wallet's notes cannot fund any part of the balance's canonical split",
+            ),
             MigrationError::InvalidBalance(e) => write!(f, "invalid balance: {e}"),
             MigrationError::Fee(e) => write!(f, "fee computation failed: {e}"),
             MigrationError::Nu63NotActive => f.write_str("NU6.3 is not active on this network"),
@@ -1183,6 +1199,7 @@ impl<E: core::error::Error + 'static> core::error::Error for MigrationError<E> {
             MigrationError::Backend(e) => Some(e),
             MigrationError::Preparation(e) => Some(e),
             MigrationError::NothingToMigrate => None,
+            MigrationError::UnfundableSplit => None,
             // `BalanceError` (and `FeeError`, which wraps it) implements `Error` only with
             // `zcash_protocol/std`; the Display text above carries their messages instead.
             MigrationError::InvalidBalance(_) => None,
@@ -1315,7 +1332,16 @@ where
     );
     let funding_notes = denominations.migration_outputs();
     if funding_notes.is_empty() {
-        return Err(MigrationError::NothingToMigrate);
+        // An empty plan is COMPLETION when the balance itself quantizes to nothing (only residual
+        // value remains), and DEFERRAL when the balance has a canonical split that this wallet's
+        // notes cannot fund; the two need different reporting, so they are distinct errors.
+        return Err(
+            if balance_has_canonical_split(balance, transfer_fee_buffer, prep_tx_fee) {
+                MigrationError::UnfundableSplit
+            } else {
+                MigrationError::NothingToMigrate
+            },
+        );
     }
 
     // The decomposition's reconciliation verified this multiset against the preparation planner,
@@ -1565,8 +1591,10 @@ impl MigrationRunEstimate {
 /// run.
 ///
 /// A zero (or fully sub-quantum) balance yields a zero-run estimate rather than an error, since this
-/// is a preview. `rng` is drawn from only by a randomized denomination strategy; the recommended
-/// canonical strategy ignores it.
+/// is a preview; so does a balance whose canonical split the wallet's notes cannot fund at all
+/// (what [`plan_migration`] reports as [`MigrationError::UnfundableSplit`]) — either way, whatever
+/// no run migrates is reported as the final residual. `rng` is drawn from only by a randomized
+/// denomination strategy; the recommended canonical strategy ignores it.
 pub fn estimate_migration_runs<P, B, R>(
     params: &P,
     backend: &B,
@@ -4226,6 +4254,36 @@ pub(crate) mod tests {
         ));
     }
 
+    /// A split the wallet cannot fund is DEFERRAL, not completion: a balance of exactly one
+    /// canonical denomination plus its transfer buffer quantizes to that single crossing with no
+    /// preparation-fee reserve (an exact note would fund it directly), so a wallet holding the
+    /// balance any other way cannot mint the funding note — its notes sum to exactly the note's
+    /// value, leaving nothing for a preparation fee — and reconciliation drops the whole split.
+    /// The plan reports [`MigrationError::UnfundableSplit`] so an application can distinguish
+    /// "deferred until the balance changes" from [`MigrationError::NothingToMigrate`]'s "only
+    /// residual value remains".
+    #[test]
+    fn a_split_the_wallet_cannot_fund_defers_rather_than_completes() {
+        let (_, transfer_fee_buffer) =
+            canonical_fees(&test_net(), BlockHeight::from_u32(2_000_000))
+                .expect("canonical fees are computable");
+        // 1 ZEC plus the buffer, held as two notes — the same balance held as ONE note migrates as
+        // a single directly-funded crossing (see `exact_funding_note_needs_no_preparation_fee` in
+        // the denomination strategy tests).
+        let backend = MockBackend::new(
+            vec![
+                60 * COIN / 100,
+                40 * COIN / 100 + u64::from(transfer_fee_buffer),
+            ],
+            2_000_000,
+        );
+        let mut rng = ChaCha8Rng::seed_from_u64(1);
+        assert!(matches!(
+            plan_migration(&test_net(), &backend, &mut rng),
+            Err(MigrationError::UnfundableSplit)
+        ));
+    }
+
     /// A typical balance migrates in a single run, whose entry carries BOTH the denomination side
     /// (migratable value and crossing count) and the note-preparation side (layers and transactions),
     /// and the aggregates match the single run.
@@ -4304,7 +4362,11 @@ pub(crate) mod tests {
             estimate_migration_runs(&test_net(), &fragmented, &mut rng).expect("estimates");
 
         assert_eq!(est_one.run_count(), 1);
-        assert!(est_frag.run_count() >= est_one.run_count());
+        // The fragmented wallet's true consolidation fees exceed the optimistic reserve, so the
+        // split's smallest parts defer to a second run (the estimate is deterministic: seeded RNG,
+        // fixed wallet). A planner change that moves this is a behavior change to re-derive, not
+        // noise to tolerate.
+        assert_eq!(est_frag.run_count(), 2);
         assert!(
             est_frag.total_prep_transactions() > est_one.total_prep_transactions(),
             "a fragmented wallet needs more preparation: {} vs {}",

--- a/zcash_pool_migration/tests/preparation_scaling.rs
+++ b/zcash_pool_migration/tests/preparation_scaling.rs
@@ -9,21 +9,26 @@
 //!
 //! The quantities that matter, and why:
 //!
-//! - TRANSACTIONS. Every wallet note the migration SPENDS must be consumed by some preparation
-//!   transaction (at most [`CONSOLIDATION_INPUTS_PER_TX`] per transaction), every funding note must
-//!   be minted by one (at most [`FUNDING_OUTPUTS_PER_TX`] per transaction), and one transaction
-//!   moves the live note count by at most `PREP_TX_ACTIONS - 2`, so
-//!   `max(ceil(spent / 15), ceil(crossings / 14), ceil(|spent - crossings| / 14))` is a hard floor
-//!   GIVEN the selection, and the ratio of the plan to it is what the layering strategy costs on
-//!   top.
+//! - TRANSACTIONS. Every wallet note the preparation CONSOLIDATES must be consumed by some
+//!   preparation transaction (at most [`CONSOLIDATION_INPUTS_PER_TX`] per transaction), every
+//!   funding note it MINTS must be an output of one (at most [`FUNDING_OUTPUTS_PER_TX`] per
+//!   transaction), and one transaction moves the live note count by at most `PREP_TX_ACTIONS - 2`
+//!   (the count it moves the notes toward includes the residuals the preparation leaves, not just
+//!   the funding notes). Directly-funded notes touch no preparation transaction, so they are
+//!   outside all three bounds. The maximum of the three is a hard floor GIVEN the selection, and
+//!   the ratio of the plan to it is what the layering strategy costs on top.
 //! - SELECTION. That floor is conditional, not absolute: a migration only has to fund its crossings,
 //!   so the notes it must spend are the ones needed to COVER that value, not the whole wallet.
 //!   `selection_floor` is the smallest number of notes that could cover it (the largest notes
 //!   first), and the gap between it and `spent` is the part of the cost that is a choice rather than
 //!   a constraint.
 //! - LAYERS. Layers are sequential: each waits for the previous to mine, so they set the
-//!   preparation phase's wall-clock. Consolidating `n` notes at a fan-in of 15 per transaction is a
-//!   15-ary tree, so `ceil(log_15 n)` is the floor.
+//!   preparation phase's wall-clock. Each minted funding note roots its own consolidation tree at
+//!   a fan-in of 15 per transaction, and independent trees can share a layer, so `k` funding roots
+//!   of depth `d` absorb at most `k * 15^d` consolidated notes; the floor is the smallest depth
+//!   whose capacity covers them. (A single tree's `ceil(log_15 n)` is NOT a universal floor: a
+//!   plan minting several funding notes may validly consolidate in parallel, shallower than one
+//!   tree over all its notes.)
 //! - SIGNING ROUNDS. Preparation costs 16 actions per transaction against a transfer's 3, so on
 //!   these wallets it is the preparation, not the migration itself, that the user signs.
 //!
@@ -66,8 +71,14 @@ struct Measurement {
     notes: Vec<u64>,
     /// How many of them are sub-quantum.
     sub_quantum: usize,
-    /// The wallet notes the preparation actually spends.
+    /// The wallet notes the plan actually consumes: consolidated by preparation transactions, plus
+    /// those used directly as funding notes.
     spent: usize,
+    /// The wallet notes used DIRECTLY as funding notes, touching no preparation transaction.
+    direct: usize,
+    /// The residual notes the preparation leaves behind (outputs that are neither funding notes
+    /// nor consumed by a later layer).
+    residuals: usize,
     /// The preparation transactions the plan builds.
     preparations: usize,
     /// The sequential preparation layers.
@@ -86,18 +97,31 @@ struct Measurement {
 }
 
 impl Measurement {
-    /// The hard floor on preparation transactions GIVEN the notes the plan chose to spend and the
-    /// funding notes it mints: each spent note is consumed at most `CONSOLIDATION_INPUTS_PER_TX`
-    /// per transaction, each funding note takes an output slot of which a transaction has at most
-    /// `FUNDING_OUTPUTS_PER_TX`, and a transaction changes the live note count by at most
-    /// `PREP_TX_ACTIONS - 2` in either direction, so shrinking `spent` notes to `crossings` funding
-    /// notes bounds the count from below three ways at once.
+    /// The wallet notes that pass through consolidation: the spent notes less the directly-funded
+    /// ones (which touch no preparation transaction).
+    fn consolidated(&self) -> usize {
+        self.spent - self.direct
+    }
+
+    /// The funding notes the preparation MINTS: the crossings less the directly-funded ones. Each
+    /// roots an independent consolidation tree.
+    fn minted_crossings(&self) -> usize {
+        self.crossings - self.direct
+    }
+
+    /// The hard floor on preparation transactions GIVEN the notes the plan chose to consolidate,
+    /// the funding notes it mints, and the residuals it leaves: each consolidated note is consumed
+    /// at most `CONSOLIDATION_INPUTS_PER_TX` per transaction, each minted funding note takes an
+    /// output slot of which a transaction has at most `FUNDING_OUTPUTS_PER_TX`, and a transaction
+    /// changes the live note count by at most `PREP_TX_ACTIONS - 2` in either direction (the
+    /// preparation turns the consolidated notes into the minted funding notes AND the residuals),
+    /// so the plan's shape bounds the count from below three ways at once.
     fn transaction_floor(&self) -> usize {
         [
-            self.spent.div_ceil(CONSOLIDATION_INPUTS_PER_TX),
-            self.crossings.div_ceil(FUNDING_OUTPUTS_PER_TX),
-            self.spent
-                .abs_diff(self.crossings)
+            self.consolidated().div_ceil(CONSOLIDATION_INPUTS_PER_TX),
+            self.minted_crossings().div_ceil(FUNDING_OUTPUTS_PER_TX),
+            self.consolidated()
+                .abs_diff(self.minted_crossings() + self.residuals)
                 .div_ceil(PREP_TX_ACTIONS - 2),
         ]
         .into_iter()
@@ -122,13 +146,23 @@ impl Measurement {
         self.notes.len()
     }
 
-    /// The hard floor on layers: consolidating `spent` notes at a fan-in of
-    /// `CONSOLIDATION_INPUTS_PER_TX` per transaction is a 15-ary tree of that depth.
+    /// The hard floor on layers GIVEN the plan's shape: each minted funding note roots its own
+    /// consolidation tree at a fan-in of `CONSOLIDATION_INPUTS_PER_TX`, and independent trees can
+    /// share a layer, so `k` funding roots of depth `d` absorb at most `k * 15^d` consolidated
+    /// notes; the floor is the smallest depth whose capacity covers them. Zero when nothing
+    /// consolidates — directly-funded notes pass through no layer.
     fn layer_floor(&self) -> usize {
-        let mut reachable = CONSOLIDATION_INPUTS_PER_TX;
+        let consolidated = self.consolidated();
+        if consolidated == 0 {
+            return 0;
+        }
+        // Anything consolidated feeds a tree rooted at a funding-minting transaction, so at least
+        // one funding note is minted; `max(1)` keeps the loop finite on a malformed plan.
+        let roots = self.minted_crossings().max(1);
+        let mut capacity = roots.saturating_mul(CONSOLIDATION_INPUTS_PER_TX);
         let mut depth = 1;
-        while reachable < self.spent {
-            reachable = reachable.saturating_mul(CONSOLIDATION_INPUTS_PER_TX);
+        while capacity < consolidated {
+            capacity = capacity.saturating_mul(CONSOLIDATION_INPUTS_PER_TX);
             depth += 1;
         }
         depth
@@ -155,6 +189,8 @@ fn measure(shape: WalletShape, note_count: usize, seed: u64) -> Measurement {
     Measurement {
         sub_quantum: sub_quantum_count(&notes),
         spent: spent_wallet_notes(&plan),
+        direct: plan.preparation().direct_funding_notes().len(),
+        residuals: plan.preparation().residual_count(),
         preparations: plan.preparation_tx_count(),
         layers: plan.preparation_layer_count(),
         crossings: plan.transfer_tx_count(),
@@ -240,17 +276,18 @@ fn assert_scaling_laws(shape: WalletShape, note_count: usize, seed: u64, m: &Mea
     // The floors are floors: no plan may beat them.
     assert!(
         m.preparations >= m.transaction_floor(),
-        "{case}: {} preparations beats the {} floor for {} spent notes",
+        "{case}: {} preparations beats the {} floor for {} consolidated notes",
         m.preparations,
         m.transaction_floor(),
-        m.spent,
+        m.consolidated(),
     );
     assert!(
         m.layers >= m.layer_floor(),
-        "{case}: {} layers beats the {} floor for {} spent notes",
+        "{case}: {} layers beats the {} floor for {} consolidated notes over {} funding roots",
         m.layers,
         m.layer_floor(),
-        m.spent,
+        m.consolidated(),
+        m.minted_crossings(),
     );
 
     // A migration always migrates something, and it cannot spend a note the wallet does not have.
@@ -268,12 +305,9 @@ fn assert_scaling_laws(shape: WalletShape, note_count: usize, seed: u64, m: &Mea
         m.preparation_share() * 100.0,
     );
 
-    // Planning is pure arithmetic; it must not become the bottleneck at these note counts.
-    assert!(
-        m.planning < Duration::from_secs(1),
-        "{case}: planning took {:?}",
-        m.planning,
-    );
+    // No wall-clock assertion here: planning is sub-millisecond at these counts, but a loaded CI
+    // runner can stall any process, so the default suite REPORTS the duration (the `plan ms`
+    // column) and only the opt-in heavy sweep gates on it.
 }
 
 /// PREPARATION SCALING on messy wallets of a few hundred to a thousand notes.
@@ -305,6 +339,16 @@ fn preparation_scales_into_the_thousands() {
             let m = measure(shape, note_count, seed);
             report(shape, &m);
             assert_scaling_laws(shape, note_count, seed, &m);
+
+            // Planning is pure arithmetic; it must not become the bottleneck even at these counts.
+            // The wall-clock threshold lives only in this opt-in sweep so that runner load cannot
+            // fail the default suite.
+            assert!(
+                m.planning < Duration::from_secs(1),
+                "{} / {note_count} notes: planning took {:?}",
+                shape.label(),
+                m.planning,
+            );
         }
     }
 }


### PR DESCRIPTION
> **Note:** this PR was merged at its original three-commit head. A fourth commit (gating the exact-funding split on the wallet's note count, which unsticks the exact-denomination-balance corner described below) was in flight at merge time and landed separately in #2949.

Follow-up to the review of #2945 (merged), addressing the four findings posted there by @Cosmos-Harry plus two issues surfaced by a subsequent self-review. Part of #2630.

## What

- **`MigrationError::UnfundableSplit`.** `plan_migration` reported every empty denomination plan as `NothingToMigrate`, conflating completion (the balance quantizes to nothing; only residual value remains) with deferral (the balance has a canonical split that this wallet's notes cannot fund). The reachable deferral shapes: a balance of exactly one canonical denomination plus its transfer buffer held as anything other than that exact note — the notes sum to exactly the funding note, leaving no room for any preparation fee (resolved in #2949 by note-count gating) — and a wallet so fragmented that consolidating it costs more than the balance can pay. The new variant lets an application report "deferred until the spendable balance changes" instead of completion with value stranded. The discrimination is by whether the balance's canonical split is nonempty, a pure function of the balance, so it reveals nothing about the note shape. This commit also pins the fragmented-wallet estimate to its measured 2 runs (review finding: the changed `>=` assertion had become vacuous).

- **The truncation property is anchored to the quantizer.** The prefix proptest defined the canonical split as the plan under the optimistic count-only stub. Those agree everywhere except the corner the generator cannot reach (a single note of exactly one denomination plus its buffer, probability ~1e-9 per draw): there the canonical split forgoes the fee reserve so an exact note can fund it directly, a stub that charges a fee reconciles that split away, and the exact-note wallet publishes a crossing that is not a prefix of the stub's empty plan. The property now compares against `unconstrained_split` itself. Deterministic tests cover the regimes the 1–19-note generator misses (review finding): the exact-balance corner from both sides, the cap regime (55 source notes crossing as exactly 50 repeated `DENOM_CAP` parts), and suffix truncation (300 minimum-denomination notes publishing a nonempty strict prefix).

- **The scaling floors are bounded by the plan's shape** (review finding: `ceil(log_15(spent))` is not a universal layer floor — independent consolidation trees can share a layer). The layer floor now derives from funding roots: `k` minted funding notes of depth `d` absorb at most `k * 15^d` consolidated notes, so the floor is the smallest depth whose capacity covers them. Both floors exclude directly-funded notes, which touch no preparation transaction and pass through no layer, and the note-count-delta bound now counts the residuals a preparation leaves — two further instances of the same overconstraint class. The one-second planning wall-clock gate moved to the `#[ignore]`d heavy sweep (review finding): the default suite still reports the duration (`plan ms` column) without gating on it, so runner load cannot fail CI. Planning measures sub-millisecond at 1,000 notes and ≤13 ms at 5,000, in debug builds.

## Verification

274 unit tests (4 new), the fast scaling sweep, and the heavy 2,000–5,000-note sweep all pass; clippy and rustfmt are clean; each commit builds and passes its tests independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)