### PR TITLE
zcash_pool_migration: gate the exact-funding split on the note count

### DIFF
--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -70,13 +70,26 @@ and this library adheres to Rust's notion of
   how the wallet's notes happen to hold the balance. A wallet that cannot fund
   the entire canonical split migrates a prefix of it in the current run, with
   the remainder deferred to a later run.
+- `denomination::DenominationStrategy::plan` and
+  `denomination::plan_denominations` now take the wallet's spendable note
+  count alongside its balance. The count participates in the decomposition
+  only through the predicate `count == 1`, which gates the exact-funding
+  exception to the preparation-fee reserve: a lone note necessarily equals the
+  balance, so a balance of exactly one canonical denomination plus its
+  transfer buffer is certain to fund that crossing directly and reserves no
+  fee, while the same balance held as two or more notes cannot avoid
+  preparation and retains the reserve (stepping down the series) instead of
+  quantizing into a split no such wallet could fund. Beyond that bit, the
+  published values remain a function of the balance alone.
 - `engine::MigrationError` has a new `UnfundableSplit` variant, and
   `engine::plan_migration` returns it (rather than `NothingToMigrate`) when the
   balance quantizes to at least one canonical part but the wallet's current
-  notes cannot fund any part of that split. This is deferral, not completion:
-  value above the residual threshold remains, and it can migrate once the
-  spendable balance changes. `NothingToMigrate` now means only that the balance
-  itself has nothing left to quantize.
+  notes cannot fund any part of that split — a wallet so fragmented that the
+  preparation fees for consolidating it exceed what the balance can cover.
+  This is deferral, not completion: value above the residual threshold
+  remains, and it can migrate once the spendable balance changes.
+  `NothingToMigrate` now means only that the balance itself has nothing left
+  to quantize.
 - `satisfiability::advance_migration` now returns `satisfiability::Advance`
   rather than a bare `state::AdvanceStep`: read the step to perform via
   `Advance::step`, and the outlook — when the migration next has work, and of

--- a/zcash_pool_migration/src/build/end_to_end.rs
+++ b/zcash_pool_migration/src/build/end_to_end.rs
@@ -50,6 +50,7 @@ fn migration_pipeline_end_to_end() {
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
         plan_denominations(
             Zatoshis::const_from_u64(balance),
+            balance_zats.len(),
             buffer,
             prep_fee,
             &prep_tx_count,

--- a/zcash_pool_migration/src/denomination.rs
+++ b/zcash_pool_migration/src/denomination.rs
@@ -291,20 +291,27 @@ pub trait DenominationStrategy {
     /// Decompose `total_input_zatoshi` into self-funding notes, accounting the preparation fees at
     /// each step of the decomposition.
     ///
-    /// `prep_tx_fee_zatoshi` is the ZIP-317 fee of one canonical (padded) preparation transaction,
-    /// computed by the caller from the canonical shape. `prep_tx_count` is the capability that
-    /// answers, for a candidate multiset of prepared-note values (each `crossing + buffer`), how
-    /// many preparation transactions minting them will take — `None` when the wallet's notes cannot
-    /// mint that multiset at all. The engine backs it with the preparation planner. A strategy must
-    /// use it only to RECONCILE a split it computed from the balance alone — dropping parts the
-    /// wallet cannot fund, never substituting different denominations — so the published values
-    /// remain a function of the balance, not of the wallet's note shape. `rng` is used by
-    /// randomized strategies and ignored by deterministic ones; it is bound as [`CryptoRng`]
-    /// because a randomized strategy's draws decide the on-chain crossing values, which are
-    /// privacy-relevant.
+    /// `spendable_note_count` is how many spendable notes hold `total_input`. A strategy may
+    /// consult it only through the single predicate `spendable_note_count == 1`, which decides
+    /// whether preparation is avoidable at all: a lone note necessarily equals the balance, so a
+    /// balance of exactly one denomination plus its buffer is certain to fund that crossing
+    /// directly with no preparation fee, while with two or more notes no note can equal that
+    /// funding value and the fee reserve is mandatory. Beyond that bit, the published values must
+    /// remain a function of the balance alone. `prep_tx_fee_zatoshi` is the ZIP-317 fee of one
+    /// canonical (padded) preparation transaction, computed by the caller from the canonical
+    /// shape. `prep_tx_count` is the capability that answers, for a candidate multiset of
+    /// prepared-note values (each `crossing + buffer`), how many preparation transactions minting
+    /// them will take — `None` when the wallet's notes cannot mint that multiset at all. The
+    /// engine backs it with the preparation planner. A strategy must use it only to RECONCILE a
+    /// split it computed as above — dropping parts the wallet cannot fund, never substituting
+    /// different denominations — so the published values cannot otherwise depend on the wallet's
+    /// note shape. `rng` is used by randomized strategies and ignored by deterministic ones; it is
+    /// bound as [`CryptoRng`] because a randomized strategy's draws decide the on-chain crossing
+    /// values, which are privacy-relevant.
     fn plan<R: RngCore + CryptoRng>(
         &self,
         total_input: Zatoshis,
+        spendable_note_count: usize,
         prep_tx_fee: Zatoshis,
         prep_tx_count: &dyn Fn(&[Zatoshis]) -> Option<usize>,
         rng: &mut R,
@@ -322,6 +329,7 @@ pub(crate) fn zat(value: u64) -> Zatoshis {
 /// quantization), sized by the caller-computed canonical fees (see [`DenominationStrategy::plan`]).
 pub fn plan_denominations<R: RngCore + CryptoRng>(
     total_input: Zatoshis,
+    spendable_note_count: usize,
     transfer_fee_buffer: Zatoshis,
     prep_tx_fee: Zatoshis,
     prep_tx_count: &dyn Fn(&[Zatoshis]) -> Option<usize>,
@@ -329,25 +337,31 @@ pub fn plan_denominations<R: RngCore + CryptoRng>(
 ) -> DenominationPlan {
     CanonicalOneTwoFive::recommended(transfer_fee_buffer).plan(
         total_input,
+        spendable_note_count,
         prep_tx_fee,
         prep_tx_count,
         rng,
     )
 }
 
-/// Whether `total_input` quantizes to at least one canonical part under the recommended strategy —
-/// that is, whether SOME wallet holding this balance could migrate part of it. A pure function of
-/// the balance and fees: reconciliation against a concrete wallet's notes can only truncate the
-/// canonical split, never extend it, so a balance for which this is `false` has nothing to migrate
-/// regardless of note shape, while `true` with an empty reconciled plan means the WALLET's notes —
-/// not the balance — blocked the run (see
+/// Whether `total_input`, held as `spendable_note_count` notes, quantizes to at least one canonical
+/// part under the recommended strategy — that is, whether a wallet in this state could migrate part
+/// of its balance if its note values allowed. Independent of the note VALUES: reconciliation
+/// against them can only truncate the canonical split, never extend it, so a state for which this
+/// is `false` has nothing to migrate regardless of how the notes hold the value, while `true` with
+/// an empty reconciled plan means the note values — not the balance — blocked the run (see
 /// [`MigrationError::UnfundableSplit`](crate::engine::MigrationError::UnfundableSplit)).
 pub(crate) fn balance_has_canonical_split(
     total_input: Zatoshis,
+    spendable_note_count: usize,
     transfer_fee_buffer: Zatoshis,
     prep_tx_fee: Zatoshis,
 ) -> bool {
     !CanonicalOneTwoFive::recommended(transfer_fee_buffer)
-        .unconstrained_split(u64::from(total_input), u64::from(prep_tx_fee))
+        .unconstrained_split(
+            u64::from(total_input),
+            spendable_note_count,
+            u64::from(prep_tx_fee),
+        )
         .is_empty()
 }

--- a/zcash_pool_migration/src/denomination/strategies.rs
+++ b/zcash_pool_migration/src/denomination/strategies.rs
@@ -73,28 +73,32 @@ impl CanonicalOneTwoFive {
 
 impl CanonicalOneTwoFive {
     /// The UNCONSTRAINED canonical split of `total_input_zatoshi`: the non-increasing sequence of
-    /// crossing values the balance quantizes into, a pure function of the balance (and this
-    /// strategy's bounds), independent of how the wallet's notes happen to hold it.
+    /// crossing values the balance quantizes into, a function of the balance (and this strategy's
+    /// bounds) plus exactly one bit of the wallet's note structure — whether a single note holds
+    /// the whole balance — and nothing else about how the notes hold it.
     ///
     /// Fees are reserved as the split grows, under the optimistic one-transaction-per-
-    /// [`FUNDING_OUTPUTS_PER_TX`]-notes preparation model. The exception is a balance containing
-    /// exactly one self-funding canonical denomination: that split is retained because an exact
-    /// wallet note can fund it directly without a preparation transaction. Whether the wallet
-    /// actually contains that note is decided later during reconciliation — and a wallet holding
-    /// that balance any OTHER way cannot fund the part at all (the notes sum to exactly the funding
-    /// note, leaving no room for any preparation fee), so reconciliation defers the WHOLE split to
-    /// a later run rather than reshaping it (see
-    /// [`MigrationError::UnfundableSplit`](crate::engine::MigrationError::UnfundableSplit)).
+    /// [`FUNDING_OUTPUTS_PER_TX`]-notes preparation model. The exception is a balance of exactly
+    /// one self-funding canonical denomination held as a SINGLE note: the note necessarily equals
+    /// the balance, so it is certain to fund the crossing directly with no preparation transaction,
+    /// and the fee reserve is safely omitted. The count gates that exception rather than merely
+    /// informing it: with two or more notes none can equal that funding value, preparation — and
+    /// its fee — is inevitable, and omitting the reserve would leave the split unfundable by every
+    /// wallet holding the balance. The count participates ONLY through this
+    /// `spendable_note_count == 1` predicate; the published values otherwise remain a function of
+    /// the balance alone.
     pub(crate) fn unconstrained_split(
         &self,
         total_input_zatoshi: u64,
+        spendable_note_count: usize,
         prep_tx_fee_zatoshi: u64,
     ) -> Vec<u64> {
         let buffer = self.buffer_zatoshi;
         // Smallest self-funding note: the minimum denomination plus its transfer buffer.
         let min_note = self.min_denomination_zatoshi + buffer;
         let exact_crossing = total_input_zatoshi.saturating_sub(buffer);
-        if self.max_notes > 0
+        if spendable_note_count == 1
+            && self.max_notes > 0
             && total_input_zatoshi >= buffer
             && (self.min_denomination_zatoshi..=self.max_denomination_zatoshi)
                 .contains(&exact_crossing)
@@ -144,6 +148,7 @@ impl DenominationStrategy for CanonicalOneTwoFive {
     fn plan<R: RngCore + CryptoRng>(
         &self,
         total_input: Zatoshis,
+        spendable_note_count: usize,
         prep_tx_fee: Zatoshis,
         prep_tx_count: &dyn Fn(&[Zatoshis]) -> Option<usize>,
         _rng: &mut R,
@@ -155,10 +160,14 @@ impl DenominationStrategy for CanonicalOneTwoFive {
         let prep_tx_fee_zatoshi = u64::from(prep_tx_fee);
         let buffer = self.buffer_zatoshi;
 
-        // QUANTIZE once: the canonical split is a function of the BALANCE alone, so the published
+        // QUANTIZE once: the canonical split is a function of the BALANCE alone (plus the one
+        // exact-funding bit of the note count — see `unconstrained_split`), so the published
         // values can collide across wallets holding the same balance differently.
-        let mut crossing_values =
-            self.unconstrained_split(total_input_zatoshi, prep_tx_fee_zatoshi);
+        let mut crossing_values = self.unconstrained_split(
+            total_input_zatoshi,
+            spendable_note_count,
+            prep_tx_fee_zatoshi,
+        );
         let mut notes: Vec<u64> = crossing_values.iter().map(|&c| c + buffer).collect();
         let typed = |notes: &[u64]| notes.iter().map(|&v| zat(v)).collect::<Vec<Zatoshis>>();
 
@@ -226,6 +235,11 @@ mod tests {
         Some(notes.len().div_ceil(FUNDING_OUTPUTS_PER_TX))
     }
 
+    /// A generic multi-note wallet count for tests that model no concrete wallet: any count
+    /// above one keeps the optimistic fee reserve in place (the exact-funding special case
+    /// requires a lone note).
+    const MULTI_NOTE: usize = 2;
+
     /// Read a plan's crossing values back into the tests' u64 domain.
     fn crossings_u64(p: &DenominationPlan) -> Vec<u64> {
         p.crossing_values().iter().map(|&v| u64::from(v)).collect()
@@ -262,7 +276,13 @@ mod tests {
     fn crossings(total: u64) -> Vec<u64> {
         let s = CanonicalOneTwoFive::new(64, DENOM_CAP, MAX_RESIDUAL_VALUE, Zatoshis::ZERO);
         let mut rng = ChaCha8Rng::seed_from_u64(0);
-        crossings_u64(&s.plan(zat(total), Zatoshis::ZERO, &prep_tx_count_stub, &mut rng))
+        crossings_u64(&s.plan(
+            zat(total),
+            MULTI_NOTE,
+            Zatoshis::ZERO,
+            &prep_tx_count_stub,
+            &mut rng,
+        ))
     }
 
     proptest! {
@@ -276,7 +296,7 @@ mod tests {
             let buffer = zip317_buffer();
             let floor = u64::from(MAX_RESIDUAL_VALUE);
             let mut rng = ChaCha8Rng::seed_from_u64(0);
-            let p = s.plan(zat(total), zat(fee), &prep_tx_count_stub, &mut rng);
+            let p = s.plan(zat(total), MULTI_NOTE, zat(fee), &prep_tx_count_stub, &mut rng);
 
             // Value is conserved exactly: the prepared notes, the stepwise-reserved preparation
             // fees, and the change partition the balance; and the reserved fees are the per-tx fee
@@ -322,7 +342,7 @@ mod tests {
 
             // The RNG is ignored: a different seed yields the same plan.
             let mut other = ChaCha8Rng::seed_from_u64(1);
-            prop_assert_eq!(&p, &s.plan(zat(total), zat(fee), &prep_tx_count_stub, &mut other));
+            prop_assert_eq!(&p, &s.plan(zat(total), MULTI_NOTE, zat(fee), &prep_tx_count_stub, &mut other));
         }
     }
 
@@ -334,6 +354,7 @@ mod tests {
         let mut rng = ChaCha8Rng::seed_from_u64(0);
         let p = s.plan(
             zat(MAX_MONEY),
+            MULTI_NOTE,
             Zatoshis::ZERO,
             &prep_tx_count_stub,
             &mut rng,
@@ -353,7 +374,13 @@ mod tests {
         let buffer = zip317_buffer();
         let below = u64::from(MAX_RESIDUAL_VALUE) + buffer - 1;
         let mut rng = ChaCha8Rng::seed_from_u64(0);
-        let p = s.plan(zat(below), Zatoshis::ZERO, &prep_tx_count_stub, &mut rng);
+        let p = s.plan(
+            zat(below),
+            MULTI_NOTE,
+            Zatoshis::ZERO,
+            &prep_tx_count_stub,
+            &mut rng,
+        );
         assert!(p.crossing_values().is_empty());
         assert_eq!(p.change(), Some(zat(below)));
     }
@@ -403,7 +430,13 @@ mod tests {
         let balance = quantum + buffer + prep_fee;
         let s = canonical(MIGRATION_MAX_PREPARED_NOTES_PER_RUN);
         let mut rng = ChaCha8Rng::seed_from_u64(0);
-        let p = s.plan(zat(balance), zat(prep_fee), &prep_tx_count_stub, &mut rng);
+        let p = s.plan(
+            zat(balance),
+            MULTI_NOTE,
+            zat(prep_fee),
+            &prep_tx_count_stub,
+            &mut rng,
+        );
 
         assert_eq!(
             crossings_u64(&p),
@@ -473,6 +506,7 @@ mod tests {
 
         let plan = canonical(MIGRATION_MAX_PREPARED_NOTES_PER_RUN).plan(
             zat(funding),
+            available.len(),
             zat(prep_fee),
             &prep_tx_count,
             &mut rng,
@@ -568,6 +602,7 @@ mod tests {
         let mut rng = ChaCha8Rng::seed_from_u64(0);
         let plan = s.plan(
             zat(balance_zatoshi),
+            MULTI_NOTE,
             Zatoshis::ZERO,
             &prep_tx_count_stub,
             &mut rng,
@@ -853,8 +888,9 @@ mod tests {
                     .map(|plan| plan.transaction_count())
             };
             let mut rng = ChaCha8Rng::seed_from_u64(0);
-            let constrained = crossings_u64(&s.plan(zat(total), zat(fee), &real, &mut rng));
-            let canonical = s.unconstrained_split(total, fee);
+            let constrained =
+                crossings_u64(&s.plan(zat(total), notes.len(), zat(fee), &real, &mut rng));
+            let canonical = s.unconstrained_split(total, notes.len(), fee);
 
             prop_assert!(
                 constrained.len() <= canonical.len()
@@ -866,19 +902,20 @@ mod tests {
         }
     }
 
-    /// The prefix contract at the corner the proptest's generator cannot reach: a balance of
-    /// exactly one canonical denomination plus its transfer buffer. Its canonical split is that
-    /// single denomination with NO fee reserve (an exact note funds it directly), so a wallet
-    /// holding the balance as the exact note publishes the full split — and a wallet holding it any
-    /// other way can fund no part of it (there is no room for any preparation fee) and publishes
-    /// the empty prefix, deferring the whole balance rather than reshaping the split.
+    /// The exact-funding bit at the corner the proptest's generator cannot reach: a balance of
+    /// exactly one canonical denomination plus its transfer buffer. Held as a SINGLE note, the
+    /// split is that denomination with NO fee reserve, and the note is certain to fund it directly
+    /// — zero preparation fees. Held any other way, no note can equal the funding value, so
+    /// preparation is inevitable: the split retains its fee reserve, steps down the series, and the
+    /// wallet migrates the stepped-down split in full. The note count is what keeps a balance the
+    /// wallet CAN fund from quantizing into one it cannot.
     #[test]
-    fn an_exact_denomination_balance_migrates_fully_or_not_at_all() {
+    fn an_exact_denomination_balance_migrates_under_any_holding() {
         let buffer = zip317_buffer();
         let fee = 16 * MARGINAL_FEE.into_u64();
         let total = COIN + buffer;
         let s = CanonicalOneTwoFive::recommended(zat(buffer));
-        assert_eq!(s.unconstrained_split(total, fee), vec![COIN]);
+        assert_eq!(s.unconstrained_split(total, 1, fee), vec![COIN]);
 
         let plan_against = |notes: &[u64]| {
             let available: Vec<Zatoshis> = notes.iter().map(|&v| zat(v)).collect();
@@ -888,7 +925,7 @@ mod tests {
                     .map(|plan| plan.transaction_count())
             };
             let mut rng = ChaCha8Rng::seed_from_u64(0);
-            s.plan(zat(total), zat(fee), &real, &mut rng)
+            s.plan(zat(total), notes.len(), zat(fee), &real, &mut rng)
         };
 
         // The exact note: the full canonical split, funded directly, nothing reserved.
@@ -896,11 +933,12 @@ mod tests {
         assert_eq!(crossings_u64(&exact), vec![COIN]);
         assert_eq!(exact.prep_fees(), Zatoshis::ZERO);
 
-        // The same balance as two notes: no preparation can mint the funding note (the notes sum to
-        // exactly its value), so the whole split defers and the balance stays as change.
+        // The same balance as two notes: the fee-reserving split, migrated in full through one
+        // preparation transaction rather than deferred.
         let split = plan_against(&[60 * COIN / 100, 40 * COIN / 100 + buffer]);
-        assert_eq!(crossings_u64(&split), Vec::<u64>::new());
-        assert_eq!(split.change(), Some(zat(total)));
+        assert_eq!(crossings_u64(&split), s.unconstrained_split(total, 2, fee));
+        assert!(!split.crossing_values().is_empty());
+        assert_eq!(split.prep_fees(), zat(fee));
     }
 
     /// The cap regime: a balance whose canonical split saturates
@@ -920,7 +958,7 @@ mod tests {
         let available: Vec<Zatoshis> = notes.iter().map(|&v| zat(v)).collect();
         let s = CanonicalOneTwoFive::recommended(zat(buffer));
 
-        let canonical = s.unconstrained_split(total, fee);
+        let canonical = s.unconstrained_split(total, notes.len(), fee);
         assert_eq!(
             canonical,
             vec![cap; MIGRATION_MAX_PREPARED_NOTES_PER_RUN],
@@ -933,7 +971,7 @@ mod tests {
                 .map(|plan| plan.transaction_count())
         };
         let mut rng = ChaCha8Rng::seed_from_u64(0);
-        let plan = s.plan(zat(total), zat(fee), &real, &mut rng);
+        let plan = s.plan(zat(total), notes.len(), zat(fee), &real, &mut rng);
         assert_eq!(crossings_u64(&plan), canonical);
     }
 
@@ -959,8 +997,9 @@ mod tests {
                 .map(|plan| plan.transaction_count())
         };
         let mut rng = ChaCha8Rng::seed_from_u64(0);
-        let constrained = crossings_u64(&s.plan(zat(total), zat(fee), &real, &mut rng));
-        let canonical = s.unconstrained_split(total, fee);
+        let constrained =
+            crossings_u64(&s.plan(zat(total), notes.len(), zat(fee), &real, &mut rng));
+        let canonical = s.unconstrained_split(total, notes.len(), fee);
 
         assert!(
             !constrained.is_empty() && constrained.len() < canonical.len(),

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -1159,13 +1159,12 @@ pub enum MigrationError<E> {
     /// drops parts of the canonical split (never substitutes smaller denominations — see
     /// [`DenominationStrategy::plan`](crate::denomination::DenominationStrategy::plan)), so a
     /// wallet whose notes cannot mint even the split's first part has no migratable decomposition
-    /// until its spendable balance changes. The known shapes: a balance of exactly one canonical
-    /// denomination plus its transfer buffer held as anything other than that exact note (the notes
-    /// sum to exactly the funding note, leaving no room for any preparation fee), and a wallet so
-    /// fragmented that consolidating it costs more than the balance can pay. Unlike
+    /// until its spendable balance changes. The reachable shape is a wallet so fragmented that
+    /// consolidating enough of it to mint even the split's largest part costs more in preparation
+    /// fees than the balance can cover. Unlike
     /// [`NothingToMigrate`](Self::NothingToMigrate), this is NOT completion: value above the
-    /// residual threshold remains, and an application should report it as deferred rather than
-    /// migrated.
+    /// residual threshold remains, and an application should report it as deferred (until the
+    /// spendable balance changes) rather than migrated.
     UnfundableSplit,
     /// The backend's note values do not form a valid balance (their sum exceeds the maximum money
     /// supply).
@@ -1325,6 +1324,7 @@ where
     };
     let denominations = plan_denominations(
         balance,
+        notes.len(),
         transfer_fee_buffer,
         prep_tx_fee,
         &prep_tx_count,
@@ -1334,9 +1334,9 @@ where
     if funding_notes.is_empty() {
         // An empty plan is COMPLETION when the balance itself quantizes to nothing (only residual
         // value remains), and DEFERRAL when the balance has a canonical split that this wallet's
-        // notes cannot fund; the two need different reporting, so they are distinct errors.
+        // note values cannot fund; the two need different reporting, so they are distinct errors.
         return Err(
-            if balance_has_canonical_split(balance, transfer_fee_buffer, prep_tx_fee) {
+            if balance_has_canonical_split(balance, notes.len(), transfer_fee_buffer, prep_tx_fee) {
                 MigrationError::UnfundableSplit
             } else {
                 MigrationError::NothingToMigrate
@@ -1637,6 +1637,7 @@ where
             };
             plan_denominations(
                 balance,
+                notes.len(),
                 transfer_fee_buffer,
                 prep_tx_fee,
                 &prep_tx_count,
@@ -4254,29 +4255,17 @@ pub(crate) mod tests {
         ));
     }
 
-    /// A split the wallet cannot fund is DEFERRAL, not completion: a balance of exactly one
-    /// canonical denomination plus its transfer buffer quantizes to that single crossing with no
-    /// preparation-fee reserve (an exact note would fund it directly), so a wallet holding the
-    /// balance any other way cannot mint the funding note — its notes sum to exactly the note's
-    /// value, leaving nothing for a preparation fee — and reconciliation drops the whole split.
-    /// The plan reports [`MigrationError::UnfundableSplit`] so an application can distinguish
-    /// "deferred until the balance changes" from [`MigrationError::NothingToMigrate`]'s "only
-    /// residual value remains".
+    /// A split the wallet cannot fund is DEFERRAL, not completion: the balance clears the smallest
+    /// self-funding note plus its fee reserve, so it quantizes to a nonempty canonical split, but
+    /// consolidating the wallet's dust costs more in preparation fees than the balance can cover —
+    /// 120 notes of 10,000 zatoshi need at least eight consolidation transactions (15 inputs each)
+    /// whose fees alone exceed half the balance, so no preparation can mint even the split's only
+    /// part. The plan reports [`MigrationError::UnfundableSplit`] so an application can
+    /// distinguish "deferred until the spendable balance changes" from
+    /// [`MigrationError::NothingToMigrate`]'s "only residual value remains".
     #[test]
     fn a_split_the_wallet_cannot_fund_defers_rather_than_completes() {
-        let (_, transfer_fee_buffer) =
-            canonical_fees(&test_net(), BlockHeight::from_u32(2_000_000))
-                .expect("canonical fees are computable");
-        // 1 ZEC plus the buffer, held as two notes — the same balance held as ONE note migrates as
-        // a single directly-funded crossing (see `exact_funding_note_needs_no_preparation_fee` in
-        // the denomination strategy tests).
-        let backend = MockBackend::new(
-            vec![
-                60 * COIN / 100,
-                40 * COIN / 100 + u64::from(transfer_fee_buffer),
-            ],
-            2_000_000,
-        );
+        let backend = MockBackend::new(vec![10_000; 120], 2_000_000);
         let mut rng = ChaCha8Rng::seed_from_u64(1);
         assert!(matches!(
             plan_migration(&test_net(), &backend, &mut rng),

--- a/zcash_pool_migration/tests/engine_plan.rs
+++ b/zcash_pool_migration/tests/engine_plan.rs
@@ -150,7 +150,9 @@ fn full_migration_of_one_quantum_is_one_layer_one_transaction() {
 #[test]
 fn reconciliation_drops_the_unfundable_tail_for_a_many_equal_note_source() {
     let balance = 50 * COIN;
-    let backend = MockBackend::new(vec![5 * COIN; 10], 2_000_000); // ten equal 5-ZEC notes
+    let source_notes = vec![5 * COIN; 10]; // ten equal 5-ZEC notes
+    let source_note_count = source_notes.len();
+    let backend = MockBackend::new(source_notes, 2_000_000);
     let mut rng = ChaCha8Rng::seed_from_u64(1);
     let plan = plan_migration(&regtest_network(true), &backend, &mut rng)
         .expect("a fundable balance plans");
@@ -165,6 +167,7 @@ fn reconciliation_drops_the_unfundable_tail_for_a_many_equal_note_source() {
     let mut ref_rng = ChaCha8Rng::seed_from_u64(1);
     let proposed = plan_denominations(
         zat(balance),
+        source_note_count,
         transfer_buffer,
         prep_tx_fee,
         &prep_tx_count_stub,


### PR DESCRIPTION
Follow-up to #2947, which was merged before its final commit was pushed; this PR carries that remaining commit, rebased onto the merge. Part of #2630. Design discussion in the #2947 review thread.

## What

The exact-funding exception (b7c3f37503) removed the preparation-fee reserve for a balance of exactly one canonical denomination plus its transfer buffer, betting that an exact wallet note funds the crossing directly. For a wallet holding that balance any other way the bet is unwinnable — the notes sum to exactly the funding note, leaving no room for any preparation fee — so reconciliation dropped the whole split and the wallet was stuck at `UnfundableSplit` until its balance changed, at any denomination up to the cap.

`DenominationStrategy::plan` and `plan_denominations` now receive the wallet's spendable note count, and the exception applies only when a SINGLE note holds the balance — where the bet is a certainty, since a lone note necessarily equals the balance. With two or more notes, none can equal the funding value, preparation is inevitable, and the split retains its fee reserve, stepping down the series into a decomposition such a wallet can always fund. The count participates only through this one `count == 1` predicate; beyond that bit the published values remain a function of the balance alone.

Consequences, pinned by tests:

- The two-note exact-denomination wallet now migrates the full fee-reserving split through one preparation transaction instead of sticking (`an_exact_denomination_balance_migrates_under_any_holding`).
- `UnfundableSplit` narrows to genuinely fee-bound wallets — consolidation fees exceeding what the balance can cover — and its regression test uses that shape (120 × 10,000-zatoshi dust, provably unfundable).
- The latent counterexample the exception left in `honours_the_contract` (an exact-denomination balance's reserve-free split reconciled away by the fee-charging stub, failing the residual bound; unreachable at ~1e-14 per draw but false as stated) is gone.

## Why not derive the fee reservation from the count

The per-transaction preparation fee is a constant of the canonical padded 16-action shape and stays wallet-independent. Deriving the *number* of reserved transactions from the count (≈ `max(ceil(k/14), ceil((n−k)/14))`, accurate to ~2–13% for the current planner at 1,000 notes) was considered and rejected: it would bake the current spend-the-whole-wallet planner into the published values — wrong in both directions once input selection lands — and widen the split's dependence on note structure from one bit to the full count, while truncation already repairs the optimistic reserve at the same end-state cost (the tail defers to the next run).

## Verification

274 unit tests and all integration targets pass; clippy and rustfmt clean; `zcash_pool_migration_memory` and `zcash_client_sqlite` compile against the signature change. The tree is identical to the fully verified pre-restructure state of the #2947 branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)