### PR TITLE
zcash_pool_migration: wallet-adapter options + planned-transaction graph exposure

### DIFF
--- a/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
+++ b/zcash_client_sqlite/src/pool_migration/orchard_ironwood.rs
@@ -1781,16 +1781,95 @@ mod check_step_satisfiability {
 mod mined_height {
     use rusqlite::named_params;
 
+    use core::convert::Infallible;
+
+    use zcash_client_backend::data_api::Account as _;
+    use zcash_client_backend::data_api::WalletRead as _;
     use zcash_client_backend::data_api::testing::TestState;
-    use zcash_pool_migration::engine::PoolMigrationRead;
+    use zcash_pool_migration::engine::{MigrationState, MigrationTransaction, PoolMigrationRead};
+    use zcash_pool_migration::satisfiability::{ReorgSettleDepth, StepSatisfiability};
+    use zcash_pool_migration::wallet::WalletMigration;
     use zcash_protocol::TxId;
     use zcash_protocol::consensus::BlockHeight;
     use zcash_protocol::local_consensus::LocalNetwork;
 
     use super::PoolMigrations;
     use super::check_step_satisfiability::{unscanned_wallet, wallet_with_scanned_note};
+    use crate::AccountUuid;
     use crate::testing::{BlockCache, db::TestDb};
     use crate::util::SystemClock;
+
+    /// A store that refuses every question, so a [`WalletMigration`] built over it can only answer
+    /// from the WALLET. That is what makes [`store_and_adapter_agree`] a real comparison: an
+    /// adapter that delegated its mining lookup to its store would panic here rather than
+    /// trivially agreeing with the store it delegated to.
+    struct NoStore;
+
+    impl PoolMigrationRead for NoStore {
+        type Error = Infallible;
+
+        fn get_migration(&self) -> Result<Option<MigrationState>, Self::Error> {
+            panic!("the mining comparison reads no migration")
+        }
+
+        fn check_step_satisfiability(
+            &self,
+            _tx: &MigrationTransaction,
+            _settle: ReorgSettleDepth,
+        ) -> Result<StepSatisfiability, Self::Error> {
+            panic!("the mining comparison consults no oracle")
+        }
+
+        fn mined_height(&self, _txid: TxId) -> Result<Option<BlockHeight>, Self::Error> {
+            panic!("the adapter must answer mined_height from the wallet, not from its store")
+        }
+    }
+
+    /// Ask both implementations of the mining lookup about `txid` over one wallet — this store,
+    /// and `zcash_pool_migration`'s [`WalletMigration`] adapter reading the same wallet directly —
+    /// assert they agree, and return the answer they agree on.
+    ///
+    /// The two encode the same rollback-safety rule at different layers: the store applies the
+    /// fully-scanned bound in SQL, the adapter applies it over `WalletRead`. An application built
+    /// on this crate has both in play at once (the adapter's `PoolMigrationRead` impl wraps this
+    /// store), so a disagreement would make a migration's promotions depend on which one the
+    /// caller happened to hold — which is precisely the reason the adapter delegates nothing here.
+    fn store_and_adapter_agree(
+        st: &mut TestState<BlockCache, TestDb, LocalNetwork>,
+        account: AccountUuid,
+        txid: TxId,
+    ) -> Option<BlockHeight> {
+        let from_store = {
+            let store = PoolMigrations::for_account(
+                *st.network(),
+                SystemClock,
+                st.wallet_mut().conn_mut(),
+                account,
+            )
+            .expect("the account exists");
+            store.mined_height(txid).expect("the store answers")
+        };
+
+        // The adapter reads the wallet through `WalletRead`, so it needs the wallet itself — hence
+        // the store borrow above ends before this one begins.
+        let ufvk = st
+            .wallet()
+            .db()
+            .get_account(account)
+            .expect("the account reads")
+            .expect("the account exists")
+            .ufvk()
+            .expect("the account has a unified full viewing key")
+            .clone();
+        let adapter = WalletMigration::new(st.wallet().db(), account, ufvk, NoStore);
+        let from_adapter = adapter.mined_height(txid).expect("the adapter answers");
+
+        assert_eq!(
+            from_store, from_adapter,
+            "the store and the wallet-backed adapter must report one mined height for {txid:?}",
+        );
+        from_store
+    }
 
     /// Insert a transaction the wallet knows of, at `mined_height`, with no spend join: the mining
     /// lookup reads `transactions` alone, so nothing here needs a note or a spender.
@@ -1916,6 +1995,73 @@ mod mined_height {
         )
         .expect("the account exists");
         assert_eq!(store.mined_height(txid).expect("the store answers"), None);
+    }
+
+    /// This store and `zcash_pool_migration`'s `WalletMigration` adapter answer the mining lookup
+    /// ALIKE, over one wallet, in every state that distinguishes the rule: an unscanned wallet, an
+    /// inclusion inside the fully-scanned region, and one observed only above it.
+    ///
+    /// Two implementations of one rule is the thing worth testing here. The adapter is what an
+    /// application drives the engine through, and it wraps this store, so the pair is live in
+    /// every real migration; they nonetheless read the wallet by different routes (SQL over
+    /// `transactions` bounded by `fully_scanned_height`, versus `WalletRead::get_tx_height`
+    /// bounded by `block_fully_scanned`). Because they agree, the adapter needs no delegation to
+    /// this store to be correct — and this is what would catch the day one of the two routes
+    /// stopped applying the bound.
+    #[test]
+    fn the_store_and_the_wallet_adapter_report_one_mined_height() {
+        // Nothing scanned: no chain state backs an inclusion, so a transaction the wallet has been
+        // TOLD about (status retrieval, say) is still not promotable. The adapter must reach this
+        // answer without erroring, which is why it reads the fully-scanned bound before asking
+        // about the transaction at all.
+        let (mut st, account) = unscanned_wallet();
+        assert!(
+            st.wallet()
+                .block_fully_scanned()
+                .expect("reads the fully-scanned block")
+                .is_none(),
+            "precondition: the wallet has scanned nothing",
+        );
+        let unscanned_txid = TxId::from_bytes([8; 32]);
+        record_transaction(&mut st, unscanned_txid, Some(BlockHeight::from_u32(100)));
+        assert_eq!(
+            store_and_adapter_agree(&mut st, account, unscanned_txid),
+            None,
+            "an unscanned wallet promotes nothing",
+        );
+
+        let (mut st, account, _nf, as_of_height) = wallet_with_scanned_note();
+
+        // Inside the fully-scanned region: both report the height, and the drive promotes on it.
+        let mined_txid = TxId::from_bytes([9; 32]);
+        record_transaction(&mut st, mined_txid, Some(as_of_height));
+        assert_eq!(
+            store_and_adapter_agree(&mut st, account, mined_txid),
+            Some(as_of_height),
+        );
+
+        // Above it: a mined height the wallet learned ahead of scanning is withheld by both, so
+        // neither can promote onto a block whose rollback would not truncate the promotion.
+        let ahead_txid = TxId::from_bytes([10; 32]);
+        record_transaction(&mut st, ahead_txid, Some(as_of_height + 1));
+        assert_eq!(
+            store_and_adapter_agree(&mut st, account, ahead_txid),
+            None,
+            "an inclusion above the scanned region is not yet promotable",
+        );
+
+        // And the two absences that are not about the bound at all: a known-but-unmined
+        // transaction, and one the wallet has never heard of.
+        let unmined_txid = TxId::from_bytes([11; 32]);
+        record_transaction(&mut st, unmined_txid, None);
+        assert_eq!(
+            store_and_adapter_agree(&mut st, account, unmined_txid),
+            None
+        );
+        assert_eq!(
+            store_and_adapter_agree(&mut st, account, TxId::from_bytes([12; 32])),
+            None,
+        );
     }
 }
 

--- a/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
+++ b/zcash_client_sqlite/tests/pool_migration_prove_chain_sim.rs
@@ -760,7 +760,7 @@ impl Run {
             let adapter = WalletMigration::new(
                 self.st.wallet(),
                 self.account_id,
-                self.usk.clone(),
+                self.usk.to_unified_full_viewing_key(),
                 MigrationTestStore::holding(stored),
             );
             let plan = engine::plan_migration(&self.network, &adapter, &mut rng)
@@ -769,10 +769,14 @@ impl Run {
             let migrated = plan.denominations().total_migratable();
             let change = plan.denominations().change().map(u64::from).unwrap_or(0);
             let mut adapter = adapter;
+            // The adapter holds viewing authority only; the spending key is the commit's own
+            // argument, live for that call (and checked against the account's viewing key there).
+            let sk = self.usk.orchard();
             let (state, _) = engine::commit_preparation_with_funding(
                 &self.network,
                 tip,
                 &mut adapter,
+                sk,
                 &plan,
                 &mut rng,
                 ReplanThreshold::DEFAULT,
@@ -1554,8 +1558,12 @@ fn migration_anchors_to_the_wallets_configured_retention_grid() {
         .expect("reads the chain height")
         .expect("the wallet has a chain tip");
     let mut rng = ChaCha8Rng::seed_from_u64(0);
-    let mut adapter =
-        WalletMigration::new(st.wallet(), account_id, usk, MigrationTestStore::default());
+    let mut adapter = WalletMigration::new(
+        st.wallet(),
+        account_id,
+        usk.to_unified_full_viewing_key(),
+        MigrationTestStore::default(),
+    );
 
     // The adapter reports the wallet's grid, not the ZIP 318 default, and scales the delays to it
     // rather than crossing a 12-block grid with three-hour ZIP 318 delays.
@@ -1570,10 +1578,12 @@ fn migration_anchors_to_the_wallets_configured_retention_grid() {
     );
 
     let plan = engine::plan_migration(&network, &adapter, &mut rng).expect("plans the migration");
+    let sk = usk.orchard();
     let (state, _) = engine::commit_preparation_with_funding(
         &network,
         tip,
         &mut adapter,
+        sk,
         &plan,
         &mut rng,
         ReplanThreshold::DEFAULT,
@@ -2098,7 +2108,7 @@ fn cancel_returns_the_balance_and_retains_the_record() {
         let adapter = WalletMigration::new(
             run.st.wallet(),
             run.account_id,
-            run.usk.clone(),
+            run.usk.to_unified_full_viewing_key(),
             MigrationTestStore::holding(stored),
         );
         let mut rng = ChaCha8Rng::seed_from_u64(0xCA);
@@ -2238,7 +2248,7 @@ fn a_send_max_sweep_marks_the_migration_and_forces_a_replan() {
         let adapter = WalletMigration::new(
             run.st.wallet(),
             run.account_id,
-            run.usk.clone(),
+            run.usk.to_unified_full_viewing_key(),
             MigrationTestStore::holding(stored),
         );
         assert!(
@@ -2271,17 +2281,19 @@ fn a_send_max_sweep_marks_the_migration_and_forces_a_replan() {
         let mut adapter = WalletMigration::new(
             run.st.wallet(),
             run.account_id,
-            run.usk.clone(),
+            run.usk.to_unified_full_viewing_key(),
             MigrationTestStore::holding(stored),
         );
         let plan = engine::plan_migration(&run.network, &adapter, &mut rng)
             .expect("plans the fresh balance");
+        let sk = run.usk.orchard();
         assert!(
             matches!(
                 engine::commit_preparation_with_funding(
                     &run.network,
                     tip,
                     &mut adapter,
+                    sk,
                     &plan,
                     &mut rng,
                     ReplanThreshold::DEFAULT,
@@ -2311,15 +2323,17 @@ fn a_send_max_sweep_marks_the_migration_and_forces_a_replan() {
     let mut adapter = WalletMigration::new(
         run.st.wallet(),
         run.account_id,
-        run.usk.clone(),
+        run.usk.to_unified_full_viewing_key(),
         MigrationTestStore::holding(stored),
     );
     let plan =
         engine::plan_migration(&run.network, &adapter, &mut rng).expect("plans the fresh balance");
+    let sk = run.usk.orchard();
     let (replanned, _) = engine::commit_preparation_with_funding(
         &run.network,
         tip,
         &mut adapter,
+        sk,
         &plan,
         &mut rng,
         ReplanThreshold::DEFAULT,

--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -7,6 +7,64 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- `engine::CommitError::NoOrchardViewingKey` and
+  `engine::RebuildError::NoOrchardViewingKey`, reported by the entry points that
+  need the account's Orchard full viewing key when `MigrationCrypto::orchard_fvk`
+  has none to give.
+- `engine::CommitError::WrongSpendAuthority` and
+  `engine::RebuildError::WrongSpendAuthority`, reported when the spending key
+  passed to a signing entry point is not the account's — its full viewing key is
+  not the one the backend reports. Refused before anything is built, because
+  signing cannot catch it: `build::sign_pczt` must skip a spend its key does not
+  match (a migration PCZT carries padding dummies with throwaway keys), so a
+  foreign key would sign nothing, succeed, and persist a run recorded as
+  `Signed` whose transactions carry no signatures.
+
+### Changed
+- `wallet::WalletMigration::new` takes the account's `UnifiedFullViewingKey`
+  where it took a `UnifiedSpendingKey`, and is infallible. The adapter holds
+  viewing authority and nothing else, and it holds the unified key WHOLE rather
+  than reducing it to its Orchard component, so constructing one asks nothing of
+  the key. A caller passes `usk.to_unified_full_viewing_key()` where it passed
+  the spending key, or the account's own stored key. A watch-only account, or
+  one whose spending key lives on a hardware wallet, is therefore an ordinary
+  user of the adapter — it plans, builds and commits here and routes the signing
+  to whoever holds the key.
+- `engine::MigrationCrypto::orchard_fvk` returns
+  `Option<&orchard::keys::FullViewingKey>` rather than a `Result`: a backend is
+  handed the account's key rather than going to look for one, so producing it
+  cannot fail, and `None` — a unified key with no Orchard component — is
+  reported by the entry point that needs the key, at the point it needs it.
+- The spend authority is now an ARGUMENT to the operations that sign, not
+  something a backend holds: `engine::MigrationCrypto::sign` is gone, and
+  `engine::commit_preparation`, `engine::commit_preparation_with_funding` and
+  `engine::rebuild_expired_transfer` each take an
+  `&orchard::keys::SpendingKey` (a caller holding a `UnifiedSpendingKey` passes
+  `usk.orchard()`). The unsigned entry points
+  — `engine::build_preparation_unsigned` and
+  `engine::rebuild_expired_transfer_unsigned` — are unchanged and take none. A
+  wallet backend therefore no longer has to hold, or be able to reach, its
+  account's spending key in order to plan or build a migration, and "signing
+  with no authority" is not a state any of these types can be in.
+
+  They take the SPENDING key rather than the spend-authorizing key derived from
+  it so that the key can be checked against the account's viewing key before
+  anything is built (see `engine::CommitError::WrongSpendAuthority`). Nothing
+  retains either key.
+
+### Removed
+- `engine::MigrationCrypto::sign`, a required method of that trait. A backend is
+  no longer asked to sign, so it need not be able to: the spend authority is an
+  argument to `engine::commit_preparation`,
+  `engine::commit_preparation_with_funding` and
+  `engine::rebuild_expired_transfer`. An implementation should delete its `sign`
+  method; a caller that relied on the backend signing passes `usk.orchard()` to
+  those calls instead.
+- `wallet::Error::Sign(BuildError)`, which reported a failure of that adapter
+  method. A signing failure now arrives as `engine::CommitError::Build` or
+  `engine::RebuildError::Build`, from the entry point that was given the key.
+
 ## [0.1.0-rc.7] - 2026-08-07
 
 ### Added

--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -74,6 +74,18 @@ and this library adheres to Rust's notion of
   spends, and the commit indexes its own recovered notes by that choice instead
   of searching for one again, so the note a crossing spends is necessarily the
   one whose producer that crossing was recorded as waiting on.
+- `wallet::WalletMigration`'s `PoolMigrationRead::mined_height` now reads the
+  wallet's fully-scanned height FIRST and reports nothing mined when there is
+  none, rather than looking the transaction's mined height up first and then
+  discarding it. The answer is unchanged wherever the old order produced one —
+  nothing is promotable outside the scanned region either way — but a wallet
+  that has never synced is now answered instead of surfacing whatever error its
+  backend raises for a transaction lookup with no chain tip
+  (`zcash_client_sqlite` raises one). Against `zcash_client_sqlite`'s own
+  migration store — which applies the same bound in SQL — the adapter is now
+  value-equal in every reachable state, which is why it delegates to no store:
+  the equality is asserted for that pairing specifically, not claimed for every
+  possible store.
 
 ### Removed
 - `engine::MigrationCrypto::sign`, a required method of that trait. A backend is

--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -8,6 +8,17 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+- `signing_rounds::PlannedTx::depends_on` and
+  `signing_rounds::PlannedTx::scheduled_height`: what each transaction of a
+  plan will wait on, and when it will broadcast, as
+  `engine::commit_preparation` will stamp them on the built transaction. A
+  consumer can now preview a run's whole execution shape — its dependency graph
+  and its timeline — from an unconsented `engine::MigrationPlan`, through the
+  same two accessors the committed `engine::MigrationTransaction` answers with.
+  `scheduled_height` is an `Option`, `None` being the plan that holds no drawn
+  height for a transaction it contains: unconstructible through the public API,
+  and refused by `engine::commit_preparation`, but reported rather than
+  dropped so that no transaction's id depends on it.
 - `engine::CommitError::NoOrchardViewingKey` and
   `engine::RebuildError::NoOrchardViewingKey`, reported by the entry points that
   need the account's Orchard full viewing key when `MigrationCrypto::orchard_fvk`
@@ -41,8 +52,8 @@ and this library adheres to Rust's notion of
   `engine::commit_preparation`, `engine::commit_preparation_with_funding` and
   `engine::rebuild_expired_transfer` each take an
   `&orchard::keys::SpendingKey` (a caller holding a `UnifiedSpendingKey` passes
-  `usk.orchard()`). The unsigned entry points
-  — `engine::build_preparation_unsigned` and
+  `usk.orchard()`). The unsigned entry points —
+  `engine::build_preparation_unsigned` and
   `engine::rebuild_expired_transfer_unsigned` — are unchanged and take none. A
   wallet backend therefore no longer has to hold, or be able to reach, its
   account's spending key in order to plan or build a migration, and "signing
@@ -52,6 +63,17 @@ and this library adheres to Rust's notion of
   it so that the key can be checked against the account's viewing key before
   anything is built (see `engine::CommitError::WrongSpendAuthority`). Nothing
   retains either key.
+- `signing_rounds::PlannedTx` now carries its dependencies and its scheduled
+  height, so it is `Clone` rather than `Copy`, and
+  `signing_rounds::PlannedTx::new` takes them.
+  `engine::MigrationPlan::planned_transactions` is now the single place a
+  migration's `(id, depends_on, scheduled_height)` assignment is derived:
+  `engine::commit_preparation` reads those rows rather than working the same
+  rules out again while it builds, so a previewed run and the committed run
+  cannot disagree. The plan likewise decides WHICH minted note each transaction
+  spends, and the commit indexes its own recovered notes by that choice instead
+  of searching for one again, so the note a crossing spends is necessarily the
+  one whose producer that crossing was recorded as waiting on.
 
 ### Removed
 - `engine::MigrationCrypto::sign`, a required method of that trait. A backend is

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -45,18 +45,13 @@
 //! [`preparation`]: crate::preparation
 //! [`scheduling`]: crate::scheduling
 
+#[cfg(feature = "orchard")]
+use crate::build::{AccountDerivation, build_prep_tx, build_transfer_pczt};
+use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
 use core::{
     fmt,
     num::{NonZeroU32, NonZeroUsize},
-};
-#[cfg(feature = "orchard")]
-use {
-    crate::{
-        build::{AccountDerivation, build_prep_tx, build_transfer_pczt},
-        preparation::PrepOutput,
-    },
-    alloc::collections::BTreeMap,
 };
 
 use corez::io;
@@ -76,7 +71,9 @@ use zcash_primitives::transaction::fees::{FeeRule as _, transparent, zip317};
 use crate::satisfiability::{DuenessTargets, UnsatisfiableCause};
 use crate::{
     denomination::{DenominationPlan, balance_has_canonical_split, plan_denominations},
-    preparation::{PREP_TX_ACTIONS, PrepError, PrepInput, PreparationPlan, plan_preparation},
+    preparation::{
+        PREP_TX_ACTIONS, PrepError, PrepInput, PrepOutput, PreparationPlan, plan_preparation,
+    },
     satisfiability::{ReorgSettleDepth, ReplanThreshold, StepSatisfiability, UnsatisfiableKind},
     scheduling::{self, Schedule},
     signing_rounds::{
@@ -990,6 +987,163 @@ pub struct MigrationPlan {
     schedule: Vec<Schedule>,
 }
 
+/// A note a plan's preparation phase mints (or a wallet note it funds a crossing with directly),
+/// as [`MigrationPlan::planned_run`] tracks it while working out which transaction spends which
+/// note: what the note is worth, which transaction mints it (`None` for a wallet note that needs
+/// no preparation), and whether a later transaction has already claimed it.
+///
+/// The commit holds the same sequence with the note PLAINTEXTS it recovers from the built bundles
+/// ([`MintedNote`]), grown in the same order, and spends by [`MintedOrdinal`] into it — so the note
+/// a transaction spends is the note the plan assigned it, not one the commit found again.
+struct PlannedNote {
+    value: Zatoshis,
+    producer: Option<MigrationTransferId>,
+    claimed: bool,
+}
+
+/// A note the preparation phase mints, addressed by its POSITION in the sequence of them.
+///
+/// The sequence is grown once per plan, in a fixed order — each preparation transaction's
+/// non-change outputs as the plan declares them, layer by layer, then the directly-funded wallet
+/// notes — and [`MigrationPlan::planned_run`] is the only thing that assigns positions in it. The
+/// commit grows the same sequence with the real notes and INDEXES it, so an ordinal means the same
+/// note on both sides by construction rather than by two searches agreeing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct MintedOrdinal(usize);
+
+/// Where a minted note came from: the `(layer, transaction, output)` coordinate of the plan output
+/// that mints it, as [`PrepInput::Prior`] names it.
+///
+/// Only non-change outputs get one, because only those enter the minted sequence — which is what
+/// makes a `Prior` naming a [`Change`](PrepOutput::Change) output a plan defect this can report
+/// rather than a value match that quietly succeeds against some other note.
+type MintedAt = (usize, usize, usize);
+
+/// Claim the minted note the plan output at `coordinate` produces, yielding its position.
+///
+/// This is the FEEDER claim, and it is a lookup, not a search: [`PrepInput::Prior`] already names
+/// the output it spends, so there is exactly one right answer and no rule for this walk to invent.
+/// (An earlier version matched by value, which is a second answer to a question the plan had
+/// already answered — two answers that agree only for the plans the crate's own planner happens to
+/// produce.)
+///
+/// `None` when the coordinate names no minted note: it is out of range, it names a change output,
+/// or it points at a transaction not yet built (its own, or a later one). Each is a malformed plan,
+/// which [`commit_preparation`] refuses as [`CommitError::InconsistentPlan`].
+fn claim_planned_note_at(
+    minted: &mut [PlannedNote],
+    minted_at: &BTreeMap<MintedAt, MintedOrdinal>,
+    coordinate: MintedAt,
+) -> Option<MintedOrdinal> {
+    let ordinal = *minted_at.get(&coordinate)?;
+    let note = minted.get_mut(ordinal.0)?;
+    // A coordinate claimed twice is a plan that spends one note twice. The second claim resolves
+    // to nothing, exactly as a coordinate naming no note does, so both are refused in the same
+    // place — before the build starts — rather than one of them surfacing mid-commit.
+    if note.claimed {
+        return None;
+    }
+    note.claimed = true;
+    Some(ordinal)
+}
+
+/// Claim the first unclaimed note of exactly `value` from `minted`, yielding its position. `None`
+/// when no such note remains: the plan asks for a funding note it does not mint, and
+/// [`commit_preparation`] refuses it as [`CommitError::InconsistentPlan`].
+///
+/// First-fit on value is used for the TRANSFER funding notes and nothing else, because that is the
+/// one assignment the plan carries no coordinate for: a crossing names the value it needs, not the
+/// output that mints it. It is decided here, once, and indexed downstream.
+fn claim_planned_note(minted: &mut [PlannedNote], value: Zatoshis) -> Option<MintedOrdinal> {
+    let ordinal = minted
+        .iter()
+        .position(|note| !note.claimed && note.value == value)?;
+    minted[ordinal].claimed = true;
+    Some(MintedOrdinal(ordinal))
+}
+
+/// A plan's transactions together with the note assignment that makes them buildable: the public
+/// preview rows, and for each transaction the [`MintedOrdinal`]s it spends.
+///
+/// The two travel together because they are decided together, in one walk over the plan
+/// ([`MigrationPlan::planned_run`]). [`MigrationPlan::planned_transactions`] publishes the rows;
+/// [`commit_preparation`] takes both, which is what keeps "which transaction waits on which" and
+/// "which note each spends" from being two independent answers.
+struct PlannedRun {
+    rows: Vec<PlannedTx>,
+    /// Per preparation transaction, in row order: the note each of its
+    /// [`Prior`](PrepInput::Prior) inputs claims, in input order.
+    ///
+    /// Read by the build, which is Orchard-only; the assignment is still MADE without the feature,
+    /// because it is what the rows' dependencies are derived from.
+    #[cfg_attr(not(feature = "orchard"), allow(dead_code))]
+    prep_feeders: Vec<Vec<Option<MintedOrdinal>>>,
+    /// Per crossing, in crossing order: the funding note it claims.
+    #[cfg_attr(not(feature = "orchard"), allow(dead_code))]
+    transfer_funding: Vec<Option<MintedOrdinal>>,
+}
+
+/// A [`PlannedRun`] whose every claim resolved: each spend names a note the plan mints.
+///
+/// The `Option`s are gone, which is the point — inside the build there is no "the plan named no
+/// note for this" case to handle transaction by transaction, because a plan with one never reaches
+/// it. [`PlannedRun::into_buildable`] is where that is established, before anything is built.
+#[cfg(feature = "orchard")]
+struct BuildableRun {
+    rows: Vec<PlannedTx>,
+    prep_feeders: Vec<Vec<MintedOrdinal>>,
+    transfer_funding: Vec<MintedOrdinal>,
+}
+
+#[cfg(feature = "orchard")]
+impl PlannedRun {
+    /// Check that the plan names a note for every spend its transactions make, yielding the form
+    /// the commit builds from.
+    ///
+    /// Unreachable for a plan [`plan_migration`] produced: its preparation phase mints exactly the
+    /// funding notes the denomination split asks for, and each layer's feeders come from the layer
+    /// before it. A plan that nonetheless asks a transaction to spend a note it does not mint is
+    /// refused HERE — before the first transaction is built, rather than partway through a commit
+    /// that has already signed some of them.
+    fn into_buildable<E>(self) -> Result<BuildableRun, CommitError<E>> {
+        let prep_feeders = self
+            .prep_feeders
+            .into_iter()
+            .enumerate()
+            .map(|(index, feeders)| {
+                feeders
+                    .into_iter()
+                    .map(|claim| {
+                        claim.ok_or_else(|| {
+                            CommitError::InconsistentPlan(format!(
+                                "preparation transaction {index} spends a note the plan does not \
+                                 mint, or that an earlier transaction has already spent"
+                            ))
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let transfer_funding = self
+            .transfer_funding
+            .into_iter()
+            .enumerate()
+            .map(|(crossing, claim)| {
+                claim.ok_or_else(|| {
+                    CommitError::InconsistentPlan(format!(
+                        "no minted funding note for crossing {crossing}"
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(BuildableRun {
+            rows: self.rows,
+            prep_feeders,
+            transfer_funding,
+        })
+    }
+}
+
 impl MigrationPlan {
     /// The denomination decomposition (the denominations and residual). It already reflects
     /// reconciliation against the preparation fees: when the fees did not fit the balance, the
@@ -1041,29 +1195,178 @@ impl MigrationPlan {
 
     /// Every transaction this plan will build, enumerated BEFORE building in the exact order the
     /// commit assigns [`MigrationTransferId`]s (each preparation layer in order, then each transfer by
-    /// crossing), so a [`PlannedTx`]'s id equals the id the built transaction will carry. Each
-    /// carries its [`action_weight`](crate::signing_rounds::action_weight). This is a pure function
-    /// of the plan, recomputed on demand, so planning stays unchanged.
+    /// crossing), so a [`PlannedTx`]'s id equals the id the built transaction will carry.
+    ///
+    /// Each row carries everything the commit will stamp on the built transaction beyond its
+    /// PCZT: its [`action_weight`](crate::signing_rounds::action_weight), the ids it
+    /// [`depends_on`](PlannedTx::depends_on), and its
+    /// [`scheduled_height`](PlannedTx::scheduled_height). Those last two are what make the run's
+    /// EXECUTION SHAPE — which transactions wait on which, and when each is due — previewable from
+    /// a plan the user has not consented to yet, through the same two accessors the committed
+    /// [`MigrationTransaction`] answers with, so a consumer needs one rendering of a migration
+    /// rather than one for the proposal and another for the stored run.
+    ///
+    /// This is where those three facts are DECIDED, for the preview and for the run alike:
+    /// [`commit_preparation`] builds from these rows rather than working the ids, dependencies and
+    /// heights out again as it goes, so a previewed run and the committed run cannot describe
+    /// different things. It is a pure function of the plan, recomputed on demand, so planning
+    /// stays unchanged and no preview can perturb what a later commit builds.
+    ///
+    /// The dependency rules:
+    ///
+    /// - A preparation transaction in layer 0 waits on nothing; one in a later layer waits on
+    ///   EVERY id of the layer before it, not merely the transactions minting the notes it spends
+    ///   (a layer is serialized against the one before it as a whole).
+    /// - A transfer waits on the one preparation transaction that mints ITS funding note, so a
+    ///   crossing releases as soon as its own note is on chain. Which note that is, is settled
+    ///   here — by walking the minted notes in build order and claiming the first unclaimed one of
+    ///   the required value — and the commit is HANDED that choice as a position in the sequence
+    ///   rather than repeating the search, so the note it spends is necessarily the one this
+    ///   dependency was read off. A crossing funded by a wallet note the plan spends directly
+    ///   ([`PreparationPlan::direct_funding_notes`]) waits on nothing.
+    ///
+    /// [`PreparationPlan::direct_funding_notes`]: crate::preparation::PreparationPlan::direct_funding_notes
     pub fn planned_transactions(&self) -> Vec<PlannedTx> {
-        let mut txs = Vec::with_capacity(self.total_transactions());
+        self.planned_run().rows
+    }
+
+    /// The preview rows AND the note assignment behind them: which minted note each transaction
+    /// spends, as a [`MintedOrdinal`] into the sequence the preparation phase mints.
+    ///
+    /// One walk decides both, which is the point. The rows say what waits on what; the ordinals
+    /// say which note each transaction spends — and the second is what the first is DERIVED from,
+    /// since a crossing waits on whichever transaction mints the note it claims. A commit that
+    /// took the rows but re-searched for the notes could spend a different note than the row's
+    /// dependency names; it takes both, and indexes.
+    fn planned_run(&self) -> PlannedRun {
+        let mut rows = Vec::with_capacity(self.total_transactions());
+        // The notes the preparation phase mints, in the order the commit pushes them, so an
+        // ordinal into this sequence names the same note in the commit's own sequence.
+        let mut minted: Vec<PlannedNote> = Vec::new();
+        // Where each minted note came from, so a `Prior` input is resolved by the coordinate it
+        // NAMES rather than by a second search for something of the right value.
+        let mut minted_at: BTreeMap<MintedAt, MintedOrdinal> = BTreeMap::new();
+        let mut prep_feeders: Vec<Vec<Option<MintedOrdinal>>> = Vec::new();
         let mut next = 0u32;
+        let mut previous_layer: Vec<MigrationTransferId> = Vec::new();
         for (layer, layer_txs) in self.preparation.layers().iter().enumerate() {
-            for index in 0..layer_txs.len() {
-                txs.push(PlannedTx::new(
-                    MigrationTransferId::new(next),
-                    MigrationTxKind::Preparation { layer, index },
-                ));
+            let mut this_layer: Vec<MigrationTransferId> = Vec::with_capacity(layer_txs.len());
+            for (index, prep_tx) in layer_txs.iter().enumerate() {
+                let id = MigrationTransferId::new(next);
                 next += 1;
+                this_layer.push(id);
+
+                // Claim this transaction's feeder notes before recording its own outputs, exactly
+                // as the commit resolves a transaction's spends before growing its pool with what
+                // that transaction produces. (That order is also why a `Prior` naming this
+                // transaction's own output, or a later one, resolves to nothing.) A claim that
+                // resolves to nothing is RECORDED as the absence it is: the commit refuses such a
+                // plan (see `PlannedRun`), rather than either side quietly spending some other
+                // note.
+                let feeders = prep_tx
+                    .inputs()
+                    .iter()
+                    .filter_map(|input| match input {
+                        PrepInput::Prior {
+                            layer,
+                            transaction,
+                            output,
+                            ..
+                        } => Some(claim_planned_note_at(
+                            &mut minted,
+                            &minted_at,
+                            (*layer, *transaction, *output),
+                        )),
+                        PrepInput::Wallet { .. } => None,
+                    })
+                    .collect();
+                prep_feeders.push(feeders);
+
+                for (output_index, output) in prep_tx.outputs().iter().enumerate() {
+                    match output {
+                        PrepOutput::Funding(value) | PrepOutput::Intermediate(value) => {
+                            minted_at
+                                .insert((layer, index, output_index), MintedOrdinal(minted.len()));
+                            minted.push(PlannedNote {
+                                value: *value,
+                                producer: Some(id),
+                                claimed: false,
+                            });
+                        }
+                        // Change stays in the source pool: it funds no later transaction, so it
+                        // gets no coordinate, and a `Prior` that names one is refused rather than
+                        // silently served some other note.
+                        PrepOutput::Change(_) => {}
+                    }
+                }
+
+                rows.push(PlannedTx::new(
+                    id,
+                    MigrationTxKind::Preparation { layer, index },
+                    if layer == 0 {
+                        Vec::new()
+                    } else {
+                        previous_layer.clone()
+                    },
+                    self.prep_broadcast_height(layer, index),
+                ));
             }
+            previous_layer = this_layer;
         }
+
+        // A direct-funding wallet note already exists on chain, so the crossing it funds waits on
+        // no producer. Appended after the minted notes, as the commit appends them.
+        for &(_wallet_index, value) in self.preparation.direct_funding_notes() {
+            minted.push(PlannedNote {
+                value,
+                producer: None,
+                claimed: false,
+            });
+        }
+
+        let funding_notes = self.funding_notes();
+        let mut transfer_funding = Vec::with_capacity(self.transfer_tx_count());
         for crossing in 0..self.transfer_tx_count() {
-            txs.push(PlannedTx::new(
-                MigrationTransferId::new(next),
-                MigrationTxKind::Transfer { crossing },
-            ));
+            let id = MigrationTransferId::new(next);
             next += 1;
+            let claim = funding_notes
+                .get(crossing)
+                .and_then(|value| claim_planned_note(&mut minted, *value));
+            transfer_funding.push(claim);
+            // The crossing waits on whatever mints the note it just claimed — nothing, for a
+            // wallet note the plan spends directly. A crossing that claimed NO note waits on
+            // nothing either, but only because such a plan cannot be committed at all; the commit
+            // refuses it before building rather than treating it as independent.
+            let producer = claim.and_then(|ordinal| minted[ordinal.0].producer);
+            rows.push(PlannedTx::new(
+                id,
+                MigrationTxKind::Transfer { crossing },
+                producer.into_iter().collect(),
+                self.schedule.get(crossing).map(Schedule::broadcast_height),
+            ));
         }
-        txs
+
+        PlannedRun {
+            rows,
+            prep_feeders,
+            transfer_funding,
+        }
+    }
+
+    /// The drawn broadcast height of the preparation transaction at `[layer][index]`: the height
+    /// the commit stamps on it, and whose canonical expiry window its pre-signature commits to.
+    ///
+    /// The schedule is index-aligned with the preparation layers by construction —
+    /// [`plan_migration`] draws exactly one height per transaction of each layer, and a
+    /// [`MigrationPlan`] cannot be built any other way — so this misses only for a plan
+    /// [`commit_preparation`] would itself reject as [`CommitError::InconsistentPlan`]. Such a
+    /// transaction still gets a row, with no height, rather than being dropped: every id after it,
+    /// and every dependency naming one, is defined by its POSITION in the list.
+    fn prep_broadcast_height(&self, layer: usize, index: usize) -> Option<BlockHeight> {
+        self.prep_schedule
+            .get(layer)
+            .and_then(|heights| heights.get(index))
+            .copied()
     }
 
     /// The total number of transactions this plan builds and signs: its preparation transactions
@@ -3140,18 +3443,24 @@ fn finish_built_pczt<E>(
 }
 
 /// A spendable note recovered from an already-built preparation transaction, or a direct-funding
-/// wallet note, tracked by the commit so a later transaction can spend it BY VALUE before it is
-/// mined. Its signable plaintext is fixed at build time (its `rho` is the paired spend's nullifier
-/// and its `rseed` is drawn by the builder); only its tree position awaits mining, and that matters
-/// only to the proof (deferred to proving time, ZIP 374). `consumed` guards against spending it
-/// twice, and `producer` is the preparation transaction that mints it (or `None` for a
-/// direct-funding wallet note), so a transfer depends only on its own funding note's producer.
+/// wallet note, tracked by the commit so a later transaction can spend it before it is mined. Its
+/// signable plaintext is fixed at build time (its `rho` is the paired spend's nullifier and its
+/// `rseed` is drawn by the builder); only its tree position awaits mining, and that matters only to
+/// the proof (deferred to proving time, ZIP 374).
+///
+/// The commit's counterpart to the [`PlannedNote`] the plan works over, carrying the recovered
+/// plaintext the plan has no way to know. The two sequences are grown in the same order, and the
+/// commit spends out of this one BY [`MintedOrdinal`] — the position the PLAN assigned — never by
+/// looking for a note of the right value. That is the whole mechanism: the note spent here is the
+/// note the plan assigned, so it cannot be a different note than the one the transaction's recorded
+/// dependency was derived from. `value` is checked against the plan's expectation and `consumed`
+/// against a second claim, but only to catch the two sequences having diverged, which is a defect
+/// in the plan rather than something to resolve.
 #[cfg(feature = "orchard")]
 struct MintedNote {
     value: Zatoshis,
     note: orchard::note::Note,
     consumed: bool,
-    producer: Option<MigrationTransferId>,
 }
 
 /// Commit a planned migration: build and pre-sign EVERY transaction — each preparation layer, in
@@ -3283,10 +3592,16 @@ where
         + PoolMigrationWrite,
     R: RngCore + rand_core::CryptoRng,
 {
+    // The run's shape — which transaction gets which id, what each waits on, when each is
+    // scheduled, and which minted note each spends — is decided ONCE, by the plan, and the build
+    // below reads it. The rows are the same list a consumer previews for consent, so what is
+    // committed is literally what was shown; the note assignment travels with them, so the note a
+    // transaction spends here is the one the row's dependency was derived from.
+    let planned = plan.planned_run().into_buildable()?;
     let mut committer = Committer::start(params, target_height, backend, rng, signing)?;
-    committer.build_preparation_layers(plan)?;
+    committer.build_preparation_layers(plan, &planned)?;
     committer.add_direct_funding(plan)?;
-    committer.build_transfers(plan)?;
+    committer.build_transfers(plan, &planned)?;
     // `into_state` consumes the committer, releasing its `&mut backend` reborrow, so the store
     // write below can borrow `backend` again.
     let output = committer.into_state(plan, replan_threshold);
@@ -3338,17 +3653,18 @@ where
 }
 
 /// Hosts the shared mutable state that building a whole committed migration threads through its
-/// stages: the accumulating `transactions`/`unsigned` outputs, the `next_id` counter, the per-layer
-/// `layer_ids` (so a later layer, and the transfers, can depend on the layer before them), and the
-/// `minted` pool of notes that already-built preparation transactions (and direct-funding wallet
-/// notes) mint for later spends. Owning the backend, rng, and resolved `fvk` lets each stage of
-/// [`commit_preparation_inner`] be a method: [`Committer::start`] then
-/// [`Committer::build_preparation_layers`], [`Committer::add_direct_funding`],
-/// [`Committer::build_transfers`], and finally [`Committer::into_state`], which consumes the
-/// committer and returns the assembled state (releasing the `&mut backend` reborrow so the caller
-/// can persist it). `plan` is deliberately NOT a field: passing it as a method parameter avoids
-/// borrowing `self` both immutably (to iterate the plan) and mutably (to call `next_id`/the
-/// resolvers) at once.
+/// stages: the accumulating `transactions`/`unsigned` outputs, and the `minted` pool of notes that
+/// already-built preparation transactions (and direct-funding wallet notes) mint for later spends.
+/// Owning the backend, rng, and resolved `fvk` lets each stage of [`commit_preparation_inner`] be a
+/// method: [`Committer::start`] then [`Committer::build_preparation_layers`],
+/// [`Committer::add_direct_funding`], [`Committer::build_transfers`], and finally
+/// [`Committer::into_state`], which consumes the committer and returns the assembled state
+/// (releasing the `&mut backend` reborrow so the caller can persist it).
+///
+/// It holds NO ids, dependency sets or scheduled heights of its own: those come from
+/// [`MigrationPlan::planned_transactions`], whose rows each build stage walks. `plan` and those
+/// rows are deliberately NOT fields: passing them as method parameters avoids borrowing `self`
+/// both immutably (to read them) and mutably (to call the note resolvers) at once.
 #[cfg(feature = "orchard")]
 struct Committer<'a, P, B, R> {
     params: &'a P,
@@ -3362,8 +3678,6 @@ struct Committer<'a, P, B, R> {
     account_derivation: Option<AccountDerivation>,
     transactions: Vec<MigrationTransaction>,
     unsigned: Vec<UnsignedMigrationTx>,
-    next_id: u32,
-    layer_ids: Vec<Vec<MigrationTransferId>>,
     minted: Vec<MintedNote>,
     /// Each transfer paired with the funding note it spends, captured as the transfer is built.
     /// The commit path already recovers every funding note's plaintext to build the transfer; a
@@ -3426,29 +3740,27 @@ where
             account_derivation,
             transactions: Vec::new(),
             unsigned: Vec::new(),
-            next_id: 0,
-            layer_ids: Vec::new(),
             minted: Vec::new(),
             transfer_funding: Vec::new(),
         })
     }
 
-    /// Assign and consume the next sequential transaction id.
-    fn next_id(&mut self) -> MigrationTransferId {
-        let id = MigrationTransferId(self.next_id);
-        self.next_id += 1;
-        id
-    }
-
     /// Resolve the Orchard notes a preparation transaction spends: wallet notes from the backend
-    /// (checking each against its planned value), and feeder notes from the `minted` pool (marking
-    /// each consumed).
+    /// (checking each against its planned value), and feeder notes by the ORDINAL the plan
+    /// assigned each `Prior` input (marking each consumed).
+    ///
+    /// `feeders` holds one ordinal per `Prior` input, in input order, from
+    /// [`MigrationPlan::planned_run`]. Indexing rather than searching by value is what makes the
+    /// note spent here the note the plan assigned: a search could land on a different note of the
+    /// same value than the plan's walk did, and the transaction's recorded dependency comes from
+    /// the plan's walk.
     fn resolve_prep_spends(
         &mut self,
         prep_tx: &crate::preparation::PrepTransaction,
-        layer: usize,
+        feeders: &[MintedOrdinal],
     ) -> Result<Vec<orchard::note::Note>, CommitError<<B as MigrationBackend>::Error>> {
         let mut spends = Vec::with_capacity(prep_tx.inputs().len());
+        let mut feeders = feeders.iter();
         for input in prep_tx.inputs() {
             match input {
                 PrepInput::Wallet { index, value } => {
@@ -3470,131 +3782,186 @@ where
                 PrepInput::Prior { value, .. } => {
                     // A feeder minted by an earlier layer, recovered when that layer was
                     // built above (the plan's layers are in topological order).
-                    let feeder = self
-                        .minted
-                        .iter_mut()
-                        .find(|m| !m.consumed && m.value == *value)
-                        .ok_or_else(|| {
-                            CommitError::InconsistentPlan(format!(
-                                "layer {layer} spends a feeder note of value {} that no \
-                                 earlier layer mints",
-                                u64::from(*value)
-                            ))
-                        })?;
-                    feeder.consumed = true;
-                    spends.push(feeder.note);
+                    let ordinal = feeders.next().ok_or_else(|| {
+                        CommitError::InconsistentPlan(
+                            "the plan assigned fewer feeder notes than this transaction spends"
+                                .into(),
+                        )
+                    })?;
+                    spends.push(self.claim_minted(*ordinal, *value)?);
                 }
             }
+        }
+        // Both directions of the same disagreement: the plan assigned feeders this transaction
+        // does not spend, so the assignment describes some other transaction than the one being
+        // built, and the ordinals used above cannot be trusted to be its.
+        if feeders.next().is_some() {
+            return Err(CommitError::InconsistentPlan(
+                "the plan assigned more feeder notes than this transaction spends".into(),
+            ));
         }
         Ok(spends)
     }
 
-    /// Build and pre-sign every preparation transaction, layer by layer in topological order,
-    /// growing the `minted` pool with each transaction's recovered spendable outputs.
+    /// The recovered plaintext of the minted note at `ordinal`, marked consumed.
+    ///
+    /// The plan assigned this ordinal to this spend, so the checks are on the POOL agreeing with
+    /// the plan, not on finding a note: an out-of-range ordinal, a note of the wrong value, or one
+    /// a previous spend already took all mean the plan's sequence and the built one have diverged,
+    /// which is a defect in the plan rather than a condition to recover from.
+    fn claim_minted(
+        &mut self,
+        ordinal: MintedOrdinal,
+        value: Zatoshis,
+    ) -> Result<orchard::note::Note, CommitError<<B as MigrationBackend>::Error>> {
+        let so_far = self.minted.len();
+        let minted = self.minted.get_mut(ordinal.0).ok_or_else(|| {
+            CommitError::InconsistentPlan(format!(
+                "the plan claims minted note {} but only {so_far} have been minted",
+                ordinal.0,
+            ))
+        })?;
+        if minted.consumed {
+            return Err(CommitError::InconsistentPlan(format!(
+                "the plan claims minted note {} twice",
+                ordinal.0
+            )));
+        }
+        if minted.value != value {
+            return Err(CommitError::InconsistentPlan(format!(
+                "the plan claims minted note {} for a spend of {} zatoshis, but it holds {}",
+                ordinal.0,
+                u64::from(value),
+                u64::from(minted.value),
+            )));
+        }
+        minted.consumed = true;
+        Ok(minted.note)
+    }
+
+    /// Build and pre-sign every preparation transaction `planned` names, in the order it names
+    /// them (which is layer by layer in topological order), growing the `minted` pool with each
+    /// transaction's recovered spendable outputs.
+    ///
+    /// `planned` is the plan's own [`BuildableRun`], and it — not this loop — decides each
+    /// transaction's id, what it depends on, when it is scheduled, and which minted notes it
+    /// spends. Each row's [`Preparation`](MigrationTxKind::Preparation) kind carries the
+    /// `[layer][index]` coordinates this looks the plan's transaction up by, so the planned rows
+    /// drive the walk and the plan answers what to build.
     fn build_preparation_layers(
         &mut self,
         plan: &MigrationPlan,
+        planned: &BuildableRun,
     ) -> Result<(), CommitError<<B as MigrationBackend>::Error>> {
-        for (layer, prep_layer) in plan.preparation().layers().iter().enumerate() {
-            let mut this_layer_ids: Vec<MigrationTransferId> = Vec::with_capacity(prep_layer.len());
-            for (index, prep_tx) in prep_layer.iter().enumerate() {
-                let id = self.next_id();
-                this_layer_ids.push(id);
+        for (position, planned_tx) in planned.rows.iter().enumerate() {
+            let (layer, index) = match planned_tx.kind() {
+                MigrationTxKind::Preparation { layer, index } => (layer, index),
+                // The transfers, which `planned` lists after every preparation transaction, are
+                // built by `build_transfers` once the notes funding them exist.
+                MigrationTxKind::Transfer { .. } => continue,
+            };
+            let prep_tx = plan
+                .preparation()
+                .layers()
+                .get(layer)
+                .and_then(|prep_layer| prep_layer.get(index))
+                .ok_or_else(|| {
+                    CommitError::InconsistentPlan(format!(
+                        "the plan has no preparation transaction at layer {layer} index {index}"
+                    ))
+                })?;
+            let id = planned_tx.id();
+            let depends_on = planned_tx.depends_on().to_vec();
+            // The preparation rows come first and in order, so a preparation row's position is
+            // its index into the plan's per-transaction feeder assignment.
+            let feeders = planned.prep_feeders.get(position).ok_or_else(|| {
+                CommitError::InconsistentPlan(format!(
+                    "the plan assigns no feeder notes to preparation transaction {position}"
+                ))
+            })?;
 
-                let spends = self.resolve_prep_spends(prep_tx, layer)?;
+            let spends = self.resolve_prep_spends(prep_tx, feeders)?;
 
-                let depends_on = if layer == 0 {
-                    Vec::new()
-                } else {
-                    self.layer_ids
-                        .last()
-                        .cloned()
-                        .expect("a layer after layer 0 has a preceding layer")
-                };
-                // The drawn preparation schedule temporally decouples the transactions of a layer
-                // from one another (see `MigrationPlan::prep_schedule`). The expiry the
-                // pre-signature commits to must match that schedule, not the build height: the
-                // canonical rolling window at the scheduled height.
-                let scheduled_height = *plan
-                    .prep_schedule()
-                    .get(layer)
-                    .and_then(|layer_schedule| layer_schedule.get(index))
-                    .ok_or_else(|| {
-                        CommitError::InconsistentPlan(format!(
-                            "preparation schedule has no entry for layer {layer} transaction {index}"
-                        ))
-                    })?;
-                let expiry_height = crate::scheduling::expiry_height(scheduled_height);
-                // The field accesses `self.params`/`self.fvk`/`self.account_derivation`/`self.rng`
-                // are DISJOINT, so the borrow checker accepts them together here — as long as no
-                // whole-`self` method call (like `next_id`/`resolve_prep_spends` above) is
-                // interleaved.
-                let (pczt, placed) = build_prep_tx(
-                    self.params,
-                    u32::from(self.target_height),
-                    u32::from(expiry_height),
-                    &self.fvk,
-                    spends,
-                    prep_tx.outputs(),
-                    self.account_derivation.as_ref(),
-                    &mut *self.rng,
-                )
-                .map_err(CommitError::Build)?;
+            // The drawn preparation schedule temporally decouples the transactions of a layer
+            // from one another (see `MigrationPlan::prep_schedule`). The expiry the
+            // pre-signature commits to must match that schedule, not the build height: the
+            // canonical rolling window at the scheduled height. A plan holding no drawn height
+            // for a transaction it contains is malformed — `planned` reports the absence rather
+            // than dropping the transaction, and this is where it is refused.
+            let scheduled_height = planned_tx.scheduled_height().ok_or_else(|| {
+                CommitError::InconsistentPlan(format!(
+                    "preparation schedule has no entry for layer {layer} transaction {index}"
+                ))
+            })?;
+            let expiry_height = crate::scheduling::expiry_height(scheduled_height);
+            // The field accesses `self.params`/`self.fvk`/`self.account_derivation`/`self.rng`
+            // are DISJOINT, so the borrow checker accepts them together here — as long as no
+            // whole-`self` method call (like `resolve_prep_spends` above) is interleaved.
+            let (pczt, placed) = build_prep_tx(
+                self.params,
+                u32::from(self.target_height),
+                u32::from(expiry_height),
+                &self.fvk,
+                spends,
+                prep_tx.outputs(),
+                self.account_derivation.as_ref(),
+                &mut *self.rng,
+            )
+            .map_err(CommitError::Build)?;
 
-                // Grow the minted pool with this transaction's recovered spendable outputs. Change
-                // outputs are excluded: they stay in the source pool and must never be matched to a
-                // feeder or funding request of a coincidentally equal value.
-                for (_action_index, output, note) in placed {
-                    match output {
-                        PrepOutput::Funding(value) | PrepOutput::Intermediate(value) => {
-                            self.minted.push(MintedNote {
-                                value,
-                                note,
-                                consumed: false,
-                                producer: Some(id),
-                            });
-                        }
-                        PrepOutput::Change(_) => {}
+            // Grow the minted pool with this transaction's recovered spendable outputs, in the
+            // order the plan declares them, which is the order `planned` assumed when it decided
+            // which crossing each note funds. Change outputs are excluded: they stay in the source
+            // pool and must never be matched to a feeder or funding request of a coincidentally
+            // equal value.
+            for (_action_index, output, note) in placed {
+                match output {
+                    PrepOutput::Funding(value) | PrepOutput::Intermediate(value) => {
+                        self.minted.push(MintedNote {
+                            value,
+                            note,
+                            consumed: false,
+                        });
                     }
+                    PrepOutput::Change(_) => {}
                 }
+            }
 
-                // Cache the real-spend nullifiers off the built PCZT before it is consumed by
-                // signing/serialization, so the feature-free state machine never re-parses the
-                // stored bytes.
-                let spend_nullifiers = crate::pczt_spends::real_spend_nullifiers(&pczt)
-                    .map_err(CommitError::RealSpends)?
-                    .into_iter()
-                    .map(|(_, nf)| nf.to_bytes())
-                    .collect();
-                let (bytes, txid, tx_state) = finish_built_pczt(pczt, self.signing)?;
-                if matches!(self.signing, Signing::External) {
-                    self.unsigned.push(UnsignedMigrationTx {
-                        id,
-                        pczt: bytes.clone(),
-                        actions: crate::preparation::PREP_TX_ACTIONS,
-                    });
-                }
-                self.transactions.push(MigrationTransaction {
+            // Cache the real-spend nullifiers off the built PCZT before it is consumed by
+            // signing/serialization, so the feature-free state machine never re-parses the
+            // stored bytes.
+            let spend_nullifiers = crate::pczt_spends::real_spend_nullifiers(&pczt)
+                .map_err(CommitError::RealSpends)?
+                .into_iter()
+                .map(|(_, nf)| nf.to_bytes())
+                .collect();
+            let (bytes, txid, tx_state) = finish_built_pczt(pczt, self.signing)?;
+            if matches!(self.signing, Signing::External) {
+                self.unsigned.push(UnsignedMigrationTx {
                     id,
-                    kind: MigrationTxKind::Preparation { layer, index },
-                    pczt: bytes,
-                    depends_on,
-                    scheduled_height,
-                    expiry_height,
-                    anchor_boundary: None,
-                    txid,
-                    state: tx_state,
-                    // The engine does not yet acquire locks; a later slice that draws a
-                    // `LockOwner` for the commit would set this here.
-                    lock_owner: None,
-                    // A freshly committed transaction carries no spent-input observation.
-                    unsatisfiable: None,
-                    spend_nullifiers,
-                    // Nor a rejected broadcast: it has not been broadcast at all.
-                    broadcast_failure_at: None,
+                    pczt: bytes.clone(),
+                    actions: crate::preparation::PREP_TX_ACTIONS,
                 });
             }
-            self.layer_ids.push(this_layer_ids);
+            self.transactions.push(MigrationTransaction {
+                id,
+                kind: planned_tx.kind(),
+                pczt: bytes,
+                depends_on,
+                scheduled_height,
+                expiry_height,
+                anchor_boundary: None,
+                txid,
+                state: tx_state,
+                // The engine does not yet acquire locks; a later slice that draws a
+                // `LockOwner` for the commit would set this here.
+                lock_owner: None,
+                // A freshly committed transaction carries no spent-input observation.
+                unsatisfiable: None,
+                spend_nullifiers,
+                // Nor a rejected broadcast: it has not been broadcast at all.
+                broadcast_failure_at: None,
+            });
         }
         Ok(())
     }
@@ -3613,28 +3980,35 @@ where
             if note.value().inner() != u64::from(value) {
                 return Err(CommitError::StalePlan);
             }
-            // A direct-funding wallet note already exists on-chain, so its transfer has no producer
-            // to wait on.
+            // Appended AFTER every minted note, as `MigrationPlan::planned_transactions` assumes
+            // when it decides which crossing each note funds. A direct-funding wallet note already
+            // exists on chain, so the crossing that claims it waits on nothing.
             self.minted.push(MintedNote {
                 value,
                 note,
                 consumed: false,
-                producer: None,
             });
         }
         Ok(())
     }
 
-    /// Build and pre-sign every transfer, spending each crossing's funding note out of the `minted`
-    /// pool and drawing the boundary anchor it will prove against.
+    /// Build and pre-sign every transfer `planned` names, spending each crossing's funding note
+    /// out of the `minted` pool and drawing the boundary anchor it will prove against.
+    ///
+    /// `planned` is the plan's own [`BuildableRun`], which supplies each transfer's id,
+    /// dependency, scheduled height and funding-note ORDINAL; this resolves only what the plan
+    /// cannot know — that note's PLAINTEXT, recovered from the built preparation bundles. The
+    /// ordinal is why the note spent here is necessarily the one whose producer the plan made this
+    /// crossing wait on.
     fn build_transfers(
         &mut self,
         plan: &MigrationPlan,
+        planned: &BuildableRun,
     ) -> Result<(), CommitError<<B as MigrationBackend>::Error>> {
         // Each transfer waits only for the preparation transaction that MINTS ITS OWN funding note
-        // to be mined (recorded as that note's producer in `minted`), not for the whole last layer:
-        // as soon as a transfer's own funding note is on-chain it may broadcast at its scheduled
-        // height, independently of the other crossings' preparation. This follows ZIP 318's
+        // to be mined, not for the whole last layer: as soon as a transfer's own funding note is
+        // on-chain it may broadcast at its scheduled height, independently of the other crossings'
+        // preparation. This follows ZIP 318's
         // per-note availability MUST ("wait until the boundary that closes the anchor-height bucket
         // in which a note-preparation transaction was mined has passed before treating ITS output
         // notes as available for migration") and consciously RELAXES the more conservative SHOULD
@@ -3676,33 +4050,40 @@ where
         // The grid to draw from is the backend's, so the boundary each transfer anchors to is one
         // whose checkpoint that backend retains.
         let anchor_bucket_interval = self.backend.scheduling_params().anchor_bucket_interval();
-        for (crossing, schedule) in plan.schedule().iter().enumerate() {
-            let id = self.next_id();
+        let funding_notes = plan.funding_notes();
+        for planned_tx in &planned.rows {
+            let crossing = match planned_tx.kind() {
+                MigrationTxKind::Transfer { crossing } => crossing,
+                // Already built, in the pass that grew the minted pool these transfers spend from.
+                MigrationTxKind::Preparation { .. } => continue,
+            };
+            let id = planned_tx.id();
+            let depends_on = planned_tx.depends_on().to_vec();
+            // The planned row has no height exactly when the plan has no schedule slot for this
+            // crossing, which is the same malformed plan the expiry read below cannot serve
+            // either; both are refused as one.
+            let (scheduled_height, expiry_height) = planned_tx
+                .scheduled_height()
+                .zip(plan.schedule().get(crossing).map(Schedule::expiry_height))
+                .ok_or_else(|| {
+                    CommitError::InconsistentPlan(format!(
+                        "the transfer schedule has no entry for crossing {crossing}"
+                    ))
+                })?;
 
-            let funding_value = *plan.funding_notes().get(crossing).ok_or_else(|| {
+            let funding_value = *funding_notes.get(crossing).ok_or_else(|| {
                 CommitError::InconsistentPlan(format!(
                     "no funding note value for crossing {crossing}"
                 ))
             })?;
-            // Copy `note`/`producer` (both `Copy`) out of the `minted` borrow so it ends before the
-            // disjoint-field build call below.
-            let (note, producer) = {
-                let funding_note = self
-                    .minted
-                    .iter_mut()
-                    .find(|m| !m.consumed && m.value == funding_value)
-                    .ok_or_else(|| {
-                        CommitError::InconsistentPlan(format!(
-                            "no minted funding note for crossing {crossing}"
-                        ))
-                    })?;
-                funding_note.consumed = true;
-                (funding_note.note, funding_note.producer)
-            };
-            // Depend only on the preparation transaction that mints this funding note (or nothing,
-            // for a direct-funding wallet note), so this crossing releases as soon as its own note
-            // is mined.
-            let depends_on: Vec<MigrationTransferId> = producer.into_iter().collect();
+            let ordinal = *planned.transfer_funding.get(crossing).ok_or_else(|| {
+                CommitError::InconsistentPlan(format!(
+                    "the plan assigns no funding note to crossing {crossing}"
+                ))
+            })?;
+            // `note` is `Copy`, so the `minted` borrow ends here — before the disjoint-field build
+            // call below.
+            let note = self.claim_minted(ordinal, funding_value)?;
             let crossing_value = *plan
                 .denominations()
                 .crossing_values()
@@ -3716,7 +4097,7 @@ where
             let pczt = build_transfer_pczt(
                 self.params,
                 u32::from(self.target_height),
-                u32::from(schedule.expiry_height()),
+                u32::from(expiry_height),
                 &self.fvk,
                 note,
                 crossing_value,
@@ -3728,7 +4109,7 @@ where
                 anchor_bucket_interval,
                 nu63_activation,
                 est_last_prep_height,
-                schedule.broadcast_height(),
+                scheduled_height,
                 self.rng,
             )
             .ok_or(CommitError::StalePlan)?;
@@ -3750,11 +4131,11 @@ where
             }
             self.transactions.push(MigrationTransaction {
                 id,
-                kind: MigrationTxKind::Transfer { crossing },
+                kind: planned_tx.kind(),
                 pczt: bytes,
                 depends_on,
-                scheduled_height: schedule.broadcast_height(),
-                expiry_height: schedule.expiry_height(),
+                scheduled_height,
+                expiry_height,
                 anchor_boundary: Some(anchor_boundary),
                 txid,
                 state: tx_state,
@@ -4511,6 +4892,163 @@ pub(crate) mod tests {
                 min_signing_rounds(run.prep_transactions(), run.crossings(), keystone)
             );
         }
+    }
+
+    /// A plan whose layers mint two notes of EQUAL value, where a later transaction's
+    /// [`PrepInput::Prior`] names the SECOND of them.
+    ///
+    /// The whole point of the fixture is that the coordinate and a first-fit-by-value search
+    /// disagree: first-fit would hand the feeder the first note, the coordinate names the second.
+    /// The crate's own planner does not produce such a plan (it emits feeders in claim order), but
+    /// [`crate::preparation::PreparationPlan`] is public and validates coordinates —
+    /// `PreparationPlan::is_valid` knows nothing of first-fit — so a third-party planner can, and
+    /// then the note spent and the note the dependency names must still be the same one.
+    ///
+    /// `feeder` is the coordinate the layer-1 transaction spends, so a caller can also point it at
+    /// something the plan does not mint.
+    fn equal_valued_feeders_plan(
+        feeder: (usize, usize, usize),
+        with_change: bool,
+    ) -> MigrationPlan {
+        let value = Zatoshis::const_from_u64(10_000_000);
+        let funding = Zatoshis::const_from_u64(9_000_000);
+        // Two indistinguishable-by-value notes, from different producers. With `with_change`, each
+        // minting transaction also returns a change output OF THE SAME VALUE — the shape that lets
+        // a `Prior` name a change output and still satisfy `PreparationPlan::is_valid`, which
+        // checks that the coordinate names an output of the claimed value, not what that output is
+        // FOR.
+        let mint = |wallet_index: usize| {
+            let mut outputs = alloc::vec![PrepOutput::Intermediate(value)];
+            let spend = if with_change {
+                outputs.push(PrepOutput::Change(value));
+                (value + value).expect("the doubled note value is representable")
+            } else {
+                value
+            };
+            crate::preparation::PrepTransaction::from_parts(
+                alloc::vec![PrepInput::Wallet {
+                    index: wallet_index,
+                    value: spend,
+                }],
+                outputs,
+            )
+        };
+        let (layer, transaction, output) = feeder;
+        let spender = crate::preparation::PrepTransaction::from_parts(
+            alloc::vec![PrepInput::Prior {
+                layer,
+                transaction,
+                output,
+                value,
+            }],
+            alloc::vec![PrepOutput::Funding(funding)],
+        );
+        let preparation = crate::preparation::PreparationPlan::from_parts(
+            alloc::vec![alloc::vec![mint(0), mint(1)], alloc::vec![spender]],
+            alloc::vec![],
+        );
+        // One crossing per minted note that survives the feeder claim: the funding note the
+        // layer-1 transaction mints, and whichever equal-valued note it did NOT spend.
+        let denominations = DenominationPlan::from_stored_parts(
+            alloc::vec![funding, value],
+            Zatoshis::ZERO,
+            None,
+            Zatoshis::ZERO,
+            Zatoshis::const_from_u64(20_000_000),
+            Zatoshis::const_from_u64(19_000_000),
+        )
+        .expect("the stored parts are consistent");
+        let height = |h: u32| BlockHeight::from_u32(2_000_000 + h);
+        // Real drawn schedules, in the layers' shape: nothing here turns on the heights, but a
+        // fixture that could not have been drawn is a fixture that proves less.
+        let mut rng = ChaCha8Rng::seed_from_u64(41);
+        MigrationPlan {
+            denominations,
+            preparation,
+            prep_schedule: alloc::vec![alloc::vec![height(0), height(1)], alloc::vec![height(2)]],
+            schedule: crate::scheduling::schedule(
+                &crate::scheduling::SchedulingParams::ZIP_318,
+                height(100),
+                2,
+                &mut rng,
+            ),
+        }
+    }
+
+    /// A `Prior` input spends the output its coordinate NAMES, not whichever unclaimed note
+    /// happens to have the right value.
+    ///
+    /// The plan already answers "which note does this input spend" — `PrepInput::Prior` carries
+    /// `(layer, transaction, output)` — so re-deriving it by value search would be a second answer
+    /// to a settled question, and the two answers part company as soon as two minted notes share a
+    /// value. This pins the resolution to the coordinate, in the case that discriminates: the
+    /// spender names the SECOND of two equal-valued notes, so a first-fit walk would take the
+    /// first.
+    ///
+    /// Both halves are asserted, because they fail differently. The feeder ordinal is the
+    /// mechanism; the crossing's dependency is what a wallet SEES. A first-fit walk would not
+    /// desynchronize the two — a crossing's dependency is read off the producer of the note it is
+    /// handed, so the dependency and the spent note cannot part company — it would hand the
+    /// crossing a DIFFERENT note, from the other producer, committing a differently shaped run
+    /// than the plan describes: the feeder would spend the note the plan left for the crossing,
+    /// and the crossing would wait on a transaction the plan never made it wait on.
+    #[test]
+    fn a_feeder_spends_the_output_its_coordinate_names() {
+        // Layer 0's SECOND transaction, first output: minted-sequence ordinal 1, where a
+        // value search would find ordinal 0.
+        let plan = equal_valued_feeders_plan((0, 1, 0), false);
+        let run = plan.planned_run();
+
+        assert_eq!(
+            run.prep_feeders,
+            alloc::vec![
+                alloc::vec![],
+                alloc::vec![],
+                alloc::vec![Some(MintedOrdinal(1))]
+            ],
+            "the feeder resolves to the coordinate's note, not the first of equal value",
+        );
+
+        let rows = &run.rows;
+        let (t0, t2) = (rows[0].id(), rows[2].id());
+        let leftover_crossing = rows
+            .iter()
+            .find(|row| matches!(row.kind(), MigrationTxKind::Transfer { crossing: 1 }))
+            .expect("the plan has a second crossing");
+        assert_eq!(
+            leftover_crossing.depends_on(),
+            &[t0],
+            "the crossing waits on the producer of the note it is left, which is the note the \
+             layer-1 transaction did NOT spend",
+        );
+        let funded_crossing = rows
+            .iter()
+            .find(|row| matches!(row.kind(), MigrationTxKind::Transfer { crossing: 0 }))
+            .expect("the plan has a first crossing");
+        assert_eq!(funded_crossing.depends_on(), &[t2]);
+    }
+
+    /// A `Prior` naming an output that mints NOTHING — a change output, which stays in the source
+    /// pool — resolves to no note at all.
+    ///
+    /// `PreparationPlan::is_valid` accepts the coordinate this fixture uses: it checks that the
+    /// named output carries the claimed value — which this change output deliberately does — and
+    /// not what that output is FOR. The plan is nonetheless unbuildable, and the distinction
+    /// matters because a value search would happily serve some OTHER note of that value and build
+    /// a migration the plan never described. The absence is recorded, and `commit_preparation`
+    /// refuses the plan (`PlannedRun::into_buildable`).
+    #[test]
+    fn a_feeder_naming_a_change_output_resolves_to_nothing() {
+        // Layer 0's second transaction, SECOND output: its change, which never enters the minted
+        // sequence — while a note of exactly that value is minted by both layer-0 transactions.
+        let plan = equal_valued_feeders_plan((0, 1, 1), true);
+        let run = plan.planned_run();
+
+        assert_eq!(
+            run.prep_feeders[2],
+            alloc::vec![None],
+            "a change output mints nothing, so the coordinate names nothing to spend",
+        );
     }
 
     /// The in-crate mock store answers the same three questions every store is held to: an empty

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -12,9 +12,13 @@
 //! fees (dropping the smallest denominations when the fees do not fit the balance), producing a
 //! [`MigrationPlan`] preview for the user to consent to (ZIP 318 requires consent before any funds leave
 //! the pool). After consent, [`commit_preparation`] builds and pre-signs EVERY transaction in one
-//! pass, reading the account's note plaintexts and signing through the backend traits, and
-//! persisting each transaction through the store traits. The concrete durable store, proving, and
-//! reconciliation-on-launch are grown by a later slice.
+//! pass, reading the account's note plaintexts through the backend traits, signing with the spend
+//! authority the CALLER passes to it, and persisting each transaction through the store traits.
+//! Spend authority is an argument to the two operations that sign — this one and
+//! [`rebuild_expired_transfer`] — and to nothing else, so a backend is never asked to hold it: an
+//! account whose key is on a hardware wallet uses [`build_preparation_unsigned`] and signs off
+//! device. The concrete durable store, proving, and reconciliation-on-launch are grown by a later
+//! slice.
 //!
 //! # The committed migration is stored as its transactions' PCZTs
 //!
@@ -1723,8 +1727,14 @@ pub trait MigrationCrypto {
     /// The backend's error type (shared with its [`MigrationBackend`] impl).
     type Error;
 
-    /// The account's Orchard full viewing key.
-    fn orchard_fvk(&self) -> Result<orchard::keys::FullViewingKey, Self::Error>;
+    /// The account's Orchard full viewing key, or `None` if the account has none.
+    ///
+    /// Infallible, because a backend is HANDED this key (or the unified key holding it) rather than
+    /// going to look for one: producing it does no work that can fail. `None` is the account whose
+    /// unified key carries no Orchard component — nothing this crate does can serve such an
+    /// account, and each entry point that needs the key reports that in its own error WHERE IT
+    /// NEEDS IT, rather than making every holder of a key prove up front that it has one.
+    fn orchard_fvk(&self) -> Option<&orchard::keys::FullViewingKey>;
 
     /// The ZIP 32 account the migration's notes belong to, or `None` if the account has no known
     /// derivation (an imported viewing key, say).
@@ -1739,9 +1749,6 @@ pub trait MigrationCrypto {
     /// The plaintext of the spendable wallet note at `index` (into
     /// `spendable_orchard_note_values`).
     fn resolve_wallet_note(&self, index: usize) -> Result<orchard::note::Note, Self::Error>;
-
-    /// Add the account's Orchard spend-authorization signatures to a finalized, unproven PCZT.
-    fn sign(&self, pczt: pczt::Pczt) -> Result<pczt::Pczt, Self::Error>;
 }
 
 /// A prover's typed failure: the one condition the engine handles — an input not among the
@@ -1856,13 +1863,16 @@ impl ProvedTransaction {
 /// The proving seam for a migration transfer: install a transfer's deferred anchors and witnesses
 /// (ZIP 374) against the boundary its schedule drew, then prove it.
 ///
-/// This is deliberately SEPARATE from [`MigrationCrypto`]. Signing needs only the account's spend
-/// authority and is a cheap, read-only (`&self`) operation; proving needs MUTABLE access to the
-/// wallet's Orchard commitment tree at a historical checkpoint (resolving a witness caches into the
-/// tree) plus the Orchard and Ironwood proving keys, a heavier capability with a different lifetime.
-/// Keeping proving in its own trait lets a wallet expose signing without dragging commitment-tree
-/// access and proving parameters into the same type, and lets a consumer supply a prover
-/// independently of the signer.
+/// Proving is a CAPABILITY a consumer supplies, which is why it is a trait at all, and why it is
+/// separate from both of the other two. Signing takes nothing but the account's spend authority,
+/// which is why it is not a trait but an argument to the calls that sign; reading the account's
+/// notes and keys is [`MigrationCrypto`], a cheap read-only (`&self`) borrow of a wallet. Proving
+/// is neither: it needs MUTABLE access to the wallet's Orchard commitment tree at a historical
+/// checkpoint (resolving a witness caches into the tree) plus the Orchard and Ironwood proving
+/// keys — a heavier capability, with a different lifetime, that a consumer may want to place
+/// somewhere else entirely (another process, or a machine that holds the parameters). Keeping it in
+/// its own trait lets a wallet be a migration backend without dragging commitment-tree access and
+/// proving parameters into the same type.
 #[cfg(feature = "orchard")]
 pub trait MigrationProver {
     /// The prover's error type.
@@ -1973,9 +1983,30 @@ pub trait MigrationProver {
 #[cfg(feature = "orchard")]
 #[derive(Debug)]
 pub enum CommitError<E> {
-    /// A wallet backend operation (witness, key, signing, or storage) failed.
+    /// A wallet backend operation (reading the account's key, its notes, or its storage) failed.
+    /// NOT signing: the spend authority is the caller's argument, not the backend's, so a failed
+    /// signature is a [`Build`](Self::Build).
     Backend(E),
-    /// Building a migration transaction failed. Carries the structured builder error.
+    /// The backend reports no Orchard full viewing key for the account
+    /// ([`MigrationCrypto::orchard_fvk`]), so there is nothing to build a migration against: every
+    /// transaction of a run spends and creates Orchard notes.
+    NoOrchardViewingKey,
+    /// The spending key passed to this call is not the account's: the full viewing key it derives
+    /// to is not the one the backend reports ([`MigrationCrypto::orchard_fvk`]).
+    ///
+    /// Refused BEFORE anything is built, because signing cannot catch it. A migration PCZT
+    /// contains spends this account's key is not meant to authorize — the padding dummies the
+    /// builder adds, each with its own throwaway key — so
+    /// [`sign_pczt`](crate::build::sign_pczt) must skip a spend its key does not match rather than
+    /// fail, and it cannot tell that case from EVERY real spend being unauthorizable. A foreign
+    /// key would therefore sign nothing, report success, and leave a run persisted as
+    /// [`Signed`](MigrationTxState::Signed) whose transactions carry no signatures at all — a
+    /// migration that can never be broadcast, discovered only when the first transfer is proved.
+    /// Checking the key against the account's viewing key up front is what makes that
+    /// unreachable.
+    WrongSpendAuthority,
+    /// Building a migration transaction failed, INCLUDING signing it with the authority the caller
+    /// passed. Carries the structured builder error.
     Build(crate::build::BuildError),
     /// A built migration PCZT presents no well-formed set of real spends, so the real-spend
     /// nullifier cache ([`MigrationTransaction::spend_nullifiers`]) cannot be extracted from it.
@@ -2015,6 +2046,12 @@ impl<E: fmt::Display> fmt::Display for CommitError<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             CommitError::Backend(e) => write!(f, "wallet backend error: {e}"),
+            CommitError::NoOrchardViewingKey => {
+                f.write_str("the account has no Orchard full viewing key")
+            }
+            CommitError::WrongSpendAuthority => {
+                f.write_str("the spending key is not the account's")
+            }
             CommitError::Build(e) => write!(f, "building the migration failed: {e}"),
             CommitError::RealSpends(e) => {
                 write!(f, "a built migration transaction has no real spends: {e}")
@@ -2528,7 +2565,9 @@ pub enum RebuildError<E> {
         /// The grid the backend schedules against now.
         configured: crate::scheduling::AnchorBucketInterval,
     },
-    /// Building the fresh transfer PCZT failed.
+    /// Building the fresh transfer PCZT failed, INCLUDING signing it anew with the authority the
+    /// caller passed (an expired transfer's signature hash covers its expiry, so the rebuild must
+    /// re-sign).
     Build(crate::build::BuildError),
     /// The rebuilt transfer PCZT presents no well-formed set of real spends, so the real-spend
     /// nullifier cache ([`MigrationTransaction::spend_nullifiers`]) cannot be refreshed from it.
@@ -2538,8 +2577,17 @@ pub enum RebuildError<E> {
     TxId(crate::pczt_txid::TxIdError),
     /// Serializing the rebuilt PCZT failed.
     Serialize(pczt::EncodingError),
-    /// A wallet backend or signing operation failed.
+    /// A wallet backend operation (reading the account's key or its notes) failed. NOT signing:
+    /// the spend authority is the caller's argument, not the backend's, so a failed signature is a
+    /// [`Build`](Self::Build).
     Backend(E),
+    /// The backend reports no Orchard full viewing key for the account
+    /// ([`MigrationCrypto::orchard_fvk`]), so the replacement transfer cannot be built.
+    NoOrchardViewingKey,
+    /// The spending key passed to this call is not the account's, so the rebuilt transfer would be
+    /// stored as signed while carrying no signature — see [`CommitError::WrongSpendAuthority`] for
+    /// why signing cannot catch this. Refused before the replacement is built.
+    WrongSpendAuthority,
 }
 
 #[cfg(feature = "orchard")]
@@ -2600,6 +2648,12 @@ impl<E: fmt::Display> fmt::Display for RebuildError<E> {
                 write!(f, "serializing the rebuilt transfer failed: {e:?}")
             }
             RebuildError::Backend(e) => write!(f, "wallet backend error: {e}"),
+            RebuildError::NoOrchardViewingKey => {
+                f.write_str("the account has no Orchard full viewing key")
+            }
+            RebuildError::WrongSpendAuthority => {
+                f.write_str("the spending key is not the account's")
+            }
         }
     }
 }
@@ -2625,12 +2679,13 @@ impl<E: core::error::Error> core::error::Error for RebuildError<E> {}
 /// replaces the stored PCZT. Anchors and witnesses stay DEFERRED (ZIP 374): the fresh anchor is
 /// installed at proving time, exactly as for an originally committed transfer.
 ///
-/// Signing anew is what distinguishes this step from proving and broadcasting: it needs the
-/// account's SPEND AUTHORITY, not just the viewing key and the network. This entry point signs
-/// in-process via [`MigrationCrypto::sign`], for a wallet that holds the spend authority; a
+/// Signing anew is what distinguishes this step from the other steps of driving a migration: of
+/// proving, broadcasting and advancing, none needs the account's SPEND AUTHORITY, and this one
+/// does — which is why `sk` is a parameter here and of no other drive step. (The other place it
+/// is taken at all is [`commit_preparation`], which signs the whole run once, up front.) A
 /// migration signed by an EXTERNAL (hardware or offline) signer uses
-/// [`rebuild_expired_transfer_unsigned`] instead, which leaves the rebuilt transfer awaiting the
-/// device's signature.
+/// [`rebuild_expired_transfer_unsigned`] instead, which takes no authority and leaves the rebuilt
+/// transfer awaiting the device's signature.
 ///
 /// The funding note is recovered by IDENTITY, not by value: the expired PCZT's one real spend
 /// reveals the note's nullifier, which is matched among the wallet's spendable Orchard notes. The
@@ -2649,6 +2704,7 @@ impl<E: core::error::Error> core::error::Error for RebuildError<E> {}
 pub fn rebuild_expired_transfer<P, B, R>(
     params: &P,
     backend: &B,
+    sk: &orchard::keys::SpendingKey,
     state: &mut MigrationState,
     id: MigrationTransferId,
     rng: &mut R,
@@ -2658,7 +2714,8 @@ where
     B: MigrationBackend + MigrationCrypto<Error = <B as MigrationBackend>::Error>,
     R: RngCore + rand_core::CryptoRng,
 {
-    rebuild_expired_transfer_inner(params, backend, state, id, rng, Signing::InProcess).map(|_| ())
+    rebuild_expired_transfer_inner(params, backend, state, id, rng, Signing::InProcess(sk))
+        .map(|_| ())
 }
 
 /// Rebuild an EXPIRED migration transfer for an EXTERNAL signer: construct the same entirely new
@@ -2669,8 +2726,8 @@ where
 ///
 /// An expired transaction must be signed ANEW — its signature hash covers the expiry height — and
 /// for an externally signed migration the spend authority is on the device, not in-process: the
-/// rebuild therefore requires a new signing session, unlike proving and broadcasting.
-/// [`MigrationCrypto::sign`] is never called. After the device signs, call
+/// rebuild therefore requires a new signing session, unlike proving and broadcasting. Nothing
+/// here takes a spend authority, so nothing here can sign. After the device signs, call
 /// [`MigrationState::apply_signature`] with the returned PCZT (matched by
 /// [`UnsignedMigrationTx::id`]) to move the transfer to [`Signed`](MigrationTxState::Signed), and
 /// persist with `replace_migration`.
@@ -2701,7 +2758,7 @@ fn rebuild_expired_transfer_inner<P, B, R>(
     state: &mut MigrationState,
     id: MigrationTransferId,
     rng: &mut R,
-    signing: Signing,
+    signing: Signing<'_>,
 ) -> Result<Option<UnsignedMigrationTx>, RebuildError<<B as MigrationBackend>::Error>>
 where
     P: zcash_protocol::consensus::Parameters,
@@ -2814,7 +2871,17 @@ where
     // The exact note must still be among the wallet's spendable notes; if it is gone (spent
     // outside the migration), the remaining balance must be re-planned rather than this part
     // rebuilt, so a different note of coincidentally equal value is deliberately NOT substituted.
-    let fvk = backend.orchard_fvk().map_err(RebuildError::Backend)?;
+    let fvk = backend
+        .orchard_fvk()
+        .cloned()
+        .ok_or(RebuildError::NoOrchardViewingKey)?;
+    // Before the replacement is built or signed: the key that will sign must be the account's own
+    // (see `RebuildError::WrongSpendAuthority`).
+    if let Signing::InProcess(sk) = signing
+        && orchard::keys::FullViewingKey::from(sk) != fvk
+    {
+        return Err(RebuildError::WrongSpendAuthority);
+    }
     let account_derivation = backend
         .account_derivation()
         .map_err(RebuildError::Backend)?;
@@ -2875,8 +2942,10 @@ where
     // not affect it — see `crate::pczt_txid`).
     let txid = crate::pczt_txid::pczt_txid(&pczt).map_err(RebuildError::TxId)?;
     let (bytes, new_state, unsigned) = match signing {
-        Signing::InProcess => {
-            let signed = backend.sign(pczt).map_err(RebuildError::Backend)?;
+        Signing::InProcess(sk) => {
+            let signed =
+                crate::build::sign_pczt(pczt, &orchard::keys::SpendAuthorizingKey::from(sk))
+                    .map_err(RebuildError::Build)?;
             let bytes = signed.serialize().map_err(RebuildError::Serialize)?;
             (bytes, MigrationTxState::Signed, None)
         }
@@ -2909,13 +2978,22 @@ where
     Ok(unsigned)
 }
 
-/// How a freshly built migration PCZT is finished by the commit functions: signed in-process with the
-/// wallet's spend authority, or left unsigned for an external (hardware or offline) signer.
+/// How a freshly built migration PCZT is finished by the commit functions: signed in-process with
+/// the spend authority the caller PASSED IN, or left unsigned for an external (hardware or
+/// offline) signer.
+///
+/// The authority rides on the in-process variant rather than being held by the backend, which is
+/// what makes "sign in process, with no key" unrepresentable: the two arms of this enum are
+/// exactly the two things a caller can supply, and only one of them can sign.
+///
+/// It is the SPENDING key, not the spend-authorizing key derived from it, because the spending key
+/// is what the account's viewing key can be checked against — see
+/// [`CommitError::WrongSpendAuthority`]. The authorizing key is derived where the signing happens.
 #[cfg(feature = "orchard")]
 #[derive(Clone, Copy)]
-enum Signing {
-    /// Sign in-process via [`MigrationCrypto::sign`].
-    InProcess,
+enum Signing<'a> {
+    /// Sign each built PCZT here, with the spend authority of this Orchard spending key.
+    InProcess(&'a orchard::keys::SpendingKey),
     /// Leave the PCZT unsigned for an external signer; the caller receives it to sign out of band.
     External,
 }
@@ -3028,27 +3106,29 @@ impl MigrationPlan {
     }
 }
 
-/// Serialize a freshly built PCZT for storage. For [`Signing::InProcess`], sign it with the backend and
-/// return the signed bytes as [`Signed`](MigrationTxState::Signed); for [`Signing::External`], return the
-/// unsigned bytes as [`AwaitingSignature`](MigrationTxState::AwaitingSignature) (the caller also routes a
-/// copy of those bytes to the external signer).
+/// Serialize a freshly built PCZT for storage. For [`Signing::InProcess`], sign it with the
+/// authority that variant carries and return the signed bytes as
+/// [`Signed`](MigrationTxState::Signed); for [`Signing::External`], return the unsigned bytes as
+/// [`AwaitingSignature`](MigrationTxState::AwaitingSignature) (the caller also routes a copy of
+/// those bytes to the external signer).
+///
+/// Takes no backend: signing an already-built PCZT needs nothing from the wallet but the key, and
+/// the key arrives with the request.
 #[cfg(feature = "orchard")]
-fn finish_built_pczt<B>(
-    backend: &mut B,
+fn finish_built_pczt<E>(
     pczt: ::pczt::Pczt,
-    signing: Signing,
-) -> Result<(Vec<u8>, TxId, MigrationTxState), CommitError<<B as MigrationBackend>::Error>>
-where
-    B: MigrationBackend + MigrationCrypto<Error = <B as MigrationBackend>::Error>,
-{
+    signing: Signing<'_>,
+) -> Result<(Vec<u8>, TxId, MigrationTxState), CommitError<E>> {
     // Derived BEFORE signing, which is the only order that makes sense: signing needs the txid to
     // build its signature hash, so the id exists ahead of either arm below and neither can change
     // it. A migration built for an external signer is therefore as identifiable as one signed in
     // process, and stays so once the returned signature is applied.
     let txid = crate::pczt_txid::pczt_txid(&pczt).map_err(CommitError::TxId)?;
     match signing {
-        Signing::InProcess => {
-            let signed = backend.sign(pczt).map_err(CommitError::Backend)?;
+        Signing::InProcess(sk) => {
+            let signed =
+                crate::build::sign_pczt(pczt, &orchard::keys::SpendAuthorizingKey::from(sk))
+                    .map_err(CommitError::Build)?;
             let bytes = signed.serialize().map_err(CommitError::Serialize)?;
             Ok((bytes, txid, MigrationTxState::Signed))
         }
@@ -3094,11 +3174,25 @@ struct MintedNote {
 /// `rng` a cryptographically secure RNG, and `replan_threshold` the policy stamped on the committed
 /// migration (see [`MigrationState::replan_threshold`]) — pass [`ReplanThreshold::DEFAULT`] absent
 /// a specific policy.
+///
+/// `sk` is the account's Orchard spending key, and every transaction of the run is signed with its
+/// spend authority before this returns. It is an argument rather than something `backend` holds so
+/// that a wallet need not keep the key reachable in order to plan, build or store a migration: the
+/// key is live for this call. A caller holding the account's `UnifiedSpendingKey` passes
+/// `usk.orchard()`; a caller that has no key (a watch-only account, or one whose key is on a
+/// device) uses [`build_preparation_unsigned`], which takes none and hands the unsigned
+/// transactions out to be signed elsewhere.
+///
+/// It is the SPENDING key rather than the spend-authorizing key derived from it so that this call
+/// can check it is the ACCOUNT's: the full viewing key it derives to is compared against the one
+/// `backend` reports, and a mismatch is [`CommitError::WrongSpendAuthority`], refused before
+/// anything is built. Nothing here retains either key.
 #[cfg(feature = "orchard")]
 pub fn commit_preparation<P, B, R>(
     params: &P,
     target_height: BlockHeight,
     backend: &mut B,
+    sk: &orchard::keys::SpendingKey,
     plan: &MigrationPlan,
     rng: &mut R,
     replan_threshold: ReplanThreshold,
@@ -3117,7 +3211,7 @@ where
         backend,
         plan,
         rng,
-        Signing::InProcess,
+        Signing::InProcess(sk),
         replan_threshold,
     )
     .map(|output| output.state)
@@ -3178,7 +3272,7 @@ fn commit_preparation_inner<P, B, R>(
     backend: &mut B,
     plan: &MigrationPlan,
     rng: &mut R,
-    signing: Signing,
+    signing: Signing<'_>,
     replan_threshold: ReplanThreshold,
 ) -> Result<CommitOutput, CommitError<<B as MigrationBackend>::Error>>
 where
@@ -3210,12 +3304,15 @@ where
 ///
 /// `replan_threshold` is the policy stamped on the committed migration (see
 /// [`MigrationState::replan_threshold`]) — pass [`ReplanThreshold::DEFAULT`] absent a specific
-/// policy; the other parameters are as [`commit_preparation`]'s.
+/// policy; the other parameters are as [`commit_preparation`]'s, including `sk`, the account's
+/// Orchard spending key, with whose authority every transaction of the run is signed before this
+/// returns, and which is checked against the account's viewing key first.
 #[cfg(all(feature = "orchard", any(test, feature = "test-dependencies")))]
 pub fn commit_preparation_with_funding<P, B, R>(
     params: &P,
     target_height: BlockHeight,
     backend: &mut B,
+    sk: &orchard::keys::SpendingKey,
     plan: &MigrationPlan,
     rng: &mut R,
     replan_threshold: ReplanThreshold,
@@ -3234,7 +3331,7 @@ where
         backend,
         plan,
         rng,
-        Signing::InProcess,
+        Signing::InProcess(sk),
         replan_threshold,
     )
     .map(|output| (output.state, output.transfer_funding))
@@ -3258,7 +3355,7 @@ struct Committer<'a, P, B, R> {
     target_height: BlockHeight,
     backend: &'a mut B,
     rng: &'a mut R,
-    signing: Signing,
+    signing: Signing<'a>,
     fvk: orchard::keys::FullViewingKey,
     /// The ZIP 32 account every built transaction's spends are stamped with, so an external Signer
     /// can identify them. Resolved once in [`Committer::start`], alongside `fvk`.
@@ -3293,7 +3390,7 @@ where
         target_height: BlockHeight,
         backend: &'a mut B,
         rng: &'a mut R,
-        signing: Signing,
+        signing: Signing<'a>,
     ) -> Result<Self, CommitError<<B as MigrationBackend>::Error>> {
         // A committed migration is resumed from the store (or cancelled), never rebuilt over (see
         // [`MigrationState::is_terminal`]): checked FIRST, before any signing work, so a crashed or
@@ -3306,7 +3403,17 @@ where
             return Err(CommitError::MigrationInProgress);
         }
 
-        let fvk = backend.orchard_fvk().map_err(CommitError::Backend)?;
+        let fvk = backend
+            .orchard_fvk()
+            .cloned()
+            .ok_or(CommitError::NoOrchardViewingKey)?;
+        // Before ANYTHING is built or signed: the key that will sign must be the account's own.
+        // See `CommitError::WrongSpendAuthority` for why this cannot be left to signing time.
+        if let Signing::InProcess(sk) = signing
+            && orchard::keys::FullViewingKey::from(sk) != fvk
+        {
+            return Err(CommitError::WrongSpendAuthority);
+        }
         let account_derivation = backend.account_derivation().map_err(CommitError::Backend)?;
 
         Ok(Self {
@@ -3459,7 +3566,7 @@ where
                     .into_iter()
                     .map(|(_, nf)| nf.to_bytes())
                     .collect();
-                let (bytes, txid, tx_state) = finish_built_pczt(self.backend, pczt, self.signing)?;
+                let (bytes, txid, tx_state) = finish_built_pczt(pczt, self.signing)?;
                 if matches!(self.signing, Signing::External) {
                     self.unsigned.push(UnsignedMigrationTx {
                         id,
@@ -3633,7 +3740,7 @@ where
                 .into_iter()
                 .map(|(_, nf)| nf.to_bytes())
                 .collect();
-            let (bytes, txid, tx_state) = finish_built_pczt(self.backend, pczt, self.signing)?;
+            let (bytes, txid, tx_state) = finish_built_pczt(pczt, self.signing)?;
             if matches!(self.signing, Signing::External) {
                 self.unsigned.push(UnsignedMigrationTx {
                     id,
@@ -4585,8 +4692,8 @@ mod commit_tests {
     impl MigrationCrypto for CommitMock {
         type Error = core::convert::Infallible;
 
-        fn orchard_fvk(&self) -> Result<FullViewingKey, Self::Error> {
-            Ok(self.fvk.clone())
+        fn orchard_fvk(&self) -> Option<&FullViewingKey> {
+            Some(&self.fvk)
         }
 
         fn account_derivation(&self) -> Result<Option<AccountDerivation>, Self::Error> {
@@ -4595,10 +4702,6 @@ mod commit_tests {
 
         fn resolve_wallet_note(&self, index: usize) -> Result<orchard::note::Note, Self::Error> {
             Ok(self.wallet_notes[index])
-        }
-
-        fn sign(&self, pczt: pczt::Pczt) -> Result<pczt::Pczt, Self::Error> {
-            Ok(sign_pczt(pczt, &self.ask).expect("signs the migration PCZT"))
         }
     }
 
@@ -4678,6 +4781,13 @@ mod commit_tests {
         }
     }
 
+    /// The account's Orchard SPENDING key, as a caller now hands it to the entry points that sign
+    /// (`commit_preparation`, `rebuild_expired_transfer`). Derived from the same `seed` the mock
+    /// wallet's key is, so it is that account's own — which those entry points check.
+    fn sk(seed: u64) -> orchard::keys::SpendingKey {
+        spending_key(seed)
+    }
+
     /// A planned single-note migration and the mock wallet that holds the note.
     fn single_note_setup(seed: u64, balance: u64) -> (CommitMock, MigrationPlan) {
         let backend = CommitMock::new(seed, &[balance]);
@@ -4707,6 +4817,7 @@ mod commit_tests {
             &params,
             BlockHeight::from_u32(TARGET_HEIGHT),
             &mut backend,
+            &sk(seed),
             &plan,
             &mut rng,
             ReplanThreshold::DEFAULT,
@@ -4917,6 +5028,7 @@ mod commit_tests {
             &params,
             BlockHeight::from_u32(TARGET_HEIGHT),
             &mut backend,
+            &sk(seed),
             &plan,
             &mut rng,
             ReplanThreshold::DEFAULT,
@@ -4943,7 +5055,7 @@ mod commit_tests {
 
         // Rebuild it.
         let mut rng = ChaCha8Rng::seed_from_u64(seed + 2);
-        rebuild_expired_transfer(&params, &backend, &mut state, id, &mut rng)
+        rebuild_expired_transfer(&params, &backend, &sk(seed), &mut state, id, &mut rng)
             .expect("rebuilds the expired transfer");
 
         let new = &state.transactions[0];
@@ -5015,6 +5127,7 @@ mod commit_tests {
             &params,
             BlockHeight::from_u32(TARGET_HEIGHT),
             &mut backend,
+            &sk(seed),
             &plan,
             &mut rng,
             ReplanThreshold::DEFAULT,
@@ -5063,7 +5176,7 @@ mod commit_tests {
 
         // The rebuild recovers the funding note from the persisted nullifier cache.
         let mut rng = ChaCha8Rng::seed_from_u64(seed + 2);
-        rebuild_expired_transfer(&params, &backend, &mut state, id, &mut rng)
+        rebuild_expired_transfer(&params, &backend, &sk(seed), &mut state, id, &mut rng)
             .expect("rebuilds the expired proved transfer");
         let new = &state.transactions[0];
         assert_eq!(new.state, MigrationTxState::Signed);
@@ -5112,6 +5225,7 @@ mod commit_tests {
             &params,
             BlockHeight::from_u32(TARGET_HEIGHT),
             &mut backend,
+            &sk(seed),
             &plan,
             &mut rng,
             ReplanThreshold::DEFAULT,
@@ -5136,8 +5250,15 @@ mod commit_tests {
         backend.tip = latest_expiry + 1;
 
         let mut rng = ChaCha8Rng::seed_from_u64(seed + 2);
-        rebuild_expired_transfer(&params, &backend, &mut state, victim.id, &mut rng)
-            .expect("rebuilds the expired transfer");
+        rebuild_expired_transfer(
+            &params,
+            &backend,
+            &sk(seed),
+            &mut state,
+            victim.id,
+            &mut rng,
+        )
+        .expect("rebuilds the expired transfer");
 
         let rebuilt = state
             .transactions
@@ -5169,6 +5290,7 @@ mod commit_tests {
             &params,
             BlockHeight::from_u32(TARGET_HEIGHT),
             &mut backend,
+            &sk(seed),
             &plan,
             &mut rng,
             ReplanThreshold::DEFAULT,
@@ -5184,7 +5306,7 @@ mod commit_tests {
 
         let mut rng = ChaCha8Rng::seed_from_u64(seed + 2);
         assert!(matches!(
-            rebuild_expired_transfer(&params, &backend, &mut state, tx.id, &mut rng),
+            rebuild_expired_transfer(&params, &backend, &sk(seed), &mut state, tx.id, &mut rng),
             Err(RebuildError::FundingNoteUnavailable(v))
                 if v == Zatoshis::from_u64(funding_note).expect("test value is valid")
         ));
@@ -5297,6 +5419,7 @@ mod commit_tests {
             &params,
             BlockHeight::from_u32(TARGET_HEIGHT),
             &mut backend,
+            &sk(seed),
             &plan,
             &mut rng,
             ReplanThreshold::DEFAULT,
@@ -5307,13 +5430,13 @@ mod commit_tests {
         // Not expired yet (the tip is far below the expiry): rejected.
         let mut rng = ChaCha8Rng::seed_from_u64(seed + 2);
         assert!(matches!(
-            rebuild_expired_transfer(&params, &backend, &mut state, id, &mut rng),
+            rebuild_expired_transfer(&params, &backend, &sk(seed), &mut state, id, &mut rng),
             Err(RebuildError::NotExpired(rejected)) if rejected == id
         ));
         // An unknown id: rejected.
         let unknown = MigrationTransferId::new(9999);
         assert!(matches!(
-            rebuild_expired_transfer(&params, &backend, &mut state, unknown, &mut rng),
+            rebuild_expired_transfer(&params, &backend, &sk(seed), &mut state, unknown, &mut rng),
             Err(RebuildError::UnknownTransaction(rejected)) if rejected == unknown
         ));
 
@@ -5323,7 +5446,7 @@ mod commit_tests {
         state.transactions[0].kind = MigrationTxKind::Preparation { layer: 0, index: 0 };
         backend.tip = state.transactions[0].expiry_height + 1;
         assert!(matches!(
-            rebuild_expired_transfer(&params, &backend, &mut state, id, &mut rng),
+            rebuild_expired_transfer(&params, &backend, &sk(seed), &mut state, id, &mut rng),
             Err(RebuildError::NotATransfer(rejected)) if rejected == id
         ));
     }
@@ -5348,6 +5471,7 @@ mod commit_tests {
             &params,
             BlockHeight::from_u32(TARGET_HEIGHT),
             &mut backend,
+            &sk(seed),
             &plan,
             &mut rng,
             ReplanThreshold::DEFAULT,
@@ -5361,7 +5485,7 @@ mod commit_tests {
         state.transactions[0].unsatisfiable = Some((mark, UnsatisfiableKind::InputsSpent));
         let mut rng = ChaCha8Rng::seed_from_u64(seed + 2);
         assert!(matches!(
-            rebuild_expired_transfer(&params, &backend, &mut state, id, &mut rng),
+            rebuild_expired_transfer(&params, &backend, &sk(seed), &mut state, id, &mut rng),
             Err(RebuildError::Unsatisfiable(rejected)) if rejected == id
         ));
 
@@ -5378,7 +5502,7 @@ mod commit_tests {
         );
         let before = state.transactions[0].clone();
         assert!(matches!(
-            rebuild_expired_transfer(&params, &backend, &mut state, id, &mut rng),
+            rebuild_expired_transfer(&params, &backend, &sk(seed), &mut state, id, &mut rng),
             Err(RebuildError::Unsatisfiable(rejected)) if rejected == id
         ));
         assert_eq!(
@@ -5409,7 +5533,7 @@ mod commit_tests {
             None,
         ));
         assert!(matches!(
-            rebuild_expired_transfer(&params, &backend, &mut state, id, &mut rng),
+            rebuild_expired_transfer(&params, &backend, &sk(seed), &mut state, id, &mut rng),
             Err(RebuildError::Unsatisfiable(rejected)) if rejected == id
         ));
     }
@@ -5526,6 +5650,7 @@ mod commit_tests {
             &params,
             BlockHeight::from_u32(TARGET_HEIGHT),
             &mut backend,
+            &sk,
             &plan,
             &mut rng,
             ReplanThreshold::DEFAULT,
@@ -5648,6 +5773,7 @@ mod commit_tests {
             &params,
             BlockHeight::from_u32(TARGET_HEIGHT),
             &mut backend,
+            &sk(seed),
             &plan,
             &mut rng,
             ReplanThreshold::DEFAULT,
@@ -5722,6 +5848,7 @@ mod commit_tests {
             &params,
             BlockHeight::from_u32(TARGET_HEIGHT),
             &mut backend,
+            &sk(seed),
             &plan,
             &mut rng2,
             ReplanThreshold::DEFAULT,
@@ -5965,6 +6092,122 @@ mod commit_tests {
         }
     }
 
+    /// A spending key that is not the account's is refused BEFORE anything is built, by both entry
+    /// points that sign — and the store is left untouched.
+    ///
+    /// This is the one failure mode signing cannot report. A migration PCZT carries padding dummy
+    /// spends the account's key is not meant to authorize, so `build::sign_pczt` skips a spend
+    /// whose authorizing key does not match instead of failing; with a foreign key EVERY real
+    /// spend is skipped, the signer returns `Ok`, and the commit records
+    /// `MigrationTxState::Signed` for transactions carrying no signature at all. Such a run is
+    /// unbroadcastable, and nothing would notice until its first transfer was proved and
+    /// submitted. The check that closes it compares the key's full viewing key against the
+    /// account's, which is why these calls take the SPENDING key rather than the authorizing key
+    /// derived from it.
+    ///
+    /// The happy path is asserted in the same test, against the same fixtures, so what the check
+    /// costs a legitimate caller is visible next to what it refuses.
+    #[test]
+    fn a_foreign_spending_key_is_refused_before_anything_is_built() {
+        let seed = 41u64;
+        let params = regtest_network(true);
+        // Another account entirely: same shape, different key.
+        let foreign = sk(seed + 1_000);
+        assert_ne!(
+            orchard::keys::FullViewingKey::from(&foreign),
+            orchard::keys::FullViewingKey::from(&sk(seed)),
+            "the fixture's two accounts really are different",
+        );
+
+        // --- commit_preparation
+        let (mut backend, plan) = single_note_setup(seed, 78 * COIN);
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
+        let refused = commit_preparation(
+            &params,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            &mut backend,
+            &foreign,
+            &plan,
+            &mut rng,
+            ReplanThreshold::DEFAULT,
+        );
+        assert!(
+            matches!(refused, Err(CommitError::WrongSpendAuthority)),
+            "a foreign key is refused, not silently used: {refused:?}",
+        );
+        assert!(
+            backend
+                .get_migration()
+                .expect("the mock store answers")
+                .is_none(),
+            "nothing was persisted: the refusal precedes the first build",
+        );
+
+        // The account's own key still commits, and commits SIGNED.
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
+        let state = commit_preparation(
+            &params,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            &mut backend,
+            &sk(seed),
+            &plan,
+            &mut rng,
+            ReplanThreshold::DEFAULT,
+        )
+        .expect("the account's own key commits");
+        assert!(
+            state
+                .transactions()
+                .iter()
+                .all(|tx| tx.state() == MigrationTxState::Signed),
+            "and every transaction is signed",
+        );
+
+        // --- rebuild_expired_transfer, over a committed run whose transfer has expired.
+        let seed = 43u64;
+        let buffer = u64::from(commit_test_fees().1);
+        let mut backend = CommitMock::new(seed, &[COIN + buffer, u64::from(prep_fee())]);
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let plan = plan_migration(&params, &backend, &mut rng).expect("a fundable balance plans");
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
+        let mut state = commit_preparation(
+            &params,
+            BlockHeight::from_u32(TARGET_HEIGHT),
+            &mut backend,
+            &sk(seed),
+            &plan,
+            &mut rng,
+            ReplanThreshold::DEFAULT,
+        )
+        .expect("commits the migration");
+        let id = state.transactions[0].id;
+        let before = state.transactions[0].clone();
+        backend.tip = before.expiry_height + 1;
+
+        let foreign = sk(seed + 1_000);
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 2);
+        let refused =
+            rebuild_expired_transfer(&params, &backend, &foreign, &mut state, id, &mut rng);
+        assert!(
+            matches!(refused, Err(RebuildError::WrongSpendAuthority)),
+            "a foreign key is refused here too: {refused:?}",
+        );
+        assert_eq!(
+            state.transactions[0], before,
+            "and the stored transaction is untouched — not rebuilt, not re-signed, not rescheduled",
+        );
+
+        // The account's own key rebuilds it.
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 2);
+        rebuild_expired_transfer(&params, &backend, &sk(seed), &mut state, id, &mut rng)
+            .expect("the account's own key rebuilds");
+        assert_eq!(state.transactions[0].state, MigrationTxState::Signed);
+        assert_ne!(
+            state.transactions[0].pczt, before.pczt,
+            "the rebuild really did replace the artifact",
+        );
+    }
+
     /// A committed migration must be resumed, never rebuilt over: a second commit while the
     /// stored migration is non-terminal is refused (its pre-signed transactions may already be
     /// broadcast, and a rebuilt migration would double-spend the same notes); a terminal
@@ -5980,6 +6223,7 @@ mod commit_tests {
             &params,
             BlockHeight::from_u32(TARGET_HEIGHT),
             &mut backend,
+            &sk(seed),
             &plan,
             &mut rng,
             ReplanThreshold::DEFAULT,
@@ -5992,6 +6236,7 @@ mod commit_tests {
                 &params,
                 BlockHeight::from_u32(TARGET_HEIGHT),
                 &mut backend,
+                &sk(seed),
                 &plan,
                 &mut rng,
                 ReplanThreshold::DEFAULT,
@@ -6008,6 +6253,7 @@ mod commit_tests {
             &params,
             BlockHeight::from_u32(TARGET_HEIGHT),
             &mut backend,
+            &sk(seed),
             &plan,
             &mut rng,
             ReplanThreshold::DEFAULT,
@@ -6032,6 +6278,7 @@ mod commit_tests {
                 &regtest_network(true),
                 BlockHeight::from_u32(TARGET_HEIGHT),
                 &mut backend,
+                &sk(seed),
                 &plan,
                 &mut rng,
                 ReplanThreshold::DEFAULT,
@@ -6056,6 +6303,7 @@ mod commit_tests {
             &params,
             BlockHeight::from_u32(TARGET_HEIGHT),
             &mut backend,
+            &sk(seed),
             &plan,
             &mut rng,
             ReplanThreshold::DEFAULT,
@@ -6157,6 +6405,7 @@ mod commit_tests {
             &params,
             BlockHeight::from_u32(TARGET_HEIGHT),
             &mut backend,
+            &sk(seed),
             &plan,
             &mut rng,
             ReplanThreshold::DEFAULT,
@@ -6341,6 +6590,7 @@ mod commit_tests {
             &params,
             BlockHeight::from_u32(TARGET_HEIGHT),
             &mut backend,
+            &sk(seed),
             &plan,
             &mut rng,
             ReplanThreshold::DEFAULT,
@@ -6389,7 +6639,7 @@ mod commit_tests {
         // is invalid rather than this transfer being repairable.
         let mut rng = ChaCha8Rng::seed_from_u64(seed + 2);
         assert!(matches!(
-            rebuild_expired_transfer(&params, &backend, &mut state, transfer_id, &mut rng),
+            rebuild_expired_transfer(&params, &backend, &sk(seed), &mut state, transfer_id, &mut rng),
             Err(RebuildError::AnchorIntervalMismatch {
                 committed: c,
                 configured: g,
@@ -6501,6 +6751,7 @@ mod commit_tests {
             &regtest_network(true),
             BlockHeight::from_u32(TARGET_HEIGHT),
             &mut backend,
+            &sk(seed),
             &plan,
             &mut rng,
             ReplanThreshold::DEFAULT,

--- a/zcash_pool_migration/src/signing_rounds.rs
+++ b/zcash_pool_migration/src/signing_rounds.rs
@@ -26,6 +26,8 @@
 use alloc::vec::Vec;
 use core::num::{NonZeroU32, NonZeroUsize};
 
+use zcash_protocol::consensus::BlockHeight;
+
 use crate::engine::{MigrationTransferId, MigrationTxKind};
 
 /// The Orchard-family actions a padded preparation transaction carries.
@@ -101,22 +103,39 @@ const fn nz(n: u32) -> NonZeroU32 {
 
 /// A transaction a migration plan WILL build, described before it is built: its stable ordinal (the
 /// [`MigrationTransferId`] the build later assigns, since the plan enumerates in commit order), what it
-/// does, and how many Orchard actions the signer processes for it.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// does, how many Orchard actions the signer processes for it, and the two facts that place it in
+/// the run — what must mine before it, and when it is scheduled to broadcast.
+///
+/// Every field is what the COMMIT will stamp on the built transaction, so a consumer can show the
+/// whole run's execution shape (its dependency graph and its timeline) from a plan the user has
+/// not consented to yet, and then find each preview row again by id once the run is committed. See
+/// [`MigrationPlan::planned_transactions`](crate::engine::MigrationPlan::planned_transactions),
+/// which is the only thing that should construct one for a real plan.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PlannedTx {
     id: MigrationTransferId,
     kind: MigrationTxKind,
     actions: u32,
+    depends_on: Vec<MigrationTransferId>,
+    scheduled_height: Option<BlockHeight>,
 }
 
 impl PlannedTx {
-    /// A planned transaction of `kind`, identified by `id`, with its canonical [`action_weight`].
+    /// A planned transaction of `kind`, identified by `id`, waiting on `depends_on` and scheduled
+    /// for `scheduled_height`, with its canonical [`action_weight`].
     #[must_use]
-    pub const fn new(id: MigrationTransferId, kind: MigrationTxKind) -> Self {
+    pub fn new(
+        id: MigrationTransferId,
+        kind: MigrationTxKind,
+        depends_on: Vec<MigrationTransferId>,
+        scheduled_height: Option<BlockHeight>,
+    ) -> Self {
         Self {
             id,
             kind,
             actions: action_weight(kind),
+            depends_on,
+            scheduled_height,
         }
     }
 
@@ -136,6 +155,37 @@ impl PlannedTx {
     #[must_use]
     pub const fn actions(&self) -> u32 {
         self.actions
+    }
+
+    /// The transactions that must MINE before this one may be broadcast, by the id each will carry
+    /// — the value the commit stores as
+    /// [`MigrationTransaction::depends_on`](crate::engine::MigrationTransaction::depends_on).
+    ///
+    /// Empty for a transaction that waits on nothing: a preparation transaction in layer 0, whose
+    /// inputs are the wallet's own notes, or a crossing funded directly by a wallet note. (A plan
+    /// that named no note at all for a crossing would also show it waiting on nothing, but such a
+    /// plan is unconstructible through this crate's API and `commit_preparation` refuses it before
+    /// building anything, so no run is ever previewed from one.)
+    #[must_use]
+    pub fn depends_on(&self) -> &[MigrationTransferId] {
+        &self.depends_on
+    }
+
+    /// The height at which this transaction is scheduled to broadcast — the value the commit
+    /// stores as
+    /// [`MigrationTransaction::scheduled_height`](crate::engine::MigrationTransaction::scheduled_height).
+    ///
+    /// Not a promise of when it WILL broadcast: a dependency that mines late holds a transaction
+    /// past its drawn height, and the engine re-spreads a run that falls too far behind. It is the
+    /// timeline the user consents to.
+    ///
+    /// `None` only for a plan that holds no drawn height for a transaction it contains, which the
+    /// public API cannot produce (a plan's schedules are drawn one height per transaction) and
+    /// which `commit_preparation` refuses to build. The row is still reported, so that no id is
+    /// renumbered by the absence.
+    #[must_use]
+    pub const fn scheduled_height(&self) -> Option<BlockHeight> {
+        self.scheduled_height
     }
 
     /// Whether this is a preparation transaction.
@@ -246,11 +296,11 @@ impl SigningRoundStrategy for MinRounds {
     fn pack(&self, txs: &[PlannedTx], budget: SigningRoundBudget) -> Vec<PlannedSigningRound> {
         let mut preps: Vec<PlannedTx> = txs
             .iter()
-            .copied()
-            .filter(PlannedTx::is_preparation)
+            .filter(|tx| tx.is_preparation())
+            .cloned()
             .collect();
         let mut transfers: Vec<PlannedTx> =
-            txs.iter().copied().filter(PlannedTx::is_transfer).collect();
+            txs.iter().filter(|tx| tx.is_transfer()).cloned().collect();
         let assignment = solve_two_size(preps.len(), transfers.len(), budget);
 
         // Consume preparation and transfer transactions from the front into each round's quota.
@@ -288,13 +338,13 @@ impl SigningRoundStrategy for NextFit {
         let mut rounds: Vec<PlannedSigningRound> = Vec::new();
         let mut current: Vec<PlannedTx> = Vec::new();
         let mut current_actions = 0u32;
-        for &tx in txs {
+        for tx in txs {
             if !current.is_empty() && current_actions.saturating_add(tx.actions()) > cap {
                 rounds.push(PlannedSigningRound::new(core::mem::take(&mut current)));
                 current_actions = 0;
             }
             current_actions = current_actions.saturating_add(tx.actions());
-            current.push(tx);
+            current.push(tx.clone());
         }
         if !current.is_empty() {
             rounds.push(PlannedSigningRound::new(current));

--- a/zcash_pool_migration/src/testing/scenarios.rs
+++ b/zcash_pool_migration/src/testing/scenarios.rs
@@ -7,6 +7,7 @@
 
 use core::fmt::Debug;
 
+use zcash_protocol::consensus::BlockHeight;
 use zcash_protocol::value::COIN;
 
 use crate::engine::{MigrationTransferId, MigrationTxKind};
@@ -14,15 +15,30 @@ use crate::signing_rounds::{PREPARATION_ACTIONS, PlannedTx, SigningRoundBudget, 
 
 use alloc::vec::Vec;
 
+/// The height the synthetic runs [`planned_txs`] builds are scheduled from, an arbitrary
+/// post-activation height: the packing problem is indifferent to WHEN a transaction broadcasts, so
+/// the schedule only has to be well-formed, not drawn.
+const SCENARIO_BASE_HEIGHT: u32 = 2_000_000;
+
 /// Build the canonical planned-transaction list for `n_prep` preparation and `n_transfer` transfer
 /// transactions (preparation first, then transfers), with sequential ids.
+///
+/// The shape is the simplest real one: a single preparation layer (so nothing waits on anything)
+/// funding crossings directly, on a schedule of one transaction per block. That is enough for the
+/// signing-round packing suite, which reads only each transaction's kind and action weight — a
+/// packer that consulted a dependency or a height would be reordering signatures by something
+/// signing does not depend on (ZIP 374 defers anchors and witnesses, so signing-time transactions
+/// are independent).
 pub fn planned_txs(n_prep: usize, n_transfer: usize) -> Vec<PlannedTx> {
     let mut txs = Vec::with_capacity(n_prep + n_transfer);
     let mut id = 0u32;
+    let height = |id: u32| Some(BlockHeight::from_u32(SCENARIO_BASE_HEIGHT + id));
     for index in 0..n_prep {
         txs.push(PlannedTx::new(
             MigrationTransferId::new(id),
             MigrationTxKind::Preparation { layer: 0, index },
+            Vec::new(),
+            height(id),
         ));
         id += 1;
     }
@@ -30,6 +46,8 @@ pub fn planned_txs(n_prep: usize, n_transfer: usize) -> Vec<PlannedTx> {
         txs.push(PlannedTx::new(
             MigrationTransferId::new(id),
             MigrationTxKind::Transfer { crossing },
+            Vec::new(),
+            height(id),
         ));
         id += 1;
     }

--- a/zcash_pool_migration/src/wallet.rs
+++ b/zcash_pool_migration/src/wallet.rs
@@ -1,14 +1,21 @@
 //! A wallet-backed adapter that turns any `zcash_client_backend` wallet into a migration wallet.
 //!
 //! The engine's build and commit path needs an implementation of [`MigrationBackend`] +
-//! [`MigrationCrypto`] (the account's viewing key, its spendable notes' plaintexts, and signing)
-//! and a [`PoolMigrationRead`] / [`PoolMigrationWrite`] store. This module supplies the first two
-//! for free over the traits a `zcash_client_backend` wallet already implements ([`WalletRead`],
-//! [`InputSource`]) plus the account's [`UnifiedSpendingKey`], and delegates the store to a value
-//! the caller supplies (for example `zcash_client_sqlite`'s `pool_migration` store over the same
-//! wallet database). A consuming application (zallet, or any other `zcash_client_backend` wallet)
-//! then
+//! [`MigrationCrypto`] (the account's viewing key, its spendable notes' plaintexts) and a
+//! [`PoolMigrationRead`] / [`PoolMigrationWrite`] store. This module supplies the first two for
+//! free over the traits a `zcash_client_backend` wallet already implements ([`WalletRead`],
+//! [`InputSource`]) plus the account's viewing key, and delegates the store to a value the caller
+//! supplies (for example `zcash_client_sqlite`'s `pool_migration` store over the same wallet
+//! database). A consuming application (zallet, or any other `zcash_client_backend` wallet) then
 //! runs [`commit_preparation`] with no hand-wired cryptography.
+//!
+//! [`WalletMigration`] holds VIEWING authority and nothing more. It is built from an account's
+//! [`UnifiedFullViewingKey`], and there is no way to give it a spending key: the engine takes the
+//! spend authority as an argument to the operations that actually sign
+//! ([`commit_preparation`] and [`rebuild_expired_transfer`]), so the key is live for one call
+//! rather than for the lifetime of an adapter that mostly does not need it. A watch-only account
+//! and one whose key lives on a hardware wallet are therefore ordinary users of this adapter:
+//! they plan and build here and route the signing elsewhere.
 //!
 //! [`WalletMigration`] holds the wallet by a SHARED borrow and touches no note commitment tree:
 //! every migration transaction is built and signed with its anchor and witnesses deferred to
@@ -19,6 +26,7 @@
 //! before broadcast.
 //!
 //! [`commit_preparation`]: crate::engine::commit_preparation
+//! [`rebuild_expired_transfer`]: crate::engine::rebuild_expired_transfer
 
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
@@ -28,7 +36,7 @@ use core::num::NonZeroU32;
 
 use ::orchard::Anchor;
 use ::orchard::circuit::OrchardCircuitVersion;
-use ::orchard::keys::{FullViewingKey, SpendAuthorizingKey};
+use ::orchard::keys::FullViewingKey;
 use ::orchard::note::{Note as OrchardNote, Nullifier};
 use ::orchard::tree::MerklePath;
 use incrementalmerkletree::Position;
@@ -45,12 +53,12 @@ use zcash_client_backend::data_api::{
     },
 };
 use zcash_client_backend::wallet::OutputRef;
-use zcash_keys::keys::UnifiedSpendingKey;
+use zcash_keys::keys::UnifiedFullViewingKey;
 use zcash_primitives::transaction::TxId;
 use zcash_primitives::transaction::builder::cached_orchard_proving_key;
 use zcash_protocol::{PoolType, ShieldedPool, consensus::BlockHeight, value::Zatoshis};
 
-use crate::build::{AccountDerivation, sign_pczt};
+use crate::build::AccountDerivation;
 use crate::engine::{
     MigrationBackend, MigrationCrypto, MigrationLockOwner, MigrationProver, MigrationState,
     MigrationTransaction, MigrationTransferId, MigrationTxState, PoolMigrationRead,
@@ -75,8 +83,6 @@ pub enum Error<WRE, ISE, SE> {
     NoteNotFound(usize),
     /// The wallet has no chain tip (it has never synced), so no note selection target exists.
     ChainTipUnknown,
-    /// Signing the migration PCZT failed.
-    Sign(crate::build::BuildError),
     /// The spendable note at this index has a value that is not a valid [`Zatoshis`] amount
     /// (it exceeds the money-supply cap).
     InvalidNoteValue(usize),
@@ -90,7 +96,6 @@ impl<WRE: fmt::Display, ISE: fmt::Display, SE: fmt::Display> fmt::Display for Er
             Error::Store(e) => write!(f, "migration store error: {e}"),
             Error::NoteNotFound(i) => write!(f, "no spendable note at index {i}"),
             Error::ChainTipUnknown => f.write_str("the wallet has no chain tip"),
-            Error::Sign(e) => write!(f, "signing the migration failed: {e}"),
             Error::InvalidNoteValue(i) => {
                 write!(f, "spendable note {i} has an invalid (out-of-range) value")
             }
@@ -114,18 +119,29 @@ type AdapterError<W, St> =
 /// and its value in zatoshi.
 type SpendableNote = (OrchardNote, Position, u64);
 
-/// A migration wallet built over a `zcash_client_backend` wallet `W`, an account, its
-/// [`UnifiedSpendingKey`], and a migration store `St`.
+/// A migration wallet built over a `zcash_client_backend` wallet `W`, an account, that account's
+/// Orchard VIEWING key, and a migration store `St`.
 ///
 /// The wallet is held by a shared borrow: the migration never touches the note commitment tree
 /// (anchors and witnesses are deferred to proving time), so nothing here needs `&mut W`.
+///
+/// There is no spending key here, and no constructor that takes one. Signing is a parameter of
+/// the engine calls that sign, so this type cannot be the thing that holds an account's spend
+/// authority alive.
 pub struct WalletMigration<'a, W, St>
 where
     W: WalletRead + InputSource,
 {
     wallet: &'a W,
     account: <W as InputSource>::AccountId,
-    usk: UnifiedSpendingKey,
+    /// The account's unified full viewing key, as the caller supplied it.
+    ///
+    /// Stored whole rather than reduced to its Orchard component at construction, so that
+    /// constructing an adapter asks nothing of the key: an account whose unified key has no
+    /// Orchard component is a real account, and the fact that this crate cannot serve it is
+    /// reported by the operation that needs the Orchard key, not by the act of naming the account
+    /// (see [`MigrationCrypto::orchard_fvk`]).
+    ufvk: UnifiedFullViewingKey,
     store: St,
     /// The inter-arrival delays to schedule under, or `None` to derive them from the wallet's own
     /// anchor bucket interval by the ZIP 318 ratios.
@@ -141,7 +157,17 @@ where
     <W as InputSource>::AccountId: Copy,
     St: PoolMigrationRead,
 {
-    /// Wrap a wallet, an account, its spending key, and a store as a migration wallet.
+    /// Wrap a wallet, an account, that account's unified FULL VIEWING key, and a store as a
+    /// migration wallet.
+    ///
+    /// Everything a migration does short of signing — selecting the account's notes, planning the
+    /// denomination split and the schedule, building each transaction's PCZT, reading and writing
+    /// the store, and (through [`WalletMigrationProver`]) proving — is a viewing-key operation, so
+    /// viewing authority is all this adapter ever needs. The spend authority for the two engine
+    /// calls that sign is passed to those calls; a watch-only account and a hardware-wallet
+    /// account, which have none to give, use the unsigned entry points instead
+    /// (`build_preparation_unsigned`, `rebuild_expired_transfer_unsigned`) and route the signing
+    /// to whoever holds the key.
     ///
     /// The migration is scheduled under the wallet's own anchor retention interval — not
     /// configurable here; see [`MigrationBackend::scheduling_params`] — with inter-arrival delays
@@ -149,16 +175,29 @@ where
     /// gets exactly the ZIP 318 delays, and a wallet configured with a shortened grid gets the same
     /// schedule shape compressed by the same factor, rather than a short grid crossed with
     /// ninety-minute delays. Override the delays with [`Self::with_scheduling_delays`].
+    ///
+    /// The viewing key is the CALLER's to choose rather than being read from the account record,
+    /// because a wallet may hold several keys that view one account (an imported UFVK beside a
+    /// derived one) and only the caller knows which the migration's notes belong to. Pass the key
+    /// the account's spendable notes were received with — the same one
+    /// [`WalletMigrationProver::new`] must be given, since a mismatched key computes nullifiers
+    /// that match no note and every spend resolution fails, and the same one whose spend authority
+    /// the signing calls are given.
+    ///
+    /// A key with no Orchard component is accepted here and refused where it is USED: an
+    /// account this crate cannot migrate is still an account, and the engine's build, commit and
+    /// prove paths are already fallible, so they are where "this account has no Orchard key" is
+    /// worth saying. Construction asks nothing of the key at all.
     pub fn new(
         wallet: &'a W,
         account: <W as InputSource>::AccountId,
-        usk: UnifiedSpendingKey,
+        ufvk: UnifiedFullViewingKey,
         store: St,
     ) -> Self {
         Self {
             wallet,
             account,
-            usk,
+            ufvk,
             store,
             scheduling_delays: None,
             spendable: RefCell::new(None),
@@ -283,8 +322,13 @@ where
 {
     type Error = AdapterError<W, St>;
 
-    fn orchard_fvk(&self) -> Result<FullViewingKey, Self::Error> {
-        Ok(FullViewingKey::from(self.usk.orchard()))
+    /// The Orchard component of the key the adapter was constructed with — never re-read from the
+    /// account record, so a migration is built against exactly the key its caller named.
+    ///
+    /// `None` for a unified key that carries no Orchard component: such an account holds no notes
+    /// this crate can migrate, which each engine entry point reports for itself.
+    fn orchard_fvk(&self) -> Option<&FullViewingKey> {
+        self.ufvk.orchard()
     }
 
     /// The account's derivation as the wallet records it, or `None` for an account the wallet
@@ -306,11 +350,6 @@ where
         let notes = self.spendable_orchard()?;
         let &(note, _, _) = notes.get(index).ok_or(Error::NoteNotFound(index))?;
         Ok(note)
-    }
-
-    fn sign(&self, pczt: ::pczt::Pczt) -> Result<::pczt::Pczt, Self::Error> {
-        let ask = SpendAuthorizingKey::from(self.usk.orchard());
-        sign_pczt(pczt, &ask).map_err(Error::Sign)
     }
 }
 
@@ -914,9 +953,69 @@ mod tests {
     use super::*;
 
     use rand_core::{CryptoRng, RngCore};
-    use zcash_protocol::consensus::Parameters;
+    use zcash_client_backend::data_api::testing::MockWalletDb;
+    use zcash_keys::keys::UnifiedSpendingKey;
+    use zcash_protocol::consensus::{Network, Parameters};
 
+    use crate::build::test_util::{TARGET_HEIGHT, regtest_network};
     use crate::engine::commit_preparation;
+
+    /// A store that persists nothing and observes nothing: the adapter's KEY handling is what the
+    /// tests below exercise, and the account's viewing key is not routed through the store. Every
+    /// answer is the empty one a store with no migration gives.
+    struct NoStore;
+
+    impl PoolMigrationRead for NoStore {
+        type Error = core::convert::Infallible;
+
+        fn get_migration(&self) -> Result<Option<MigrationState>, Self::Error> {
+            Ok(None)
+        }
+
+        fn check_step_satisfiability(
+            &self,
+            _tx: &MigrationTransaction,
+            _settle: ReorgSettleDepth,
+        ) -> Result<StepSatisfiability, Self::Error> {
+            Ok(StepSatisfiability::NotYetSatisfiable {
+                as_of_height: BlockHeight::from_u32(TARGET_HEIGHT),
+            })
+        }
+
+        fn mined_height(&self, _txid: TxId) -> Result<Option<BlockHeight>, Self::Error> {
+            Ok(None)
+        }
+    }
+
+    /// An account's unified spending key, derived from a `seed` byte so the tests can vary the
+    /// account. Only its unified FULL VIEWING key reaches the adapter; the spending key stays
+    /// here, which is the property under test.
+    fn account_usk(seed: u8) -> UnifiedSpendingKey {
+        UnifiedSpendingKey::from_seed(&regtest_network(true), &[seed; 32], zip32::AccountId::ZERO)
+            .expect("the seed derives a unified spending key")
+    }
+
+    /// The adapter serves the Orchard viewing key it was CONSTRUCTED with, and that key is the
+    /// account's — the one whose spend authority the signing calls will be given, so what this
+    /// adapter plans and builds is what that authority can sign.
+    ///
+    /// There is deliberately no counterpart test for signing through the adapter: it holds no
+    /// spending key and offers no way to give it one, so "the adapter signs" is not a state this
+    /// type can be in. The compiler enforces what a runtime error used to report.
+    #[test]
+    fn the_adapter_serves_the_viewing_key_it_was_built_with() {
+        let wallet = MockWalletDb::new(Network::TestNetwork);
+        let usk = account_usk(3);
+        let expected = FullViewingKey::from(usk.orchard());
+
+        let adapter = WalletMigration::new(&wallet, 0, usk.to_unified_full_viewing_key(), NoStore);
+
+        assert_eq!(
+            adapter.orchard_fvk(),
+            Some(&expected),
+            "the adapter extracts the Orchard component of the key it was given",
+        );
+    }
 
     /// Compile-time proof that `WalletMigration` over ANY `zcash_client_backend` wallet `W` and ANY
     /// migration store `St` satisfies every trait bound `commit_preparation` requires (backend +

--- a/zcash_pool_migration/src/wallet.rs
+++ b/zcash_pool_migration/src/wallet.rs
@@ -379,18 +379,33 @@ where
     /// this adapter is the seam that has one. The fully-scanned bound is applied here rather than
     /// left to `get_tx_height` — which reports a mined height as soon as the wallet learns it,
     /// including ahead of scanning — so a promotion cannot rest on a block outside the region a
-    /// rollback would truncate. A wallet that has scanned nothing reports nothing mined.
+    /// rollback would truncate.
+    ///
+    /// The bound is read FIRST, and a wallet with no fully-scanned region answers `None` without
+    /// the inclusion lookup ever being made. That is not an optimization: nothing is promotable
+    /// when there is no scanned region — every answer this gives has to be one a rollback of the
+    /// block carrying the transaction would withdraw, and a wallet that has scanned nothing has no
+    /// such region to withdraw from — so the question the second lookup asks does not arise. It
+    /// also keeps this total on a wallet that has never synced, where a backend may have no chain
+    /// tip to answer `get_tx_height` against at all, which is the state in which a store applying
+    /// the same rule at its own layer (`zcash_client_sqlite`'s does) answers `None`. The two agree
+    /// on every value, so a wallet whose store also implements this needs no delegation here.
+    ///
+    /// Errors from either lookup are propagated, never read as an absence: an answer the wallet
+    /// could not give is not the answer that nothing is mined.
     fn mined_height(&self, txid: TxId) -> Result<Option<BlockHeight>, Self::Error> {
-        let Some(mined) = self.wallet.get_tx_height(txid).map_err(Error::WalletRead)? else {
+        let Some(scanned) = self
+            .wallet
+            .block_fully_scanned()
+            .map_err(Error::WalletRead)?
+        else {
             return Ok(None);
         };
         Ok(self
             .wallet
-            .block_fully_scanned()
+            .get_tx_height(txid)
             .map_err(Error::WalletRead)?
-            .map(|meta| meta.block_height())
-            .filter(|scanned| mined <= *scanned)
-            .map(|_| mined))
+            .filter(|mined| *mined <= scanned.block_height()))
     }
 }
 

--- a/zcash_pool_migration/tests/engine_commit.rs
+++ b/zcash_pool_migration/tests/engine_commit.rs
@@ -31,6 +31,13 @@ use zcash_pool_migration::signing_rounds::SigningRoundBudget;
 use zcash_pool_migration::state::AdvanceStep;
 use zcash_pool_migration_memory::{CommitMock, TARGET_HEIGHT, regtest_network, spending_key};
 
+/// The account's Orchard SPENDING key, as a caller now hands it to the entry points that sign
+/// (`commit_preparation`, `rebuild_expired_transfer`). Derived from the same `seed` the mock
+/// wallet's key is, so it is that account's own — which those entry points check.
+fn sk(seed: u64) -> orchard::keys::SpendingKey {
+    spending_key(seed)
+}
+
 /// A planned single-note migration and the mock wallet that holds the note.
 fn single_note_setup(seed: u64, balance: u64) -> (CommitMock, MigrationPlan) {
     let backend = CommitMock::new(seed, &[balance]);
@@ -60,6 +67,7 @@ fn commits_the_whole_migration_in_one_pass() {
         &params,
         BlockHeight::from_u32(TARGET_HEIGHT),
         &mut backend,
+        &sk(seed),
         &plan,
         &mut rng,
         ReplanThreshold::DEFAULT,
@@ -130,6 +138,7 @@ fn commits_a_multi_layer_migration_in_one_pass() {
         &params,
         BlockHeight::from_u32(TARGET_HEIGHT),
         &mut backend,
+        &sk(seed),
         &plan,
         &mut rng,
         ReplanThreshold::DEFAULT,
@@ -336,6 +345,7 @@ fn every_committed_transaction_has_a_derivable_txid() {
         &regtest_network(true),
         BlockHeight::from_u32(TARGET_HEIGHT),
         &mut backend,
+        &sk(seed),
         &plan,
         &mut rng,
         ReplanThreshold::DEFAULT,
@@ -380,6 +390,7 @@ fn advance_promotes_a_proved_transaction_whose_broadcast_was_never_recorded() {
         &regtest_network(true),
         BlockHeight::from_u32(TARGET_HEIGHT),
         &mut backend,
+        &sk(seed),
         &plan,
         &mut rng,
         ReplanThreshold::DEFAULT,

--- a/zcash_pool_migration/tests/engine_commit.rs
+++ b/zcash_pool_migration/tests/engine_commit.rs
@@ -17,6 +17,8 @@ use zcash_protocol::consensus::BlockHeight;
 use zcash_protocol::value::COIN;
 
 use zcash_pool_migration::build::sign_pczt;
+#[cfg(feature = "test-dependencies")]
+use zcash_pool_migration::engine::MigrationTransferId;
 use zcash_pool_migration::engine::{
     MigrationPlan, MigrationState, MigrationStatus, MigrationTxKind, MigrationTxState,
     PoolMigrationRead, PoolMigrationWrite, batch_unsigned_by_action_budget,
@@ -40,11 +42,353 @@ fn sk(seed: u64) -> orchard::keys::SpendingKey {
 
 /// A planned single-note migration and the mock wallet that holds the note.
 fn single_note_setup(seed: u64, balance: u64) -> (CommitMock, MigrationPlan) {
-    let backend = CommitMock::new(seed, &[balance]);
+    notes_setup(seed, &[balance])
+}
+
+/// A planned migration and the mock wallet holding the notes it is planned over.
+fn notes_setup(seed: u64, balances: &[u64]) -> (CommitMock, MigrationPlan) {
+    let backend = CommitMock::new(seed, balances);
     let mut rng = ChaCha8Rng::seed_from_u64(seed);
     let plan = plan_migration(&regtest_network(true), &backend, &mut rng)
         .expect("a fundable balance plans");
     (backend, plan)
+}
+
+/// Commit `plan` and assert that the run it committed is the run
+/// [`MigrationPlan::planned_transactions`] described.
+///
+/// Be precise about what this can and cannot catch. `commit_preparation` now COPIES each row's id,
+/// dependencies and scheduled height onto the transaction it builds, so those three per-row
+/// comparisons assert that copies are copies — they cannot detect a disagreement, because there is
+/// no longer a second derivation to disagree. What they do pin is everything around the copying:
+///
+/// - LENGTH: the plan enumerated exactly the transactions the commit built, no more and no fewer.
+/// - ORDER: the rows and the built transactions correspond POSITION for position, and each row's
+///   id is the id its transaction carries — so the preview a user consented to can be matched back
+///   to the stored run by id.
+/// - ACCEPTANCE: the plan the preview describes is one the commit will actually build. A row whose
+///   height or funding note the plan never named is refused outright, so reaching these assertions
+///   at all means the previewed run was buildable.
+/// - PURITY: previewing did not perturb the plan — the same enumeration is available, unchanged,
+///   after the commit.
+///
+/// The one thing the two sides still derive separately is the funding note's PLAINTEXT, which only
+/// the commit can know; `assert_transfers_spend_their_producers_notes` covers that seam.
+///
+/// Returns the committed state, for a caller that wants to assert more about the run.
+fn assert_preview_matches_commit(
+    seed: u64,
+    backend: &mut CommitMock,
+    plan: &MigrationPlan,
+) -> MigrationState {
+    let previewed = plan.planned_transactions();
+
+    let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
+    let state = commit_preparation(
+        &regtest_network(true),
+        BlockHeight::from_u32(TARGET_HEIGHT),
+        backend,
+        &sk(seed),
+        plan,
+        &mut rng,
+        ReplanThreshold::DEFAULT,
+    )
+    .expect("commits the migration");
+
+    assert_eq!(
+        previewed.len(),
+        state.transactions().len(),
+        "the preview lists exactly the transactions the commit builds",
+    );
+    for (preview, committed) in previewed.iter().zip(state.transactions()) {
+        assert_eq!(
+            preview.id(),
+            committed.id(),
+            "the preview's ordinals are the commit's, in the commit's order",
+        );
+        assert_eq!(preview.kind(), committed.kind(), "tx {:?}", preview.id());
+        assert_eq!(
+            preview.depends_on(),
+            committed.depends_on(),
+            "tx {:?} waits on what the preview said it would",
+            preview.id(),
+        );
+        // A committed transaction always has a height; the preview's `None` is the malformed-plan
+        // case the commit refuses outright, so reaching here at all means it was `Some`.
+        assert_eq!(
+            preview.scheduled_height(),
+            Some(committed.scheduled_height()),
+            "tx {:?} is scheduled where the preview said it would be",
+            preview.id(),
+        );
+    }
+
+    // `planned_transactions` is a pure function of the plan: committing it neither consumed nor
+    // altered the plan, so the same preview is still available (and identical) afterwards.
+    assert_eq!(
+        plan.planned_transactions(),
+        previewed,
+        "planned_transactions is a pure function of the plan",
+    );
+
+    state
+}
+
+/// Assert that every transfer spends a note MINTED BY the transaction its `depends_on` names — and
+/// that a transfer that waits on nothing spends a note no preparation transaction in the run
+/// minted (a wallet note the plan funds directly).
+///
+/// This is the seam the row-by-row comparison cannot reach. The plan decides which minted note
+/// each crossing spends and derives that crossing's dependency from whichever transaction mints
+/// it; the commit resolves the note's PLAINTEXT for itself. If those two ever named different
+/// notes, a crossing would be recorded waiting on a transaction that does not mint what it
+/// spends — the migration would broadcast a transfer whose funding note is not yet on chain.
+///
+/// The link is checked through the note's `rho`, which for a note minted by a preparation
+/// transaction IS the nullifier of the action that created it. So a funding note belongs to
+/// exactly the transaction among whose action nullifiers its `rho` appears — no value matching
+/// involved, which is the point.
+#[cfg(feature = "test-dependencies")]
+fn assert_transfers_spend_their_producers_notes(
+    state: &MigrationState,
+    transfer_funding: &[(MigrationTransferId, orchard::note::Note)],
+) {
+    assert!(!transfer_funding.is_empty(), "the run has transfers");
+
+    // Every action nullifier of each committed preparation transaction: the set of rhos its
+    // outputs can carry.
+    let mint_actions = |tx: &zcash_pool_migration::engine::MigrationTransaction| -> Vec<[u8; 32]> {
+        pczt::Pczt::parse(tx.pczt())
+            .expect("the stored PCZT parses")
+            .orchard()
+            .actions()
+            .iter()
+            .map(|action| *action.spend().nullifier())
+            .collect()
+    };
+
+    for (id, note) in transfer_funding {
+        let transfer = state
+            .transactions()
+            .iter()
+            .find(|t| t.id() == *id)
+            .expect("the funding pairing names a committed transaction");
+        let rho = note.rho().to_bytes();
+
+        match transfer.depends_on().as_slice() {
+            [] => {
+                for tx in state.transactions() {
+                    if matches!(tx.kind(), MigrationTxKind::Preparation { .. }) {
+                        assert!(
+                            !mint_actions(tx).contains(&rho),
+                            "transfer {id:?} waits on nothing, so its funding note must not be \
+                             minted by preparation transaction {:?}",
+                            tx.id(),
+                        );
+                    }
+                }
+            }
+            [producer_id] => {
+                let producer = state
+                    .transactions()
+                    .iter()
+                    .find(|t| t.id() == *producer_id)
+                    .expect("the dependency names a committed transaction");
+                assert!(
+                    matches!(producer.kind(), MigrationTxKind::Preparation { .. }),
+                    "a transfer waits on a preparation transaction",
+                );
+                assert!(
+                    mint_actions(producer).contains(&rho),
+                    "transfer {id:?} spends a note minted by {producer_id:?}, the transaction it \
+                     waits on",
+                );
+            }
+            many => panic!(
+                "a transfer waits on at most one producer, not {}",
+                many.len()
+            ),
+        }
+    }
+}
+
+/// The funding-note seam, over the three funding shapes one run can mix: notes minted by a single
+/// layer, notes minted by the LAST of several layers, and a note the wallet already holds.
+///
+/// Driven through `commit_preparation_with_funding`, the entry point that returns each transfer
+/// paired with the funding note it actually built against — the only place the note the commit
+/// resolved is observable from outside.
+#[cfg(feature = "test-dependencies")]
+#[test]
+fn every_transfer_spends_the_note_its_producer_mints() {
+    for (name, seed, balances) in [
+        ("one layer", 7u64, alloc_balances(&[78])),
+        ("two layers", 11, alloc_balances(&[1_000])),
+        ("a directly-funded crossing", 29, direct_funding_balances()),
+    ] {
+        let (mut backend, plan) = notes_setup(seed, &balances);
+        let mut rng = ChaCha8Rng::seed_from_u64(seed + 1);
+        let (state, transfer_funding) =
+            zcash_pool_migration::engine::commit_preparation_with_funding(
+                &regtest_network(true),
+                BlockHeight::from_u32(TARGET_HEIGHT),
+                &mut backend,
+                &sk(seed),
+                &plan,
+                &mut rng,
+                ReplanThreshold::DEFAULT,
+            )
+            .unwrap_or_else(|e| panic!("{name}: commits the migration: {e:?}"));
+
+        assert_eq!(
+            transfer_funding.len(),
+            plan.transfer_tx_count(),
+            "{name}: one funding note per crossing",
+        );
+        assert_transfers_spend_their_producers_notes(&state, &transfer_funding);
+    }
+}
+
+/// Note values in ZEC as the mock wallet takes them (zatoshi).
+#[cfg(feature = "test-dependencies")]
+fn alloc_balances(zec: &[u64]) -> Vec<u64> {
+    zec.iter().map(|z| z * COIN).collect()
+}
+
+/// A wallet holding one note that is already exactly a funding note (a denomination plus the fee
+/// buffer) beside a note that must be prepared, so one crossing is directly funded and the rest
+/// are minted.
+#[cfg(feature = "test-dependencies")]
+fn direct_funding_balances() -> Vec<u64> {
+    let (_probe_backend, probe) = single_note_setup(2, 2 * (COIN / 100));
+    let buffer = u64::from(probe.denominations().note_fee_buffer());
+    vec![COIN + buffer, 78 * COIN]
+}
+
+/// A single-layer run: every transfer waits on the one preparation transaction that mints the
+/// funding notes, and the preview says so before anything is built.
+#[test]
+fn plan_previews_a_single_layer_run() {
+    let seed = 7u64;
+    let (mut backend, plan) = single_note_setup(seed, 78 * COIN);
+    assert_eq!(plan.preparation().layer_count(), 1);
+    assert!(plan.transfer_tx_count() >= 2, "several crossings");
+
+    let previewed = plan.planned_transactions();
+    let prep_ids: Vec<_> = previewed
+        .iter()
+        .filter(|tx| tx.is_preparation())
+        .map(|tx| tx.id())
+        .collect();
+    assert_eq!(prep_ids.len(), 1, "one preparation transaction");
+    for transfer in previewed.iter().filter(|tx| tx.is_transfer()) {
+        assert_eq!(
+            transfer.depends_on(),
+            &prep_ids[..],
+            "every crossing waits on the transaction that mints its funding note",
+        );
+    }
+
+    assert_preview_matches_commit(seed, &mut backend, &plan);
+}
+
+/// A multi-layer run: the preview carries the whole-preceding-layer dependency of each later
+/// preparation transaction, and resolves each crossing to the ONE transaction that mints its own
+/// funding note — the two dependency rules the commit applies, in the case that distinguishes
+/// them.
+#[test]
+fn plan_previews_a_multi_layer_run() {
+    let seed = 11u64;
+    let (mut backend, plan) = single_note_setup(seed, 1_000 * COIN);
+    assert_eq!(
+        plan.preparation().layer_count(),
+        2,
+        "the whale fans out across two layers",
+    );
+
+    let previewed = plan.planned_transactions();
+    let layer_ids = |layer: usize| -> Vec<_> {
+        previewed
+            .iter()
+            .filter(|tx| matches!(tx.kind(), MigrationTxKind::Preparation { layer: l, .. } if l == layer))
+            .map(|tx| tx.id())
+            .collect()
+    };
+    let layer0 = layer_ids(0);
+    let layer1 = layer_ids(1);
+    assert!(!layer0.is_empty() && !layer1.is_empty());
+
+    for tx in previewed.iter() {
+        match tx.kind() {
+            MigrationTxKind::Preparation { layer: 0, .. } => {
+                assert!(tx.depends_on().is_empty(), "layer 0 waits on nothing");
+            }
+            MigrationTxKind::Preparation { .. } => {
+                assert_eq!(
+                    tx.depends_on(),
+                    &layer0[..],
+                    "a later layer waits on the WHOLE layer before it",
+                );
+            }
+            MigrationTxKind::Transfer { .. } => {
+                assert_eq!(
+                    tx.depends_on().len(),
+                    1,
+                    "a crossing waits on its own funding note's producer, and only that",
+                );
+                assert!(
+                    layer0.contains(&tx.depends_on()[0]) || layer1.contains(&tx.depends_on()[0]),
+                    "and that producer is one of the preparation transactions",
+                );
+            }
+        }
+    }
+    assert!(
+        previewed
+            .iter()
+            .any(|tx| tx.is_transfer() && layer1.contains(&tx.depends_on()[0])),
+        "at least one crossing is funded by the LAST layer, so the resolution is not trivially \
+         layer 0",
+    );
+
+    assert_preview_matches_commit(seed, &mut backend, &plan);
+}
+
+/// A crossing whose funding note the wallet already holds is spent DIRECTLY: no preparation
+/// transaction mints it, so it waits on nothing. The preview must not hand it a dependency
+/// belonging to some other crossing of the same value, which is the mistake a value-matched walk
+/// makes if it does not track which notes are already claimed.
+#[test]
+fn plan_previews_a_directly_funded_crossing() {
+    // The fee buffer a crossing's funding note carries on top of its denomination, discovered from
+    // a probe plan exactly as the planner computes it. A wallet note of a denomination PLUS that
+    // buffer is already a funding note, so the planner spends it directly.
+    let (_probe_backend, probe) = single_note_setup(2, 2 * (COIN / 100));
+    let buffer = u64::from(probe.denominations().note_fee_buffer());
+
+    let seed = 29u64;
+    let (mut backend, plan) = notes_setup(seed, &[COIN + buffer, 78 * COIN]);
+    assert_eq!(
+        plan.preparation().direct_funding_notes().len(),
+        1,
+        "one crossing is funded straight from the wallet",
+    );
+    assert!(
+        plan.preparation_tx_count() >= 1,
+        "and the rest are minted, so both kinds of funding are in one run",
+    );
+
+    let previewed = plan.planned_transactions();
+    assert_eq!(
+        previewed
+            .iter()
+            .filter(|tx| tx.is_transfer() && tx.depends_on().is_empty())
+            .count(),
+        1,
+        "exactly the directly-funded crossing waits on nothing",
+    );
+
+    assert_preview_matches_commit(seed, &mut backend, &plan);
 }
 
 /// The WHOLE migration, every preparation transaction and every transfer, is built and SIGNED in the

--- a/zcash_pool_migration/tests/signing_rounds_e2e.rs
+++ b/zcash_pool_migration/tests/signing_rounds_e2e.rs
@@ -25,6 +25,8 @@ use rand_chacha::ChaCha8Rng;
 use rand_core::SeedableRng;
 use zcash_protocol::{consensus::BlockHeight, value::COIN};
 
+use orchard::keys::SpendAuthorizingKey;
+use zcash_pool_migration::build::sign_pczt;
 #[cfg(feature = "test-dependencies")]
 use zcash_pool_migration::{
     denomination::MIGRATION_MAX_PREPARED_NOTES_PER_RUN,
@@ -35,8 +37,8 @@ use zcash_pool_migration::{
 };
 use zcash_pool_migration::{
     engine::{
-        MigrationCrypto, MigrationPlan, MigrationState, MigrationTxState, PoolMigrationWrite,
-        UnsignedMigrationTx, build_preparation_unsigned, estimate_migration_runs, plan_migration,
+        MigrationPlan, MigrationState, MigrationTxState, PoolMigrationWrite, UnsignedMigrationTx,
+        build_preparation_unsigned, estimate_migration_runs, plan_migration,
     },
     satisfiability::ReplanThreshold,
     signing_rounds::{MinRounds, NextFit, SigningRoundBudget},
@@ -58,22 +60,23 @@ fn plan_for(seed: u64, values_zec: &[u64]) -> (CommitMock, MigrationPlan) {
     plan_notes(seed, &notes)
 }
 
-/// Sign one round's unsigned PCZTs with the wallet's signer and apply the signatures back. The
-/// `signer` is anything implementing [`MigrationCrypto`] — the trait a wallet plugs its Orchard
-/// spend authority into (here the `CommitMock` backend; a real wallet passes its own implementation,
-/// or routes the bytes to a hardware device that returns the signed PCZT).
-fn sign_round_and_apply<C>(signer: &C, state: &mut MigrationState, round: Vec<UnsignedMigrationTx>)
-where
-    C: MigrationCrypto,
-    C::Error: std::fmt::Debug,
-{
+/// Sign one round's unsigned PCZTs with the account's spend authority and apply the signatures
+/// back.
+///
+/// This models the EXTERNAL signer: the engine handed these PCZTs out unsigned precisely because
+/// it was given no authority, and whoever holds the key — a hardware device, or as here a key the
+/// test holds — returns each signed. Nothing about the migration backend is involved, which is why
+/// this takes a key rather than a signing trait.
+fn sign_round_and_apply(
+    ask: &SpendAuthorizingKey,
+    state: &mut MigrationState,
+    round: Vec<UnsignedMigrationTx>,
+) {
     for unsigned_tx in round {
         // The wallet keeps the id to match the signed PCZT back; the bytes go to the signer.
         let (id, bytes) = unsigned_tx.into_parts();
         let unsigned = pczt::Pczt::parse(&bytes).expect("the unsigned PCZT parses");
-        let signed = signer
-            .sign(unsigned)
-            .expect("the signer authorizes the transaction");
+        let signed = sign_pczt(unsigned, ask).expect("the signer authorizes the transaction");
         assert!(state.apply_signature(id, signed.serialize().expect("serializes the signed PCZT")));
     }
 }
@@ -142,7 +145,7 @@ fn keystone_external_signing_end_to_end() {
     for round in rounds {
         // Each round honours the signer's 96-action budget.
         assert!(round.iter().map(|u| u.actions()).sum::<usize>() <= budget.max_actions() as usize);
-        sign_round_and_apply(&backend, &mut state, round);
+        sign_round_and_apply(&backend.ask, &mut state, round);
     }
 
     // The whole migration is signed, without anything having been broadcast or mined.

--- a/zcash_pool_migration_memory/src/lib.rs
+++ b/zcash_pool_migration_memory/src/lib.rs
@@ -38,7 +38,7 @@ use zcash_protocol::consensus::BlockHeight;
 use zcash_protocol::local_consensus::LocalNetwork;
 use zcash_protocol::value::Zatoshis;
 
-use zcash_pool_migration::build::{AccountDerivation, sign_pczt};
+use zcash_pool_migration::build::AccountDerivation;
 use zcash_pool_migration::engine::{
     MigrationBackend, MigrationCrypto, MigrationState, MigrationTransaction, MigrationTransferId,
     MigrationTxState, PoolMigrationRead, PoolMigrationWrite, ProvedTransaction,
@@ -416,7 +416,10 @@ pub struct CommitMock {
     pub wallet_notes: Vec<Note>,
     /// The account's Orchard full viewing key.
     pub fvk: FullViewingKey,
-    /// The account's Orchard spend-authorizing key, used to sign the migration PCZTs.
+    /// The account's Orchard spend-authorizing key. The mock does NOT sign with it: the engine
+    /// takes the spend authority as an argument to the calls that sign, so a test passes this to
+    /// `commit_preparation` / `rebuild_expired_transfer` (and uses it to play the external signer)
+    /// rather than the backend signing on its own behalf.
     pub ask: SpendAuthorizingKey,
     /// The ZIP 32 account the notes belong to, as a seeded wallet would report it. `None` models a
     /// wallet that knows no derivation for the account (an imported viewing key).
@@ -563,8 +566,8 @@ impl PoolMigrationWrite for CommitMock {
 impl MigrationCrypto for CommitMock {
     type Error = core::convert::Infallible;
 
-    fn orchard_fvk(&self) -> Result<FullViewingKey, Self::Error> {
-        Ok(self.fvk.clone())
+    fn orchard_fvk(&self) -> Option<&FullViewingKey> {
+        Some(&self.fvk)
     }
 
     fn account_derivation(&self) -> Result<Option<AccountDerivation>, Self::Error> {
@@ -573,9 +576,5 @@ impl MigrationCrypto for CommitMock {
 
     fn resolve_wallet_note(&self, index: usize) -> Result<Note, Self::Error> {
         Ok(self.wallet_notes[index])
-    }
-
-    fn sign(&self, pczt: pczt::Pczt) -> Result<pczt::Pczt, Self::Error> {
-        Ok(sign_pczt(pczt, &self.ask).expect("signs the migration PCZT"))
     }
 }


### PR DESCRIPTION
**Draft — under review.** Lets the Zcash Swift SDK delete its near-verbatim fork of `wallet::WalletMigration` and its re-derivation of the pre-commit plan preview (context: the discussion on #2938).

Three commits, each green on its own:

1. **Never hold spending authority in the adapter** — `WalletMigration::new(wallet, account, &UnifiedFullViewingKey, store)` is infallible and stores the UFVK as supplied; the adapter holds viewing authority only. `sign` leaves `MigrationCrypto`, whose `orchard_fvk` now answers `Option<FullViewingKey>` extracted on demand — a missing Orchard component surfaces where the key is actually needed (`CommitError::NoOrchardViewingKey` / `RebuildError::NoOrchardViewingKey`), not at construction. The signing entry points (`commit_preparation`, `commit_preparation_with_funding`, `rebuild_expired_transfer`) take `ask: &orchard::keys::SpendAuthorizingKey` per call. "Signing without authority" is unrepresentable. (`&SpendAuthorizingKey` rather than `&UnifiedSpendingKey` is deliberate: the entry points live at the `orchard` feature layer; `zcash_keys` exists only in `wallet`.)
2. **Decide a run's shape once, when the plan is made** — `PlannedTx` carries `depends_on` and `scheduled_height` (heights as pure reads of the plan's stored schedules), and `commit_preparation` READS the planned rows instead of running a parallel watermark walk. Note claiming is ordinal-indexed on BOTH sides: feeder inputs resolve by their `(layer, transaction, output)` coordinate, transfer funding by first-fit (the one assignment with no coordinate), and the commit indexes the minted pool by the recorded ordinals — plan and commit cannot claim different notes by construction. A coordinate naming nothing is a loud `InconsistentPlan` before anything is built. The fully-explicit endpoint (ids as stored plan data) is #2950.
3. **Read the scanned bound before the mining lookup** — `mined_height` answers `Ok(None)` on a wallet with no fully-scanned region instead of erroring `ChainHeightUnknown`; value-equal with `zcash_client_sqlite`'s store implementation in every reachable case, pinned by a store-equality test whose adapter runs over a store stub that panics on every method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)