### PR TITLE
Release pczt 0.9.3 and zcash_client_sqlite 0.22.0-rc.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7193,7 +7193,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.7"
+version = "0.22.0-rc.8"
 dependencies = [
  "ambassador",
  "assert_matches",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7340,7 +7340,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_pool_migration"
-version = "0.1.0-rc.6"
+version = "0.1.0-rc.7"
 dependencies = [
  "blake2b_simd",
  "corez",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ zcash_client_backend = { version = "0.24.0-rc.7", path = "zcash_client_backend",
 # time, then flip this back to `path = "components/zcash_encoding"` at "0.5".
 zcash_encoding = { version = "0.4", default-features = false }
 zcash_keys = { version = "0.16.1", path = "zcash_keys", default-features = false  }
-zcash_pool_migration = { version = "0.1.0-rc.6", path = "zcash_pool_migration" }
+zcash_pool_migration = { version = "0.1.0-rc.7", path = "zcash_pool_migration" }
 zcash_protocol = { version = "0.10.4", path = "components/zcash_protocol", default-features = false }
 zip321 = { version = "0.9.0-rc.1", path = "components/zip321" }
 

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,6 +1,10 @@
 
 # cargo-vet imports lock
 
+[[unpublished.zcash_client_sqlite]]
+version = "0.22.0-rc.8"
+audited_as = "0.22.0-rc.7"
+
 [[unpublished.zcash_pool_migration]]
 version = "0.1.0-rc.7"
 audited_as = "0.1.0-rc.6"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,25 +1,9 @@
 
 # cargo-vet imports lock
 
-[[unpublished.pczt]]
-version = "0.9.2"
-audited_as = "0.9.1"
-
-[[unpublished.zcash_client_backend]]
-version = "0.24.0-rc.7"
-audited_as = "0.24.0-rc.6"
-
-[[unpublished.zcash_client_sqlite]]
-version = "0.22.0-rc.7"
-audited_as = "0.22.0-rc.6"
-
 [[unpublished.zcash_pool_migration]]
-version = "0.1.0-rc.6"
-audited_as = "0.1.0-rc.5"
-
-[[unpublished.zcash_protocol]]
-version = "0.10.4"
-audited_as = "0.10.3"
+version = "0.1.0-rc.7"
+audited_as = "0.1.0-rc.6"
 
 [[publisher.bumpalo]]
 version = "3.16.0"
@@ -113,8 +97,8 @@ user-login = "ebfull"
 user-name = "Sean Bowe"
 
 [[publisher.pczt]]
-version = "0.9.1"
-when = "2026-07-27"
+version = "0.9.2"
+when = "2026-08-04"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -469,15 +453,15 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_client_backend]]
-version = "0.24.0-rc.6"
-when = "2026-07-30"
+version = "0.24.0-rc.7"
+when = "2026-08-04"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_client_sqlite]]
-version = "0.22.0-rc.6"
-when = "2026-07-30"
+version = "0.22.0-rc.7"
+when = "2026-08-04"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -511,8 +495,8 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_pool_migration]]
-version = "0.1.0-rc.5"
-when = "2026-07-30"
+version = "0.1.0-rc.6"
+when = "2026-08-04"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -532,8 +516,8 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_protocol]]
-version = "0.10.3"
-when = "2026-07-30"
+version = "0.10.4"
+when = "2026-08-04"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -10,7 +10,14 @@ workspace.
 
 ## [Unreleased]
 
+## [0.22.0-rc.8] - 2026-08-07
+
 ### Added
+- `wallet::init::migrations` release-state constants backfilling every
+  published crate version whose migration-graph state had no constant:
+  `V_0_7_0`, `V_0_8_0_RC1`, `V_0_8_0_RC4`, `V_0_8_0_RC5`, `V_0_8_1`,
+  `V_0_22_0_RC5`, and `V_0_22_0_RC6`. Each was computed from the corresponding
+  crate artifact published on crates.io.
 - The `v_migration_transactions` view: one row per SCHEDULED pool-migration
   transaction (belonging to a non-terminal migration and not yet broadcast),
   with its identity, kind, lifecycle state, scheduled and expiry heights,
@@ -38,7 +45,6 @@ workspace.
   earlier releases wrote at prove time: their spend marks froze the input
   notes out of the user's balance until each transaction's expiry, with
   nothing left to broadcast them.
-
 - `pool_migration::MigrationUuid`: the stable external identity of one
   pool-migration record, safe to hand across an FFI (row ids are not stable
   across a restore).
@@ -58,6 +64,12 @@ workspace.
 
 ### Changed
 - Migrated to `zcash_pool_migration 0.1.0-rc.7`.
+- The pool-migration transactions table's `txid` column is now a `BLOB` holding
+  the transaction id's internal bytes, matching how the wallet's own
+  `transactions` table keys them; it was hex `TEXT`. An application querying
+  this table directly must bind and read raw bytes, and must not route them
+  through the display encoding, which is byte-reversed. The
+  `orchard_ironwood_migration_txid_blob` migration converts existing rows.
 - `WalletWrite::store_transactions_to_be_sent` now upserts each transaction's
   sent-output records, so storing a transaction the wallet has already
   recorded replaces that record instead of failing.
@@ -116,6 +128,14 @@ workspace.
   excluded only `complete` migrations; nothing will drive a terminal migration
   further, so those checkpoints were kept for proofs that will never be
   requested and, the migration being terminal, were never revisited.
+- `wallet::init::migrations::V_0_8_0` held the leaf state of the 0.8.1 release
+  rather than 0.8.0's: the published 0.8.0 crate's final migration was
+  `v_transactions_shielding_balance`, with `v_transactions_note_uniqueness`
+  following in 0.8.1. The constant now records the true 0.8.0 state, and the
+  0.8.1 state it previously held is the new `V_0_8_1`. An external migration
+  anchored on `V_0_8_0` now anchors one migration earlier in the graph, which
+  cannot invalidate its ordering because every migration `V_0_8_0` previously
+  named is still ordered after the corrected state.
 
 ## [0.22.0-rc.7] - 2026-08-03
 
@@ -140,12 +160,6 @@ workspace.
 - `zcash_client_sqlite::testing::db::TestDb::conn` and `TestDb::conn_mut`, for
   tests that open a sibling store (a `pool_migration` `PoolMigrations`, say)
   over the wallet database's own connection.
-- `zcash_client_sqlite::wallet::init::migrations` release-state constants
-  backfilling every published crate version whose migration-graph state had no
-  constant: `V_0_7_0`, `V_0_8_0_RC1`, `V_0_8_0_RC4`, `V_0_8_0_RC5`, `V_0_8_1`,
-  `V_0_22_0_RC5`, and `V_0_22_0_RC6`. Each backfilled state was computed from
-  the corresponding crate artifact published on crates.io, and the
-  between-releases migration test now walks through all of them.
 
 ### Changed
 - Migrated to `zcash_client_backend 0.24.0-rc.7`, `zcash_pool_migration 0.1.0-rc.6`.
@@ -232,20 +246,6 @@ workspace.
   reports nothing mined rather than erroring. Together with the truncation hook
   above, a stored migration's mined heights now follow the wallet's scan in both
   directions with no consumer hook in either.
-
-### Fixed
-- `zcash_client_sqlite::wallet::init::migrations::V_0_8_0` held the leaf state
-  of the 0.8.1 release rather than 0.8.0's: the published 0.8.0 crate's final
-  migration was `v_transactions_shielding_balance`, with
-  `v_transactions_note_uniqueness` following in 0.8.1. The constant now records
-  the true 0.8.0 state, and the 0.8.1 state it previously held is the new
-  `V_0_8_1`. An external migration anchored on `V_0_8_0` now anchors one
-  migration earlier in the graph, which cannot invalidate its ordering because
-  every migration `V_0_8_0` previously named is still ordered after the
-  corrected state.
-- `V_0_17_0` was missing from the sequence of release states that the
-  between-releases migration test walks, so upgrades passing through the 0.17.0
-  state were never exercised.
 
 ## [0.22.0-rc.6] - 2026-07-29
 

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -57,6 +57,7 @@ workspace.
   one in progress.
 
 ### Changed
+- Migrated to `zcash_pool_migration 0.1.0-rc.7`.
 - `WalletWrite::store_transactions_to_be_sent` now upserts each transaction's
   sent-output records, so storing a transaction the wallet has already
   recorded replaces that record instead of failing.

--- a/zcash_client_sqlite/Cargo.toml
+++ b/zcash_client_sqlite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_client_sqlite"
 description = "An SQLite-based Zcash light client"
-version = "0.22.0-rc.7"
+version = "0.22.0-rc.8"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Kris Nuttycombe <kris@electriccoin.co>"

--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -7,7 +7,18 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.1.0-rc.7] - 2026-08-07
+
 ### Added
+- `engine::MigrationLockOwner`, the token identifying the holder of the
+  wallet-side locks on a migration transaction's input notes.
+- `engine::MigrationProver::lock_spent_notes` (required), called by
+  `prove_transfer` and `prove_preparation` once the proof succeeds, so a
+  transaction reserves the notes it spends for exactly as long as it is proved
+  and awaiting broadcast. An implementation that models no lock state returns
+  `Ok(None)`.
+- `wallet::WalletProveError::Lock`, reporting a note that another flow has
+  already reserved.
 - `state::MigrationState::mark_cancelled`, which moves a non-terminal migration
   to that status. A no-op on an already-terminal migration, so terminality is
   never overwritten. This is a status change only: it does not release any hold
@@ -53,6 +64,9 @@ and this library adheres to Rust's notion of
 - `preparation::Portfolio`, implemented for `()` and for `(H, T)` where `H:
   PreparationStrategy` and `T: Portfolio`, so a set of strategies is written
   `(A, (B, (C, ())))`.
+- `testing::assert_strategy_conformance` and `testing::assert_dominates`, the
+  conformance suite an implementation of `preparation::PreparationStrategy`
+  inherits by calling them.
 
 ### Changed
 - `wallet::WalletMigration` now snapshots the account's spendable Orchard
@@ -156,6 +170,21 @@ and this library adheres to Rust's notion of
   broken by transaction id. Storage order is dependency order, which diverges
   from the schedule once `engine::rebuild_expired_transfer` reschedules a
   transfer in place.
+- `engine::MigrationTransaction::lock_owner` and
+  `MigrationTransaction::from_parts` now use `MigrationLockOwner` in place of a
+  bare `[u8; 32]`.
+- `engine::MigrationState::set_transaction_proved` takes the lock owner the
+  transaction's notes were reserved under, so a store write persists the proven
+  artifact and its lock token together.
+- `wallet::WalletProveError` has a fourth type parameter, the lock store's
+  error type.
+- `wallet::WalletMigrationProver` implements `engine::MigrationProver` only for
+  a wallet that is also an `OutputLockStore`.
+
+### Removed
+- `zip318_shape`, and with it `zip318_shape::evidence_from_pczt`. A consumer
+  that gathered `zcash_protocol::zip318::Zip318Evidence` from an unmined PCZT
+  must now assemble it from the `pczt` bundle observations itself.
 
 ## [0.1.0-rc.6] - 2026-08-03
 
@@ -490,15 +519,6 @@ and this library adheres to Rust's notion of
   transfer schedule's drawn anchor boundaries and broadcast heights.
 - `zcash_pool_migration::engine::MigrationState::sync_wakeup_schedule`, the above computed over a
   committed migration's transfers that still need proofs.
-- `zcash_pool_migration::engine::MigrationLockOwner`, the token identifying the
-  holder of the wallet-side locks on a migration transaction's input notes.
-- `zcash_pool_migration::engine::MigrationProver::lock_spent_notes`, called by
-  `prove_transfer` and `prove_preparation` once the proof succeeds, so a
-  transaction reserves the notes it spends for exactly as long as it is proved
-  and awaiting broadcast. It is a REQUIRED method: an existing prover must
-  implement it, returning `Ok(None)` if it models no lock state.
-- `zcash_pool_migration::wallet::WalletProveError::Lock`, reporting a note that
-  another flow has already reserved.
 
 ### Changed
 - Migrated to `zcash_client_backend 0.24.0-rc.5`.
@@ -529,16 +549,6 @@ and this library adheres to Rust's notion of
 - `zcash_pool_migration::wallet::WalletMigration` implements `MigrationCrypto`
   only where the wallet's `WalletRead::AccountId` and `InputSource::AccountId`
   are the same type, which is required to read the account's derivation.
-- `zcash_pool_migration::engine::MigrationTransaction::lock_owner` and
-  `MigrationTransaction::from_parts` now use `MigrationLockOwner` in place of a
-  bare `[u8; 32]`.
-- `zcash_pool_migration::engine::MigrationState::set_transaction_proved` takes
-  the lock owner the transaction's notes were reserved under, so a store write
-  persists the proven artifact and its lock token together.
-- `zcash_pool_migration::wallet::WalletProveError` has a fourth type parameter,
-  the lock store's error type.
-- `zcash_pool_migration::wallet::WalletMigrationProver` implements
-  `MigrationProver` only for a wallet that is also an `OutputLockStore`.
 
 ## [0.1.0-rc.3] - 2026-07-26
 

--- a/zcash_pool_migration/Cargo.toml
+++ b/zcash_pool_migration/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_pool_migration"
 description = "Backend-agnostic value-pool migration engine for Zcash wallets"
-version = "0.1.0-rc.6"
+version = "0.1.0-rc.7"
 authors = [
     "Danny Willems <be.danny.willems@gmail.com>",
     "John Boyd <john@coldnoise.net>",


### PR DESCRIPTION
| Crate | Version |
| --- | --- |
| `zcash_pool_migration` | `0.1.0-rc.6` → `0.1.0-rc.7` |
| `zcash_client_sqlite` | `0.22.0-rc.7` → `0.22.0-rc.8` |
| `pczt` | `0.9.2` → `0.9.3` |

### Why `pczt` is in this round

`zcash_pool_migration 0.1.0-rc.7` was published from this branch and **does not
compile against `pczt 0.9.2`**: `ProveError`'s `Display` impl formats a
`pczt::ParseError` with `{e}`, and that impl only exists unreleased (#2901).
`zcash_client_sqlite 0.22.0-rc.8` has the same dependency in
`FinalizeError` and in the `orchard_ironwood_migration_unsatisfiability`
migration, and its publish failed on it.

`pczt 0.9.3` is additive (new trait impls; `orchard` and `sapling` added to the
default feature set), so the published rc.7's `^0.9.2` requirement admits it and
publishing it repairs that artifact in place. Verified by compiling the
published `zcash_pool_migration 0.1.0-rc.7` straight from the registry against
this `pczt`, with every other dependency resolved from crates.io. The workspace
requirement is bumped to `0.9.3`, so `zcash_client_sqlite 0.22.0-rc.8` requires
it outright rather than merely tolerating it.

Because the branch was already published from, the `pczt` release commit sits on
top of the other two rather than in dependency order.

No other crate lower in the stack needs a release. The remaining unreleased
lower-crate APIs these crates reach — `zcash_protocol::TxId::from_hex` and
`zcash_address::test_vectors` — are used solely from `#[cfg(test)]` code, which
the publish verification build does not compile. The one
`zcash_client_backend` change that touches this seam
(`WalletWrite::store_transactions_to_be_sent` idempotence, #2911) is
documentation only.

## What the round ships

**`zcash_pool_migration`** — the preparation planner gains a strategy seam and
a second strategy (#2937, #2943, #2945), denomination decomposition now
quantizes once and reconciles by truncation (#2947, #2949), a migration's notes
are locked from proving until broadcast (#2799), `advance_migration` returns the
next-step outlook and re-spreads a missed broadcast schedule (#2910, #2936), the
whole provable set is served as one `Prove` step (#2939), and migrations gain a
`Cancelled` status (#2914).

**`zcash_client_sqlite`** — pool-migration history is retained in the schema
with a durable per-record identity and a history read API (#2921, #2923), a
migration can be cancelled (#2926), the wallet-side transaction record is
written at broadcast rather than at proving (#2799), scheduled migration
transactions are exposed as views (#2929), and transactions the wallet builds
are classified against ZIP 318 as they are stored (#2915, #2916).

## CHANGELOG corrections

The audit found three blocks of entries filed under already-published version
headings — the result of branches authored before a release was cut writing into
what was then `## [Unreleased]`. Each was verified absent from the corresponding
tag and moved into the section being cut, per `AGENTS.md` ("correct such an
entry only when it was inaccurate as written"):

- `zcash_pool_migration`: the note-locking API (`MigrationLockOwner`,
  `MigrationProver::lock_spent_notes`, `WalletProveError::Lock` and its fourth
  type parameter, `MigrationState::set_transaction_proved`'s signature) was
  filed under `0.1.0-rc.4`, but is absent from rc.4, rc.5 and rc.6. It ships
  here for the first time, and it is a breaking change for any out-of-tree
  `MigrationProver`.
- `zcash_client_sqlite`: the `wallet::init::migrations` release-state constants,
  and the `### Fixed` block covering the `V_0_8_0` correction, were both filed
  under `0.22.0-rc.7`.

Two further entries were added where the CHANGELOG had none: the removal of the
public `zip318_shape` module, and the pool-migration `txid` column becoming a
`BLOB`, which an application querying that table directly must adapt to.

## Publish ordering

`zcash_pool_migration 0.1.0-rc.7` is already published. `pczt 0.9.3` must go
next — it unblocks both that artifact and this round — and
`zcash_client_sqlite 0.22.0-rc.8` last.

Both `pczt-0.9.3` and `zcash_client_sqlite-0.22.0-rc.8` will be tagged at the
tip of this branch, since the `pczt` release commit lands after the
`zcash_client_sqlite` one.

## Verification

`cargo check --tests --all-features`, `cargo vet` (with `prune`) and
`cargo fmt --all` pass on each release commit. Note that `cargo semver-checks`
reports nothing across an `rc.N` → `rc.N+1` bump — it classifies the bump as
major and skips all 253 lints — so the public-surface audit was done by diffing
the rustdoc JSON of each baseline against the release.

Prepared with Claude Code assistance.
