### PR TITLE
Release pczt version 0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3188,7 +3188,7 @@ dependencies = [
 
 [[package]]
 name = "pczt"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "blake2b_simd",
  "bls12_381",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ zcash_note_encryption = "0.4.1"
 zcash_primitives = { version = "0.30.0", path = "zcash_primitives", default-features = false }
 zcash_proofs = { version = "0.30.0", path = "zcash_proofs", default-features = false }
 
-pczt = { version = "0.9.2", path = "pczt", default-features = false }
+pczt = { version = "0.9.3", path = "pczt", default-features = false }
 
 # Shielded protocols
 bellman = { version = "0.14", default-features = false, features = ["groth16"] }

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -10,6 +10,8 @@ workspace.
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-08-07
+
 ### Added
 - `impl {core::fmt::Display, core::error::Error} for pczt::ParseError`
 - `impl {core::fmt::Display, core::error::Error} for pczt::ExtractError`

--- a/pczt/Cargo.toml
+++ b/pczt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pczt"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Jack Grigg <jack@electriccoin.co>"]
 edition.workspace = true
 rust-version.workspace = true

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,13 +1,13 @@
 
 # cargo-vet imports lock
 
+[[unpublished.pczt]]
+version = "0.9.3"
+audited_as = "0.9.2"
+
 [[unpublished.zcash_client_sqlite]]
 version = "0.22.0-rc.8"
 audited_as = "0.22.0-rc.7"
-
-[[unpublished.zcash_pool_migration]]
-version = "0.1.0-rc.7"
-audited_as = "0.1.0-rc.6"
 
 [[publisher.bumpalo]]
 version = "3.16.0"
@@ -499,8 +499,8 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.zcash_pool_migration]]
-version = "0.1.0-rc.6"
-when = "2026-08-04"
+version = "0.1.0-rc.7"
+when = "2026-08-07"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"


### PR DESCRIPTION
The `Display` and `Error` impls on `ParseError` and `ExtractError` are required by `zcash_pool_migration 0.1.0-rc.7`, which is already published and does not compile against `pczt 0.9.2`. Its `^0.9.2` requirement admits this release, so publishing it repairs that artifact; `zcash_client_sqlite 0.22.0-rc.8` now requires `pczt 0.9.3` outright.