### PR TITLE
ci: block merging a release PR until its tags exist upstream

### DIFF
--- a/.github/helpers/check-release-tags.py
+++ b/.github/helpers/check-release-tags.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Require that every crate version bumped in a pull request is already tagged.
+
+A crate's `[package] version` changes only when it is released, so that bump is
+what a release IS — not the commit subject that happens to accompany it. For each
+`Cargo.toml` whose package version differs between the base and the head of the
+pull request, the tag `<name>-<new version>` must exist upstream and must name a
+commit the pull request introduces.
+
+Tagging therefore happens on the release branch before the merge. The merge
+neither squashes nor rebases, so a tag made then still names a commit that lands,
+and a released version can never reach the default branch without a tag
+identifying what it shipped.
+
+Requiring the tagged commit to lie in the pull request's range, rather than to be
+one specific commit, accommodates both tagging conventions: one tag per crate on
+that crate's own release commit, and — for a round whose commits are not in
+dependency order — every tag on the branch tip.
+
+Reads the range from BASE_SHA and HEAD_SHA; with either unset there is nothing to
+judge and the check passes. REMOTE selects the remote to consult (default
+`origin`).
+
+A manifest added by the pull request is skipped: introducing a crate is not a
+version bump, and a crate is routinely added and iterated before its first
+release.
+"""
+
+import os
+import subprocess
+import sys
+import tomllib
+
+
+def git(*args, check=True):
+    return subprocess.run(["git", *args], capture_output=True, text=True, check=check)
+
+
+def manifest_at(ref, path):
+    """The parsed manifest at `ref`, or None if it does not exist there."""
+    r = git("show", f"{ref}:{path}", check=False)
+    if r.returncode != 0:
+        return None
+    try:
+        return tomllib.loads(r.stdout)
+    except tomllib.TOMLDecodeError:
+        return None
+
+
+def package_version(manifest, ref):
+    """A manifest's own version, resolving `version.workspace = true`.
+
+    Returns None for a manifest with no `[package]` (the workspace root), so a
+    `[workspace.dependencies]` requirement bump is never mistaken for a release.
+    """
+    package = (manifest or {}).get("package")
+    if not package:
+        return None
+    version = package.get("version")
+    if isinstance(version, dict) and version.get("workspace"):
+        root = manifest_at(ref, "Cargo.toml") or {}
+        version = root.get("workspace", {}).get("package", {}).get("version")
+    return version if isinstance(version, str) else None
+
+
+def released_crates(base, head):
+    """The (name, version) of each crate whose version this range bumps."""
+    changed = git("diff", "--name-only", f"{base}..{head}", "--", "*Cargo.toml").stdout
+    for path in changed.splitlines():
+        head_manifest = manifest_at(head, path)
+        if head_manifest is None:
+            continue
+        package = head_manifest.get("package", {})
+        if package.get("publish") is False:
+            continue
+        new = package_version(head_manifest, head)
+        if new is None:
+            continue
+        base_manifest = manifest_at(base, path)
+        if base_manifest is None:
+            continue
+        if package_version(base_manifest, base) == new:
+            continue
+        name = package.get("name")
+        if name:
+            yield path, name, new
+
+
+def tagged_commit(remote, tag):
+    """The commit `tag` names on `remote`, or None if there is no such tag.
+
+    Annotated tags are peeled, so the result is a commit rather than a tag
+    object.
+    """
+    refs = git(
+        "ls-remote", "--tags", remote, f"refs/tags/{tag}", f"refs/tags/{tag}^{{}}"
+    ).stdout
+    peeled = plain = None
+    for line in refs.splitlines():
+        sha, _, ref = line.partition("\t")
+        if ref.endswith("^{}"):
+            peeled = sha
+        else:
+            plain = sha
+    return peeled or plain
+
+
+def introduced_by_range(sha, base, head):
+    """Whether `sha` is a commit this range adds: reachable from head, not base."""
+    if git("cat-file", "-e", f"{sha}^{{commit}}", check=False).returncode != 0:
+        return False
+    reachable = git("merge-base", "--is-ancestor", sha, head, check=False).returncode == 0
+    in_base = git("merge-base", "--is-ancestor", sha, base, check=False).returncode == 0
+    return reachable and not in_base
+
+
+def main():
+    base, head = os.environ.get("BASE_SHA"), os.environ.get("HEAD_SHA")
+    remote = os.environ.get("REMOTE", "origin")
+    if not base or not head:
+        print("No commit range supplied; nothing to check.")
+        return 0
+
+    releases = list(released_crates(base, head))
+    if not releases:
+        print("No crate versions are bumped in this range.")
+        return 0
+
+    problems = []
+    for path, name, version in releases:
+        tag = f"{name}-{version}"
+        at = tagged_commit(remote, tag)
+        if at is None:
+            problems.append(f"{tag}: no such tag on {remote} ({path} bumps to {version})")
+        elif not introduced_by_range(at, base, head):
+            problems.append(
+                f"{tag}: names {at[:12]}, which this pull request does not introduce"
+            )
+        else:
+            print(f"{tag}: OK ({at[:12]})")
+
+    if problems:
+        print("\nCrate versions bumped without a matching tag:\n", file=sys.stderr)
+        for p in problems:
+            print(f"  {p}", file=sys.stderr)
+        print(
+            "\nTag each release commit and push the tags before merging; see"
+            "\nCONTRIBUTING.md. A release must not reach the default branch"
+            "\nuntagged, because the version it published would then name no"
+            "\nidentifiable commit.",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -654,6 +654,28 @@ jobs:
       - name: Check consistency
         run: python3 .github/helpers/check-dep-graph.py
 
+  release-tags:
+    name: Bumped crate versions are tagged
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Check that each bumped crate version is tagged upstream
+        env:
+          BASE_SHA: >-
+            ${{
+              github.event.pull_request.base.sha
+              || github.event.merge_group.base_sha
+            }}
+          HEAD_SHA: >-
+            ${{
+              github.event.pull_request.head.sha
+              || github.event.merge_group.head_sha
+            }}
+        run: python3 .github/helpers/check-release-tags.py
+
   protobuf:
     name: protobuf consistency
     runs-on: ubuntu-latest
@@ -738,6 +760,7 @@ jobs:
       - doc-links
       - fmt
       - protobuf
+      - release-tags
       - uuid
     if: ${{ always() }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
A crate version that reaches the default branch untagged leaves a published
release naming no identifiable commit, and the tag can no longer be placed
without guessing which commit it was cut from. Nothing prevented that: tagging
is a documented step performed after the merge.

`release-tags` compares each `Cargo.toml`'s `[package] version` between the
pull request's base and head, and for every crate whose version changed
requires the tag `<name>-<new version>` to exist upstream naming a commit the
pull request introduces. It is a dependency of `required-checks` — the context
the "Merge Requirements" ruleset requires — so it gates merging with no ruleset
change needed.

### Why the version bump, and not the commit subject

A `[package] version` changes only when a crate is released, so the bump is what
a release *is*; a commit subject is a convention that can drift. The manifest is
read with a TOML parser rather than by matching `version =` lines, because every
release also bumps `[workspace.dependencies]` requirements in the root
`Cargo.toml` — those lines are `version =` changes too, and line matching would
report them as releases of crates that were not released.

### Which commit the tag must name

The tagged commit must lie in the pull request's range rather than be one
specific commit, which accommodates both conventions in use: one tag per crate
on that crate's own release commit, and — for a round whose commits are not in
dependency order, as in #2954 — every tag on the branch tip.

A manifest the pull request adds is skipped, since introducing a crate is not a
version bump and a crate is routinely added and iterated before its first
release. Crates marked `publish = false` are skipped outright.

### Verification

Exercised against real history in this repository:

| Case | Result |
| --- | --- |
| The `0.22.0-rc.8` round, tags pushed | passes, naming all three crates |
| `zcash_client_sqlite 0.22.0-rc.7`, tag exists | passes |
| A range bumping only dependency requirements | no releases detected |
| `zcash_pool_migration 0.1.0-rc.4` — released, never tagged | **fails**, correctly |

The range predicate was unit-tested over five placements of the tagged commit:
at the head (tip tagging), at a mid-range release commit, at the base, on an
unrelated older commit, and naming a commit that does not exist. Only the first
two are accepted.

Note this can only gate pull requests, so it would not have caught
`zcash_pool_migration 0.1.0-rc.4` or the `0.22.0-rc.8` round at the time; its
first real exercise is the next release.

The companion change is procedural: release PRs are now opened as drafts and
tagged before merge.

Closes #2956

Prepared with Claude Code assistance.
