### PR TITLE
zcash_pool_migration: Let a wallet cap one run's prepared notes

### DIFF
--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -31,8 +31,38 @@ and this library adheres to Rust's notion of
   match (a migration PCZT carries padding dummies with throwaway keys), so a
   foreign key would sign nothing, succeed, and persist a run recorded as
   `Signed` whose transactions carry no signatures.
+- `denomination::CanonicalOneTwoFive::with_max_notes`, the ZIP 318 canonical
+  strategy with a caller-chosen per-run note count. Only the count is a
+  parameter: the `{1, 2, 5} * 10^k` denomination set and its `DENOM_CAP` and
+  `MAX_RESIDUAL_VALUE` bounds are normative ZIP 318 values, so they are not
+  caller-settable and do not appear in the signature. A wallet chooses how big
+  one run is; it never chooses which values cross the turnstile, because the
+  privacy argument rests on every wallet publishing from the same set.
+  `denomination::CanonicalOneTwoFive::recommended` now delegates to it.
+- `engine::estimate_migration_runs_with`, the preview counterpart of
+  `engine::plan_migration_with`: it takes the same preparation portfolio and the
+  same per-run note cap, in the same order, so an application can preview the
+  runs it is about to plan. The same values must be passed to both, or the
+  preview will not describe the runs that get planned. Its cost scales inversely
+  with the cap, since a bigger run means fewer runs to iterate.
 
 ### Changed
+- `denomination::MIGRATION_MAX_PREPARED_NOTES_PER_RUN` is a `NonZeroUsize` where
+  it was a `usize`. A run that prepares no notes migrates nothing, so zero is
+  not a cap a caller can now express. Read it with `.get()` where a `usize` is
+  wanted.
+- `denomination::plan_denominations` takes a `NonZeroUsize` per-run note cap,
+  after the spendable note count, and `engine::plan_migration_with` takes one in
+  second position, after the portfolio. This is the only denomination knob a
+  wallet may set; the denomination scheme and its ZIP 318 bounds remain fixed.
+  `engine::plan_migration` is unchanged and passes
+  `denomination::MIGRATION_MAX_PREPARED_NOTES_PER_RUN`, as does
+  `engine::estimate_migration_runs`.
+- `engine::estimate_migration_runs` now plans each estimated run's preparation
+  through the same portfolio the plan will use. It previously always estimated
+  against the crate's default strategies, so an application planning under
+  `engine::plan_migration_with` with a different portfolio could be previewed a
+  run count that its own plans would not produce.
 - `wallet::WalletMigration::new` takes the account's `UnifiedFullViewingKey`
   where it took a `UnifiedSpendingKey`, and is infallible. The adapter holds
   viewing authority and nothing else, and it holds the unified key WHOLE rather

--- a/zcash_pool_migration/src/build/end_to_end.rs
+++ b/zcash_pool_migration/src/build/end_to_end.rs
@@ -18,7 +18,7 @@ use zcash_protocol::consensus::BlockHeight;
 use zcash_protocol::value::Zatoshis;
 use zcash_protocol::zip318::{CROSSING_DESTINATION_ACTIONS, CROSSING_SOURCE_ACTIONS};
 
-use crate::denomination::plan_denominations;
+use crate::denomination::{MIGRATION_MAX_PREPARED_NOTES_PER_RUN, plan_denominations};
 use crate::preparation::{PREP_TX_ACTIONS, PrepInput, plan_preparation};
 
 /// denomination plan -> preparation plan -> build + sign a preparation transaction -> build + sign a
@@ -51,6 +51,7 @@ fn migration_pipeline_end_to_end() {
         plan_denominations(
             Zatoshis::const_from_u64(balance),
             balance_zats.len(),
+            MIGRATION_MAX_PREPARED_NOTES_PER_RUN,
             buffer,
             prep_fee,
             &prep_tx_count,

--- a/zcash_pool_migration/src/denomination.rs
+++ b/zcash_pool_migration/src/denomination.rs
@@ -118,6 +118,7 @@
 //! [ZIP 318]: https://zips.z.cash/zip-0318
 
 use alloc::vec::Vec;
+use core::num::NonZeroUsize;
 
 use rand_core::{CryptoRng, RngCore};
 
@@ -137,16 +138,23 @@ pub use strategies::CanonicalOneTwoFive;
 /// remainder too (which can compromise privacy, so it is shown with a disclaimer) or lock it to keep
 /// that privacy.
 ///
-/// Both are defaults: the cap and minimum actually used are chosen per run by the caller (the
-/// wallet) and passed to the strategy constructor.
+/// Both are NORMATIVE: they are the bounds ZIP 318 fixes for the denomination set, so they are not
+/// caller-settable. A wallet chooses how many notes a run prepares (see
+/// [`MIGRATION_MAX_PREPARED_NOTES_PER_RUN`]), never which values may cross.
 pub use zcash_protocol::zip318::{DENOM_CAP, MAX_RESIDUAL_VALUE};
 
 /// The default cap on how many notes one migration run prepares. Bounding the note count keeps the
 /// decomposition a bounded problem and bounds each run's transaction and proving cost; a larger
 /// balance migrates over several runs.
 ///
-/// This is a policy default of this crate, not a ZIP 318 constant.
-pub const MIGRATION_MAX_PREPARED_NOTES_PER_RUN: usize = 50;
+/// This is a policy default of this crate, not a ZIP 318 constant: the ZIP fixes the denomination
+/// set (`{1, 2, 5} * 10^k`) and its bounds ([`DENOM_CAP`] and [`MAX_RESIDUAL_VALUE`]), but says
+/// nothing about how many notes one run may prepare. The count is therefore the caller's to choose
+/// — a wallet may override it per run — while the set and its bounds are not caller-settable.
+pub const MIGRATION_MAX_PREPARED_NOTES_PER_RUN: NonZeroUsize = match NonZeroUsize::new(50) {
+    Some(v) => v,
+    None => panic!("nonzero"),
+};
 
 /// The outcome of denomination planning: the self-funding notes to create, the values that will
 /// cross the turnstile, and the residual kept in the source pool. Produced by a
@@ -325,17 +333,26 @@ pub(crate) fn zat(value: u64) -> Zatoshis {
     Zatoshis::from_u64(value).expect("split values are bounded by the validated total input")
 }
 
-/// Convenience wrapper: plan with the recommended [`CanonicalOneTwoFive`] strategy (ZIP 318 canonical
-/// quantization), sized by the caller-computed canonical fees (see [`DenominationStrategy::plan`]).
-pub fn plan_denominations<R: RngCore + CryptoRng>(
+/// Convenience wrapper: plan with the canonical [`CanonicalOneTwoFive`] strategy (ZIP 318 canonical
+/// quantization) capped at `max_notes` prepared notes, sized by the caller-computed canonical fees
+/// (see [`DenominationStrategy::plan`]).
+///
+/// `max_notes` is the ONLY knob: the denomination set and its [`DENOM_CAP`]/[`MAX_RESIDUAL_VALUE`]
+/// bounds are normative ZIP 318 values, not parameters. Pass
+/// [`MIGRATION_MAX_PREPARED_NOTES_PER_RUN`] for this crate's default.
+pub fn plan_denominations<R>(
     total_input: Zatoshis,
     spendable_note_count: usize,
+    max_notes: NonZeroUsize,
     transfer_fee_buffer: Zatoshis,
     prep_tx_fee: Zatoshis,
     prep_tx_count: &dyn Fn(&[Zatoshis]) -> Option<usize>,
     rng: &mut R,
-) -> DenominationPlan {
-    CanonicalOneTwoFive::recommended(transfer_fee_buffer).plan(
+) -> DenominationPlan
+where
+    R: RngCore + CryptoRng,
+{
+    CanonicalOneTwoFive::with_max_notes(max_notes, transfer_fee_buffer).plan(
         total_input,
         spendable_note_count,
         prep_tx_fee,
@@ -351,13 +368,20 @@ pub fn plan_denominations<R: RngCore + CryptoRng>(
 /// is `false` has nothing to migrate regardless of how the notes hold the value, while `true` with
 /// an empty reconciled plan means the note values — not the balance — blocked the run (see
 /// [`MigrationError::UnfundableSplit`](crate::engine::MigrationError::UnfundableSplit)).
+///
+/// The answer does not in fact depend on `max_notes`: a first part forms or not from the balance,
+/// the transfer buffer and the preparation fee alone, and every positive cap admits that first
+/// part, so the emptiness of the split is invariant across caps. The cap is taken anyway so that
+/// the question is asked of the run actually being planned rather than of a hypothetical default
+/// one.
 pub(crate) fn balance_has_canonical_split(
     total_input: Zatoshis,
     spendable_note_count: usize,
+    max_notes: NonZeroUsize,
     transfer_fee_buffer: Zatoshis,
     prep_tx_fee: Zatoshis,
 ) -> bool {
-    !CanonicalOneTwoFive::recommended(transfer_fee_buffer)
+    !CanonicalOneTwoFive::with_max_notes(max_notes, transfer_fee_buffer)
         .unconstrained_split(
             u64::from(total_input),
             spendable_note_count,

--- a/zcash_pool_migration/src/denomination/strategies.rs
+++ b/zcash_pool_migration/src/denomination/strategies.rs
@@ -8,6 +8,7 @@
 //! [ZIP 318]: https://zips.z.cash/zip-0318
 
 use alloc::vec::Vec;
+use core::num::NonZeroUsize;
 
 use rand_core::{CryptoRng, RngCore};
 
@@ -58,16 +59,29 @@ impl CanonicalOneTwoFive {
         }
     }
 
-    /// The recommended configuration: [`MIGRATION_MAX_PREPARED_NOTES_PER_RUN`] notes, the
+    /// The ZIP 318 configuration with a caller-chosen per-run note count: `max_notes` notes, the
     /// [`DENOM_CAP`] maximum denomination, the [`MAX_RESIDUAL_VALUE`] minimum denomination, and the
     /// caller-computed transfer-fee buffer.
-    pub fn recommended(transfer_fee_buffer: Zatoshis) -> Self {
+    ///
+    /// The two bounds are NOT parameters here: they are the normative ZIP 318 values that fix which
+    /// denominations may cross the turnstile, and moving them would move this wallet's crossings out
+    /// of the anonymity set every other wallet shares. Only the per-run note count is the caller's
+    /// to choose; it bounds one run's transaction and proving cost and says nothing about which
+    /// values are published.
+    pub fn with_max_notes(max_notes: NonZeroUsize, transfer_fee_buffer: Zatoshis) -> Self {
         Self::new(
-            MIGRATION_MAX_PREPARED_NOTES_PER_RUN,
+            max_notes.get(),
             DENOM_CAP,
             MAX_RESIDUAL_VALUE,
             transfer_fee_buffer,
         )
+    }
+
+    /// The recommended configuration: [`MIGRATION_MAX_PREPARED_NOTES_PER_RUN`] notes, the
+    /// [`DENOM_CAP`] maximum denomination, the [`MAX_RESIDUAL_VALUE`] minimum denomination, and the
+    /// caller-computed transfer-fee buffer.
+    pub fn recommended(transfer_fee_buffer: Zatoshis) -> Self {
+        Self::with_max_notes(MIGRATION_MAX_PREPARED_NOTES_PER_RUN, transfer_fee_buffer)
     }
 }
 
@@ -261,6 +275,25 @@ mod tests {
         )
     }
 
+    /// A spendable-note count: one (the exact-funding special case `unconstrained_split` gates on)
+    /// or more (the general fee-reserving path).
+    fn arb_note_count() -> impl Strategy<Value = usize> {
+        1usize..=4
+    }
+
+    /// One balance and preparation fee, held as some note count, asked of TWO independently drawn
+    /// note caps: the input shape of the cap-invariance law.
+    fn arb_two_caps_over_one_balance() -> impl Strategy<Value = (u64, u64, usize, usize, usize)> {
+        (
+            arb_plan_input(),
+            1usize..=MAX_SAMPLED_NOTE_CAP,
+            arb_note_count(),
+        )
+            .prop_map(|((total, fee, cap_a), cap_b, note_count)| {
+                (total, fee, cap_a, cap_b, note_count)
+            })
+    }
+
     /// The canonical strategy with the given note cap and the ZIP-317 transfer buffer.
     fn canonical(max_notes: usize) -> CanonicalOneTwoFive {
         CanonicalOneTwoFive::new(
@@ -344,13 +377,40 @@ mod tests {
             let mut other = ChaCha8Rng::seed_from_u64(1);
             prop_assert_eq!(&p, &s.plan(zat(total), MULTI_NOTE, zat(fee), &prep_tx_count_stub, &mut other));
         }
+
+        /// WHETHER a balance quantizes to anything at all is invariant across note caps: the split
+        /// is empty under one positive cap exactly when it is empty under every other. The first
+        /// part forms (or does not) from the balance, the transfer buffer and the preparation fee
+        /// alone, and every positive cap admits that first part, so only the LENGTH of the split
+        /// depends on the cap, never its emptiness.
+        ///
+        /// This is the lemma
+        /// [`balance_has_canonical_split`](super::super::balance_has_canonical_split) rests on when
+        /// it distinguishes "this balance has nothing to migrate" from "this wallet's note values
+        /// cannot fund what the balance quantizes to": that verdict must not turn on the caller's
+        /// per-run note count.
+        #[test]
+        fn split_emptiness_is_cap_invariant(
+            (total, fee, cap_a, cap_b, note_count) in arb_two_caps_over_one_balance(),
+        ) {
+            let a = canonical(cap_a).unconstrained_split(total, note_count, fee);
+            let b = canonical(cap_b).unconstrained_split(total, note_count, fee);
+            prop_assert_eq!(
+                a.is_empty(),
+                b.is_empty(),
+                "caps {} and {} disagree on emptiness for balance {}",
+                cap_a,
+                cap_b,
+                total
+            );
+        }
     }
 
     /// A whale's balance is split into capped notes, so one run migrates at most `max_notes * cap`
     /// and the rest rolls over as change.
     #[test]
     fn whale_is_capped_and_rolls_over() {
-        let s = canonical(MIGRATION_MAX_PREPARED_NOTES_PER_RUN);
+        let s = canonical(MIGRATION_MAX_PREPARED_NOTES_PER_RUN.get());
         let mut rng = ChaCha8Rng::seed_from_u64(0);
         let p = s.plan(
             zat(MAX_MONEY),
@@ -359,7 +419,7 @@ mod tests {
             &prep_tx_count_stub,
             &mut rng,
         );
-        let per_run_cap = MIGRATION_MAX_PREPARED_NOTES_PER_RUN as u64 * u64::from(DENOM_CAP);
+        let per_run_cap = MIGRATION_MAX_PREPARED_NOTES_PER_RUN.get() as u64 * u64::from(DENOM_CAP);
         assert!(u64::from(p.total_migratable()) <= per_run_cap);
         assert!(
             p.change().map(u64::from).unwrap_or(0) > per_run_cap,
@@ -370,7 +430,7 @@ mod tests {
     /// A balance below the smallest self-funding note migrates nothing and keeps it all as change.
     #[test]
     fn below_min_note_migrates_nothing() {
-        let s = canonical(MIGRATION_MAX_PREPARED_NOTES_PER_RUN);
+        let s = canonical(MIGRATION_MAX_PREPARED_NOTES_PER_RUN.get());
         let buffer = zip317_buffer();
         let below = u64::from(MAX_RESIDUAL_VALUE) + buffer - 1;
         let mut rng = ChaCha8Rng::seed_from_u64(0);
@@ -428,7 +488,7 @@ mod tests {
     fn assert_one_quantum_plus_fees(quantum: u64, prep_fee: u64) {
         let buffer = zip317_buffer();
         let balance = quantum + buffer + prep_fee;
-        let s = canonical(MIGRATION_MAX_PREPARED_NOTES_PER_RUN);
+        let s = canonical(MIGRATION_MAX_PREPARED_NOTES_PER_RUN.get());
         let mut rng = ChaCha8Rng::seed_from_u64(0);
         let p = s.plan(
             zat(balance),
@@ -504,7 +564,7 @@ mod tests {
         };
         let mut rng = ChaCha8Rng::seed_from_u64(0);
 
-        let plan = canonical(MIGRATION_MAX_PREPARED_NOTES_PER_RUN).plan(
+        let plan = canonical(MIGRATION_MAX_PREPARED_NOTES_PER_RUN.get()).plan(
             zat(funding),
             available.len(),
             zat(prep_fee),
@@ -961,7 +1021,7 @@ mod tests {
         let canonical = s.unconstrained_split(total, notes.len(), fee);
         assert_eq!(
             canonical,
-            vec![cap; MIGRATION_MAX_PREPARED_NOTES_PER_RUN],
+            vec![cap; MIGRATION_MAX_PREPARED_NOTES_PER_RUN.get()],
             "the canonical split saturates the per-run cap with repeated DENOM_CAP parts"
         );
 

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -70,9 +70,12 @@ use zcash_primitives::transaction::fees::{FeeRule as _, transparent, zip317};
 #[cfg(feature = "orchard")]
 use crate::satisfiability::{DuenessTargets, UnsatisfiableCause};
 use crate::{
-    denomination::{DenominationPlan, balance_has_canonical_split, plan_denominations},
+    denomination::{
+        DenominationPlan, MIGRATION_MAX_PREPARED_NOTES_PER_RUN, balance_has_canonical_split,
+        plan_denominations,
+    },
     preparation::{
-        PREP_TX_ACTIONS, PrepError, PrepInput, PrepOutput, PreparationPlan, plan_preparation,
+        PREP_TX_ACTIONS, PrepError, PrepInput, PrepOutput, PreparationPlan, plan_preparation_with,
     },
     satisfiability::{ReorgSettleDepth, ReplanThreshold, StepSatisfiability, UnsatisfiableKind},
     scheduling::{self, Schedule},
@@ -1572,6 +1575,7 @@ where
 {
     plan_migration_with(
         &crate::preparation::default_portfolio(),
+        MIGRATION_MAX_PREPARED_NOTES_PER_RUN,
         params,
         backend,
         rng,
@@ -1579,14 +1583,22 @@ where
 }
 
 /// As [`plan_migration`], planning the preparation transactions against a chosen set of strategies
-/// rather than the ones the crate ships.
+/// rather than the ones the crate ships, and preparing at most `max_notes` notes in this run rather
+/// than the crate's [`MIGRATION_MAX_PREPARED_NOTES_PER_RUN`] default.
 ///
-/// The choice reaches the whole plan, not only its preparation transactions: the denomination
-/// decomposition asks the preparation planner what it can mint at every step, so a portfolio that
-/// can build fewer transaction shapes yields different crossings as well as different
-/// preparations.
+/// The portfolio choice reaches the whole plan, not only its preparation transactions: the
+/// denomination decomposition asks the preparation planner what it can mint at every step, so a
+/// portfolio that can build fewer transaction shapes yields different crossings as well as
+/// different preparations.
+///
+/// `max_notes` is the only denomination knob: the `{1, 2, 5} * 10^k` set and its
+/// [`DENOM_CAP`](crate::denomination::DENOM_CAP) /
+/// [`MAX_RESIDUAL_VALUE`](crate::denomination::MAX_RESIDUAL_VALUE) bounds are normative ZIP 318
+/// values and are not settable. Whichever knobs are passed here must also be passed to
+/// [`estimate_migration_runs_with`], or the preview will not describe the runs that get planned.
 pub fn plan_migration_with<Pf, P, B, R>(
     portfolio: &Pf,
+    max_notes: NonZeroUsize,
     params: &P,
     backend: &B,
     rng: &mut R,
@@ -1632,6 +1644,7 @@ where
     let denominations = plan_denominations(
         balance,
         notes.len(),
+        max_notes,
         transfer_fee_buffer,
         prep_tx_fee,
         &prep_tx_count,
@@ -1643,7 +1656,13 @@ where
         // value remains), and DEFERRAL when the balance has a canonical split that this wallet's
         // note values cannot fund; the two need different reporting, so they are distinct errors.
         return Err(
-            if balance_has_canonical_split(balance, notes.len(), transfer_fee_buffer, prep_tx_fee) {
+            if balance_has_canonical_split(
+                balance,
+                notes.len(),
+                max_notes,
+                transfer_fee_buffer,
+                prep_tx_fee,
+            ) {
                 MigrationError::UnfundableSplit
             } else {
                 MigrationError::NothingToMigrate
@@ -1912,6 +1931,38 @@ where
     B: MigrationBackend,
     R: RngCore + rand_core::CryptoRng,
 {
+    estimate_migration_runs_with(
+        &crate::preparation::default_portfolio(),
+        MIGRATION_MAX_PREPARED_NOTES_PER_RUN,
+        params,
+        backend,
+        rng,
+    )
+}
+
+/// As [`estimate_migration_runs`], estimating against a chosen set of preparation strategies rather
+/// than the ones the crate ships, and with at most `max_notes` prepared notes per run rather than
+/// the crate's [`MIGRATION_MAX_PREPARED_NOTES_PER_RUN`] default.
+///
+/// These are exactly [`plan_migration_with`]'s knobs, in the same order, because this previews the
+/// runs that function will plan: the same values must be passed to both, or the preview will not
+/// describe the runs that get planned.
+///
+/// Raising `max_notes` migrates more per run and so takes fewer runs; the whole estimate costs
+/// roughly one [`plan_migration_with`] per run, so its cost scales INVERSELY with `max_notes`.
+pub fn estimate_migration_runs_with<Pf, P, B, R>(
+    portfolio: &Pf,
+    max_notes: NonZeroUsize,
+    params: &P,
+    backend: &B,
+    rng: &mut R,
+) -> Result<MigrationRunEstimate, MigrationError<B::Error>>
+where
+    Pf: crate::preparation::Portfolio,
+    P: zcash_protocol::consensus::Parameters,
+    B: MigrationBackend,
+    R: RngCore + rand_core::CryptoRng,
+{
     let height = backend
         .chain_tip_height()
         .map_err(MigrationError::Backend)?;
@@ -1938,13 +1989,14 @@ where
         // reassigned below.
         let denominations = {
             let prep_tx_count = |funding: &[Zatoshis]| {
-                plan_preparation(&notes, funding, prep_tx_fee)
+                plan_preparation_with(portfolio, &notes, funding, prep_tx_fee)
                     .ok()
                     .map(|plan| plan.transaction_count())
             };
             plan_denominations(
                 balance,
                 notes.len(),
+                max_notes,
                 transfer_fee_buffer,
                 prep_tx_fee,
                 &prep_tx_count,
@@ -1966,8 +2018,8 @@ where
         // the note-preparation side of the estimate, and which notes it spends and which residuals it
         // leaves give the next run's note structure. The denomination plan only ever proposes a funding
         // multiset the preparation planner accepted, so this plan succeeds by construction.
-        let preparation =
-            plan_preparation(&notes, &funding, prep_tx_fee).map_err(MigrationError::Preparation)?;
+        let preparation = plan_preparation_with(portfolio, &notes, &funding, prep_tx_fee)
+            .map_err(MigrationError::Preparation)?;
         runs.push(RunEstimate {
             migratable: denominations.total_migratable(),
             crossings: funding.len(),
@@ -4836,11 +4888,11 @@ pub(crate) mod tests {
             "a whale migrates over several runs, got {}",
             est.run_count()
         );
-        let per_run_cap = MIGRATION_MAX_PREPARED_NOTES_PER_RUN as u64 * u64::from(DENOM_CAP);
+        let per_run_cap = MIGRATION_MAX_PREPARED_NOTES_PER_RUN.get() as u64 * u64::from(DENOM_CAP);
         assert_eq!(u64::from(est.runs()[0].migratable()), per_run_cap);
         assert_eq!(
             est.runs()[0].crossings(),
-            MIGRATION_MAX_PREPARED_NOTES_PER_RUN
+            MIGRATION_MAX_PREPARED_NOTES_PER_RUN.get()
         );
         let summed: usize = est.runs().iter().map(|r| r.crossings()).sum();
         assert_eq!(est.total_crossings(), summed);

--- a/zcash_pool_migration/src/preparation.rs
+++ b/zcash_pool_migration/src/preparation.rs
@@ -53,6 +53,8 @@ use rand_chacha::ChaCha8Rng;
 use rand_core::SeedableRng;
 
 #[cfg(test)]
+use crate::denomination::MIGRATION_MAX_PREPARED_NOTES_PER_RUN;
+#[cfg(test)]
 use crate::engine::{
     plan_migration_with,
     tests::{MockBackend, test_net},
@@ -684,8 +686,14 @@ pub(crate) fn assert_scenarios_under<Pf: Portfolio>(
             .expect("every row names a shared scenario");
         let backend = MockBackend::new(scenario.source_notes.to_vec(), TIP);
         let mut rng = ChaCha8Rng::seed_from_u64(SEED);
-        let plan = plan_migration_with(portfolio, &test_net(), &backend, &mut rng)
-            .expect("this rule plans every shared scenario");
+        let plan = plan_migration_with(
+            portfolio,
+            MIGRATION_MAX_PREPARED_NOTES_PER_RUN,
+            &test_net(),
+            &backend,
+            &mut rng,
+        )
+        .expect("this rule plans every shared scenario");
 
         assert_eq!(
             plan.preparation_tx_count(),

--- a/zcash_pool_migration/src/preparation.rs
+++ b/zcash_pool_migration/src/preparation.rs
@@ -47,23 +47,6 @@ use zcash_protocol::value::Zatoshis;
 
 use core::fmt;
 
-#[cfg(test)]
-use rand_chacha::ChaCha8Rng;
-#[cfg(test)]
-use rand_core::SeedableRng;
-
-#[cfg(test)]
-use crate::denomination::MIGRATION_MAX_PREPARED_NOTES_PER_RUN;
-#[cfg(test)]
-use crate::engine::{
-    plan_migration_with,
-    tests::{MockBackend, test_net},
-};
-#[cfg(test)]
-use crate::signing_rounds::SigningRoundBudget;
-#[cfg(test)]
-use crate::testing::MIGRATION_SCENARIOS;
-
 pub mod first_fit_decreasing;
 pub mod layered_greedy;
 
@@ -662,65 +645,72 @@ fn validate_instance(available: &[Zatoshis], funding: &[Zatoshis]) -> Result<(),
     Ok(())
 }
 
-/// Replay a strategy module's scenario table through a whole migration planned under `portfolio`
-/// alone: for each row, plan the named `MIGRATION_SCENARIOS` wallet with `plan_migration_with` and
-/// assert the preparation-transaction count, crossings, Keystone signing rounds, and migrated
-/// value (in units of 0.01 ZEC). Each strategy module keeps its own table; this is the one driver
-/// they all replay it through.
 #[cfg(test)]
-pub(crate) fn assert_scenarios_under<Pf: Portfolio>(
-    portfolio: &Pf,
-    scenarios: &[(&str, usize, usize, usize, u64)],
-) {
-    /// One hundredth of a ZEC, the unit the migrated column is written in.
-    const H: u64 = zcash_protocol::value::COIN / 100;
-    /// Any fixed seed: the canonical decomposition does not consult the RNG.
-    const SEED: u64 = 7;
-    /// A post-NU6.3 chain tip to plan against.
-    const TIP: u32 = 2_000_000;
-
-    for (label, preparations, crossings, keystone_rounds, migrated) in scenarios {
-        let scenario = MIGRATION_SCENARIOS
-            .iter()
-            .find(|sc| sc.label == *label)
-            .expect("every row names a shared scenario");
-        let backend = MockBackend::new(scenario.source_notes.to_vec(), TIP);
-        let mut rng = ChaCha8Rng::seed_from_u64(SEED);
-        let plan = plan_migration_with(
-            portfolio,
-            MIGRATION_MAX_PREPARED_NOTES_PER_RUN,
-            &test_net(),
-            &backend,
-            &mut rng,
-        )
-        .expect("this rule plans every shared scenario");
-
-        assert_eq!(
-            plan.preparation_tx_count(),
-            *preparations,
-            "{label}: preparations"
-        );
-        assert_eq!(plan.transfer_tx_count(), *crossings, "{label}: crossings");
-        assert_eq!(
-            plan.signing_round_count(SigningRoundBudget::KEYSTONE),
-            *keystone_rounds,
-            "{label}: Keystone rounds",
-        );
-        assert_eq!(
-            u64::from(plan.value_migrated()) / H,
-            *migrated,
-            "{label}: migrated"
-        );
-    }
-}
-
-#[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
 
+    use rand_chacha::ChaCha8Rng;
+    use rand_core::SeedableRng;
     use zcash_primitives::transaction::fees::zip317::MARGINAL_FEE;
 
-    use crate::testing::{PREPARATION_VECTORS, preparation_fee_per_tx};
+    use crate::denomination::MIGRATION_MAX_PREPARED_NOTES_PER_RUN;
+    use crate::engine::{
+        plan_migration_with,
+        tests::{MockBackend, test_net},
+    };
+    use crate::signing_rounds::SigningRoundBudget;
+    use crate::testing::{MIGRATION_SCENARIOS, PREPARATION_VECTORS, preparation_fee_per_tx};
+
+    /// Replay a strategy module's scenario table through a whole migration planned under
+    /// `portfolio` alone: for each row, plan the named `MIGRATION_SCENARIOS` wallet with
+    /// `plan_migration_with` and assert the preparation-transaction count, crossings, Keystone
+    /// signing rounds, and migrated value (in units of 0.01 ZEC). Each strategy module keeps its
+    /// own table; this is the one driver they all replay it through.
+    pub(crate) fn assert_scenarios_under<Pf: Portfolio>(
+        portfolio: &Pf,
+        scenarios: &[(&str, usize, usize, usize, u64)],
+    ) {
+        /// One hundredth of a ZEC, the unit the migrated column is written in.
+        const H: u64 = zcash_protocol::value::COIN / 100;
+        /// Any fixed seed: the canonical decomposition does not consult the RNG.
+        const SEED: u64 = 7;
+        /// A post-NU6.3 chain tip to plan against.
+        const TIP: u32 = 2_000_000;
+
+        for (label, preparations, crossings, keystone_rounds, migrated) in scenarios {
+            let scenario = MIGRATION_SCENARIOS
+                .iter()
+                .find(|sc| sc.label == *label)
+                .expect("every row names a shared scenario");
+            let backend = MockBackend::new(scenario.source_notes.to_vec(), TIP);
+            let mut rng = ChaCha8Rng::seed_from_u64(SEED);
+            let plan = plan_migration_with(
+                portfolio,
+                MIGRATION_MAX_PREPARED_NOTES_PER_RUN,
+                &test_net(),
+                &backend,
+                &mut rng,
+            )
+            .expect("this rule plans every shared scenario");
+
+            assert_eq!(
+                plan.preparation_tx_count(),
+                *preparations,
+                "{label}: preparations"
+            );
+            assert_eq!(plan.transfer_tx_count(), *crossings, "{label}: crossings");
+            assert_eq!(
+                plan.signing_round_count(SigningRoundBudget::KEYSTONE),
+                *keystone_rounds,
+                "{label}: Keystone rounds",
+            );
+            assert_eq!(
+                u64::from(plan.value_migrated()) / H,
+                *migrated,
+                "{label}: migrated"
+            );
+        }
+    }
 
     /// A representative padded [`PREP_TX_ACTIONS`]-action ZIP-317 fee reserve for the tests (each
     /// action costs one ZIP-317 marginal fee). The planner treats it opaquely.

--- a/zcash_pool_migration/src/preparation/first_fit_decreasing.rs
+++ b/zcash_pool_migration/src/preparation/first_fit_decreasing.rs
@@ -301,7 +301,7 @@ mod tests {
     /// Replays [`SCENARIOS_UNDER_THIS_RULE`] through a migration planned against this rule alone.
     #[test]
     fn what_a_migration_looks_like_under_this_rule_alone() {
-        crate::preparation::assert_scenarios_under(
+        crate::preparation::tests::assert_scenarios_under(
             &(FirstFitDecreasing, ()),
             SCENARIOS_UNDER_THIS_RULE,
         );

--- a/zcash_pool_migration/src/preparation/layered_greedy.rs
+++ b/zcash_pool_migration/src/preparation/layered_greedy.rs
@@ -1263,6 +1263,9 @@ mod tests {
     /// Replays [`SCENARIOS_UNDER_THIS_RULE`] through a migration planned against this rule alone.
     #[test]
     fn what_a_migration_looks_like_under_this_rule_alone() {
-        crate::preparation::assert_scenarios_under(&(LayeredGreedy, ()), SCENARIOS_UNDER_THIS_RULE);
+        crate::preparation::tests::assert_scenarios_under(
+            &(LayeredGreedy, ()),
+            SCENARIOS_UNDER_THIS_RULE,
+        );
     }
 }

--- a/zcash_pool_migration/src/testing/generators.rs
+++ b/zcash_pool_migration/src/testing/generators.rs
@@ -31,11 +31,6 @@ use alloc::vec::Vec;
 // fixed paths construct runs the same way.
 use super::scenarios::planned_txs;
 
-/// Convert a bounded `u64` to [`Zatoshis`]; infallible for the ranges the strategies draw from.
-fn zat(value: u64) -> Zatoshis {
-    Zatoshis::from_u64(value).expect("test amount within the money supply")
-}
-
 // --- leaf strategies ---
 
 /// An arbitrary [`MigrationTransferId`] row key.
@@ -100,11 +95,11 @@ pub fn arb_preparation_plan() -> impl Strategy<Value = PreparationPlan> {
 pub fn arb_denomination_plan() -> impl Strategy<Value = DenominationPlan> {
     (
         prop::collection::vec(arb_zatoshis(), 0..8),
-        (0u64..1_000_000).prop_map(zat),
+        (0u64..1_000_000).prop_map(Zatoshis::const_from_u64),
         prop::option::of(arb_zatoshis()),
-        (0u64..1_000_000).prop_map(zat),
-        (0u64..1_000_000_000).prop_map(zat),
-        (0u64..1_000_000_000).prop_map(zat),
+        (0u64..1_000_000).prop_map(Zatoshis::const_from_u64),
+        (0u64..1_000_000_000).prop_map(Zatoshis::const_from_u64),
+        (0u64..1_000_000_000).prop_map(Zatoshis::const_from_u64),
     )
         .prop_map(
             |(

--- a/zcash_pool_migration/tests/engine_plan.rs
+++ b/zcash_pool_migration/tests/engine_plan.rs
@@ -163,14 +163,14 @@ fn reconciliation_drops_the_unfundable_tail_for_a_many_equal_note_source() {
 
     // The baseline: the same denominations with an always-fundable preparation stub, i.e. what the
     // strategy proposes for this balance absent the equal-note source's fundability constraint.
-    // Recover the exact fees `plan_migration` used from the produced plan so the baseline matches.
+    // Recover the exact fees `plan_migration` used from the produced plan, and pass the same
+    // per-run note cap it defaults to, so the baseline matches the plan it is compared against.
     let transfer_buffer = plan.denominations().note_fee_buffer();
     let prep_tx_fee = plan.denominations().prep_fees();
     let mut ref_rng = ChaCha8Rng::seed_from_u64(1);
     let proposed = plan_denominations(
         zat(balance),
         source_note_count,
-        // The same cap `plan_migration` uses: this baseline is compared against that plan.
         MIGRATION_MAX_PREPARED_NOTES_PER_RUN,
         transfer_buffer,
         prep_tx_fee,

--- a/zcash_pool_migration/tests/engine_plan.rs
+++ b/zcash_pool_migration/tests/engine_plan.rs
@@ -14,7 +14,9 @@ use zcash_protocol::TxId;
 use zcash_protocol::consensus::BlockHeight;
 use zcash_protocol::value::{COIN, Zatoshis};
 
-use zcash_pool_migration::denomination::{DenominationPlan, plan_denominations};
+use zcash_pool_migration::denomination::{
+    DenominationPlan, MIGRATION_MAX_PREPARED_NOTES_PER_RUN, plan_denominations,
+};
 use zcash_pool_migration::engine::{
     MigrationBackend, MigrationError, MigrationState, MigrationStatus, MigrationTransaction,
     MigrationTransferId, MigrationTxKind, MigrationTxState, PoolMigrationRead, PoolMigrationWrite,
@@ -168,6 +170,8 @@ fn reconciliation_drops_the_unfundable_tail_for_a_many_equal_note_source() {
     let proposed = plan_denominations(
         zat(balance),
         source_note_count,
+        // The same cap `plan_migration` uses: this baseline is compared against that plan.
+        MIGRATION_MAX_PREPARED_NOTES_PER_RUN,
         transfer_buffer,
         prep_tx_fee,
         &prep_tx_count_stub,

--- a/zcash_pool_migration/tests/max_notes.rs
+++ b/zcash_pool_migration/tests/max_notes.rs
@@ -13,16 +13,20 @@
 use proptest::prelude::*;
 use rand_chacha::ChaCha8Rng;
 use rand_core::SeedableRng;
-use zcash_protocol::value::{COIN, Zatoshis};
-use zcash_protocol::zip318::{DENOM_CAP, MAX_RESIDUAL_VALUE, is_canonical_denomination};
-
-use zcash_pool_migration::denomination::MIGRATION_MAX_PREPARED_NOTES_PER_RUN;
-use zcash_pool_migration::engine::{
-    MigrationPlan, MigrationRunEstimate, estimate_migration_runs, estimate_migration_runs_with,
-    plan_migration, plan_migration_with,
+use zcash_protocol::{
+    value::{COIN, Zatoshis},
+    zip318::{DENOM_CAP, MAX_RESIDUAL_VALUE, is_canonical_denomination},
 };
-use zcash_pool_migration::preparation::default_portfolio;
-use zcash_pool_migration::testing::{MIGRATION_SCENARIOS, MigrationScenario};
+
+use zcash_pool_migration::{
+    denomination::MIGRATION_MAX_PREPARED_NOTES_PER_RUN,
+    engine::{
+        MigrationPlan, MigrationRunEstimate, estimate_migration_runs, estimate_migration_runs_with,
+        plan_migration, plan_migration_with,
+    },
+    preparation::default_portfolio,
+    testing::{MIGRATION_SCENARIOS, MigrationScenario},
+};
 use zcash_pool_migration_memory::{MockBackend, regtest_network};
 
 /// A post-NU6.3 chain tip to plan against.
@@ -30,11 +34,6 @@ const TIP: u32 = 2_000_000;
 /// Any fixed seed: the canonical decomposition does not consult the RNG, and both sides of every
 /// comparison below use this same seed so the schedules match too.
 const SEED: u64 = 7;
-
-/// Wrap a raw zatoshi amount for the assertions.
-fn zat(n: u64) -> Zatoshis {
-    Zatoshis::from_u64(n).expect("valid amount")
-}
 
 /// A note cap, from a plain count. The caps under test are all small positive literals.
 fn cap(n: usize) -> core::num::NonZeroUsize {
@@ -54,12 +53,6 @@ fn plan_at(scenario: &MigrationScenario, max_notes: usize) -> MigrationPlan {
         &mut rng,
     )
     .unwrap_or_else(|e| panic!("{}: cap {max_notes} should plan, got {e}", scenario.label))
-}
-
-/// The source-pool residual one run leaves: what the denomination plan could not pack into whole
-/// self-funding notes.
-fn residual(plan: &MigrationPlan) -> u64 {
-    plan.denominations().change().map(u64::from).unwrap_or(0)
 }
 
 /// Estimate the whole migration of `notes` under `max_notes`, with the default strategies.
@@ -102,7 +95,7 @@ fn raising_the_cap_migrates_more_and_lowering_it_migrates_less() {
                 sc.label
             );
             assert!(
-                residual(lower) >= residual(higher),
+                lower.residual() >= higher.residual(),
                 "{}: the residual must not grow as the cap grows",
                 sc.label
             );
@@ -117,11 +110,11 @@ fn raising_the_cap_migrates_more_and_lowering_it_migrates_less() {
             lowest.transfer_tx_count()
         );
         assert!(
-            residual(highest) < residual(lowest),
-            "{}: the raised cap should leave a smaller residual, got {} vs {}",
+            highest.residual() < lowest.residual(),
+            "{}: the raised cap should leave a smaller residual, got {:?} vs {:?}",
             sc.label,
-            residual(highest),
-            residual(lowest)
+            highest.residual(),
+            lowest.residual()
         );
         // The cap is a cap, not a target: at the scenario's own crossing count it reproduces the
         // default plan exactly.
@@ -301,7 +294,7 @@ fn the_default_path_is_unchanged() {
         );
         assert_eq!(
             plan.value_migrated(),
-            zat(sc.expected_migrated),
+            Zatoshis::const_from_u64(sc.expected_migrated),
             "{}: migrated value",
             sc.label
         );

--- a/zcash_pool_migration/tests/max_notes.rs
+++ b/zcash_pool_migration/tests/max_notes.rs
@@ -1,0 +1,336 @@
+//! The per-run note cap as an EXTERNAL crate sees it: the one denomination knob a wallet may set.
+//!
+//! A wallet chooses how many notes one migration run prepares; it does NOT choose the denomination
+//! scheme. The `{1, 2, 5} * 10^k` set and its `DENOM_CAP` / `MAX_RESIDUAL_VALUE` bounds are
+//! normative ZIP 318 values, and the privacy argument rests on every wallet publishing values from
+//! that same set. These tests exercise the wallet-facing API from outside the crate, so they see
+//! exactly the surface an SDK sees, and they pin both halves of that: the cap MOVES the run's size,
+//! and it CANNOT move the scheme or its bounds.
+//!
+//! [ZIP 318]: https://zips.z.cash/zip-0318
+#![cfg(feature = "test-dependencies")]
+
+use proptest::prelude::*;
+use rand_chacha::ChaCha8Rng;
+use rand_core::SeedableRng;
+use zcash_protocol::value::{COIN, Zatoshis};
+use zcash_protocol::zip318::{DENOM_CAP, MAX_RESIDUAL_VALUE, is_canonical_denomination};
+
+use zcash_pool_migration::denomination::MIGRATION_MAX_PREPARED_NOTES_PER_RUN;
+use zcash_pool_migration::engine::{
+    MigrationPlan, MigrationRunEstimate, estimate_migration_runs, estimate_migration_runs_with,
+    plan_migration, plan_migration_with,
+};
+use zcash_pool_migration::preparation::default_portfolio;
+use zcash_pool_migration::testing::{MIGRATION_SCENARIOS, MigrationScenario};
+use zcash_pool_migration_memory::{MockBackend, regtest_network};
+
+/// A post-NU6.3 chain tip to plan against.
+const TIP: u32 = 2_000_000;
+/// Any fixed seed: the canonical decomposition does not consult the RNG, and both sides of every
+/// comparison below use this same seed so the schedules match too.
+const SEED: u64 = 7;
+
+/// Wrap a raw zatoshi amount for the assertions.
+fn zat(n: u64) -> Zatoshis {
+    Zatoshis::from_u64(n).expect("valid amount")
+}
+
+/// A note cap, from a plain count. The caps under test are all small positive literals.
+fn cap(n: usize) -> core::num::NonZeroUsize {
+    core::num::NonZeroUsize::new(n).expect("the caps under test are positive")
+}
+
+/// Plan one run for `scenario`'s wallet under `max_notes`, with the crate's default preparation
+/// strategies (so the cap is the only thing that varies across a comparison).
+fn plan_at(scenario: &MigrationScenario, max_notes: usize) -> MigrationPlan {
+    let backend = MockBackend::new(scenario.source_notes.to_vec(), TIP);
+    let mut rng = ChaCha8Rng::seed_from_u64(SEED);
+    plan_migration_with(
+        &default_portfolio(),
+        cap(max_notes),
+        &regtest_network(true),
+        &backend,
+        &mut rng,
+    )
+    .unwrap_or_else(|e| panic!("{}: cap {max_notes} should plan, got {e}", scenario.label))
+}
+
+/// The source-pool residual one run leaves: what the denomination plan could not pack into whole
+/// self-funding notes.
+fn residual(plan: &MigrationPlan) -> u64 {
+    plan.denominations().change().map(u64::from).unwrap_or(0)
+}
+
+/// Estimate the whole migration of `notes` under `max_notes`, with the default strategies.
+fn estimate_at(notes: &[u64], max_notes: usize) -> MigrationRunEstimate {
+    let backend = MockBackend::new(notes.to_vec(), TIP);
+    let mut rng = ChaCha8Rng::seed_from_u64(SEED);
+    estimate_migration_runs_with(
+        &default_portfolio(),
+        cap(max_notes),
+        &regtest_network(true),
+        &backend,
+        &mut rng,
+    )
+    .expect("a fundable balance estimates")
+}
+
+/// The scenarios with enough crossings to compare three distinct caps (one, one short of the full
+/// split, and the full split).
+fn multi_crossing_scenarios() -> impl Iterator<Item = &'static MigrationScenario> {
+    MIGRATION_SCENARIOS
+        .iter()
+        .filter(|sc| sc.expected_transfers >= 3)
+}
+
+/// Raising the cap migrates MORE and leaves LESS behind; lowering it migrates less and leaves more.
+/// Checked as the full monotone chain over every cap from one up to the scenario's own crossing
+/// count: crossings are non-decreasing in the cap, the residual is non-increasing, and the two ends
+/// differ strictly. That is the whole user-visible effect of the knob — a bigger run, not different
+/// values.
+#[test]
+fn raising_the_cap_migrates_more_and_lowering_it_migrates_less() {
+    for sc in multi_crossing_scenarios() {
+        let full = sc.expected_transfers;
+        let plans: Vec<MigrationPlan> = (1..=full).map(|c| plan_at(sc, c)).collect();
+
+        for (lower, higher) in plans.iter().zip(plans.iter().skip(1)) {
+            assert!(
+                lower.transfer_tx_count() <= higher.transfer_tx_count(),
+                "{}: crossings must not shrink as the cap grows",
+                sc.label
+            );
+            assert!(
+                residual(lower) >= residual(higher),
+                "{}: the residual must not grow as the cap grows",
+                sc.label
+            );
+        }
+
+        let (lowest, highest) = (&plans[0], &plans[full - 1]);
+        assert!(
+            highest.transfer_tx_count() > lowest.transfer_tx_count(),
+            "{}: the raised cap should cross more, got {} at cap {full} vs {} at cap 1",
+            sc.label,
+            highest.transfer_tx_count(),
+            lowest.transfer_tx_count()
+        );
+        assert!(
+            residual(highest) < residual(lowest),
+            "{}: the raised cap should leave a smaller residual, got {} vs {}",
+            sc.label,
+            residual(highest),
+            residual(lowest)
+        );
+        // The cap is a cap, not a target: at the scenario's own crossing count it reproduces the
+        // default plan exactly.
+        assert_eq!(
+            highest.transfer_tx_count(),
+            sc.expected_transfers,
+            "{}: the full cap reproduces the default split",
+            sc.label
+        );
+    }
+}
+
+/// The preview and the plan describe the SAME run under a custom cap: passed the same knobs, the
+/// estimate's first run is exactly what `plan_migration_with` plans (same crossings, same
+/// preparation transactions, same migrated value). This is the claim both `_with` docs make, and it
+/// is what breaks if an application passes its cap to only one of them.
+#[test]
+fn the_estimate_previews_the_run_the_plan_builds_under_a_custom_cap() {
+    /// A cap well below every scenario's crossing count, so it actually binds.
+    const CUSTOM_CAP: usize = 2;
+
+    for sc in multi_crossing_scenarios() {
+        let plan = plan_at(sc, CUSTOM_CAP);
+        let est = estimate_at(sc.source_notes, CUSTOM_CAP);
+        let first = est.runs().first().expect("a fundable balance has a run");
+
+        assert_eq!(
+            first.crossings(),
+            plan.transfer_tx_count(),
+            "{}: previewed crossings",
+            sc.label
+        );
+        assert_eq!(
+            first.prep_transactions(),
+            plan.preparation_tx_count(),
+            "{}: previewed preparation transactions",
+            sc.label
+        );
+        assert_eq!(
+            first.migratable(),
+            plan.value_migrated(),
+            "{}: previewed migrated value",
+            sc.label
+        );
+    }
+}
+
+/// A capped run is a smaller bite, so the whole migration takes more of them: a whale that the
+/// default cap clears in a few runs needs strictly more under a tighter cap, and every run honours
+/// the cap it was given. (The two do NOT migrate the same total: more runs pay more per-run
+/// preparation and transfer fees, so a tighter cap migrates slightly less value overall.)
+#[test]
+fn a_tighter_cap_takes_more_runs_to_migrate_the_same_whale() {
+    /// A balance well beyond one default run's capacity (50 notes of at most 10,000 ZEC).
+    const WHALE: u64 = 1_200_000 * COIN;
+    /// A cap far below the default, so each run is a much smaller bite.
+    const TIGHT_CAP: usize = 5;
+
+    let whale = [WHALE];
+    let default = estimate_at(&whale, MIGRATION_MAX_PREPARED_NOTES_PER_RUN.get());
+    let tight = estimate_at(&whale, TIGHT_CAP);
+
+    assert!(
+        tight.run_count() > default.run_count(),
+        "a tighter cap should take more runs, got {} vs {}",
+        tight.run_count(),
+        default.run_count()
+    );
+    assert!(
+        tight.runs().iter().all(|r| r.crossings() <= TIGHT_CAP),
+        "every run must honour the cap it was given"
+    );
+    assert_eq!(
+        default.runs()[0].crossings(),
+        MIGRATION_MAX_PREPARED_NOTES_PER_RUN.get(),
+        "the default run fills the default cap for a whale"
+    );
+}
+
+/// A scenario index and a note cap: the input shape of the law that the cap cannot move the scheme.
+fn arb_scenario_and_cap() -> impl Strategy<Value = (usize, usize)> {
+    /// The largest cap sampled. Above the biggest scenario's crossing count, so the sampled range
+    /// spans both the binding and the non-binding regime.
+    const MAX_SAMPLED_CAP: usize = 16;
+
+    (0..MIGRATION_SCENARIOS.len(), 1usize..=MAX_SAMPLED_CAP)
+}
+
+proptest! {
+    /// THE key law: the one knob a wallet may set moves how MANY notes a run prepares and nothing
+    /// else. For any wallet and any cap, the run publishes at most `max_notes` crossings, and every
+    /// crossing is still a canonical ZIP 318 denomination — on the `{1, 2, 5} * 10^k` series and
+    /// within `[MAX_RESIDUAL_VALUE, DENOM_CAP]`, which is exactly what
+    /// `is_canonical_denomination` decides. No cap can push a value out of the set every other
+    /// wallet publishes from, which is where the anonymity set lives.
+    #[test]
+    fn the_cap_bounds_the_count_and_never_moves_the_scheme(
+        (index, max_notes) in arb_scenario_and_cap(),
+    ) {
+        let sc = &MIGRATION_SCENARIOS[index];
+        let backend = MockBackend::new(sc.source_notes.to_vec(), TIP);
+        let mut rng = ChaCha8Rng::seed_from_u64(SEED);
+        let planned = plan_migration_with(
+            &default_portfolio(),
+            cap(max_notes),
+            &regtest_network(true),
+            &backend,
+            &mut rng,
+        );
+        // A cap too small for this wallet's notes to fund anything is a legitimate empty outcome,
+        // not a violation: the law below constrains what a run PUBLISHES.
+        let Ok(plan) = planned else { return Ok(()) };
+
+        let crossings = plan.denominations().crossing_values();
+        prop_assert!(
+            crossings.len() <= max_notes,
+            "{}: {} crossings exceed the cap {}",
+            sc.label,
+            crossings.len(),
+            max_notes
+        );
+        for &crossing in crossings {
+            prop_assert!(
+                is_canonical_denomination(crossing),
+                "{}: {} is not a canonical ZIP 318 denomination",
+                sc.label,
+                u64::from(crossing)
+            );
+            prop_assert!(
+                crossing >= MAX_RESIDUAL_VALUE && crossing <= DENOM_CAP,
+                "{}: {} is outside the ZIP 318 bounds",
+                sc.label,
+                u64::from(crossing)
+            );
+        }
+    }
+}
+
+/// The default path is unchanged: `plan_migration` still plans exactly what the crate's defaults
+/// plan — the default portfolio at `MIGRATION_MAX_PREPARED_NOTES_PER_RUN` — and still reproduces
+/// every shared scenario's pinned shape. The Android SDK calls this signature, so it is
+/// load-bearing that adding the knob did not move it.
+#[test]
+fn the_default_path_is_unchanged() {
+    for sc in MIGRATION_SCENARIOS {
+        let backend = MockBackend::new(sc.source_notes.to_vec(), TIP);
+        let mut rng = ChaCha8Rng::seed_from_u64(SEED);
+        let plan = plan_migration(&regtest_network(true), &backend, &mut rng)
+            .unwrap_or_else(|e| panic!("{}: should plan, got {e}", sc.label));
+
+        let explicit = plan_at(sc, MIGRATION_MAX_PREPARED_NOTES_PER_RUN.get());
+        assert_eq!(
+            plan.denominations(),
+            explicit.denominations(),
+            "{}: the default path must equal the explicit defaults",
+            sc.label
+        );
+        assert_eq!(
+            plan.funding_notes(),
+            explicit.funding_notes(),
+            "{}: funding notes",
+            sc.label
+        );
+
+        // And the scenario's own pinned shape still holds.
+        assert_eq!(
+            plan.preparation_tx_count(),
+            sc.expected_preparations,
+            "{}: preparations",
+            sc.label
+        );
+        assert_eq!(
+            plan.transfer_tx_count(),
+            sc.expected_transfers,
+            "{}: crossings",
+            sc.label
+        );
+        assert_eq!(
+            plan.value_migrated(),
+            zat(sc.expected_migrated),
+            "{}: migrated value",
+            sc.label
+        );
+    }
+}
+
+/// `estimate_migration_runs` likewise still previews the defaults: the same estimate as
+/// `estimate_migration_runs_with` given the default portfolio and note cap.
+#[test]
+fn the_default_estimate_is_unchanged() {
+    for sc in MIGRATION_SCENARIOS {
+        let backend = MockBackend::new(sc.source_notes.to_vec(), TIP);
+        let mut rng = ChaCha8Rng::seed_from_u64(SEED);
+        let est = estimate_migration_runs(&regtest_network(true), &backend, &mut rng)
+            .expect("a fundable balance estimates");
+        let explicit = estimate_at(sc.source_notes, MIGRATION_MAX_PREPARED_NOTES_PER_RUN.get());
+
+        assert_eq!(est.run_count(), explicit.run_count(), "{}: runs", sc.label);
+        assert_eq!(
+            est.total_crossings(),
+            explicit.total_crossings(),
+            "{}: crossings",
+            sc.label
+        );
+        assert_eq!(
+            est.final_residual(),
+            explicit.final_residual(),
+            "{}: residual",
+            sc.label
+        );
+    }
+}

--- a/zcash_pool_migration/tests/signing_rounds_e2e.rs
+++ b/zcash_pool_migration/tests/signing_rounds_e2e.rs
@@ -289,7 +289,7 @@ fn migration_scenarios_end_to_end() {
 
         // Every scenario's quanta fit one run (within the per-run note cap).
         assert!(
-            sc.expected_transfers <= MIGRATION_MAX_PREPARED_NOTES_PER_RUN,
+            sc.expected_transfers <= MIGRATION_MAX_PREPARED_NOTES_PER_RUN.get(),
             "{}: quanta fit one run",
             sc.label
         );
@@ -473,7 +473,7 @@ fn total_keystone_rounds_evolve_across_runs() {
         // per-run sum (rounds cannot span runs).
         for run in est.runs() {
             assert!(run.crossings() >= 1);
-            assert!(run.crossings() <= MIGRATION_MAX_PREPARED_NOTES_PER_RUN);
+            assert!(run.crossings() <= MIGRATION_MAX_PREPARED_NOTES_PER_RUN.get());
         }
         let summed: usize = est
             .runs()


### PR DESCRIPTION
## Motivation

`plan_migration` and `plan_migration_with` hardcoded `CanonicalOneTwoFive::recommended(...)`,
so the per-run note cap (`MIGRATION_MAX_PREPARED_NOTES_PER_RUN`, 50) could not be chosen by
the wallet. A wallet has real reasons to vary it: a hot-wallet account can afford a longer run,
while an account signing through an external device may want a shorter one so a run fits fewer
signing rounds. A balance beyond one run's capacity simply migrates over more runs.

The crate already documented this as a caller's choice without offering any way to make it.
`MIGRATION_MAX_PREPARED_NOTES_PER_RUN` is described as "a policy default of this crate, not a
ZIP 318 constant" — the ZIP fixes the denomination set and its bounds but says nothing about
how many crossings one run may prepare. This makes the API match that description.

## What this does NOT do

The denomination scheme stays fixed. There is no `DenominationStrategy` injection: the trait
remains an internal seam, every crossing is still a canonical `{1, 2, 5} * 10^k` value, and
`DENOM_CAP` and `MAX_RESIDUAL_VALUE` stay pinned to their `zcash_protocol::zip318` values and
appear in no new signature. Only the per-run note count, which ZIP 318 does not define, is the
caller's to choose. A doc comment on the re-export claiming those two bounds were also
caller-chosen was inaccurate and has been corrected.

New `CanonicalOneTwoFive::with_max_notes` exists so the ZIP 318 bounds are named in exactly
one place and no call site can vary them.

## Also fixed here

`estimate_migration_runs` planned its preparations with `plan_preparation` (the default
portfolio) even when the caller had planned with a different one through `plan_migration_with`,
so the previewed run count could describe a different migration from the one that would be
planned. The new `estimate_migration_runs_with` takes both knobs in the same order as
`plan_migration_with`, and its docs say they must be passed to both.

## Breaking changes

Acceptable at `0.1.0-rc.7`; `[Unreleased]` already carries larger ones.

- `plan_migration_with` takes `max_notes: NonZeroUsize` in second position.
- `denomination::plan_denominations` takes the same.
- `MIGRATION_MAX_PREPARED_NOTES_PER_RUN` is now a `NonZeroUsize`. A default that cannot be
  passed where the parameter is expected is not much of a default; `SigningRoundBudget::DEFAULT`
  is typed the same way. `NonZeroUsize` also makes a zero cap unrepresentable, which today
  yields an empty split reported as `NothingToMigrate`/`UnfundableSplit` — describing the
  wallet's state rather than the bad argument.

`plan_migration`, `estimate_migration_runs`, and `CanonicalOneTwoFive::new` are unchanged.

## Testing

`cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and
`cargo test --release --all-features` are green (280 lib + 32 integration tests). New
`tests/max_notes.rs` covers raising and lowering the cap, estimate/plan agreement under a
custom cap, and that the default path is unchanged. A proptest asserts the property that
matters most: for any cap and balance, the crossing count stays within the cap and every
crossing is still canonical, so the one knob cannot move the scheme or its bounds. A second
proptest pins the cap-invariance of `balance_has_canonical_split`'s emptiness answer, which
the new doc claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
