### PR TITLE
Add CLAUDE.md as a symlink to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## What

Adds `CLAUDE.md` at the repository root as a symlink to `AGENTS.md`.

## Why

Claude Code automatically loads `CLAUDE.md` from the repository root into an agent's
context at session start. It does **not** load `AGENTS.md`. Since this repository has only
`AGENTS.md`, its conventions were never in context automatically: an agent working here
reconstructed them from memory of past review comments, or simply did not know them.

That is not hypothetical. It produced avoidable review churn on #2962 over the rules in
the "Imports" section, and those are precisely the rules tooling cannot catch:
`imports_granularity` is nightly-only and unstable, and rustfmt deliberately leaves
`#[cfg]`-gated imports untouched, so `cargo fmt`, clippy and the test suite all pass green
on non-compliant imports. Human review was the only detector. The same omission meant the
contribution gate at the top of `AGENTS.md` was never run.

The effect reaches subagents too, which matters here because much agent work is delegated:
per the Claude Code documentation, every subagent except the built-in Explore and Plan
loads the project `CLAUDE.md`. Today they inherit nothing from `AGENTS.md`.

## Why a symlink

It keeps `AGENTS.md` the single source of truth, so the two cannot drift, and every other
agent tool that reads `AGENTS.md` by name is unaffected. This repository already tracks
symlinks (`zcash_client_backend/proto/*.proto`), so it needs no new tooling support.

## Caveat

A checkout without symlink support, which on Windows requires `core.symlinks` and
developer mode, materializes `CLAUDE.md` as a plain file whose contents are the string
`AGENTS.md`. That degrades gracefully, since the file still names the document to read.

Worth noting for a follow-up: the Claude Code documentation suggests keeping `CLAUDE.md`
under about 200 lines, and warns that longer files still load in full but may reduce
adherence. `AGENTS.md` is 667 lines. If that proves to be a problem in practice, the
documented alternative is `.claude/rules/` with `paths:` frontmatter, which loads
conventions only when matching files enter context. This PR deliberately does not do that,
since it would split the source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
