### PR TITLE
zcash_pool_migration: Let a signer's capacity size one run

### DIFF
--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -45,6 +45,37 @@ and this library adheres to Rust's notion of
   runs it is about to plan. The same values must be passed to both, or the
   preview will not describe the runs that get planned. Its cost scales inversely
   with the cap, since a bigger run means fewer runs to iterate.
+- `signing_rounds::RunSigningCapacity`, `signing_rounds::RunShape` and
+  `signing_rounds::largest_run_size_within`: bounding a run by what a signer will
+  sign, and the search that turns that bound into a per-run note cap. This is the
+  inverse of the round count in the run SIZE, as
+  `signing_rounds::min_budget_for_rounds` is its inverse in the BUDGET. Under a
+  round count non-decreasing in the cap — which the canonical decomposition
+  gives — the chosen cap is the largest run the signer signs; otherwise it is
+  still one that fits.
+- `engine::plan_migration_for_signer` and
+  `engine::plan_migration_for_signer_with`, which size a run by an external
+  signer's capacity instead of by a note count, so one run is one signing
+  session. A note cap cannot express that bound: a run's actions are
+  `16 * preparations + 3 * transfers`, and the preparation count follows the
+  wallet's fragmentation, so the same cap yields a one-round run for one wallet
+  and a four-round run for another. Both sizings are supported;
+  `engine::plan_migration` and `engine::plan_migration_with` are unchanged and
+  keep sizing by note count. The resulting plan exceeds the signer's rounds only
+  when a one-note run already does, which no smaller run can fix; the overflow is
+  visible in `engine::MigrationPlan::signing_round_count`.
+- `engine::estimate_migration_runs_for_signer` and
+  `engine::estimate_migration_runs_for_signer_with`, the preview counterparts,
+  taking exactly the planning functions' knobs. Sizing is per run, over that
+  run's own note structure, so a wallet migrates fewer notes in the runs that
+  consolidate its fragmentation and more once its notes are larger.
+- `engine::RunSizing`, `engine::plan_migration_sized_with` and
+  `engine::estimate_migration_runs_sized_with`: the bound as a VALUE (a note
+  count or a signer capacity) and the entry points that take it, for an
+  application that lets the user choose between the two and carries that choice.
+  The fixed-bound entry points are these with one variant pre-chosen.
+- `testing::arb_run_signing_capacity`, a `proptest` strategy over
+  `signing_rounds::RunSigningCapacity`.
 
 ### Changed
 - `denomination::MIGRATION_MAX_PREPARED_NOTES_PER_RUN` is a `NonZeroUsize` where

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -80,8 +80,9 @@ use crate::{
     satisfiability::{ReorgSettleDepth, ReplanThreshold, StepSatisfiability, UnsatisfiableKind},
     scheduling::{self, Schedule},
     signing_rounds::{
-        MinRounds, PlannedSigningRound, PlannedTx, SigningRoundBudget, SigningRoundStrategy,
-        min_budget_for_rounds, min_signing_rounds,
+        MinRounds, PlannedSigningRound, PlannedTx, RunShape, RunSigningCapacity,
+        SigningRoundBudget, SigningRoundStrategy, largest_run_size_within, min_budget_for_rounds,
+        min_signing_rounds,
     },
 };
 
@@ -1609,6 +1610,173 @@ where
     B: MigrationBackend,
     R: RngCore + rand_core::CryptoRng,
 {
+    plan_migration_sized_with(portfolio, RunSizing::Notes(max_notes), params, backend, rng)
+}
+
+/// As [`plan_migration`], sizing the run to what an external signer of `capacity` will sign rather
+/// than to a fixed note count: the run is capped at the largest number of notes that keeps it within
+/// the signer's rounds, so one run is one signing session.
+///
+/// This is the sizing to use with a capacity-limited hardware signer (for example
+/// [`RunSigningCapacity::KEYSTONE`]). A note cap cannot express that bound: a run's actions are
+/// `16 * preparations + 3 * transfers`, and the preparation count depends on how fragmented the
+/// wallet is, so the same cap yields a one-round run for one wallet and a four-round run for
+/// another. What remains un-migrated is migrated by the next run, exactly as when a run is bounded
+/// by a note cap.
+///
+/// The resulting plan takes more than [`RunSigningCapacity::max_rounds`] rounds only when a
+/// one-note run already exceeds the budget, which no smaller run can fix; check
+/// [`MigrationPlan::signing_round_count`] if that case must be surfaced.
+pub fn plan_migration_for_signer<P, B, R>(
+    capacity: RunSigningCapacity,
+    params: &P,
+    backend: &B,
+    rng: &mut R,
+) -> Result<MigrationPlan, MigrationError<B::Error>>
+where
+    P: zcash_protocol::consensus::Parameters,
+    B: MigrationBackend,
+    R: RngCore + rand_core::CryptoRng,
+{
+    plan_migration_for_signer_with(
+        &crate::preparation::default_portfolio(),
+        capacity,
+        params,
+        backend,
+        rng,
+    )
+}
+
+/// As [`plan_migration_for_signer`], planning the preparation transactions against a chosen set of
+/// strategies rather than the ones the crate ships.
+///
+/// Sizing the run costs `O(log capacity.max_notes())` denomination and preparation planning passes
+/// before the run is planned, so this is a few times the cost of [`plan_migration_with`]. Whichever
+/// knobs are passed here must also be passed to [`estimate_migration_runs_for_signer_with`], or the
+/// preview will not describe the runs that get planned.
+pub fn plan_migration_for_signer_with<Pf, P, B, R>(
+    portfolio: &Pf,
+    capacity: RunSigningCapacity,
+    params: &P,
+    backend: &B,
+    rng: &mut R,
+) -> Result<MigrationPlan, MigrationError<B::Error>>
+where
+    Pf: crate::preparation::Portfolio,
+    P: zcash_protocol::consensus::Parameters,
+    B: MigrationBackend,
+    R: RngCore + rand_core::CryptoRng,
+{
+    plan_migration_sized_with(portfolio, RunSizing::Signer(capacity), params, backend, rng)
+}
+
+/// What bounds one migration run: a note COUNT, or an external signer's CAPACITY (an action budget
+/// per interaction, and how many interactions a run may take).
+///
+/// The two are alternatives, and an application that lets the user choose between them stores this
+/// and passes it to [`plan_migration_sized_with`] and [`estimate_migration_runs_sized_with`]. Each
+/// also has its own entry points, so neither requires going through this type.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RunSizing {
+    /// Prepare at most this many notes, whatever that costs the signer.
+    Notes(NonZeroUsize),
+    /// Prepare as many notes as this signer signs within its rounds, at most
+    /// [`RunSigningCapacity::max_notes`].
+    Signer(RunSigningCapacity),
+}
+
+impl Default for RunSizing {
+    /// The crate's default: [`MIGRATION_MAX_PREPARED_NOTES_PER_RUN`] notes.
+    fn default() -> Self {
+        Self::Notes(MIGRATION_MAX_PREPARED_NOTES_PER_RUN)
+    }
+}
+
+/// The transaction counts a run capped at `max_notes` would have, over the note structure `notes`
+/// (whose validated total is `balance`): what the denomination and preparation planners produce,
+/// before anything is scheduled. The sizing probe of [`largest_run_size_within`].
+fn run_shape_at<Pf, R>(
+    portfolio: &Pf,
+    notes: &[Zatoshis],
+    balance: Zatoshis,
+    max_notes: NonZeroUsize,
+    transfer_fee_buffer: Zatoshis,
+    prep_tx_fee: Zatoshis,
+    rng: &mut R,
+) -> RunShape
+where
+    Pf: crate::preparation::Portfolio,
+    R: RngCore + rand_core::CryptoRng,
+{
+    let prep_tx_count = |funding: &[Zatoshis]| {
+        plan_preparation_with(portfolio, notes, funding, prep_tx_fee)
+            .ok()
+            .map(|plan| plan.transaction_count())
+    };
+    let funding = plan_denominations(
+        balance,
+        notes.len(),
+        max_notes,
+        transfer_fee_buffer,
+        prep_tx_fee,
+        &prep_tx_count,
+        rng,
+    )
+    .migration_outputs();
+    // The denomination plan only ever proposes a funding multiset the preparation planner accepted,
+    // so this re-plan succeeds; a run that migrates nothing has no preparation either.
+    let preparations = prep_tx_count(&funding).unwrap_or(0);
+    RunShape::new(preparations, funding.len())
+}
+
+/// The note cap `sizing` chooses for a run over the note structure `notes` (whose validated total is
+/// `balance`).
+fn resolve_max_notes<Pf, R>(
+    sizing: RunSizing,
+    portfolio: &Pf,
+    notes: &[Zatoshis],
+    balance: Zatoshis,
+    transfer_fee_buffer: Zatoshis,
+    prep_tx_fee: Zatoshis,
+    rng: &mut R,
+) -> NonZeroUsize
+where
+    Pf: crate::preparation::Portfolio,
+    R: RngCore + rand_core::CryptoRng,
+{
+    match sizing {
+        RunSizing::Notes(max_notes) => max_notes,
+        RunSizing::Signer(capacity) => largest_run_size_within(capacity, |max_notes| {
+            run_shape_at(
+                portfolio,
+                notes,
+                balance,
+                max_notes,
+                transfer_fee_buffer,
+                prep_tx_fee,
+                rng,
+            )
+        }),
+    }
+}
+
+/// As [`plan_migration`], with both knobs explicit: the preparation strategies to plan against, and
+/// whichever [`RunSizing`] bounds the run. For an application that carries the user's choice of
+/// bound as a value; the fixed-bound entry points ([`plan_migration_with`],
+/// [`plan_migration_for_signer_with`]) are this function with one variant pre-chosen.
+pub fn plan_migration_sized_with<Pf, P, B, R>(
+    portfolio: &Pf,
+    sizing: RunSizing,
+    params: &P,
+    backend: &B,
+    rng: &mut R,
+) -> Result<MigrationPlan, MigrationError<B::Error>>
+where
+    Pf: crate::preparation::Portfolio,
+    P: zcash_protocol::consensus::Parameters,
+    B: MigrationBackend,
+    R: RngCore + rand_core::CryptoRng,
+{
     let notes = backend
         .spendable_orchard_note_values()
         .map_err(MigrationError::Backend)?;
@@ -1632,6 +1800,18 @@ where
     // The canonical fees, computed once from the canonical transaction shapes and reused throughout.
     let (prep_tx_fee, transfer_fee_buffer) =
         canonical_fees(params, commit_height).map_err(MigrationError::Fee)?;
+
+    // This run's note cap: the caller's, or the largest one an external signer of the given capacity
+    // signs within its rounds, measured over this wallet's current notes.
+    let max_notes = resolve_max_notes(
+        sizing,
+        portfolio,
+        &notes,
+        balance,
+        transfer_fee_buffer,
+        prep_tx_fee,
+        rng,
+    );
 
     // The preparation-layout capability the decomposition's reconciliation consults: how many
     // preparation transactions minting a candidate funding multiset takes, or `None` when the
@@ -1963,6 +2143,74 @@ where
     B: MigrationBackend,
     R: RngCore + rand_core::CryptoRng,
 {
+    estimate_migration_runs_sized_with(portfolio, RunSizing::Notes(max_notes), params, backend, rng)
+}
+
+/// As [`estimate_migration_runs`], previewing the runs [`plan_migration_for_signer`] will plan: each
+/// run is sized to what an external signer of `capacity` will sign, so the run count is the number
+/// of signing sessions rather than a function of a note cap.
+///
+/// Sizing is per run, over that run's own note structure, so the runs are not uniform: a wallet
+/// whose first runs consolidate deep fragmentation migrates fewer notes per run there than later,
+/// once its notes are larger.
+pub fn estimate_migration_runs_for_signer<P, B, R>(
+    capacity: RunSigningCapacity,
+    params: &P,
+    backend: &B,
+    rng: &mut R,
+) -> Result<MigrationRunEstimate, MigrationError<B::Error>>
+where
+    P: zcash_protocol::consensus::Parameters,
+    B: MigrationBackend,
+    R: RngCore + rand_core::CryptoRng,
+{
+    estimate_migration_runs_for_signer_with(
+        &crate::preparation::default_portfolio(),
+        capacity,
+        params,
+        backend,
+        rng,
+    )
+}
+
+/// As [`estimate_migration_runs_for_signer`], estimating against a chosen set of preparation
+/// strategies rather than the ones the crate ships.
+///
+/// These are exactly [`plan_migration_for_signer_with`]'s knobs, because this previews the runs that
+/// function will plan: the same values must be passed to both, or the preview will not describe the
+/// runs that get planned.
+pub fn estimate_migration_runs_for_signer_with<Pf, P, B, R>(
+    portfolio: &Pf,
+    capacity: RunSigningCapacity,
+    params: &P,
+    backend: &B,
+    rng: &mut R,
+) -> Result<MigrationRunEstimate, MigrationError<B::Error>>
+where
+    Pf: crate::preparation::Portfolio,
+    P: zcash_protocol::consensus::Parameters,
+    B: MigrationBackend,
+    R: RngCore + rand_core::CryptoRng,
+{
+    estimate_migration_runs_sized_with(portfolio, RunSizing::Signer(capacity), params, backend, rng)
+}
+
+/// As [`estimate_migration_runs`], with both knobs explicit: the preparation strategies to estimate
+/// against, and whichever [`RunSizing`] bounds each run. The preview counterpart of
+/// [`plan_migration_sized_with`], taking exactly its knobs.
+pub fn estimate_migration_runs_sized_with<Pf, P, B, R>(
+    portfolio: &Pf,
+    sizing: RunSizing,
+    params: &P,
+    backend: &B,
+    rng: &mut R,
+) -> Result<MigrationRunEstimate, MigrationError<B::Error>>
+where
+    Pf: crate::preparation::Portfolio,
+    P: zcash_protocol::consensus::Parameters,
+    B: MigrationBackend,
+    R: RngCore + rand_core::CryptoRng,
+{
     let height = backend
         .chain_tip_height()
         .map_err(MigrationError::Backend)?;
@@ -1987,6 +2235,19 @@ where
         // — and hence the whole run count — depends on the wallet's note structure, not just its
         // total value. The closure's borrow of `notes` is released with the block, before `notes` is
         // reassigned below.
+        // This run's note cap, chosen over the note structure THIS run starts from: a signer-sized
+        // migration re-sizes every run, since the wallet's fragmentation — and so a run's
+        // preparation cost — changes as earlier runs consolidate it.
+        let max_notes = resolve_max_notes(
+            sizing,
+            portfolio,
+            &notes,
+            balance,
+            transfer_fee_buffer,
+            prep_tx_fee,
+            rng,
+        );
+
         let denominations = {
             let prep_tx_count = |funding: &[Zatoshis]| {
                 plan_preparation_with(portfolio, &notes, funding, prep_tx_fee)

--- a/zcash_pool_migration/src/signing_rounds.rs
+++ b/zcash_pool_migration/src/signing_rounds.rs
@@ -18,6 +18,15 @@
 //! 374), so the packer may mix preparation and transfer across rounds; broadcast order stays a
 //! separate concern of the schedule.
 //!
+//! # The two inverse queries
+//!
+//! Packing answers "how many rounds does this run take". Both inverses are here as well, for the
+//! application that must decide something rather than display it: [`min_budget_for_rounds`] inverts
+//! the map in the BUDGET ("which signer signs this run in one interaction"), and
+//! [`largest_run_size_within`] inverts it in the run SIZE ("how big a run does this signer sign in
+//! one interaction"). The latter is what sizes a run for a capacity-limited signer, since a run's
+//! action count is not a function of its note count alone — see [`RunSigningCapacity`].
+//!
 //! The pluggable [`SigningRoundStrategy`] is the "named solution of the NP problem" seam, mirroring
 //! [`DenominationStrategy`](crate::denomination::DenominationStrategy): [`MinRounds`] (the optimal
 //! default) and [`NextFit`] (an order-preserving greedy). Any new solution inherits the crate's
@@ -28,7 +37,10 @@ use core::num::{NonZeroU32, NonZeroUsize};
 
 use zcash_protocol::consensus::BlockHeight;
 
-use crate::engine::{MigrationTransferId, MigrationTxKind};
+use crate::{
+    denomination::MIGRATION_MAX_PREPARED_NOTES_PER_RUN,
+    engine::{MigrationTransferId, MigrationTxKind},
+};
 
 /// The Orchard-family actions a padded preparation transaction carries.
 pub const PREPARATION_ACTIONS: u32 = crate::preparation::PREP_TX_ACTIONS as u32;
@@ -422,6 +434,158 @@ pub fn min_budget_for_rounds(n_prep: usize, n_transfer: usize, k: NonZeroUsize) 
     nz(lo)
 }
 
+/// The transaction counts of one migration run, the only inputs the round count depends on: its
+/// preparation transactions (16 actions each) and its pool-crossing transfers (3 actions each).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RunShape {
+    preparation_transactions: usize,
+    transfers: usize,
+}
+
+impl RunShape {
+    /// A run of `preparation_transactions` preparation transactions and `transfers` transfers.
+    #[must_use]
+    pub const fn new(preparation_transactions: usize, transfers: usize) -> Self {
+        Self {
+            preparation_transactions,
+            transfers,
+        }
+    }
+
+    /// The run's preparation transactions.
+    #[must_use]
+    pub const fn preparation_transactions(self) -> usize {
+        self.preparation_transactions
+    }
+
+    /// The run's pool-crossing transfers (one per funding note).
+    #[must_use]
+    pub const fn transfers(self) -> usize {
+        self.transfers
+    }
+
+    /// The number of signing rounds this run needs under `budget`, the optimal [`MinRounds`] count.
+    #[must_use]
+    pub fn signing_rounds(self, budget: SigningRoundBudget) -> usize {
+        min_signing_rounds(self.preparation_transactions, self.transfers, budget)
+    }
+}
+
+/// What one migration run may ask of a signer: at most [`max_rounds`](Self::max_rounds)
+/// interactions of at most [`budget`](Self::budget) total actions each, from a run preparing at most
+/// [`max_notes`](Self::max_notes) notes.
+///
+/// This is the capacity-side statement of a run's size. The note cap alone cannot make it: a run's
+/// actions are `16 * preparations + 3 * transfers`, and the preparation count is a function of the
+/// wallet's note structure (how deeply it must be consolidated), not of the number of notes the run
+/// mints. `max_notes` is therefore a CEILING the sizing never exceeds, not the target; see
+/// [`largest_run_size_within`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RunSigningCapacity {
+    budget: SigningRoundBudget,
+    max_rounds: NonZeroUsize,
+    max_notes: NonZeroUsize,
+}
+
+impl RunSigningCapacity {
+    /// A Keystone signing each run in a single interaction: [`SigningRoundBudget::KEYSTONE`], one
+    /// round, and the crate's default note ceiling.
+    pub const KEYSTONE: Self = Self::single_round(SigningRoundBudget::KEYSTONE);
+
+    /// A signer of `budget` actions per interaction that signs each run in ONE interaction, over a
+    /// run of at most [`MIGRATION_MAX_PREPARED_NOTES_PER_RUN`] notes.
+    #[must_use]
+    pub const fn single_round(budget: SigningRoundBudget) -> Self {
+        Self::new(
+            budget,
+            NonZeroUsize::MIN,
+            MIGRATION_MAX_PREPARED_NOTES_PER_RUN,
+        )
+    }
+
+    /// A signer of `budget` actions per interaction, allowed `max_rounds` interactions per run, over
+    /// a run of at most `max_notes` notes.
+    #[must_use]
+    pub const fn new(
+        budget: SigningRoundBudget,
+        max_rounds: NonZeroUsize,
+        max_notes: NonZeroUsize,
+    ) -> Self {
+        Self {
+            budget,
+            max_rounds,
+            max_notes,
+        }
+    }
+
+    /// The per-round action budget.
+    #[must_use]
+    pub const fn budget(self) -> SigningRoundBudget {
+        self.budget
+    }
+
+    /// The number of signing interactions one run may take.
+    #[must_use]
+    pub const fn max_rounds(self) -> NonZeroUsize {
+        self.max_rounds
+    }
+
+    /// The largest per-run note cap the sizing may choose.
+    #[must_use]
+    pub const fn max_notes(self) -> NonZeroUsize {
+        self.max_notes
+    }
+}
+
+/// The largest per-run note cap, at most [`RunSigningCapacity::max_notes`], whose run `shape_at`
+/// reports as signable within `capacity` — the inverse of "how many rounds does this run take",
+/// dual to [`min_budget_for_rounds`] (which inverts the same map in the budget instead of the size).
+///
+/// `shape_at` answers what a run capped at `n` notes would look like; it is called
+/// `O(log max_notes)` times.
+///
+/// The returned cap is one `shape_at` reported as fitting, EXCEPT when even a one-note run exceeds
+/// the capacity, in which case it is one: a wallet fragmented enough that minting a single funding
+/// note takes more consolidation than a round holds cannot be made to fit by shrinking the run, and
+/// the caller sees the overflow in the resulting plan's
+/// [`signing_round_count`](crate::engine::MigrationPlan::signing_round_count).
+///
+/// It is the LARGEST such cap whenever the run's round count is non-decreasing in the cap, which
+/// holds for this crate's canonical decomposition (raising the cap extends the split rather than
+/// reshaping it) and for any preparation portfolio that does not mint more notes with fewer
+/// transactions. Under that monotonicity this function and the round count are adjoint —
+/// `shape_at(n).signing_rounds(budget) <= max_rounds` exactly when `n` is at most the returned cap —
+/// so the result is the greatest run that fits. A portfolio violating it still gets a cap that
+/// fits, just not necessarily the largest.
+#[must_use]
+pub fn largest_run_size_within<F>(capacity: RunSigningCapacity, mut shape_at: F) -> NonZeroUsize
+where
+    F: FnMut(NonZeroUsize) -> RunShape,
+{
+    let mut fits = |n: NonZeroUsize| {
+        shape_at(n).signing_rounds(capacity.budget()) <= capacity.max_rounds().get()
+    };
+    // The whole run fits: the common case, and the one that costs a single probe.
+    if fits(capacity.max_notes()) {
+        return capacity.max_notes();
+    }
+    // Binary-search the largest cap that fits, keeping only caps a probe accepted, so the answer is
+    // certified even where the round count is not monotone in the cap.
+    let mut best = NonZeroUsize::MIN;
+    let (mut lo, mut hi) = (1usize, capacity.max_notes().get() - 1);
+    while lo <= hi {
+        let mid = lo + (hi - lo) / 2;
+        let cap = NonZeroUsize::new(mid).expect("`lo` starts at one, so `mid` is at least one");
+        if fits(cap) {
+            best = cap;
+            lo = mid + 1;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    best
+}
+
 /// Total actions of `n_prep` preparation and `n_transfer` transfer transactions (u32-saturating).
 fn total_actions(n_prep: usize, n_transfer: usize) -> u32 {
     let prep = (n_prep as u64).saturating_mul(u64::from(PREPARATION_ACTIONS));
@@ -546,6 +710,8 @@ fn div_ceil_u64(a: u64, b: u64) -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use proptest::{prop_assert, prop_assert_eq};
+
     use super::*;
 
     fn assert_valid(
@@ -645,6 +811,127 @@ mod tests {
             let n_transfer = txs.iter().filter(|t| t.is_transfer()).count();
             crate::testing::assert_optimal_round_count(&MinRounds, n_prep, n_transfer, budget);
             crate::testing::assert_no_worse_than(&MinRounds, &NextFit, n_prep, n_transfer, budget);
+        }
+    }
+
+    /// An oracle over explicit per-cap shapes: `shapes[n - 1]` is the run a cap of `n` notes
+    /// produces. Records every cap it was asked about, so a test can bound the probe count.
+    fn oracle<'a>(
+        shapes: &'a [RunShape],
+        probes: &'a mut Vec<usize>,
+    ) -> impl FnMut(NonZeroUsize) -> RunShape + 'a {
+        move |n| {
+            probes.push(n.get());
+            shapes[n.get() - 1]
+        }
+    }
+
+    /// Per-cap shapes that grow with the cap: `n` transfers, one preparation transaction per
+    /// `FUNDING_OUTPUTS_PER_TX` of them — the shape of a run over an unfragmented wallet.
+    fn monotone_shapes(ceiling: usize) -> Vec<RunShape> {
+        (1..=ceiling)
+            .map(|n| RunShape::new(n.div_ceil(crate::preparation::FUNDING_OUTPUTS_PER_TX), n))
+            .collect()
+    }
+
+    #[test]
+    fn sizing_fills_a_keystone_round() {
+        let ceiling = MIGRATION_MAX_PREPARED_NOTES_PER_RUN;
+        let shapes = monotone_shapes(ceiling.get());
+        let mut probes = Vec::new();
+        let chosen =
+            largest_run_size_within(RunSigningCapacity::KEYSTONE, oracle(&shapes, &mut probes));
+        // 5 notes: one preparation transaction (16 actions) and 5 transfers (15) is 31 of the 96;
+        // 6 notes would take a second preparation transaction and 34 actions, still one round.
+        assert!(chosen.get() > 5, "a Keystone round holds more than 5 notes");
+        assert_eq!(
+            shapes[chosen.get() - 1].signing_rounds(SigningRoundBudget::KEYSTONE),
+            1,
+            "the chosen cap signs in one round"
+        );
+        assert!(
+            chosen == ceiling
+                || shapes[chosen.get()].signing_rounds(SigningRoundBudget::KEYSTONE) > 1,
+            "one note more needs a second round"
+        );
+        assert!(
+            probes.len() <= usize::BITS as usize - ceiling.get().leading_zeros() as usize + 1,
+            "the search probes logarithmically, not linearly: {probes:?}"
+        );
+    }
+
+    #[test]
+    fn sizing_bottoms_out_at_one_note() {
+        // A wallet so fragmented that minting even one funding note takes 7 preparation
+        // transactions (112 actions): no cap fits a Keystone round, and the smallest run is
+        // returned rather than a failure.
+        let shapes: Vec<RunShape> = (1..=10).map(|n| RunShape::new(6 + n, n)).collect();
+        let mut probes = Vec::new();
+        let capacity = RunSigningCapacity::new(
+            SigningRoundBudget::KEYSTONE,
+            NonZeroUsize::MIN,
+            NonZeroUsize::new(shapes.len()).unwrap(),
+        );
+        let chosen = largest_run_size_within(capacity, oracle(&shapes, &mut probes));
+        assert_eq!(chosen, NonZeroUsize::MIN);
+        assert!(
+            shapes[0].signing_rounds(SigningRoundBudget::KEYSTONE) > 1,
+            "this wallet cannot be made to fit, which is what the caller must see"
+        );
+    }
+
+    proptest::proptest! {
+        // The ADJUNCTION: for a run whose round count is non-decreasing in the cap, a cap fits the
+        // signer exactly when it is at most the chosen one. That is what makes the chosen cap the
+        // greatest run the signer signs, not merely one that fits.
+        #[test]
+        fn sizing_is_adjoint_to_the_round_count(
+            capacity in crate::testing::arb_run_signing_capacity(),
+        ) {
+            let shapes = monotone_shapes(capacity.max_notes().get());
+            let mut probes = Vec::new();
+            let chosen = largest_run_size_within(capacity, oracle(&shapes, &mut probes));
+            prop_assert!(chosen <= capacity.max_notes());
+            for (i, shape) in shapes.iter().enumerate() {
+                let cap = i + 1;
+                let fits = shape.signing_rounds(capacity.budget()) <= capacity.max_rounds().get();
+                // The one asymmetry: when not even a one-note run fits, the minimum is returned
+                // anyway, since no smaller run exists to fall back to.
+                if cap == 1 && !fits {
+                    prop_assert_eq!(chosen, NonZeroUsize::MIN);
+                    continue;
+                }
+                prop_assert_eq!(fits, cap <= chosen.get(), "cap {} against {:?}", cap, chosen);
+            }
+        }
+
+        // Without monotonicity the chosen cap is no longer maximal, but it is still one a probe
+        // accepted — the guarantee an arbitrary preparation portfolio gets.
+        #[test]
+        fn sizing_always_returns_a_cap_that_fits(
+            capacity in crate::testing::arb_run_signing_capacity(),
+            raw in proptest::collection::vec((0usize..12, 0usize..40), 1..64),
+        ) {
+            // Reshape the arbitrary (and so arbitrarily non-monotone) counts to the ceiling.
+            let shapes: Vec<RunShape> = (0..capacity.max_notes().get())
+                .map(|i| {
+                    let (prep, transfers) = raw[i % raw.len()];
+                    RunShape::new(prep, transfers)
+                })
+                .collect();
+            let mut probes = Vec::new();
+            let chosen = largest_run_size_within(capacity, oracle(&shapes, &mut probes));
+            prop_assert!(chosen <= capacity.max_notes());
+            let fits = shapes[chosen.get() - 1].signing_rounds(capacity.budget())
+                <= capacity.max_rounds().get();
+            prop_assert!(
+                fits || chosen == NonZeroUsize::MIN,
+                "only a probed-feasible cap is returned, unless nothing fits"
+            );
+            prop_assert!(
+                probes.contains(&chosen.get()) || chosen == NonZeroUsize::MIN,
+                "the returned cap was measured, not assumed"
+            );
         }
     }
 

--- a/zcash_pool_migration/src/testing/generators.rs
+++ b/zcash_pool_migration/src/testing/generators.rs
@@ -5,7 +5,7 @@
 //! so does any downstream store crate: generating the SAME values everywhere is what makes one
 //! store's coverage comparable to another's.
 
-use core::num::NonZeroU32;
+use core::num::{NonZeroU32, NonZeroUsize};
 
 use proptest::prelude::*;
 
@@ -23,7 +23,7 @@ use crate::engine::{
 use crate::preparation::{PrepInput, PrepOutput, PrepTransaction, PreparationPlan};
 use crate::satisfiability::{ReplanThreshold, UnsatisfiableKind};
 use crate::scheduling::AnchorBucketInterval;
-use crate::signing_rounds::{PlannedTx, SigningRoundBudget};
+use crate::signing_rounds::{PlannedTx, RunSigningCapacity, SigningRoundBudget};
 
 use alloc::vec::Vec;
 
@@ -368,6 +368,21 @@ pub fn arb_signing_round_budget() -> impl Strategy<Value = SigningRoundBudget> {
         Just(SigningRoundBudget::DEFAULT),
         (floor..=1024u32)
             .prop_map(|n| SigningRoundBudget::new(NonZeroU32::new(n).expect("nonzero"))),
+    ]
+}
+
+/// An arbitrary [`RunSigningCapacity`], covering the named [`RunSigningCapacity::KEYSTONE`] plus a
+/// spread of budgets, per-run round allowances, and note ceilings.
+pub fn arb_run_signing_capacity() -> impl Strategy<Value = RunSigningCapacity> {
+    prop_oneof![
+        Just(RunSigningCapacity::KEYSTONE),
+        (arb_signing_round_budget(), 1usize..4, 1usize..60).prop_map(
+            |(budget, max_rounds, max_notes)| RunSigningCapacity::new(
+                budget,
+                NonZeroUsize::new(max_rounds).expect("nonzero"),
+                NonZeroUsize::new(max_notes).expect("nonzero"),
+            )
+        ),
     ]
 }
 

--- a/zcash_pool_migration/tests/signer_capacity.rs
+++ b/zcash_pool_migration/tests/signer_capacity.rs
@@ -1,0 +1,284 @@
+//! Sizing a run by SIGNER CAPACITY instead of by note count, as an external crate sees it.
+//!
+//! A wallet picks one of two ways to bound a run, and both are first-class:
+//!
+//! - by NOTE COUNT (`plan_migration_with`), when the wallet wants a fixed run size;
+//! - by SIGNER CAPACITY (`plan_migration_for_signer`), when a hardware signer bounds how much it
+//!   will sign in one interaction.
+//!
+//! Only the second can promise "one run is one signing session", because a run's actions are
+//! `16 * preparations + 3 * transfers` and the preparation count follows the wallet's fragmentation,
+//! not the note cap. These tests pin that difference: the same wallets that need several Keystone
+//! rounds under the default note cap plan in one round when sized for the signer, the note-cap API
+//! keeps behaving exactly as before, and the estimate previews the runs the planner will build.
+#![cfg(feature = "test-dependencies")]
+
+use core::num::NonZeroUsize;
+
+use proptest::prelude::*;
+use rand_chacha::ChaCha8Rng;
+use rand_core::SeedableRng;
+
+use zcash_pool_migration::{
+    denomination::MIGRATION_MAX_PREPARED_NOTES_PER_RUN,
+    engine::{
+        MigrationPlan, MigrationRunEstimate, RunSizing, estimate_migration_runs_for_signer,
+        plan_migration, plan_migration_for_signer, plan_migration_sized_with, plan_migration_with,
+    },
+    preparation::default_portfolio,
+    signing_rounds::{RunSigningCapacity, SigningRoundBudget},
+    testing::{
+        MIGRATION_SCENARIOS, MigrationScenario, WalletShape, arb_run_signing_capacity,
+        generate_notes,
+    },
+};
+use zcash_pool_migration_memory::{MockBackend, regtest_network};
+
+/// A post-NU6.3 chain tip to plan against.
+const TIP: u32 = 2_000_000;
+/// Any fixed seed: the canonical decomposition does not consult the RNG, and every comparison below
+/// uses this same seed so the schedules match too.
+const SEED: u64 = 7;
+
+/// Plan one run for `notes`, sized for a signer of `capacity`.
+fn plan_for_signer(notes: &[u64], capacity: RunSigningCapacity) -> MigrationPlan {
+    let backend = MockBackend::new(notes.to_vec(), TIP);
+    let mut rng = ChaCha8Rng::seed_from_u64(SEED);
+    plan_migration_for_signer(capacity, &regtest_network(true), &backend, &mut rng)
+        .expect("a fundable balance plans")
+}
+
+/// Plan one run for `notes` through the entry point that takes the bound as a value.
+fn plan_sized(notes: &[u64], sizing: RunSizing) -> MigrationPlan {
+    let backend = MockBackend::new(notes.to_vec(), TIP);
+    let mut rng = ChaCha8Rng::seed_from_u64(SEED);
+    plan_migration_sized_with(
+        &default_portfolio(),
+        sizing,
+        &regtest_network(true),
+        &backend,
+        &mut rng,
+    )
+    .expect("a fundable balance plans")
+}
+
+/// Estimate the whole migration of `notes` with every run sized for a signer of `capacity`.
+fn estimate_for_signer(notes: &[u64], capacity: RunSigningCapacity) -> MigrationRunEstimate {
+    let backend = MockBackend::new(notes.to_vec(), TIP);
+    let mut rng = ChaCha8Rng::seed_from_u64(SEED);
+    estimate_migration_runs_for_signer(capacity, &regtest_network(true), &backend, &mut rng)
+        .expect("a fundable balance estimates")
+}
+
+/// The scenarios whose one run takes more than one Keystone round under the default note cap: the
+/// wallets the multi-round QR flow was built for.
+fn multi_round_scenarios() -> impl Iterator<Item = &'static MigrationScenario> {
+    MIGRATION_SCENARIOS
+        .iter()
+        .filter(|sc| sc.expected_keystone_rounds > 1)
+}
+
+/// Sizing for a Keystone turns each of those runs into ONE signing round.
+#[test]
+fn a_keystone_sized_run_is_one_signing_round() {
+    let mut sized = 0;
+    for scenario in multi_round_scenarios() {
+        let plan = plan_for_signer(scenario.source_notes, RunSigningCapacity::KEYSTONE);
+        assert_eq!(
+            plan.signing_round_count(SigningRoundBudget::KEYSTONE),
+            1,
+            "{}: a Keystone-sized run signs in one round, not {}",
+            scenario.label,
+            plan.signing_round_count(SigningRoundBudget::KEYSTONE),
+        );
+        assert!(
+            plan.total_actions() <= SigningRoundBudget::KEYSTONE.max_actions(),
+            "{}: the run fits the device's per-round budget",
+            scenario.label,
+        );
+        sized += 1;
+    }
+    assert!(
+        sized > 0,
+        "the scenarios must include a wallet that needs several rounds under the note cap, \
+         or this proves nothing"
+    );
+}
+
+/// The two sizings coexist: the note-cap API is unchanged, and on a wallet where they differ the
+/// signer-sized run is the smaller one — that is the whole trade, fewer notes per run in exchange
+/// for one interaction per run.
+#[test]
+fn note_count_and_signer_capacity_are_both_available() {
+    for scenario in multi_round_scenarios() {
+        let backend = MockBackend::new(scenario.source_notes.to_vec(), TIP);
+        let mut rng = ChaCha8Rng::seed_from_u64(SEED);
+        let by_notes = plan_migration(&regtest_network(true), &backend, &mut rng)
+            .expect("a fundable balance plans");
+        assert_eq!(
+            by_notes.signing_round_count(SigningRoundBudget::KEYSTONE),
+            scenario.expected_keystone_rounds,
+            "{}: the note-cap sizing is unchanged",
+            scenario.label,
+        );
+
+        let by_capacity = plan_for_signer(scenario.source_notes, RunSigningCapacity::KEYSTONE);
+        assert!(
+            by_capacity.transfer_tx_count() < by_notes.transfer_tx_count(),
+            "{}: fitting one round costs crossings this run defers to the next",
+            scenario.label,
+        );
+        assert!(
+            by_capacity.value_migrated() < by_notes.value_migrated(),
+            "{}: and defers value with them",
+            scenario.label,
+        );
+    }
+}
+
+/// An explicit note cap reaches the same plan the signer sizing chose, so the sizing is a CHOICE OF
+/// CAP and nothing else: it never reshapes a run beyond bounding how many notes it prepares.
+#[test]
+fn signer_sizing_only_chooses_the_cap() {
+    for scenario in multi_round_scenarios() {
+        let by_capacity = plan_for_signer(scenario.source_notes, RunSigningCapacity::KEYSTONE);
+        let cap = NonZeroUsize::new(by_capacity.transfer_tx_count())
+            .expect("a planned run crosses at least one note");
+
+        let backend = MockBackend::new(scenario.source_notes.to_vec(), TIP);
+        let mut rng = ChaCha8Rng::seed_from_u64(SEED);
+        let by_notes = plan_migration_with(
+            &default_portfolio(),
+            cap,
+            &regtest_network(true),
+            &backend,
+            &mut rng,
+        )
+        .expect("a fundable balance plans");
+        assert_eq!(
+            by_capacity.planned_transactions(),
+            by_notes.planned_transactions(),
+            "{}: the signer-sized plan builds the run the note-capped plan builds at the chosen cap",
+            scenario.label,
+        );
+        assert_eq!(
+            (by_capacity.value_migrated(), by_capacity.residual()),
+            (by_notes.value_migrated(), by_notes.residual()),
+            "{}: and migrates and defers the same value",
+            scenario.label,
+        );
+    }
+}
+
+/// One entry point carries either bound, so an application can hold the user's choice as a value
+/// and plan through it: each `RunSizing` reaches the same plan its own entry point does.
+#[test]
+fn one_entry_point_carries_either_bound() {
+    for scenario in multi_round_scenarios() {
+        let by_notes = plan_sized(scenario.source_notes, RunSizing::default());
+        let backend = MockBackend::new(scenario.source_notes.to_vec(), TIP);
+        let mut rng = ChaCha8Rng::seed_from_u64(SEED);
+        let default_plan = plan_migration(&regtest_network(true), &backend, &mut rng)
+            .expect("a fundable balance plans");
+        assert_eq!(
+            by_notes.planned_transactions(),
+            default_plan.planned_transactions(),
+            "{}: the note-count bound plans what `plan_migration` plans",
+            scenario.label,
+        );
+
+        let by_capacity = plan_sized(
+            scenario.source_notes,
+            RunSizing::Signer(RunSigningCapacity::KEYSTONE),
+        );
+        assert_eq!(
+            by_capacity.planned_transactions(),
+            plan_for_signer(scenario.source_notes, RunSigningCapacity::KEYSTONE)
+                .planned_transactions(),
+            "{}: the signer bound plans what `plan_migration_for_signer` plans",
+            scenario.label,
+        );
+    }
+}
+
+/// The estimate previews what the planner will build: its first run is the run
+/// `plan_migration_for_signer` plans, and every run it forecasts is one signing round.
+#[test]
+fn the_estimate_previews_signer_sized_runs() {
+    for scenario in MIGRATION_SCENARIOS {
+        let estimate = estimate_for_signer(scenario.source_notes, RunSigningCapacity::KEYSTONE);
+        let plan = plan_for_signer(scenario.source_notes, RunSigningCapacity::KEYSTONE);
+
+        let first = estimate
+            .runs()
+            .first()
+            .expect("a fundable wallet has a run");
+        assert_eq!(
+            (first.crossings(), first.prep_transactions()),
+            (plan.transfer_tx_count(), plan.preparation_tx_count()),
+            "{}: the preview describes the run that gets planned",
+            scenario.label,
+        );
+        for (i, run) in estimate.runs().iter().enumerate() {
+            assert_eq!(
+                run.signing_rounds(SigningRoundBudget::KEYSTONE),
+                1,
+                "{}: run {i} is one signing round",
+                scenario.label,
+            );
+        }
+        assert_eq!(
+            estimate.total_signing_rounds(SigningRoundBudget::KEYSTONE),
+            estimate.run_count(),
+            "{}: the whole migration is one round per run",
+            scenario.label,
+        );
+    }
+}
+
+proptest! {
+    // Over arbitrary wallet shapes and signer capacities: a sized run never exceeds the note
+    // ceiling, and it stays within the signer's rounds unless a ONE-note run already exceeds them
+    // (a wallet so fragmented that minting a single funding note takes more consolidation than a
+    // round holds, which no smaller run can fix).
+    #![proptest_config(ProptestConfig::with_cases(24))]
+    #[test]
+    fn a_sized_run_fits_its_signer_or_cannot_be_shrunk(
+        shape in prop::sample::select(WalletShape::ALL),
+        note_count in 1usize..40,
+        capacity in arb_run_signing_capacity(),
+        seed in any::<u64>(),
+    ) {
+        let notes = generate_notes(shape, note_count, &mut ChaCha8Rng::seed_from_u64(seed));
+        let backend = MockBackend::new(notes.clone(), TIP);
+        let mut rng = ChaCha8Rng::seed_from_u64(SEED);
+        let Ok(plan) = plan_migration_for_signer(
+            capacity,
+            &regtest_network(true),
+            &backend,
+            &mut rng,
+        ) else {
+            // Nothing to migrate from this wallet; the sizing has nothing to say about it.
+            return Ok(());
+        };
+
+        prop_assert!(
+            plan.transfer_tx_count() <= capacity.max_notes().get(),
+            "{}: the sizing never exceeds the note ceiling",
+            shape.label(),
+        );
+        prop_assert!(
+            plan.transfer_tx_count() <= MIGRATION_MAX_PREPARED_NOTES_PER_RUN.get(),
+            "{}: and never exceeds the crate's default ceiling",
+            shape.label(),
+        );
+        let rounds = plan.signing_round_count(capacity.budget());
+        prop_assert!(
+            rounds <= capacity.max_rounds().get() || plan.transfer_tx_count() == 1,
+            "{}: {rounds} rounds over {} crossings and {} preparations",
+            shape.label(),
+            plan.transfer_tx_count(),
+            plan.preparation_tx_count(),
+        );
+    }
+}


### PR DESCRIPTION
Stacked on #2962 (base `dw/pool-migration-note-cap`); review that one first.

## The problem

A per-run note cap cannot bound what an external signer is asked to sign in one
interaction. A run's signing workload is `16 * preparations + 3 * transfers`,
and the preparation count follows the wallet's FRAGMENTATION rather than the
number of notes the run mints. So one cap gives one wallet a single-round run
and another a four-round run, and a Keystone user sees several QR signing rounds
inside what the UI presents as one migration run.

`signing_round_count(budget)` already reports that after the fact. Nothing could
ask for it in advance.

## The change

`signing_rounds::RunSigningCapacity` states the bound a device actually has —
actions per interaction, interactions per run, and a note ceiling never to
exceed — and `signing_rounds::largest_run_size_within` turns it into a note cap
by searching for the largest run that fits.

That search is the inverse of the round count in the run SIZE, as the existing
`min_budget_for_rounds` is its inverse in the BUDGET; the two now sit together.
It probes the sizing oracle logarithmically (once when the whole run already
fits) and only ever returns a cap a probe accepted, so an arbitrary preparation
portfolio still gets a run that fits even where the round count is not monotone
in the cap. Under monotonicity — what the canonical decomposition gives, since
raising the cap extends the split rather than reshaping it — the two are adjoint
and the chosen cap is the largest run the signer signs.

The one case no sizing can fix is a wallet fragmented enough that minting even a
single funding note overflows a round. The run is planned anyway and the
overflow stays visible in `MigrationPlan::signing_round_count`.

## API

Both bounds are first-class and nothing existing changes shape:

| entry point | bound |
| --- | --- |
| `plan_migration` | default note cap (unchanged) |
| `plan_migration_with(portfolio, max_notes, ..)` | note count (unchanged signature) |
| `plan_migration_for_signer(capacity, ..)` | signer capacity |
| `plan_migration_for_signer_with(portfolio, capacity, ..)` | signer capacity + portfolio |
| `plan_migration_sized_with(portfolio, sizing, ..)` | either, as a `RunSizing` value |

`estimate_migration_runs*` mirrors all five. Sizing is per run, over the note
structure that run starts from, so the preview describes the runs the planner
will build: a wallet migrates fewer notes in the runs that consolidate its
fragmentation and more once its notes are larger.

`RunSizing` is public so an application that lets the user choose between the
two bounds can carry that choice as a value.

## Testing

`cargo test -p zcash_pool_migration --all-features` (284 unit + every
integration test), `cargo fmt --check`, `cargo clippy --all-features
--all-targets -D warnings`, `cargo check --workspace --all-features` and
`--no-default-features`, all clean.

The search's unit tests hold it to the adjunction against an explicit oracle and
to feasibility against a deliberately non-monotone one. `tests/signer_capacity.rs`
drives the wallet-facing API from outside the crate: the scenarios that need
several Keystone rounds under the note cap plan in one round when sized for the
signer, the signer-sized plan is exactly the note-capped plan at the chosen cap
(so sizing only picks a cap, it never reshapes a run), one entry point reaches
either bound, and every run the estimate forecasts is one signing round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
