### PR TITLE
pczt: Pin the in-memory size of every structure a PCZT allocates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,6 +468,36 @@ jobs:
         working-directory: ./ci-build
         run: cargo build --verbose --target ${{ matrix.target }}
 
+  size-assertions:
+    name: Structure sizes on ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - thumbv7em-none-eabihf
+        include:
+          - target: thumbv7em-none-eabihf
+            build_deps: >
+              gcc-arm-none-eabi
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install linux build dependencies
+        run: sudo apt update && sudo apt install ${{ matrix.build_deps }}
+        if: matrix.build_deps != ''
+      - name: Add target
+        run: rustup target add ${{ matrix.target }}
+      # `pczt`'s size assertions are `const`, so type checking proves them: covering a
+      # 32-bit target needs no test runner, no emulator and no device. The 64-bit half
+      # is covered by the ordinary test job, which compiles the same module under
+      # `cfg(test)`.
+      - name: Check the 32-bit sizes of the structures a PCZT allocates
+        run: >
+          cargo check -p pczt --target ${{ matrix.target }}
+          --no-default-features
+          --features orchard,sapling,transparent,size-assertions
+
   bitrot:
     name: Bitrot check
     runs-on: ubuntu-latest

--- a/pczt/Cargo.toml
+++ b/pczt/Cargo.toml
@@ -157,6 +157,10 @@ tx-extractor = [
     "transparent",
 ]
 
+# Undocumented internal feature flag that compiles the `size_regression` assertions
+# outside a test build, so they can be checked for a target that cannot run tests.
+size-assertions = []
+
 # Undocumented internal feature flag for enabling features needed for tests.
 internal-tests = [
     "io-finalizer",

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -64,6 +64,9 @@ pub mod orchard;
 pub mod sapling;
 pub mod transparent;
 
+#[cfg(any(test, feature = "size-assertions"))]
+mod size_regression;
+
 pub(crate) const MAGIC_BYTES: &[u8; 4] = b"PCZT";
 pub(crate) const PCZT_VERSION_1: u32 = 1;
 pub(crate) const PCZT_VERSION_2: u32 = 2;

--- a/pczt/src/size_regression.rs
+++ b/pczt/src/size_regression.rs
@@ -1,0 +1,113 @@
+//! Compile-time assertions pinning the in-memory size of every structure a PCZT
+//! allocates.
+//!
+//! A PCZT is parsed in full before anything is signed, so its in-memory footprint, not
+//! its serialized size, is what bounds how large a transaction a memory-constrained
+//! signer can handle. On a hardware wallet that budget is measured in hundreds of
+//! kilobytes, and a bundle holds one [`orchard::Action`] per action, so a field added to
+//! `Action` costs its size times the action count, times however many copies of the
+//! parsed PCZT are live at once. These assertions make that cost visible in the commit
+//! that introduces it rather than in a signing failure on a device.
+//!
+//! The numbers are not a target. They are a record of what the layout is today, so that
+//! a change to it has to be deliberate.
+//!
+//! # Why two numbers per type
+//!
+//! `size_of` is target-dependent: pointers, and therefore the `Vec` and `BTreeMap`
+//! headers these structures are full of, are half the width on a 32-bit target. A signer
+//! runs on 32-bit hardware while CI runs on 64-bit, so pinning only the host size would
+//! leave the interesting target unpinned. Both are recorded, selected by
+//! `target_pointer_width`.
+//!
+//! # How each is checked
+//!
+//! The 64-bit assertions are compiled by any ordinary test build:
+//!
+//! ```text
+//! cargo test -p pczt --all-features
+//! ```
+//!
+//! The 32-bit assertions need a 32-bit target. A `const` assertion is evaluated during
+//! type checking, so `cargo check` proves them without a test runner, an emulator, or a
+//! device, which is what makes covering an embedded target practical at all:
+//!
+//! ```text
+//! cargo check -p pczt --target thumbv7em-none-eabihf \
+//!     --no-default-features --features orchard,sapling,transparent,size-assertions
+//! ```
+//!
+//! The `size-assertions` feature exists only to compile this module outside a test
+//! build, since a `no_std` target cannot build the test harness.
+//!
+//! # Updating a number
+//!
+//! Measure it; do not compute it by hand and do not guess. A failing assertion reports
+//! that a size changed but not what it changed to, so to read the new value, temporarily
+//! add
+//!
+//! ```text
+//! const _: [(); 0] = [(); size_of::<Type>()];
+//! ```
+//!
+//! and build for the target in question: the mismatch names the actual size. Then update
+//! both numbers, because a change almost never moves only one of them.
+//!
+//! # A note on what dominates
+//!
+//! Of [`orchard::Spend`]'s bytes, 1032 are the `witness` field, an
+//! `Option<(u32, [[u8; 32]; 32])>` that occupies its full size whether or not a witness
+//! is present, because it has no niche to store the discriminant in. Under ZIP 374 a
+//! witness is authorizing data that a signer never sees, so on a signing path those
+//! bytes are reserved for a field that is structurally empty. Boxing it would cost a
+//! pointer instead, and would not change the serialized encoding, since `postcard`
+//! encodes `Box<T>` exactly as `T`. That change is deliberately NOT made here: this
+//! module's job is to pin the current layout so such a change can be measured.
+
+/// Pins a type's size on both pointer widths this crate is built for.
+///
+/// Takes both numbers together so they cannot drift apart, and so a reader sees the
+/// 32-bit cost next to the 64-bit one rather than having to build for a device to
+/// discover it.
+macro_rules! assert_size_of {
+    ($t:ty, w64 = $w64:expr, w32 = $w32:expr $(,)?) => {
+        #[cfg(target_pointer_width = "64")]
+        const _: () = assert!(
+            size_of::<$t>() == $w64,
+            concat!(stringify!($t), " changed size on a 64-bit target"),
+        );
+        #[cfg(target_pointer_width = "32")]
+        const _: () = assert!(
+            size_of::<$t>() == $w32,
+            concat!(stringify!($t), " changed size on a 32-bit target"),
+        );
+    };
+}
+
+assert_size_of!(crate::Pczt, w64 = 528, w32 = 408);
+assert_size_of!(crate::common::Global, w64 = 56, w32 = 44);
+assert_size_of!(crate::common::Zip32Derivation, w64 = 56, w32 = 44);
+
+// One `Action` per Orchard action, so every byte here is multiplied by the action count
+// of the bundle. `Spend` is the bulk of it, and the `witness` field is the bulk of that.
+#[cfg(feature = "orchard")]
+mod orchard {
+    assert_size_of!(crate::orchard::Bundle, w64 = 136, w32 = 112);
+    assert_size_of!(crate::orchard::Action, w64 = 1960, w32 = 1872);
+    assert_size_of!(crate::orchard::Spend, w64 = 1536, w32 = 1512);
+    assert_size_of!(crate::orchard::Output, w64 = 352, w32 = 288);
+}
+
+#[cfg(feature = "sapling")]
+mod sapling {
+    assert_size_of!(crate::sapling::Bundle, w64 = 144, w32 = 112);
+    assert_size_of!(crate::sapling::Spend, w64 = 1760, w32 = 1736);
+    assert_size_of!(crate::sapling::Output, w64 = 600, w32 = 544);
+}
+
+#[cfg(feature = "transparent")]
+mod transparent {
+    assert_size_of!(crate::transparent::Bundle, w64 = 48, w32 = 24);
+    assert_size_of!(crate::transparent::Input, w64 = 312, w32 = 192);
+    assert_size_of!(crate::transparent::Output, w64 = 128, w32 = 72);
+}


### PR DESCRIPTION
Draft: opening early for a view on the approach, not because it is unfinished.

## Why

A PCZT is parsed in full before anything is signed, so its IN-MEMORY footprint,
not its serialized size, is what bounds the largest transaction a
memory-constrained signer can take. A bundle holds one `orchard::Action` per
action, so a field added to `Action` costs its size times the action count,
times however many copies of the parsed PCZT are live at once.

On a hardware wallet with a few hundred kilobytes of heap that arithmetic
decides whether a transaction can be signed at all, and nothing today makes it
visible: a growth surfaces as a signing failure on a device rather than in the
commit that caused it.

## What this does

Records the current layout as compile-time assertions. The numbers are not a
target; they are a baseline, so that changing one has to be deliberate and lands
in the same diff as the change that moved it.

Measured, not computed:

| type | 64-bit | 32-bit |
| --- | --- | --- |
| `orchard::Action` | 1960 | 1872 |
| `orchard::Spend` | 1536 | 1512 |
| `orchard::Output` | 352 | 288 |
| `orchard::Bundle` | 136 | 112 |
| `sapling::Spend` | 1760 | 1736 |
| `sapling::Output` | 600 | 544 |
| `sapling::Bundle` | 144 | 112 |
| `transparent::Input` | 312 | 192 |
| `transparent::Output` | 128 | 72 |
| `transparent::Bundle` | 48 | 24 |
| `Pczt` | 528 | 408 |
| `common::Global` | 56 | 44 |
| `common::Zip32Derivation` | 56 | 44 |

Each size is pinned TWICE, per `target_pointer_width`, in one macro invocation
so the two cannot drift apart. `size_of` is target-dependent, and the `Vec` and
`BTreeMap` headers these structures are full of are half the width on a 32-bit
target, so pinning only the host size would leave unpinned exactly the target
where memory is scarce. The 32-bit column was obtained by building for
`thumbv7em-none-eabihf`, not by hand arithmetic.

## How each half is checked

The assertions are `const`, so they are evaluated during type checking. That is
what makes covering an embedded target practical: `cargo check` proves them with
no test runner, no emulator and no device.

- 64-bit: any ordinary `cargo test -p pczt`, via `cfg(test)`. No flag needed.
- 32-bit: the new `size-assertions` CI job, `cargo check -p pczt --target
  thumbv7em-none-eabihf --no-default-features --features
  orchard,sapling,transparent,size-assertions`.

That is why the module sits behind a feature rather than `cfg(test)` alone: a
`no_std` target cannot build the test harness. `size-assertions` is internal and
undocumented, in the same spirit as `internal-tests`, and the module compiles in
neither an ordinary build nor a dependent's.

The CI job is separate from `build-nostd` rather than folded into it, because
that job deliberately builds through a synthetic crate to keep dev-dependencies
out, whereas here the crate's own `cfg`-gated module is the thing that has to be
compiled. It reuses the same target toolchain that job already installs.

## Verified to fail, not merely to pass

A regression test that cannot fail is worth nothing, so both halves were checked
by deliberately altering a number:

```
error[E0080]: evaluation panicked: crate::orchard::Action changed size on a 64-bit target
error[E0080]: evaluation panicked: crate::orchard::Action changed size on a 32-bit target
```

Also green: `cargo test -p pczt --all-features`, `cargo fmt --check`, `cargo
clippy -p pczt --all-features --all-targets -- -D warnings`, and the default
`cargo check -p pczt` with the module correctly absent.

## What this deliberately does NOT do

It changes no layout. One number stands out -- 1032 of `orchard::Spend`'s bytes
are the `witness` field, an `Option<(u32, [[u8; 32]; 32])>` that occupies its
full size whether or not a witness is present, because it has no niche. Under
ZIP 374 a witness is authorizing data a signer never sees, so on a signing path
those bytes are reserved for a field that is structurally empty, and the same
cost is paid again by the Ironwood bundle, which is an `orchard::Bundle` too.

Boxing it would cost a pointer instead and would not change the serialized
encoding, since `postcard` encodes `Box<T>` exactly as `T`. That is a separate
change with a real trade-off for the prover, where the witness IS present, and
it belongs in its own PR. This one exists so that such a change can be measured
rather than asserted.

## Question for reviewers

Whether a cargo feature is the right gate, or whether you would rather see a
`cfg` flag passed via `RUSTFLAGS`, given that features are public API surface
even when undocumented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
