### PR TITLE
zcash_client_backend: Add WalletRead::get_account_received_outputs

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -10,6 +10,14 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- Additions under the `zcashd-compat` feature flag:
+  - `zcash_client_backend::data_api::WalletRead::get_account_received_outputs`
+  - `zcash_client_backend::data_api::ReceivedOutputsQuery`
+  - `zcash_client_backend::data_api::AccountReceivedOutput`
+  - `zcash_client_backend::data_api::MinedPosition`
+  - `zcash_client_backend::data_api::MinedStateFilter`
+
 ## [0.24.0] - 2026-08-18
 
 ### Added

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -2497,6 +2497,30 @@ pub trait WalletRead {
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
     ) -> Result<Vec<ReceivedTransactionOutput>, Self::Error>;
+
+    /// Returns the outputs received by the given account that are selected by the given
+    /// query, including outputs that have already been spent.
+    ///
+    /// Results are returned in a stable order: by mined height ascending, then by
+    /// transaction index within the block, then by pool, then by output index, with
+    /// outputs of unmined transactions ordered after all mined outputs. The query's
+    /// `offset` and `limit` are applied to this ordering, so that a caller can paginate
+    /// the full listing.
+    ///
+    /// This is a zcashd-compatibility API for wallets that serve zcashd-style
+    /// received-output history listings; it is not intended for use in light client
+    /// contexts, and its cost is proportional to the size of the selected page, not to
+    /// the account's full history.
+    #[cfg(feature = "zcashd-compat")]
+    fn get_account_received_outputs(
+        &self,
+        _account: Self::AccountId,
+        _query: &ReceivedOutputsQuery,
+    ) -> Result<Vec<AccountReceivedOutput>, Self::Error> {
+        unimplemented!(
+            "WalletRead::get_account_received_outputs must be overridden for wallets that provide zcashd-compatible received-output listings"
+        )
+    }
 }
 
 /// Read-only operations required for testing light wallet functions.
@@ -3183,6 +3207,223 @@ impl ReceivedTransactionOutput {
     /// data.
     pub fn confirmations_until_spendable(&self) -> u32 {
         self.confirmations_until_spendable
+    }
+}
+
+/// A filter for selecting received outputs according to whether the transaction that
+/// produced them has been mined.
+#[cfg(feature = "zcashd-compat")]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+pub enum MinedStateFilter {
+    /// Select only outputs of transactions that have been mined.
+    #[default]
+    MinedOnly,
+    /// Select outputs of both mined and unmined transactions.
+    All,
+}
+
+/// The position of a mined transaction within the main chain.
+#[cfg(feature = "zcashd-compat")]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct MinedPosition {
+    height: BlockHeight,
+    tx_index: Option<TxIndex>,
+    block_time: Option<u32>,
+}
+
+#[cfg(feature = "zcashd-compat")]
+impl MinedPosition {
+    /// Constructs a [`MinedPosition`] from its constituent parts.
+    pub fn from_parts(
+        height: BlockHeight,
+        tx_index: Option<TxIndex>,
+        block_time: Option<u32>,
+    ) -> Self {
+        Self {
+            height,
+            tx_index,
+            block_time,
+        }
+    }
+
+    /// Returns the height of the block in which the transaction was mined.
+    pub fn height(&self) -> BlockHeight {
+        self.height
+    }
+
+    /// Returns the index of the transaction within its block, if known to the wallet.
+    pub fn tx_index(&self) -> Option<TxIndex> {
+        self.tx_index
+    }
+
+    /// Returns the time field of the block in which the transaction was mined, expressed
+    /// in seconds since the POSIX epoch, if the wallet has scanned that block.
+    pub fn block_time(&self) -> Option<u32> {
+        self.block_time
+    }
+}
+
+/// A query defining a subset of the outputs received by an account.
+///
+/// Used with [`WalletRead::get_account_received_outputs`].
+#[cfg(feature = "zcashd-compat")]
+#[derive(Debug, Clone)]
+pub struct ReceivedOutputsQuery {
+    address_filter: Option<Address>,
+    max_mined_height: Option<BlockHeight>,
+    mined_state_filter: MinedStateFilter,
+    offset: u32,
+    limit: Option<NonZeroU32>,
+}
+
+#[cfg(feature = "zcashd-compat")]
+impl ReceivedOutputsQuery {
+    /// Constructs a [`ReceivedOutputsQuery`] from its constituent parts.
+    ///
+    /// ### Fields:
+    /// * `address_filter` - if `Some`, select only outputs received on the given address,
+    ///   as it was exposed by the wallet. If the address is not known to the wallet, the
+    ///   query selects no outputs.
+    /// * `max_mined_height` - if `Some`, select only outputs of transactions mined at or
+    ///   below the given height.
+    /// * `mined_state_filter` - whether outputs of unmined transactions are selected.
+    /// * `offset` - the number of outputs of the selected set to skip, in the result
+    ///   ordering documented at [`WalletRead::get_account_received_outputs`].
+    /// * `limit` - if `Some`, the maximum number of outputs to return.
+    pub fn from_parts(
+        address_filter: Option<Address>,
+        max_mined_height: Option<BlockHeight>,
+        mined_state_filter: MinedStateFilter,
+        offset: u32,
+        limit: Option<NonZeroU32>,
+    ) -> Self {
+        Self {
+            address_filter,
+            max_mined_height,
+            mined_state_filter,
+            offset,
+            limit,
+        }
+    }
+
+    /// Returns the address to which the selected outputs are restricted, if any.
+    pub fn address_filter(&self) -> Option<&Address> {
+        self.address_filter.as_ref()
+    }
+
+    /// Returns the maximum mined height of transactions whose outputs are selected, if any.
+    pub fn max_mined_height(&self) -> Option<BlockHeight> {
+        self.max_mined_height
+    }
+
+    /// Returns whether outputs of unmined transactions are selected.
+    pub fn mined_state_filter(&self) -> MinedStateFilter {
+        self.mined_state_filter
+    }
+
+    /// Returns the number of outputs of the selected set that will be skipped.
+    pub fn offset(&self) -> u32 {
+        self.offset
+    }
+
+    /// Returns the maximum number of outputs that will be returned, if any.
+    pub fn limit(&self) -> Option<NonZeroU32> {
+        self.limit
+    }
+}
+
+/// An output received by an account, as returned by
+/// [`WalletRead::get_account_received_outputs`].
+///
+/// This type is capable of representing both shielded and transparent outputs, whether
+/// or not they have been spent.
+#[cfg(feature = "zcashd-compat")]
+#[derive(Debug, Clone)]
+pub struct AccountReceivedOutput {
+    pool_type: PoolType,
+    txid: TxId,
+    output_index: usize,
+    value: Zatoshis,
+    is_change: bool,
+    address: Option<Address>,
+    memo: Option<MemoBytes>,
+    mined_position: Option<MinedPosition>,
+}
+
+#[cfg(feature = "zcashd-compat")]
+impl AccountReceivedOutput {
+    /// Constructs an [`AccountReceivedOutput`] from its constituent parts.
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_parts(
+        pool_type: PoolType,
+        txid: TxId,
+        output_index: usize,
+        value: Zatoshis,
+        is_change: bool,
+        address: Option<Address>,
+        memo: Option<MemoBytes>,
+        mined_position: Option<MinedPosition>,
+    ) -> Self {
+        Self {
+            pool_type,
+            txid,
+            output_index,
+            value,
+            is_change,
+            address,
+            memo,
+            mined_position,
+        }
+    }
+
+    /// Returns the pool in which the output value was received.
+    pub fn pool_type(&self) -> PoolType {
+        self.pool_type
+    }
+
+    /// Returns the ID of the transaction containing the output.
+    pub fn txid(&self) -> TxId {
+        self.txid
+    }
+
+    /// Returns the index of the output among the transaction's outputs to the associated
+    /// pool: the index of the output within the transparent outputs, the Sapling output
+    /// index, or the Orchard or Ironwood action index.
+    pub fn output_index(&self) -> usize {
+        self.output_index
+    }
+
+    /// Returns the value of the output.
+    pub fn value(&self) -> Zatoshis {
+        self.value
+    }
+
+    /// Returns whether the output was received as change: either it was received on an
+    /// internal-scope (change) address, or the receiving account also spent value in the
+    /// transaction that produced it.
+    pub fn is_change(&self) -> bool {
+        self.is_change
+    }
+
+    /// Returns the address on which the output was received, as it was exposed by the
+    /// wallet. This is `None` for outputs received on wallet-internal (change) addresses,
+    /// which are never exposed.
+    pub fn address(&self) -> Option<&Address> {
+        self.address.as_ref()
+    }
+
+    /// Returns the memo associated with the output, if any.
+    ///
+    /// This is `None` for transparent outputs, and for shielded outputs whose memo has
+    /// not yet been retrieved from the chain.
+    pub fn memo(&self) -> Option<&MemoBytes> {
+        self.memo.as_ref()
+    }
+
+    /// Returns the position in the main chain of the transaction containing the output,
+    /// or `None` if the transaction is unmined.
+    pub fn mined_position(&self) -> Option<MinedPosition> {
+        self.mined_position
     }
 }
 

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -15,6 +15,8 @@ workspace.
   transactions deferred to the post-import rescan because the wallet had no
   view of the chain tip against which to store them; such transactions were
   previously conflated with `transactions_without_wallet_relevance`.
+- Support for `WalletRead::get_account_received_outputs` (under the
+  `zcashd-compat` feature).
 
 ### Fixed
 - Reading back a stored unmined transaction with a zero expiry height (such as

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -1470,6 +1470,15 @@ impl<C: Borrow<rusqlite::Connection>, P: consensus::Parameters, CL, R> WalletRea
             confirmations_policy,
         )
     }
+
+    #[cfg(feature = "zcashd-compat")]
+    fn get_account_received_outputs(
+        &self,
+        account: Self::AccountId,
+        query: &data_api::ReceivedOutputsQuery,
+    ) -> Result<Vec<data_api::AccountReceivedOutput>, Self::Error> {
+        wallet::get_account_received_outputs(self.conn.borrow(), &self.params, account, query)
+    }
 }
 
 #[cfg(any(test, feature = "test-dependencies"))]

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -172,6 +172,9 @@ use FindAccountForAddressError as E;
 #[cfg(feature = "zcashd-compat")]
 use {
     crate::wallet::encoding::{decode_legacy_account_index, encode_legacy_account_index},
+    zcash_client_backend::data_api::{
+        AccountReceivedOutput, MinedPosition, MinedStateFilter, ReceivedOutputsQuery,
+    },
     zcash_keys::keys::zcashd,
 };
 #[cfg(feature = "transparent-key-import")]
@@ -5997,6 +6000,157 @@ pub(crate) fn get_received_outputs(
     Ok(results)
 }
 
+/// The SQLite `LIMIT` value that disables the limit clause.
+#[cfg(feature = "zcashd-compat")]
+const SQLITE_NO_LIMIT: i64 = -1;
+
+#[cfg(feature = "zcashd-compat")]
+pub(crate) fn get_account_received_outputs<P: consensus::Parameters>(
+    conn: &rusqlite::Connection,
+    params: &P,
+    account_uuid: AccountUuid,
+    query: &ReceivedOutputsQuery,
+) -> Result<Vec<AccountReceivedOutput>, SqliteClientError> {
+    let account_ref = get_account_ref(conn, account_uuid)?;
+
+    // Resolve the address filter to an `addresses` row identifier. An address that the
+    // wallet has never exposed selects no outputs; outputs received on internal (change)
+    // addresses have no `addresses` row and so are never selected by an address filter.
+    let address_id_filter = match query.address_filter() {
+        Some(addr) => {
+            let addr_str = addr.encode(params);
+            match conn
+                .query_row(
+                    "SELECT id FROM addresses
+                     WHERE account_id = :account_id
+                     AND (address = :address
+                          OR cached_transparent_receiver_address = :address)",
+                    named_params![
+                        ":account_id": account_ref.0,
+                        ":address": addr_str,
+                    ],
+                    |row| row.get::<_, i64>("id"),
+                )
+                .optional()?
+            {
+                Some(id) => Some(id),
+                None => return Ok(vec![]),
+            }
+        }
+        None => None,
+    };
+
+    let include_unmined = matches!(query.mined_state_filter(), MinedStateFilter::All);
+
+    let mut stmt_received = conn.prepare_cached(
+        "SELECT ro.pool, t.txid, ro.output_index, ro.value, ro.is_change, ro.memo,
+                ro.address_id, a.address, a.cached_transparent_receiver_address, a.key_scope,
+                t.mined_height, t.tx_index, blocks.time AS block_time
+         FROM v_received_outputs ro
+         JOIN transactions t ON t.id_tx = ro.transaction_id
+         LEFT OUTER JOIN addresses a ON a.id = ro.address_id
+         LEFT OUTER JOIN blocks ON blocks.height = t.mined_height
+         WHERE ro.account_id = :account_id
+         AND (:address_id IS NULL OR ro.address_id = :address_id)
+         AND ((t.mined_height IS NOT NULL
+               AND (:max_mined_height IS NULL OR t.mined_height <= :max_mined_height))
+              OR (t.mined_height IS NULL AND :include_unmined))
+         ORDER BY t.mined_height ASC NULLS LAST, t.tx_index ASC, ro.pool ASC,
+                  ro.output_index ASC
+         LIMIT :limit OFFSET :offset",
+    )?;
+
+    let results = stmt_received
+        .query_and_then::<_, SqliteClientError, _, _>(
+            named_params![
+                ":account_id": account_ref.0,
+                ":address_id": address_id_filter,
+                ":max_mined_height": query.max_mined_height().map(u32::from),
+                ":include_unmined": include_unmined,
+                ":limit": query.limit().map_or(SQLITE_NO_LIMIT, |l| i64::from(l.get())),
+                ":offset": i64::from(query.offset()),
+            ],
+            |row| {
+                let pool_type = parse_pool_code(row.get("pool")?)?;
+                let txid = TxId::from_bytes(row.get("txid")?);
+                let output_index: u32 = row.get("output_index")?;
+                let value = Zatoshis::from_nonnegative_i64(row.get("value")?)?;
+                let key_scope = row
+                    .get::<_, Option<i64>>("key_scope")?
+                    .map(KeyScope::decode)
+                    .transpose()?;
+
+                // `v_received_outputs.is_change` records only whether the receiving
+                // account also spent value in the transaction that produced the output
+                // (and is hardcoded to `false` for transparent outputs); an output
+                // received on an internal-scope address is change as well. Shielded
+                // outputs received at internal scope are identified by the absence of an
+                // `addresses` row, as internal shielded receivers are never stored as
+                // addresses; internal transparent outputs are identified by the key
+                // scope of their (always present) `addresses` row.
+                let is_change: bool = match pool_type {
+                    PoolType::Transparent => key_scope == Some(KeyScope::INTERNAL),
+                    PoolType::Shielded(_) => {
+                        row.get::<_, bool>("is_change")?
+                            || row.get::<_, Option<i64>>("address_id")?.is_none()
+                    }
+                };
+
+                let address_str = match pool_type {
+                    PoolType::Transparent => {
+                        row.get::<_, Option<String>>("cached_transparent_receiver_address")?
+                    }
+                    PoolType::Shielded(_) => row.get::<_, Option<String>>("address")?,
+                };
+                let address = address_str
+                    .map(|s| {
+                        Address::decode(params, &s).ok_or_else(|| {
+                            SqliteClientError::CorruptedData(format!(
+                                "Could not decode address: {s}"
+                            ))
+                        })
+                    })
+                    .transpose()?;
+
+                let memo = row
+                    .get::<_, Option<Vec<u8>>>("memo")?
+                    .map(|b| {
+                        MemoBytes::from_bytes(&b).map_err(|_| {
+                            SqliteClientError::CorruptedData(
+                                "Could not decode memo bytes".to_owned(),
+                            )
+                        })
+                    })
+                    .transpose()?;
+
+                let mined_position = row
+                    .get::<_, Option<u32>>("mined_height")?
+                    .map(|h| {
+                        Ok::<_, SqliteClientError>(MinedPosition::from_parts(
+                            BlockHeight::from(h),
+                            row.get::<_, Option<u16>>("tx_index")?.map(TxIndex::from),
+                            row.get::<_, Option<u32>>("block_time")?,
+                        ))
+                    })
+                    .transpose()?;
+
+                Ok(AccountReceivedOutput::from_parts(
+                    pool_type,
+                    txid,
+                    output_index as usize,
+                    value,
+                    is_change,
+                    address,
+                    memo,
+                    mined_position,
+                ))
+            },
+        )?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(results)
+}
+
 /// Test utilities for wallet database assertions.
 #[cfg(any(test, feature = "test-dependencies"))]
 pub mod testing {
@@ -6475,6 +6629,183 @@ mod tests {
             .expect("transaction is present");
         assert_eq!(height, chain_tip);
         assert_eq!(tx.expiry_height(), BlockHeight::from(0));
+    }
+
+    #[test]
+    #[cfg(feature = "zcashd-compat")]
+    fn account_received_outputs_are_listed_filtered_and_paginated() {
+        use zcash_client_backend::data_api::{MinedStateFilter, ReceivedOutputsQuery};
+        use zcash_keys::address::Address;
+
+        const VALUE_1: Zatoshis = Zatoshis::const_from_u64(100_000);
+        const VALUE_2: Zatoshis = Zatoshis::const_from_u64(200_000);
+        const VALUE_3: Zatoshis = Zatoshis::const_from_u64(300_000);
+
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_block_cache(BlockCache::new())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let account_id = st.test_account().unwrap().id();
+        let dfvk = st.test_account_sapling().unwrap().clone();
+
+        let (h1, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, VALUE_1);
+        let (h2, _, _) = st.generate_next_block(&dfvk, AddressType::Internal, VALUE_2);
+        let (h3, _, _) = st.generate_next_block(&dfvk, AddressType::DefaultExternal, VALUE_3);
+        st.scan_cached_blocks(h1, 3);
+
+        let query = |address_filter, max_mined_height, mined_state_filter, offset, limit| {
+            ReceivedOutputsQuery::from_parts(
+                address_filter,
+                max_mined_height,
+                mined_state_filter,
+                offset,
+                limit,
+            )
+        };
+
+        // The full listing contains all three outputs, in height order.
+        let all = st
+            .wallet()
+            .get_account_received_outputs(
+                account_id,
+                &query(None, None, MinedStateFilter::MinedOnly, 0, None),
+            )
+            .unwrap();
+        assert_eq!(
+            all.iter().map(|o| o.value()).collect::<Vec<_>>(),
+            vec![VALUE_1, VALUE_2, VALUE_3]
+        );
+        assert_eq!(
+            all.iter()
+                .map(|o| o.mined_position().unwrap().height())
+                .collect::<Vec<_>>(),
+            vec![h1, h2, h3]
+        );
+
+        // The output received on the internal (change) address is marked as change and
+        // exposes no address; external outputs do the reverse.
+        assert!(!all[0].is_change());
+        assert!(all[0].address().is_some());
+        assert!(all[1].is_change());
+        assert!(all[1].address().is_none());
+
+        // Pagination selects the expected page of the stable ordering.
+        let page = st
+            .wallet()
+            .get_account_received_outputs(
+                account_id,
+                &query(
+                    None,
+                    None,
+                    MinedStateFilter::MinedOnly,
+                    1,
+                    NonZeroU32::new(1),
+                ),
+            )
+            .unwrap();
+        assert_eq!(page.len(), 1);
+        assert_eq!(page[0].txid(), all[1].txid());
+        assert_eq!(page[0].value(), all[1].value());
+
+        // A maximum mined height bound excludes outputs mined above it, and including
+        // unmined outputs changes nothing while no unmined transactions exist.
+        let bounded = st
+            .wallet()
+            .get_account_received_outputs(
+                account_id,
+                &query(None, Some(h2), MinedStateFilter::All, 0, None),
+            )
+            .unwrap();
+        assert_eq!(
+            bounded.iter().map(|o| o.value()).collect::<Vec<_>>(),
+            vec![VALUE_1, VALUE_2]
+        );
+
+        // Filtering by the account's unified address selects only the outputs received
+        // on that address, not outputs received on internal (change) addresses.
+        let ua = st
+            .wallet()
+            .get_last_generated_address_matching(
+                account_id,
+                UnifiedAddressRequest::AllAvailableKeys,
+            )
+            .unwrap()
+            .unwrap();
+        let on_ua = st
+            .wallet()
+            .get_account_received_outputs(
+                account_id,
+                &query(
+                    Some(Address::from(ua)),
+                    None,
+                    MinedStateFilter::MinedOnly,
+                    0,
+                    None,
+                ),
+            )
+            .unwrap();
+        assert_eq!(
+            on_ua.iter().map(|o| o.value()).collect::<Vec<_>>(),
+            vec![VALUE_1, VALUE_3]
+        );
+
+        // An address the wallet has never exposed selects no outputs.
+        let foreign = ExtendedSpendingKey::master(&[0xfe])
+            .to_diversifiable_full_viewing_key()
+            .default_address()
+            .1;
+        let on_foreign = st
+            .wallet()
+            .get_account_received_outputs(
+                account_id,
+                &query(
+                    Some(Address::Sapling(foreign)),
+                    None,
+                    MinedStateFilter::MinedOnly,
+                    0,
+                    None,
+                ),
+            )
+            .unwrap();
+        assert!(on_foreign.is_empty());
+
+        // Spending a note does not remove it from the received-output listing.
+        const SPEND_TXID_BYTES: [u8; 32] = [3; 32];
+        let spend_txid = TxId::from_bytes(SPEND_TXID_BYTES);
+        st.wallet()
+            .conn()
+            .execute(
+                "INSERT INTO transactions (txid, min_observed_height)
+                 VALUES (:txid, :min_observed_height)",
+                named_params![
+                    ":txid": spend_txid.as_ref(),
+                    ":min_observed_height": u32::from(h3),
+                ],
+            )
+            .unwrap();
+        st.wallet()
+            .conn()
+            .execute(
+                "INSERT INTO sapling_received_note_spends
+                    (sapling_received_note_id, transaction_id)
+                 SELECT srn.id, t.id_tx
+                 FROM sapling_received_notes srn
+                 JOIN transactions t ON t.txid = :txid
+                 ORDER BY srn.id
+                 LIMIT 1",
+                named_params![":txid": spend_txid.as_ref()],
+            )
+            .unwrap();
+        let after_spend = st
+            .wallet()
+            .get_account_received_outputs(
+                account_id,
+                &query(None, None, MinedStateFilter::MinedOnly, 0, None),
+            )
+            .unwrap();
+        assert_eq!(after_spend.len(), 3);
     }
 
     #[test]


### PR DESCRIPTION
Closes #2972.

Adds `WalletRead::get_account_received_outputs`, gated behind the existing `zcashd-compat` feature, per the proposal in #2972: an enumeration of the outputs received by an account — including outputs that have already been spent — with address/mined-height filters and `offset`/`limit` pagination pushed down into the implementation so that exchange-scale wallets can serve zcashd-style received-output listings (`z_listreceivedbyaddress` in Zallet, zcash/zallet#84) from indexed queries without materializing the full history.

- `zcash_client_backend`: the trait method (default `unimplemented!()` body following the `utxo_query_height` pattern), plus `ReceivedOutputsQuery`, `AccountReceivedOutput`, `MinedPosition`, and `MinedStateFilter`.
- `zcash_client_sqlite`: an implementation as a single query over `v_received_outputs` joined to `transactions`/`addresses`/`blocks`, with a stable ordering (mined height, tx index, pool, output index; unmined rows last). Change detection combines the view's same-transaction heuristic with internal-scope receipt (identified for shielded outputs by the absence of an `addresses` row, and for transparent outputs by the key scope of their address row, since the view hardcodes `is_change = 0` for pool 0).
- A `TestBuilder`-based test covering ordering, the change/address semantics, both filters, pagination, and that spent notes remain listed.

One observation from downstream integration: the default trait body means a delegating `WalletRead` implementation that forgets to forward this method compiles fine and panics at runtime (Zallet hit exactly this). That is the documented trade-off of the optional-method pattern; flagging it in case reviewers prefer a required method instead.

The branch is based on current `main`. Zallet consumes it via its `[patch.crates-io]` pin (zcash/zallet branch `rpc-z-listreceivedbyaddress`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01REAYwXV3jKoUt17miGuA7m
