### PR TITLE
zcash_pool_migration: Derive a run's signer quantities from one shape

### DIFF
--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -53,6 +53,12 @@ and this library adheres to Rust's notion of
   round count non-decreasing in the cap — which the canonical decomposition
   gives — the chosen cap is the largest run the signer signs; otherwise it is
   still one that fits.
+- `signing_rounds::RunShape::total_actions`, `engine::MigrationPlan::shape` and
+  `engine::RunEstimate::shape`. A run's signer-facing quantities all derive from
+  the same pair of transaction counts, so that pair is now named once and asked
+  the questions directly: a plan and an estimate both hand out a
+  `signing_rounds::RunShape` and delegate their action and round counts to it,
+  instead of each deriving them again.
 - `engine::plan_migration_for_signer` and
   `engine::plan_migration_for_signer_with`, which size a run by an external
   signer's capacity instead of by a note count, so one run is one signing

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -82,7 +82,6 @@ use crate::{
     signing_rounds::{
         MinRounds, PlannedSigningRound, PlannedTx, RunShape, RunSigningCapacity,
         SigningRoundBudget, SigningRoundStrategy, largest_run_size_within, min_budget_for_rounds,
-        min_signing_rounds,
     },
 };
 
@@ -1394,13 +1393,15 @@ impl MigrationPlan {
         self.preparation.layer_count()
     }
 
+    /// This plan's [`RunShape`]: the transaction counts every signer-facing quantity is derived
+    /// from, so a caller can ask a plan the same questions it asks an estimate.
+    pub fn shape(&self) -> RunShape {
+        RunShape::new(self.preparation_tx_count(), self.transfer_tx_count())
+    }
+
     /// The total Orchard-family actions across every transaction this plan builds.
     pub fn total_actions(&self) -> u32 {
-        let prep = (self.preparation_tx_count() as u64)
-            .saturating_mul(u64::from(crate::signing_rounds::PREPARATION_ACTIONS));
-        let xfer = (self.transfer_tx_count() as u64)
-            .saturating_mul(u64::from(crate::signing_rounds::TRANSFER_ACTIONS));
-        u32::try_from(prep.saturating_add(xfer)).unwrap_or(u32::MAX)
+        self.shape().total_actions()
     }
 
     /// The total value that migrates to the destination pool (the sum of the crossing values).
@@ -1437,11 +1438,7 @@ impl MigrationPlan {
     /// The number of signing rounds this plan needs for a signer bounded by `budget` (the optimal
     /// [`MinRounds`] count), without materializing the packing.
     pub fn signing_round_count(&self, budget: SigningRoundBudget) -> usize {
-        min_signing_rounds(
-            self.preparation_tx_count(),
-            self.transfer_tx_count(),
-            budget,
-        )
+        self.shape().signing_rounds(budget)
     }
 
     /// The smallest per-round budget that signs this whole plan in ONE round: the plan's total
@@ -1958,11 +1955,13 @@ impl RunEstimate {
     /// distinct from the number of interactions ([`signing_rounds`](Self::signing_rounds)): combine
     /// it with the device's per-action time to estimate how long signing this run will take.
     pub fn actions(&self) -> u32 {
-        let prep = (self.prep_transactions as u64)
-            .saturating_mul(u64::from(crate::signing_rounds::PREPARATION_ACTIONS));
-        let xfer = (self.crossings as u64)
-            .saturating_mul(u64::from(crate::signing_rounds::TRANSFER_ACTIONS));
-        u32::try_from(prep.saturating_add(xfer)).unwrap_or(u32::MAX)
+        self.shape().total_actions()
+    }
+
+    /// This run's [`RunShape`]: the transaction counts its signer-facing quantities are derived
+    /// from, and the same value the sizing search measures a candidate run by.
+    pub fn shape(&self) -> RunShape {
+        RunShape::new(self.prep_transactions, self.crossings)
     }
 
     /// The number of signing ROUNDS this run needs when an external signer is bounded by `budget`
@@ -1975,7 +1974,7 @@ impl RunEstimate {
     ///
     /// [ZIP 374]: https://zips.z.cash/zip-0374
     pub fn signing_rounds(&self, budget: SigningRoundBudget) -> usize {
-        min_signing_rounds(self.prep_transactions, self.crossings, budget)
+        self.shape().signing_rounds(budget)
     }
 }
 

--- a/zcash_pool_migration/src/signing_rounds.rs
+++ b/zcash_pool_migration/src/signing_rounds.rs
@@ -469,6 +469,13 @@ impl RunShape {
     pub fn signing_rounds(self, budget: SigningRoundBudget) -> usize {
         min_signing_rounds(self.preparation_transactions, self.transfers, budget)
     }
+
+    /// The total Orchard-family actions across this run's transactions: the signing WORKLOAD, as
+    /// distinct from [`signing_rounds`](Self::signing_rounds), the number of interactions.
+    #[must_use]
+    pub fn total_actions(self) -> u32 {
+        total_actions(self.preparation_transactions, self.transfers)
+    }
 }
 
 /// What one migration run may ask of a signer: at most [`max_rounds`](Self::max_rounds)


### PR DESCRIPTION
First of three small PRs from a duplication audit of `zcash_pool_migration` on
main. Stacked: this one, then #PR2 (sizing probe), then #PR3 (test guards).

## The duplication

A run's action count and its round count are both functions of the same pair of
numbers: the preparation transactions and the transfers it contains. That pair
was written down three times, and the arithmetic over it twice:

| | |
| --- | --- |
| `signing_rounds.rs` | `fn total_actions(n_prep, n_transfer)` — private |
| `engine.rs` | `MigrationPlan::total_actions()` |
| `engine.rs` | `RunEstimate::actions()` |

All three were the identical five lines (`saturating_mul` by the per-kind action
weights, `saturating_add`, `u32::try_from(..).unwrap_or(u32::MAX)`). The
canonical one already existed; it was just private, so `engine` reimplemented it
twice.

Three copies of a saturating multiply-and-add is not a problem today. It becomes
one the first time the action weights or the saturation policy change, because
two of the three are easy to miss.

## Why it happened, and the fix

The duplication is a symptom. `RunShape` — the type that names the pair —
arrived with the signer-capacity sizing, and the two older carriers of the same
pair were never taught about it. `RunEstimate` stores the pair under different
field names (`crossings`, `prep_transactions`); `MigrationPlan` derives it from
its own accessors.

So a plan and an estimate now both hand out a `RunShape` and delegate to it. The
arithmetic exists once, `RunShape::total_actions` sits beside the
`RunShape::signing_rounds` it belongs with, and the same question put to a plan,
an estimate, or a hypothetical run gets one answer from one place.

**No behaviour changes.** Every one of these functions returns exactly what it
returned before; `cargo check` flagged the now-unused `min_signing_rounds`
import, which is the mechanical confirmation that all call sites moved.

## Verification

`cargo test --release -p zcash_pool_migration --all-features` (8 suites, 0
failures), `cargo fmt --check`, `cargo clippy --all-features --all-targets -- -D
warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
