### PR TITLE
zcash_pool_migration: Stop a cap that cannot be planned from looking cheap

### DIFF
--- a/zcash_pool_migration/CHANGELOG.md
+++ b/zcash_pool_migration/CHANGELOG.md
@@ -52,7 +52,9 @@ and this library adheres to Rust's notion of
   `signing_rounds::min_budget_for_rounds` is its inverse in the BUDGET. Under a
   round count non-decreasing in the cap — which the canonical decomposition
   gives — the chosen cap is the largest run the signer signs; otherwise it is
-  still one that fits.
+  still one that fits. The shape oracle returns an `Option`, and a `None` — no
+  run can be built at that cap — is treated as not fitting, so a cap that cannot
+  be planned is never preferred over one that can.
 - `signing_rounds::RunShape::total_actions`, `engine::MigrationPlan::shape` and
   `engine::RunEstimate::shape`. A run's signer-facing quantities all derive from
   the same pair of transaction counts, so that pair is now named once and asked

--- a/zcash_pool_migration/src/engine.rs
+++ b/zcash_pool_migration/src/engine.rs
@@ -1692,6 +1692,52 @@ impl Default for RunSizing {
 /// The transaction counts a run capped at `max_notes` would have, over the note structure `notes`
 /// (whose validated total is `balance`): what the denomination and preparation planners produce,
 /// before anything is scheduled. The sizing probe of [`largest_run_size_within`].
+/// The denomination plan for one run over the note structure `notes` (whose validated total is
+/// `balance`), capped at `max_notes`: the canonical decomposition, reconciled against what the
+/// preparation planner can actually mint from those notes.
+///
+/// The reconciliation needs to ask "how many preparation transactions would minting this multiset
+/// take, and can it be minted at all", which is the one capability every caller of
+/// [`plan_denominations`] in this module has to supply. Supplying it once here is what keeps the
+/// sizing probe, the planner and the estimator asking the SAME question of the same wallet.
+fn plan_run_denominations<Pf, R>(
+    portfolio: &Pf,
+    notes: &[Zatoshis],
+    balance: Zatoshis,
+    max_notes: NonZeroUsize,
+    transfer_fee_buffer: Zatoshis,
+    prep_tx_fee: Zatoshis,
+    rng: &mut R,
+) -> DenominationPlan
+where
+    Pf: crate::preparation::Portfolio,
+    R: RngCore + rand_core::CryptoRng,
+{
+    plan_denominations(
+        balance,
+        notes.len(),
+        max_notes,
+        transfer_fee_buffer,
+        prep_tx_fee,
+        &|funding: &[Zatoshis]| {
+            plan_preparation_with(portfolio, notes, funding, prep_tx_fee)
+                .ok()
+                .map(|plan| plan.transaction_count())
+        },
+        rng,
+    )
+}
+
+/// The shape a run capped at `max_notes` would have over the note structure `notes`, or `None` if
+/// no such run can be built: the sizing probe of [`largest_run_size_within`].
+///
+/// `None` is what stops a cap the preparation planner rejects from being read as CHEAP. A rejected
+/// multiset has no transaction count, and reporting zero preparation transactions would make the
+/// shape the least expensive one available, so the search would prefer exactly the caps that
+/// [`plan_migration_sized_with`] then fails to plan.
+///
+/// A run that migrates nothing is a different answer: it is genuinely signable, in zero rounds, at
+/// every cap. The caller learns there is nothing to migrate when it plans, not from the sizing.
 fn run_shape_at<Pf, R>(
     portfolio: &Pf,
     notes: &[Zatoshis],
@@ -1700,30 +1746,27 @@ fn run_shape_at<Pf, R>(
     transfer_fee_buffer: Zatoshis,
     prep_tx_fee: Zatoshis,
     rng: &mut R,
-) -> RunShape
+) -> Option<RunShape>
 where
     Pf: crate::preparation::Portfolio,
     R: RngCore + rand_core::CryptoRng,
 {
-    let prep_tx_count = |funding: &[Zatoshis]| {
-        plan_preparation_with(portfolio, notes, funding, prep_tx_fee)
-            .ok()
-            .map(|plan| plan.transaction_count())
-    };
-    let funding = plan_denominations(
+    let funding = plan_run_denominations(
+        portfolio,
+        notes,
         balance,
-        notes.len(),
         max_notes,
         transfer_fee_buffer,
         prep_tx_fee,
-        &prep_tx_count,
         rng,
     )
     .migration_outputs();
-    // The denomination plan only ever proposes a funding multiset the preparation planner accepted,
-    // so this re-plan succeeds; a run that migrates nothing has no preparation either.
-    let preparations = prep_tx_count(&funding).unwrap_or(0);
-    RunShape::new(preparations, funding.len())
+    if funding.is_empty() {
+        return Some(RunShape::new(0, 0));
+    }
+    plan_preparation_with(portfolio, notes, &funding, prep_tx_fee)
+        .ok()
+        .map(|plan| RunShape::new(plan.transaction_count(), funding.len()))
 }
 
 /// The note cap `sizing` chooses for a run over the note structure `notes` (whose validated total is
@@ -1810,21 +1853,13 @@ where
         rng,
     );
 
-    // The preparation-layout capability the decomposition's reconciliation consults: how many
-    // preparation transactions minting a candidate funding multiset takes, or `None` when the
-    // wallet's notes cannot mint it (so the split drops its smallest part and asks again).
-    let prep_tx_count = |funding: &[Zatoshis]| {
-        crate::preparation::plan_preparation_with(portfolio, &notes, funding, prep_tx_fee)
-            .ok()
-            .map(|plan| plan.transaction_count())
-    };
-    let denominations = plan_denominations(
+    let denominations = plan_run_denominations(
+        portfolio,
+        &notes,
         balance,
-        notes.len(),
         max_notes,
         transfer_fee_buffer,
         prep_tx_fee,
-        &prep_tx_count,
         rng,
     );
     let funding_notes = denominations.migration_outputs();
@@ -2247,22 +2282,15 @@ where
             rng,
         );
 
-        let denominations = {
-            let prep_tx_count = |funding: &[Zatoshis]| {
-                plan_preparation_with(portfolio, &notes, funding, prep_tx_fee)
-                    .ok()
-                    .map(|plan| plan.transaction_count())
-            };
-            plan_denominations(
-                balance,
-                notes.len(),
-                max_notes,
-                transfer_fee_buffer,
-                prep_tx_fee,
-                &prep_tx_count,
-                rng,
-            )
-        };
+        let denominations = plan_run_denominations(
+            portfolio,
+            &notes,
+            balance,
+            max_notes,
+            transfer_fee_buffer,
+            prep_tx_fee,
+            rng,
+        );
 
         let funding = denominations.migration_outputs();
         if funding.is_empty() {

--- a/zcash_pool_migration/src/signing_rounds.rs
+++ b/zcash_pool_migration/src/signing_rounds.rs
@@ -548,8 +548,11 @@ impl RunSigningCapacity {
 /// reports as signable within `capacity` — the inverse of "how many rounds does this run take",
 /// dual to [`min_budget_for_rounds`] (which inverts the same map in the budget instead of the size).
 ///
-/// `shape_at` answers what a run capped at `n` notes would look like; it is called
-/// `O(log max_notes)` times.
+/// `shape_at` answers what a run capped at `n` notes would look like, or `None` if no run can be
+/// built at that cap; it is called `O(log max_notes)` times. A `None` is treated as NOT fitting,
+/// which is the conservative reading: a cap whose run cannot be built must never be preferred over
+/// one that can, and the alternative (reporting an empty shape) would make it the cheapest
+/// candidate rather than the worst.
 ///
 /// The returned cap is one `shape_at` reported as fitting, EXCEPT when even a one-note run exceeds
 /// the capacity, in which case it is one: a wallet fragmented enough that minting a single funding
@@ -567,10 +570,12 @@ impl RunSigningCapacity {
 #[must_use]
 pub fn largest_run_size_within<F>(capacity: RunSigningCapacity, mut shape_at: F) -> NonZeroUsize
 where
-    F: FnMut(NonZeroUsize) -> RunShape,
+    F: FnMut(NonZeroUsize) -> Option<RunShape>,
 {
     let mut fits = |n: NonZeroUsize| {
-        shape_at(n).signing_rounds(capacity.budget()) <= capacity.max_rounds().get()
+        shape_at(n).is_some_and(|shape| {
+            shape.signing_rounds(capacity.budget()) <= capacity.max_rounds().get()
+        })
     };
     // The whole run fits: the common case, and the one that costs a single probe.
     if fits(capacity.max_notes()) {
@@ -826,10 +831,10 @@ mod tests {
     fn oracle<'a>(
         shapes: &'a [RunShape],
         probes: &'a mut Vec<usize>,
-    ) -> impl FnMut(NonZeroUsize) -> RunShape + 'a {
+    ) -> impl FnMut(NonZeroUsize) -> Option<RunShape> + 'a {
         move |n| {
             probes.push(n.get());
-            shapes[n.get() - 1]
+            Some(shapes[n.get() - 1])
         }
     }
 
@@ -864,6 +869,34 @@ mod tests {
         assert!(
             probes.len() <= usize::BITS as usize - ceiling.get().leading_zeros() as usize + 1,
             "the search probes logarithmically, not linearly: {probes:?}"
+        );
+    }
+
+    // A cap whose run cannot be built must never be chosen, and in particular must never be
+    // preferred over one that can. Reading an unbuildable cap as an empty run would make it the
+    // CHEAPEST candidate, so the search would settle on exactly the caps that fail to plan.
+    #[test]
+    fn an_unbuildable_cap_is_never_chosen() {
+        // Every cap above 3 is unbuildable; caps 1..=3 fit comfortably.
+        let buildable = 3usize;
+        let capacity = RunSigningCapacity::new(
+            SigningRoundBudget::KEYSTONE,
+            NonZeroUsize::MIN,
+            NonZeroUsize::new(20).unwrap(),
+        );
+        let mut probes = Vec::new();
+        let chosen = largest_run_size_within(capacity, |n| {
+            probes.push(n.get());
+            (n.get() <= buildable).then(|| RunShape::new(1, n.get()))
+        });
+        assert_eq!(
+            chosen.get(),
+            buildable,
+            "the largest buildable cap is chosen, not an unbuildable one that looks cheap"
+        );
+        assert!(
+            probes.iter().any(|&n| n > buildable),
+            "the search did probe into the unbuildable range, so it really rejected it"
         );
     }
 


### PR DESCRIPTION
Second of three. Stacked on #2976; review that first.

## The bug

The sizing probe mapped a preparation-planner rejection to `unwrap_or(0)`:

```rust
let preparations = prep_tx_count(&funding).unwrap_or(0);
RunShape::new(preparations, funding.len())
```

`None` means the wallet's notes cannot mint that funding multiset. Reporting
zero preparation transactions makes it the **cheapest shape the search can be
handed** — fewest actions, so most likely to fit — and the search therefore
PREFERRED exactly the caps that `plan_migration_sized_with` then fails to plan
with `MigrationError::Preparation`.

The comment argued the case was unreachable, while the planner it calls keeps
the same error path for safety. Two defensive assumptions pointing in opposite
directions, and the one that loses is the one that decides the answer.

## The fix

The probe returns `Option<RunShape>` and `largest_run_size_within` reads `None`
as not fitting, which is the conservative direction: a cap whose run cannot be
built must never be preferred over one that can.

A run that migrates NOTHING is a different answer and keeps its own: genuinely
signable, in zero rounds, at every cap. The caller learns there is nothing to
migrate when it plans, not from the sizing.

`largest_run_size_within` is unreleased (it lands in this cycle), so widening
its oracle to `Option` is not a breaking change to any published API; the
existing CHANGELOG entry is amended rather than a new `Changed` added.

## The duplication it removes

All three callers of `plan_denominations` in this module must supply the same
capability — how many preparation transactions minting a candidate multiset
takes, or `None` when this wallet cannot mint it — and each wrote the closure
out again (`engine.rs` at three sites). `plan_run_denominations` supplies it
once.

That matters beyond tidiness: it is what keeps the sizing probe, the planner and
the estimator asking the SAME question of the same wallet. Three copies is three
chances to drift and answer differently, and the sizing's entire guarantee is
that the cap it returns was measured on the run that will actually be planned.

## Verification

The regression test was checked by reverting the fix: with `None` read as
fitting, the search settles on an unbuildable cap and
`an_unbuildable_cap_is_never_chosen` fails. Full suite green (8 suites, 0
failures), fmt and clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
