### PR TITLE
zcash_pool_migration: Fail loudly when the multi-round scenarios empty

### DIFF
--- a/zcash_pool_migration/tests/signer_capacity.rs
+++ b/zcash_pool_migration/tests/signer_capacity.rs
@@ -72,16 +72,28 @@ fn estimate_for_signer(notes: &[u64], capacity: RunSigningCapacity) -> Migration
 
 /// The scenarios whose one run takes more than one Keystone round under the default note cap: the
 /// wallets the multi-round QR flow was built for.
-fn multi_round_scenarios() -> impl Iterator<Item = &'static MigrationScenario> {
-    MIGRATION_SCENARIOS
+///
+/// Asserts the selection is non-empty, because every caller's assertions live INSIDE a loop over
+/// it. Exactly one scenario qualifies today, so a change to the fee model, the packer or that
+/// wallet's shape could empty this filter, and each of those tests would then pass while checking
+/// nothing at all. Guarding here rather than in each caller is what makes that impossible to
+/// forget for the next test that iterates this.
+fn multi_round_scenarios() -> Vec<&'static MigrationScenario> {
+    let scenarios: Vec<_> = MIGRATION_SCENARIOS
         .iter()
         .filter(|sc| sc.expected_keystone_rounds > 1)
+        .collect();
+    assert!(
+        !scenarios.is_empty(),
+        "no scenario needs several Keystone rounds under the note cap, so every test comparing \
+         the two sizings would iterate nothing and pass vacuously"
+    );
+    scenarios
 }
 
 /// Sizing for a Keystone turns each of those runs into ONE signing round.
 #[test]
 fn a_keystone_sized_run_is_one_signing_round() {
-    let mut sized = 0;
     for scenario in multi_round_scenarios() {
         let plan = plan_for_signer(scenario.source_notes, RunSigningCapacity::KEYSTONE);
         assert_eq!(
@@ -96,13 +108,7 @@ fn a_keystone_sized_run_is_one_signing_round() {
             "{}: the run fits the device's per-round budget",
             scenario.label,
         );
-        sized += 1;
     }
-    assert!(
-        sized > 0,
-        "the scenarios must include a wallet that needs several rounds under the note cap, \
-         or this proves nothing"
-    );
 }
 
 /// The two sizings coexist: the note-cap API is unchanged, and on a wallet where they differ the


### PR DESCRIPTION
Third of three. Stacked on #2977.

## The problem

Four tests in `tests/signer_capacity.rs` put their assertions inside a loop over
`multi_round_scenarios()`, which selects the wallets that need more than one
Keystone round under the default note cap.

**Exactly one scenario qualifies today** ("monotonic, ten 12 ZEC notes"). A
change to the fee model, to the packer, or to that wallet's note shape empties
the filter, and three of the four tests would then iterate nothing and pass
while checking nothing — among them `signer_sizing_only_chooses_the_cap`, which
is the test carrying the claim that sizing for a signer only picks a note cap
and never reshapes a run.

Only one of the four guarded against it, by counting iterations itself.

## The fix

The guard belongs in the selection, not the call sites: it then holds for every
caller including the next test written against this filter, and it deletes the
hand-rolled counter instead of asking three more sites to repeat it.

Checked by widening the filter until it matches nothing: all four tests fail
with the explanation rather than passing.

Test-only; no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
