### PR TITLE
Follow-up: factor out resolve_pool, per-pool input counts, P2SH recognition

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -16,26 +16,27 @@ workspace.
   address into an account as watch-only, without any associated key material.
 - `zcash_client_backend::wallet::TransparentAddressSource::StandaloneAddress`
 - `zcash_client_backend::wallet::TransparentAddressMetadata::standalone_address`
-- `zcash_client_backend::proposal::Step::estimated_serialized_size`, a
-  conservative upper-bound estimate of the serialized byte size of the
-  transaction a step describes. The estimate sums the per-element byte costs of
-  every input, output, and change output (using the v4 Sapling sizes, the
-  Orchard `ACTION_SIZE` plus per-action spend authorization signatures and
+- `zcash_client_backend::proposal::Proposal::estimated_serialized_size`, a
+  conservative upper-bound estimate of the total serialized byte size of all
+  transactions a proposal describes. The estimate sums the per-element byte
+  costs of every input, output, and change output (using the v4 Sapling sizes,
+  the Orchard `ACTION_SIZE` plus per-action spend authorization signatures and
   proof shares, and the standard P2PKH transparent sizes) plus per-bundle
   overhead added only for bundles that are present. It never under-counts, so
   comparing it against `MAX_BLOCK_BYTES` is a safe size bound for rejecting
   proposals that cannot be mined.
-- `zcash_client_backend::proposal::Step::check_transaction_size`, which
-  validates a step's estimated serialized size against `MAX_BLOCK_BYTES` and
-  returns `ProposalError::TransactionTooLarge` if exceeded. Called by the
-  input-selection paths (`propose_transaction`, `propose_send_max`,
-  `propose_shielding`); not called during proposal deserialization, so
-  previously-persisted proposals remain recoverable.
+- `zcash_client_backend::proposal::Proposal::check_transaction_size`, which
+  validates every step's estimated serialized size against `MAX_BLOCK_BYTES`
+  and returns `ProposalError::TransactionTooLarge` if exceeded. Called by the
+  `propose_transfer` / `propose_shielding` wrappers and the
+  `create_proposed_transactions` / `create_pczt_from_proposal` build entry
+  points; not called during proposal deserialization, so previously-persisted
+  proposals remain recoverable.
 - `zcash_client_backend::proposal::ProposalError::TransactionTooLarge`, returned
-  by `check_transaction_size` when the step's estimated serialized size exceeds
-  `MAX_BLOCK_BYTES`. Carries the estimated size, the limit, and the total
-  shielded input count so a wallet can explain the situation to a user in terms
-  of notes rather than bytes.
+  by `check_transaction_size` when a step's estimated serialized size exceeds
+  `MAX_BLOCK_BYTES`. Carries the estimated size, the limit, and per-pool
+  shielded input counts (Sapling, Orchard, Ironwood) so a wallet can explain
+  the situation to a user in terms of notes rather than bytes.
 
 ### Changed
 - The `orchard` feature is now enabled by default. Consumers that require a

--- a/zcash_client_backend/src/proposal.rs
+++ b/zcash_client_backend/src/proposal.rs
@@ -162,10 +162,16 @@ pub enum ProposalError {
         estimated_size: usize,
         /// The maximum serialized byte size a Zcash block may carry (`MAX_BLOCK_BYTES`).
         limit: usize,
-        /// The total number of shielded inputs (across all shielded pools) the step spends.
-        /// Carried alongside the byte counts so a wallet can explain the situation to a
-        /// user in terms of notes rather than bytes.
-        shielded_input_count: usize,
+        /// The number of Sapling inputs the step spends, including prior-step inputs.
+        /// Carried so a wallet can explain the situation in terms of notes rather than
+        /// bytes; the different shielded pools have very different per-input costs.
+        sapling_input_count: usize,
+        /// The number of Orchard inputs the step spends, including prior-step inputs.
+        #[cfg(feature = "orchard")]
+        orchard_input_count: usize,
+        /// The number of Ironwood inputs the step spends, including prior-step inputs.
+        #[cfg(feature = "orchard")]
+        ironwood_input_count: usize,
     },
 }
 
@@ -289,11 +295,30 @@ impl Display for ProposalError {
             ProposalError::TransactionTooLarge {
                 estimated_size,
                 limit,
-                shielded_input_count,
-            } => write!(
-                f,
-                "The proposed transaction's estimated serialized size ({estimated_size} bytes) exceeds the maximum block size ({limit} bytes). It spends {shielded_input_count} shielded inputs; reduce the payment amount or consolidate small notes before retrying."
-            ),
+                sapling_input_count,
+                #[cfg(feature = "orchard")]
+                orchard_input_count,
+                #[cfg(feature = "orchard")]
+                ironwood_input_count,
+            } => {
+                #[cfg(feature = "orchard")]
+                let _ = (orchard_input_count, ironwood_input_count);
+                write!(
+                    f,
+                    "The proposed transaction's estimated serialized size ({estimated_size} bytes) exceeds the maximum block size ({limit} bytes). It spends {sapling_input_count} Sapling inputs"
+                )?;
+                #[cfg(feature = "orchard")]
+                {
+                    write!(
+                        f,
+                        ", {orchard_input_count} Orchard inputs, {ironwood_input_count} Ironwood inputs"
+                    )?;
+                }
+                write!(
+                    f,
+                    "; reduce the payment amount or consolidate small notes before retrying."
+                )
+            }
         }
     }
 }
@@ -536,22 +561,13 @@ impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
     /// mineability caveat.
     pub fn estimated_serialized_size(&self) -> usize {
         let steps = self.steps();
-        // Build a resolver closure that maps a prior-step reference to the pool of
-        // the referenced output. The closure captures the proposal's step list, so
-        // `step_index()` always resolves — no panic risk.
-        let resolve_pool = |s_ref: &StepOutput| {
-            let prior = &steps[s_ref.step_index()];
-            match s_ref.output_index() {
-                StepOutputIndex::Payment(i) => *prior
-                    .payment_pools()
-                    .get(&i)
-                    .expect("payment pool exists for referenced payment"),
-                StepOutputIndex::Change(i) => prior.balance().proposed_change()[i].output_pool(),
-            }
-        };
         steps
             .iter()
-            .map(|step| step.estimated_serialized_size(&resolve_pool))
+            .map(|step| {
+                step.estimated_serialized_size(&|s_ref| {
+                    Self::resolve_prior_output_pool(steps, s_ref)
+                })
+            })
             .sum()
     }
 
@@ -566,44 +582,66 @@ impl<FeeRuleT, NoteRef> Proposal<FeeRuleT, NoteRef> {
     /// previously-persisted proposals remain recoverable.
     pub fn check_transaction_size(&self) -> Result<(), ProposalError> {
         let steps = self.steps();
-        let resolve_pool = |s_ref: &StepOutput| {
-            let prior = &steps[s_ref.step_index()];
-            match s_ref.output_index() {
-                StepOutputIndex::Payment(i) => *prior
-                    .payment_pools()
-                    .get(&i)
-                    .expect("payment pool exists for referenced payment"),
-                StepOutputIndex::Change(i) => prior.balance().proposed_change()[i].output_pool(),
-            }
-        };
         for step in steps.iter() {
-            let estimated_size = step.estimated_serialized_size(&resolve_pool);
+            let estimated_size = step
+                .estimated_serialized_size(&|s_ref| Self::resolve_prior_output_pool(steps, s_ref));
             if estimated_size > MAX_BLOCK_BYTES {
-                // Count both the step's own shielded inputs and prior-step shielded
-                // inputs, so the count matches what the estimate charged.
-                let shielded_input_count = step
-                    .shielded_inputs()
-                    .iter()
-                    .flat_map(|s| s.notes().iter())
-                    .count()
+                // Count per-pool shielded inputs (both the step's own and prior-step)
+                // so the counts match what the estimate charged.
+                let sapling_input_count = step.input_count_in_pool(PoolType::SAPLING)
                     + step
                         .prior_step_inputs()
                         .iter()
                         .filter(|s_ref| {
-                            matches!(
-                                resolve_pool(s_ref),
-                                PoolType::SAPLING | PoolType::ORCHARD | PoolType::IRONWOOD
-                            )
+                            Self::resolve_prior_output_pool(steps, s_ref) == PoolType::SAPLING
+                        })
+                        .count();
+                #[cfg(feature = "orchard")]
+                let orchard_input_count = step.input_count_in_pool(PoolType::ORCHARD)
+                    + step
+                        .prior_step_inputs()
+                        .iter()
+                        .filter(|s_ref| {
+                            Self::resolve_prior_output_pool(steps, s_ref) == PoolType::ORCHARD
+                        })
+                        .count();
+                #[cfg(feature = "orchard")]
+                let ironwood_input_count = step.input_count_in_pool(PoolType::IRONWOOD)
+                    + step
+                        .prior_step_inputs()
+                        .iter()
+                        .filter(|s_ref| {
+                            Self::resolve_prior_output_pool(steps, s_ref) == PoolType::IRONWOOD
                         })
                         .count();
                 return Err(ProposalError::TransactionTooLarge {
                     estimated_size,
                     limit: MAX_BLOCK_BYTES,
-                    shielded_input_count,
+                    sapling_input_count,
+                    #[cfg(feature = "orchard")]
+                    orchard_input_count,
+                    #[cfg(feature = "orchard")]
+                    ironwood_input_count,
                 });
             }
         }
         Ok(())
+    }
+
+    /// Resolves the pool of a prior-step output referenced by `s_ref`, by looking up
+    /// the referenced step in the proposal's step list. Shared by
+    /// [`estimated_serialized_size`](Self::estimated_serialized_size) and
+    /// [`check_transaction_size`](Self::check_transaction_size) to avoid duplicating the
+    /// `StepOutput`-to-`PoolType` resolution logic.
+    fn resolve_prior_output_pool(steps: &NonEmpty<Step<NoteRef>>, s_ref: &StepOutput) -> PoolType {
+        let prior = &steps[s_ref.step_index()];
+        match s_ref.output_index() {
+            StepOutputIndex::Payment(i) => *prior
+                .payment_pools()
+                .get(&i)
+                .expect("payment pool exists for referenced payment"),
+            StepOutputIndex::Change(i) => prior.balance().proposed_change()[i].output_pool(),
+        }
     }
 }
 
@@ -875,23 +913,23 @@ impl<NoteRef> Step<NoteRef> {
             return Err(ProposalError::MissingShieldedAnchor);
         }
 
-        if input_total != output_total {
-            return Err(ProposalError::BalanceError {
+        if input_total == output_total {
+            Ok(Self {
+                transaction_request,
+                payment_pools,
+                transparent_inputs,
+                shielded_inputs,
+                anchor_height,
+                prior_step_inputs,
+                balance,
+                is_shielding,
+            })
+        } else {
+            Err(ProposalError::BalanceError {
                 input_total,
                 output_total,
-            });
+            })
         }
-
-        Ok(Self {
-            transaction_request,
-            payment_pools,
-            transparent_inputs,
-            shielded_inputs,
-            anchor_height,
-            prior_step_inputs,
-            balance,
-            is_shielding,
-        })
     }
 
     /// Returns the transaction request that describes the payments to be made.
@@ -1868,10 +1906,16 @@ mod tests {
             Err(ProposalError::TransactionTooLarge {
                 estimated_size,
                 limit,
-                shielded_input_count,
+                sapling_input_count,
+                #[cfg(feature = "orchard")]
+                orchard_input_count,
+                #[cfg(feature = "orchard")]
+                ironwood_input_count,
             }) if limit == MAX_BLOCK_BYTES
                 && estimated_size > MAX_BLOCK_BYTES
-                && shielded_input_count == oversize_spend_count
+                && sapling_input_count == 0
+                && orchard_input_count == oversize_spend_count
+                && ironwood_input_count == 0
         );
     }
 

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -467,7 +467,6 @@ impl<AccountId: Debug> transparent_fees::InputView for WalletTransparentOutput<A
         match self.known_input_size {
             Some(size) => transparent_fees::InputSize::Known(size),
             None => {
-                // Fall back to default: only P2PKH is recognized.
                 match zcash_script::script::PubKey::parse(&self.txout.script_pubkey().0)
                     .ok()
                     .as_ref()
@@ -475,6 +474,17 @@ impl<AccountId: Debug> transparent_fees::InputView for WalletTransparentOutput<A
                 {
                     Some(zcash_script::solver::ScriptKind::PubKeyHash { .. }) => {
                         transparent_fees::InputSize::STANDARD_P2PKH
+                    }
+                    Some(zcash_script::solver::ScriptKind::ScriptHash { .. }) => {
+                        // P2SH input size depends on the redeem script, which the
+                        // wallet must set via `with_known_input_size` (the SQLite
+                        // backend does this by reading the redeem script from the DB
+                        // and computing the exact size via
+                        // `p2sh_input_serialized_len`). Without it we cannot
+                        // determine the exact input size; return `Unknown` so the
+                        // estimator falls back to the consensus-maximum input size
+                        // rather than guessing.
+                        transparent_fees::InputSize::Unknown(self.outpoint.clone())
                     }
                     _ => transparent_fees::InputSize::Unknown(self.outpoint.clone()),
                 }

--- a/zcash_primitives/src/transaction/components/sapling.rs
+++ b/zcash_primitives/src/transaction/components/sapling.rs
@@ -73,6 +73,11 @@ const CMU_BYTE_SIZE: usize = 32;
 /// The size in bytes of the encoding of a Sapling ephemeral key.
 const EPHEMERAL_KEY_BYTE_SIZE: usize = size_of::<EphemeralKeyBytes>();
 
+/// The per-bundle overhead of a Sapling bundle, excluding the per-spend and per-output
+/// data: CompactSize prefixes for the spends and outputs arrays (at most 9 + 9) +
+/// value_balance (8) + anchor (32) + binding_sig (64).
+pub const BUNDLE_OVERHEAD: usize = 9 + 9 + 8 + 32 + 64;
+
 /// Returns the enforcement policy for ZIP 212 at the given height.
 pub fn zip212_enforcement(params: &impl Parameters, height: BlockHeight) -> Zip212Enforcement {
     if params.is_nu_active(NetworkUpgrade::Canopy, height) {
@@ -88,11 +93,6 @@ pub fn zip212_enforcement(params: &impl Parameters, height: BlockHeight) -> Zip2
         Zip212Enforcement::Off
     }
 }
-
-/// The per-bundle overhead of a Sapling bundle, excluding the per-spend and per-output
-/// data: CompactSize prefixes for the spends and outputs arrays (at most 9 + 9) +
-/// value_balance (8) + anchor (32) + binding_sig (64).
-pub const BUNDLE_OVERHEAD: usize = 9 + 9 + 8 + 32 + 64;
 
 /// A map from one bundle authorization to another.
 ///


### PR DESCRIPTION
Follow-up to #2931 addressing review comments from @nuttycom and @pacu.

1. Factor out duplicated resolve_pool closure into shared method
2. Replace shielded_input_count with per-pool counts (sapling, orchard, ironwood)
3. Revert early-return in from_parts to original if/else
4. Recognize P2SH (ScriptHash) in WalletTransparentOutput::serialized_size
5. Move sapling::BUNDLE_OVERHEAD to top of file with other size constants

Co-Authored-By: Claude <noreply@anthropic.com>