### PR TITLE
zcash_client_sqlite: store and re-read unmined zero-expiry transactions

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -10,6 +10,15 @@ workspace.
 
 ## [Unreleased]
 
+### Fixed
+- Reading back a stored unmined transaction with a zero expiry height (such as
+  a coinbase transaction imported from a zcashd wallet before any chain scan)
+  no longer fails with a "Consensus branch ID not known" error. When neither a
+  mined height nor a nonzero expiry height is available, the consensus branch
+  ID (which does not affect parsing) is now selected using a fallback height
+  supplied from the wallet's view of the chain tip; the error remains only
+  when the chain tip is also unknown.
+
 ## [0.22.0] - 2026-08-18
 
 ### Added

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -10,6 +10,12 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `zewif::ZewifImportReport::transactions_deferred_no_chain_tip`: counts
+  transactions deferred to the post-import rescan because the wallet had no
+  view of the chain tip against which to store them; such transactions were
+  previously conflated with `transactions_without_wallet_relevance`.
+
 ### Fixed
 - Reading back a stored unmined transaction with a zero expiry height (such as
   a coinbase transaction imported from a zcashd wallet before any chain scan)
@@ -18,6 +24,14 @@ workspace.
   ID (which does not affect parsing) is now selected using a fallback height
   supplied from the wallet's view of the chain tip; the error remains only
   when the chain tip is also unknown.
+- `zewif::import_wallet` now establishes the wallet's view of the chain tip
+  from the document (the maximum of its export height and its transactions'
+  mined heights, clamped to the wallet birthday) whenever at least one account
+  was imported and account import itself did not establish one. Previously a
+  document whose accounts all had birthdays at or below Sapling activation —
+  a pre-Sapling zcashd wallet — left the wallet without a chain tip, so every
+  transaction was silently deferred to the post-import rescan and counted
+  under `transactions_without_wallet_relevance`.
 
 ## [0.22.0] - 2026-08-18
 

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -3110,6 +3110,7 @@ fn parse_tx<P: consensus::Parameters>(
     tx_bytes: &[u8],
     block_height: Option<BlockHeight>,
     expiry_height: Option<BlockHeight>,
+    fallback_height: Option<BlockHeight>,
 ) -> Result<(BlockHeight, Transaction), SqliteClientError> {
     // We need to provide a consensus branch ID so that pre-v5 `Transaction` structs
     // (which don't commit directly to one) can store it internally.
@@ -3119,7 +3120,8 @@ fn parse_tx<P: consensus::Parameters>(
     //   upgrade boundary, so the expiry height must be in the same epoch).
     // - Otherwise, we use a placeholder for the initial transaction parse (as the
     //   consensus branch ID is not used there), and then either use its non-zero expiry
-    //   height or return an error.
+    //   height, or fall back to the caller-supplied fallback height (typically the
+    //   wallet's view of the chain tip).
     if let Some(height) =
         block_height.or_else(|| expiry_height.filter(|h| h > &BlockHeight::from(0)))
     {
@@ -3148,6 +3150,14 @@ fn parse_tx<P: consensus::Parameters>(
             .freeze()
             .map(|t| (expiry_height, t))
             .map_err(SqliteClientError::from)
+        } else if let Some(fallback_height) = fallback_height {
+            // Unmined with no expiry, so no epoch is recorded for it. The branch ID
+            // does not affect parsing (absent from the pre-v5 serialized form; v5
+            // onward commit to their own), so select it from the caller-supplied
+            // fallback height, typically the wallet's view of the chain tip.
+            Transaction::read(tx_bytes, BranchId::for_height(params, fallback_height))
+                .map(|t| (fallback_height, t))
+                .map_err(SqliteClientError::from)
         } else {
             Err(SqliteClientError::CorruptedData(
                 "Consensus branch ID not known, cannot parse this transaction until it is mined"
@@ -3183,7 +3193,11 @@ pub(crate) fn get_transaction<P: Parameters>(
         },
     )
     .optional()?
-    .and_then(|(t_opt, b, e)| t_opt.as_ref().map(|t| parse_tx(params, t, b, e)))
+    .and_then(|(t_opt, b, e)| {
+        t_opt
+            .as_ref()
+            .map(|t| parse_tx(params, t, b, e, chain_tip_height(conn)?))
+    })
     .transpose()
 }
 
@@ -5113,6 +5127,8 @@ pub(crate) fn get_txs_spending_transparent_outputs_of<P: consensus::Parameters>(
          AND ts.transaction_id IS NOT NULL",
     )?;
 
+    let chain_tip = chain_tip_height(conn)?;
+
     spending_txs_stmt
         .query_and_then(named_params![":transaction_id": tx_ref.0], |row| {
             let spending_tx_ref = row.get(0).map(TxRef)?;
@@ -5125,6 +5141,7 @@ pub(crate) fn get_txs_spending_transparent_outputs_of<P: consensus::Parameters>(
                 &tx_bytes,
                 block.map(BlockHeight::from),
                 expiry.map(BlockHeight::from),
+                chain_tip,
             )?;
 
             Ok((spending_tx_ref, spending_tx))
@@ -6089,7 +6106,7 @@ mod tests {
     use zcash_primitives::block::BlockHash;
     use zcash_protocol::{
         TxId,
-        consensus::{BlockHeight, NetworkUpgrade, Parameters},
+        consensus::{BlockHeight, BranchId, MAIN_NETWORK, NetworkUpgrade, Parameters},
         value::Zatoshis,
         zip318::{Zip318Classification, Zip318TxKind},
     };
@@ -6101,9 +6118,9 @@ mod tests {
     };
 
     use super::{
-        KeyScope, ShieldedPool, TxQueryType, TxRef, account_birthday,
-        flag_previously_received_change, min_shared_checkpoint_height, put_zip318_classification,
-        queue_tx_retrieval, select_truncation_height,
+        KeyScope, ShieldedPool, TxQueryType, TxRef, account_birthday, chain_tip_height,
+        flag_previously_received_change, get_transaction, min_shared_checkpoint_height, parse_tx,
+        put_zip318_classification, queue_tx_retrieval, select_truncation_height,
     };
 
     use incrementalmerkletree::frontier::Frontier;
@@ -6359,6 +6376,105 @@ mod tests {
         let requests = st.wallet().transaction_data_requests().unwrap();
         assert!(requests.contains(&TransactionDataRequest::GetStatus(unexpired_txid)));
         assert!(requests.contains(&TransactionDataRequest::Enhancement(unexpired_txid)));
+    }
+
+    /// Returns a minimal serialized v1 transparent coinbase-style transaction: one input
+    /// spending the null prevout, one output. The v1 format predates ZIP 203, so the
+    /// transaction's expiry height parses as zero.
+    fn raw_v1_zero_expiry_tx() -> Vec<u8> {
+        let mut raw = vec![];
+        raw.extend_from_slice(&1u32.to_le_bytes()); // version
+        raw.push(0x01); // vin count
+        raw.extend_from_slice(&[0u8; 32]); // prevout txid (null)
+        raw.extend_from_slice(&u32::MAX.to_le_bytes()); // prevout index (coinbase)
+        raw.extend_from_slice(&[0x01, 0x51]); // script_sig
+        raw.extend_from_slice(&u32::MAX.to_le_bytes()); // sequence
+        raw.push(0x01); // vout count
+        raw.extend_from_slice(&5_000_000_000u64.to_le_bytes()); // value
+        raw.extend_from_slice(&[0x01, 0x51]); // script_pubkey
+        raw.extend_from_slice(&0u32.to_le_bytes()); // lock_time
+        raw
+    }
+
+    /// An unmined transaction with a zero expiry height carries no epoch information from
+    /// which to select a consensus branch ID, so parsing falls back to the wallet's view
+    /// of the chain tip; without a known chain tip it remains an error.
+    #[test]
+    fn parse_tx_unmined_zero_expiry_uses_fallback_height() {
+        let raw = raw_v1_zero_expiry_tx();
+        let chain_tip = MAIN_NETWORK.activation_height(NetworkUpgrade::Nu5).unwrap();
+
+        let (height, tx) = parse_tx(
+            &MAIN_NETWORK,
+            &raw,
+            None,
+            Some(BlockHeight::from(0)),
+            Some(chain_tip),
+        )
+        .unwrap();
+        assert_eq!(height, chain_tip);
+        assert_eq!(tx.expiry_height(), BlockHeight::from(0));
+        assert_eq!(
+            tx.consensus_branch_id(),
+            BranchId::for_height(&MAIN_NETWORK, chain_tip)
+        );
+
+        assert!(matches!(
+            parse_tx(&MAIN_NETWORK, &raw, None, Some(BlockHeight::from(0)), None),
+            Err(SqliteClientError::CorruptedData(_))
+        ));
+    }
+
+    /// A stored unmined transaction with a zero expiry height (e.g. a coinbase
+    /// transaction imported from a zcashd wallet before any chain scan) must be readable
+    /// back from the wallet database.
+    #[test]
+    fn get_transaction_reads_unmined_zero_expiry_tx() {
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_block_cache(BlockCache::new())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let dfvk = ExtendedSpendingKey::master(&[]).to_diversifiable_full_viewing_key();
+        let tip = st.sapling_activation_height();
+        st.generate_block_at(
+            tip,
+            BlockHash([0; 32]),
+            &[FakeCompactOutput::new(
+                &dfvk,
+                AddressType::DefaultExternal,
+                Zatoshis::const_from_u64(10_000),
+            )],
+            0,
+            0,
+            0,
+            false,
+        );
+        st.scan_cached_blocks(tip, 1);
+
+        let txid = TxId::from_bytes([3; 32]);
+        st.wallet()
+            .conn()
+            .execute(
+                "INSERT INTO transactions (txid, expiry_height, raw, min_observed_height)
+                 VALUES (:txid, 0, :raw, :min_observed_height)",
+                named_params![
+                    ":txid": txid.as_ref(),
+                    ":raw": raw_v1_zero_expiry_tx(),
+                    ":min_observed_height": u32::from(tip),
+                ],
+            )
+            .unwrap();
+
+        let chain_tip = chain_tip_height(st.wallet().conn())
+            .unwrap()
+            .expect("chain tip is known");
+        let (height, tx) = get_transaction(st.wallet().conn(), st.network(), txid)
+            .unwrap()
+            .expect("transaction is present");
+        assert_eq!(height, chain_tip);
+        assert_eq!(tx.expiry_height(), BlockHeight::from(0));
     }
 
     #[test]

--- a/zcash_client_sqlite/src/wallet/init/migrations/sapling_memo_consistency.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/sapling_memo_consistency.rs
@@ -255,7 +255,12 @@ fn get_transaction<P: consensus::Parameters>(
         },
     )
     .optional()?
-    .map(|(t, b, e)| parse_tx(params, &t, b, e))
+    // The `scan_queue` table is not guaranteed to exist at the schema version this
+    // migration runs against, so no chain tip height is available as a consensus branch
+    // ID fallback. The transactions processed by this migration were created by the
+    // wallet and therefore always have a nonzero expiry height, so no fallback is
+    // needed.
+    .map(|(t, b, e)| parse_tx(params, &t, b, e, None))
     .transpose()
 }
 

--- a/zcash_client_sqlite/src/zewif.rs
+++ b/zcash_client_sqlite/src/zewif.rs
@@ -544,13 +544,18 @@ pub struct ZewifImportReport {
     /// The number of transactions from the document that were stored because
     /// they involve the imported accounts.
     pub transactions_stored: usize,
-    /// The number of transactions from the document that were not stored,
-    /// either because trial decryption found no involvement with any imported
-    /// account, or because no imported account had established a chain tip
-    /// against which to store them. Such transactions are expected to be
-    /// recovered by the post-import rescan if they do in fact involve the
-    /// wallet.
+    /// The number of transactions from the document that were not stored
+    /// because trial decryption and transparent-output matching found no
+    /// involvement with any imported account. Such transactions are expected
+    /// to be recovered by the post-import rescan if they do in fact involve
+    /// the wallet.
     pub transactions_without_wallet_relevance: usize,
+    /// The number of transactions from the document that were deferred to the
+    /// post-import rescan because the wallet had no view of the chain tip
+    /// against which to store them. [`import_wallet`] seeds a chain view from
+    /// the document whenever at least one account is imported, so this is
+    /// nonzero primarily when no account could be imported.
+    pub transactions_deferred_no_chain_tip: usize,
     /// The number of transactions in the document that carried no raw
     /// transaction data and therefore could not be stored.
     pub transactions_without_raw_data: usize,
@@ -972,6 +977,38 @@ where
         // no evidence that the indices below it were ever handed out; only the
         // exposures the document itself accounts for may be used to infer that.
         let pre_existing_exposures = exposed_receivers(wdb, &accounts)?;
+
+        // Storing transactions requires a view of the chain tip, which account
+        // import establishes only when an account's birthday lies above Sapling
+        // activation. Otherwise seed one from the document: its transactions
+        // exist at or below the maximum of its export height and their recorded
+        // mined heights, clamped to the wallet birthday so that scanning is
+        // never requested below it.
+        if !report.imported_accounts.is_empty()
+            && wdb
+                .chain_height()
+                .map_err(ZewifImportError::Wallet)?
+                .is_none()
+        {
+            let document_tip = document
+                .transactions()
+                .values()
+                .filter_map(|tx| tx.mined_height())
+                .max()
+                .map_or(document.export_height(), |h| {
+                    h.max(document.export_height())
+                });
+            let mut assumed_tip = BlockHeight::from(u32::from(document_tip));
+            if let Some(birthday) = wdb
+                .get_wallet_birthday()
+                .map_err(ZewifImportError::Wallet)?
+            {
+                assumed_tip = assumed_tip.max(birthday);
+            }
+            wdb.update_chain_tip(assumed_tip)
+                .map_err(ZewifImportError::Wallet)?;
+        }
+
         // Import transactions before marking document-recorded exposures, so
         // that the wallet's exposure state already reflects every address the
         // document's transactions reveal to have been used on-chain.
@@ -1294,9 +1331,10 @@ where
 /// [`decrypt_and_store_transaction`] stores a transaction only when trial
 /// decryption or transparent-output matching shows wallet involvement, so the
 /// count of stored transactions is determined by querying for each transaction
-/// id after the attempt. Storage additionally requires a known chain tip, which
-/// only an imported account establishes; if none was imported, every
-/// transaction is deferred to the post-import rescan.
+/// id after the attempt. Storage additionally requires a known chain tip;
+/// [`import_wallet`] establishes one from the document whenever at least one
+/// account was imported, so only a document from which no account could be
+/// imported has every transaction deferred to the post-import rescan.
 fn import_transactions<DbT, P, S>(
     wdb: &mut DbT,
     params: &P,
@@ -1348,7 +1386,7 @@ where
         if !chain_tip_known {
             // No chain tip against which to store the transaction; defer it to
             // the post-import rescan.
-            report.transactions_without_wallet_relevance += 1;
+            report.transactions_deferred_no_chain_tip += 1;
             continue;
         }
         let recorded_txid = zcash_protocol::TxId::from_bytes(*tx.txid().as_bytes());
@@ -2715,8 +2753,120 @@ mod tests {
 
         assert!(report.imported_accounts.is_empty());
         assert_eq!(report.transactions_stored, 0);
-        assert_eq!(report.transactions_without_wallet_relevance, 1);
+        assert_eq!(report.transactions_without_wallet_relevance, 0);
+        assert_eq!(report.transactions_deferred_no_chain_tip, 1);
         assert_eq!(report.transactions_without_raw_data, 0);
+    }
+
+    /// Builds an unmined transparent-only v5 transaction with a zero expiry
+    /// height (never expiring, as for a coinbase transaction), under the
+    /// consensus rules in force at `height`.
+    fn transparent_zero_expiry_tx_to<P: consensus::Parameters>(
+        params: &P,
+        to: &TransparentAddress,
+        value: u64,
+        height: u32,
+    ) -> (zcash_protocol::TxId, Vec<u8>) {
+        let height = consensus::BlockHeight::from(height);
+        let tx = TransactionData::from_parts(
+            TxVersion::V5,
+            BranchId::for_height(params, height),
+            0,
+            consensus::BlockHeight::from(0),
+            #[cfg(all(zcash_unstable = "nu7", feature = "zip-233"))]
+            Zatoshis::ZERO,
+            Some(transparent::Bundle {
+                vin: vec![TxIn::from_parts(OutPoint::fake(), Script::default(), 0)],
+                vout: vec![TxOut::new(
+                    Zatoshis::const_from_u64(value),
+                    to.script().into(),
+                )],
+                authorization: Authorized,
+            }),
+            None,
+            None,
+            None,
+        )
+        .freeze()
+        .unwrap();
+
+        let mut bytes = vec![];
+        tx.write(&mut bytes).unwrap();
+        (tx.txid(), bytes)
+    }
+
+    /// A document whose only account has a birthday at Sapling activation (as
+    /// for a pre-Sapling zcashd wallet) establishes no chain tip as a side
+    /// effect of account import; the importer must seed one from the document
+    /// so that the document's transactions — including unmined transactions
+    /// with a zero expiry height, such as coinbase transactions recorded
+    /// before any chain scan — are stored rather than deferred.
+    #[test]
+    fn pre_sapling_birthday_document_stores_unmined_zero_expiry_transaction() {
+        let (_file, mut wdb) = regtest_wallet_db();
+        let params = regtest_local_network();
+
+        let mnemonic = <Mnemonic<English>>::from_entropy([0xAB; 32]).unwrap();
+        let seed = mnemonic.to_seed("");
+        let fp = SeedFingerprint::from_seed(&seed).unwrap();
+        let fingerprint_encoding = encode_seed_fp(&fp);
+        let usk = UnifiedSpendingKey::from_seed(&params, &seed, zip32::AccountId::ZERO).unwrap();
+        let (taddr, _) = usk.default_transparent_address();
+
+        let (txid, raw) = transparent_zero_expiry_tx_to(&params, &taddr, 100_000, 100);
+
+        let mut store = ::zewif::SecretStore::new();
+        store.add_seed(::zewif::SeedEntry::new(
+            ::zewif::SeedFingerprint::new(fingerprint_encoding.clone()),
+            ::zewif::SeedMaterial::Bip39Mnemonic(::zewif::Bip39Mnemonic::new(
+                mnemonic.phrase(),
+                None,
+            )),
+        ));
+
+        let mut account = ::zewif::Account::new(::zewif::AccountViewingKey::Ufvk(
+            ::zewif::UnifiedFullViewingKey::new(usk.to_unified_full_viewing_key().encode(&params)),
+        ));
+        account.set_name("pre-sapling");
+        // A birthday at Sapling activation (height 1 on regtest) writes no
+        // scan queue entries as a side effect of account import.
+        account.set_birthday_height(::zewif::BlockHeight::from(1));
+        account.set_key_source(::zewif::KeySource::Derived(::zewif::DerivedKeySource::new(
+            ::zewif::SeedFingerprint::new(fingerprint_encoding),
+            0,
+            None,
+        )));
+
+        let mut doc = ::zewif::Zewif::new(
+            ::zewif::BlockHeight::from(100),
+            ::zewif::BlockHash::from_bytes([0xEE; 32]),
+        );
+        let mut wallet = ::zewif::ZewifWallet::new(regtest_network(BTreeMap::new()));
+        wallet.add_account(account);
+        doc.add_wallet(wallet);
+        doc.set_secrets(::zewif::Secrets::Plain(store));
+
+        let mut tx = ::zewif::Transaction::new(::zewif::TxId::from_bytes(*txid.as_ref()));
+        tx.set_tx_data(::zewif::TransactionData::Raw(::zewif::RawTxData::new(
+            ::zewif::Data::from_bytes(&raw),
+        )));
+        doc.add_transaction(tx.txid(), tx);
+
+        let report = import_wallet(&mut wdb, &doc, &mut RecordingSink::default()).unwrap();
+
+        assert_eq!(report.imported_accounts.len(), 1);
+        assert_eq!(report.transactions_stored, 1);
+        assert_eq!(report.transactions_deferred_no_chain_tip, 0);
+        assert_eq!(report.transactions_without_wallet_relevance, 0);
+
+        // The stored transaction can be read back despite being unmined with a
+        // zero expiry height.
+        let stored = wdb
+            .get_transaction(txid)
+            .unwrap()
+            .expect("transaction was stored");
+        assert_eq!(stored.txid(), txid);
+        assert_eq!(stored.expiry_height(), consensus::BlockHeight::from(0));
     }
 
     #[test]


### PR DESCRIPTION
Two fixes for ZeWIF wallet import, found migrating real zcashd wallets under
`--no-scan` (the first is the error currently failing the zcashd migration
tests in zcash/integration-tests CI):

1. **`parse_tx` could not re-read unmined zero-expiry transactions** (e.g.
   imported coinbase): no epoch was available to select a consensus branch ID,
   and both the importer's read-back and fee accounting aborted with
   `CorruptedData`. The branch ID does not affect parsing (absent pre-v5;
   self-committed v5+), so it is now selected from the wallet's chain-tip view;
   the error remains only when the tip is also unknown.

2. **Pre-Sapling-birthday documents imported zero transactions**: account
   import only seeds the scan queue when a birthday lies above Sapling
   activation, so such wallets (on mainnet, any wallet with pre-Sapling
   history) had no chain tip and every transaction was silently deferred,
   miscounted as lacking wallet relevance. `import_wallet` now seeds the chain
   view from the document, and tip-less deferrals get their own
   `transactions_deferred_no_chain_tip` report field (new pub field on a
   non-exhaustive-less struct; crate is at 0.22.0-rc).

Regression tests cover the fallback, read-back, and an end-to-end regtest
import of an unmined zero-expiry transaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7s9MQzQ3Bmp42uabiSDbU