### PR TITLE
Authenticate the PCZT transparent spend-authorization path

### DIFF
--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -18,6 +18,9 @@ workspace.
 - `pczt::roles::signer::Signer::sign_transparent` now checks the consistency of the
   transparent input before signing it, and signs only for `SighashType::ALL`. Use
   `Signer::with_transparent_sighash_policy` to permit other sighash types.
+- `pczt::roles::spend_finalizer::SpendFinalizer::finalize_spends` now finalizes only
+  `SighashType::ALL` signatures that match their input's `sighash_type`; use
+  `SpendFinalizer::with_sighash_policy` to permit other sighash types.
 - `pczt::roles::spend_finalizer::Error` has added variant `InconsistentSighashType`.
 
 ## [0.5.0] - PLANNED

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -20,7 +20,10 @@ workspace.
   `Signer::with_transparent_sighash_policy` to permit other sighash types.
 - `pczt::roles::spend_finalizer::SpendFinalizer::finalize_spends` now finalizes only
   `SighashType::ALL` signatures that match their input's `sighash_type`; use
-  `SpendFinalizer::with_sighash_policy` to permit other sighash types.
+  `SpendFinalizer::with_sighash_policy` to permit other sighash types. Irrespective of
+  that policy, it also refuses to finalize an input whose sighash type leaves part of
+  the transaction uncommitted unless `Global.tx_modifiable` records that part as still
+  modifiable.
 - `pczt::roles::spend_finalizer::Error` has added variant `InconsistentSighashType`.
 
 ## [0.5.0] - PLANNED

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -15,6 +15,8 @@ workspace.
 - `pczt::roles::spend_finalizer::SpendFinalizer::with_sighash_policy`
 
 ### Changed
+- `pczt::roles::signer::Signer::sign_transparent` now checks the consistency of the
+  transparent input before signing it.
 - `pczt::roles::spend_finalizer::Error` has added variant `InconsistentSighashType`.
 
 ## [0.5.0] - PLANNED

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -10,6 +10,13 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `pczt::roles::signer::Signer::with_transparent_sighash_policy`
+- `pczt::roles::spend_finalizer::SpendFinalizer::with_sighash_policy`
+
+### Changed
+- `pczt::roles::spend_finalizer::Error` has added variant `InconsistentSighashType`.
+
 ## [0.5.0] - PLANNED
 
 - Migrated to `zcash_protocol 0.7`, `zcash_transparent 0.6`, `zcash_primitives 0.26`,

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -16,7 +16,8 @@ workspace.
 
 ### Changed
 - `pczt::roles::signer::Signer::sign_transparent` now checks the consistency of the
-  transparent input before signing it.
+  transparent input before signing it, and signs only for `SighashType::ALL`. Use
+  `Signer::with_transparent_sighash_policy` to permit other sighash types.
 - `pczt::roles::spend_finalizer::Error` has added variant `InconsistentSighashType`.
 
 ## [0.5.0] - PLANNED

--- a/pczt/src/roles.rs
+++ b/pczt/src/roles.rs
@@ -219,15 +219,27 @@ mod tests {
             signer.finish()
         }
 
-        #[test]
-        fn finalizer_rejects_non_all_sighash_type() {
-            let pczt = signed(
+        /// A signed PCZT whose `SIGHASH_NONE` input is consistent with
+        /// `Global.tx_modifiable`, so that the sighash policy is the only thing left to
+        /// gate on.
+        ///
+        /// The flag has to be restored by hand: the in-tree builder only ever uses
+        /// `SIGHASH_ALL`, so the Creator clears both transparent modifiability flags at
+        /// the outset, whereas a genuine `SIGHASH_NONE` flow would leave the outputs one
+        /// set.
+        fn signed_sighash_none() -> Pczt {
+            let mut pczt = signed(
                 |input| input.sighash_type = SIGHASH_NONE,
                 SighashPolicy::ANY,
             );
+            pczt.global.tx_modifiable |= FLAG_TRANSPARENT_OUTPUTS_MODIFIABLE;
+            pczt
+        }
 
+        #[test]
+        fn finalizer_rejects_non_all_sighash_type() {
             assert!(matches!(
-                SpendFinalizer::new(pczt).finalize_spends(),
+                SpendFinalizer::new(signed_sighash_none()).finalize_spends(),
                 Err(spend_finalizer::Error::TransparentFinalize(
                     SpendFinalizerError::DisallowedSighashType(_)
                 )),
@@ -236,15 +248,7 @@ mod tests {
 
         #[test]
         fn finalizer_accepts_non_all_sighash_type_under_explicit_policy() {
-            // A `SIGHASH_NONE` signature commits to none of the outputs, and the Signer
-            // correspondingly leaves the Transparent Outputs Modifiable flag set, so the
-            // modifiability gate is satisfied here.
-            let pczt = signed(
-                |input| input.sighash_type = SIGHASH_NONE,
-                SighashPolicy::ANY,
-            );
-
-            assert!(SpendFinalizer::new(pczt)
+            assert!(SpendFinalizer::new(signed_sighash_none())
                 .with_sighash_policy(SighashPolicy::ANY)
                 .finalize_spends()
                 .is_ok());
@@ -262,8 +266,9 @@ mod tests {
                     SighashPolicy::ANY,
                 );
 
-                // A hostile Combiner clears (or fails to set) the flag recording the part
-                // of the transaction that this signature leaves uncommitted.
+                // The flag recording the part of the transaction that this signature
+                // leaves uncommitted is not set, so the sighash type did not come from a
+                // deliberate multi-party flow. Not even an explicit policy allows this.
                 pczt.global.tx_modifiable &= !flag;
 
                 assert!(

--- a/pczt/src/roles.rs
+++ b/pczt/src/roles.rs
@@ -77,4 +77,226 @@ mod tests {
             io_finalizer::Error::NoSpends,
         ));
     }
+
+    /// Tests that a hostile Creator, Updater, or Combiner cannot induce the Signer or the
+    /// Spend Finalizer into producing a spend authorization over data that the coin being
+    /// spent does not commit to.
+    ///
+    /// These use a transparent-only PCZT so that the IO Finalizer does no shielded work
+    /// and no proving keys are needed.
+    #[cfg(all(
+        feature = "io-finalizer",
+        feature = "signer",
+        feature = "spend-finalizer",
+        feature = "zcp-builder"
+    ))]
+    mod transparent_authentication {
+        use ::transparent::{
+            address::TransparentAddress,
+            bundle::{OutPoint, TxOut},
+            pczt::{SignerError, SpendFinalizerError, VerifyError},
+            sighash::{SighashPolicy, SIGHASH_ANYONECANPAY, SIGHASH_NONE, SIGHASH_SINGLE},
+        };
+        use rand_core::OsRng;
+        use zcash_primitives::transaction::{
+            builder::{BuildConfig, Builder, PcztResult},
+            fees::zip317,
+        };
+        use zcash_protocol::{consensus::MainNetwork, value::Zatoshis};
+
+        use crate::{
+            common::{
+                FLAG_HAS_SIGHASH_SINGLE, FLAG_TRANSPARENT_INPUTS_MODIFIABLE,
+                FLAG_TRANSPARENT_OUTPUTS_MODIFIABLE,
+            },
+            roles::{
+                creator::Creator, io_finalizer::IoFinalizer, signer, signer::Signer,
+                spend_finalizer, spend_finalizer::SpendFinalizer,
+            },
+            Pczt,
+        };
+
+        const SIGHASH_ALL_ANYONECANPAY: u8 =
+            ::transparent::sighash::SIGHASH_ALL | SIGHASH_ANYONECANPAY;
+
+        fn secret_key() -> secp256k1::SecretKey {
+            secp256k1::SecretKey::from_slice(&[1; 32]).expect("valid")
+        }
+
+        /// A PCZT spending a single P2PKH coin to a transparent address.
+        fn transparent_pczt() -> Pczt {
+            let sk = secret_key();
+            let pubkey = sk.public_key(&secp256k1::Secp256k1::signing_only());
+            let addr = TransparentAddress::from_pubkey(&pubkey);
+
+            let coin = TxOut::new(Zatoshis::const_from_u64(1_000_000), addr.script().into());
+
+            let mut builder = Builder::new(
+                MainNetwork,
+                10_000_000.into(),
+                BuildConfig::Standard {
+                    sapling_anchor: None,
+                    orchard_anchor: None,
+                },
+            );
+            builder
+                .add_transparent_input(pubkey, OutPoint::new([1; 32], 1), coin)
+                .unwrap();
+            builder
+                .add_transparent_output(&addr, Zatoshis::const_from_u64(990_000))
+                .unwrap();
+            let PcztResult { pczt_parts, .. } = builder
+                .build_for_pczt(OsRng, &zip317::FeeRule::standard())
+                .unwrap();
+
+            IoFinalizer::new(Creator::build_from_parts(pczt_parts).unwrap())
+                .finalize_io()
+                .unwrap()
+        }
+
+        /// A PCZT whose single input has been tampered with by a hostile counterparty.
+        fn tampered_pczt(f: impl FnOnce(&mut crate::transparent::Input)) -> Pczt {
+            let mut pczt = transparent_pczt();
+            f(&mut pczt.transparent.inputs[0]);
+            pczt
+        }
+
+        #[test]
+        fn signer_rejects_unauthenticated_redeem_script() {
+            // The coin being spent is P2PKH, so it commits to no redeem script at all;
+            // `Input::sign` would otherwise search this one for the signer’s pubkey and
+            // commit to it in the sighash.
+            let pczt = tampered_pczt(|input| input.redeem_script = Some(vec![0x51]));
+
+            assert!(matches!(
+                Signer::new(pczt)
+                    .unwrap()
+                    .sign_transparent(0, &secret_key()),
+                Err(signer::Error::TransparentSign(SignerError::InvalidInput(
+                    VerifyError::NotP2sh
+                ))),
+            ));
+        }
+
+        #[test]
+        fn signer_rejects_hostile_sighash_type() {
+            let pczt = tampered_pczt(|input| {
+                input.sighash_type = SIGHASH_NONE | SIGHASH_ANYONECANPAY;
+            });
+
+            assert!(matches!(
+                Signer::new(pczt)
+                    .unwrap()
+                    .sign_transparent(0, &secret_key()),
+                Err(signer::Error::TransparentSign(
+                    SignerError::DisallowedSighashType(_)
+                )),
+            ));
+        }
+
+        #[test]
+        fn signer_accepts_hostile_sighash_type_under_explicit_policy() {
+            let pczt = tampered_pczt(|input| {
+                input.sighash_type = SIGHASH_NONE | SIGHASH_ANYONECANPAY;
+            });
+
+            assert!(Signer::new(pczt)
+                .unwrap()
+                .with_transparent_sighash_policy(SighashPolicy::ANY)
+                .sign_transparent(0, &secret_key())
+                .is_ok());
+        }
+
+        /// Signs the single input of a PCZT tampered with by `f`, under `sighash_policy`.
+        fn signed(
+            f: impl FnOnce(&mut crate::transparent::Input),
+            sighash_policy: SighashPolicy,
+        ) -> Pczt {
+            let mut signer = Signer::new(tampered_pczt(f))
+                .unwrap()
+                .with_transparent_sighash_policy(sighash_policy);
+            signer.sign_transparent(0, &secret_key()).unwrap();
+            signer.finish()
+        }
+
+        #[test]
+        fn finalizer_rejects_non_all_sighash_type() {
+            let pczt = signed(
+                |input| input.sighash_type = SIGHASH_NONE,
+                SighashPolicy::ANY,
+            );
+
+            assert!(matches!(
+                SpendFinalizer::new(pczt).finalize_spends(),
+                Err(spend_finalizer::Error::TransparentFinalize(
+                    SpendFinalizerError::DisallowedSighashType(_)
+                )),
+            ));
+        }
+
+        #[test]
+        fn finalizer_accepts_non_all_sighash_type_under_explicit_policy() {
+            // A `SIGHASH_NONE` signature commits to none of the outputs, and the Signer
+            // correspondingly leaves the Transparent Outputs Modifiable flag set, so the
+            // modifiability gate is satisfied here.
+            let pczt = signed(
+                |input| input.sighash_type = SIGHASH_NONE,
+                SighashPolicy::ANY,
+            );
+
+            assert!(SpendFinalizer::new(pczt)
+                .with_sighash_policy(SighashPolicy::ANY)
+                .finalize_spends()
+                .is_ok());
+        }
+
+        #[test]
+        fn finalizer_rejects_sighash_type_inconsistent_with_modifiability() {
+            for (sighash_type, flag) in [
+                (SIGHASH_NONE, FLAG_TRANSPARENT_OUTPUTS_MODIFIABLE),
+                (SIGHASH_ALL_ANYONECANPAY, FLAG_TRANSPARENT_INPUTS_MODIFIABLE),
+                (SIGHASH_SINGLE, FLAG_HAS_SIGHASH_SINGLE),
+            ] {
+                let mut pczt = signed(
+                    |input| input.sighash_type = sighash_type,
+                    SighashPolicy::ANY,
+                );
+
+                // A hostile Combiner clears (or fails to set) the flag recording the part
+                // of the transaction that this signature leaves uncommitted.
+                pczt.global.tx_modifiable &= !flag;
+
+                assert!(
+                    matches!(
+                        SpendFinalizer::new(pczt)
+                            .with_sighash_policy(SighashPolicy::ANY)
+                            .finalize_spends(),
+                        Err(spend_finalizer::Error::InconsistentSighashType { index: 0, .. }),
+                    ),
+                    "expected sighash type {sighash_type:#04x} to be refused",
+                );
+            }
+        }
+
+        #[test]
+        fn finalizer_accepts_all_sighash_type() {
+            let pczt = signed(|_| (), SighashPolicy::ALL_ONLY);
+            assert!(SpendFinalizer::new(pczt).finalize_spends().is_ok());
+        }
+
+        /// Guards against the modifiability gate rejecting a `SIGHASH_SINGLE` signature
+        /// that the Signer correctly recorded.
+        #[test]
+        fn finalizer_accepts_recorded_sighash_single() {
+            let pczt = signed(
+                |input| input.sighash_type = SIGHASH_SINGLE,
+                SighashPolicy::ANY,
+            );
+
+            assert!(SpendFinalizer::new(pczt)
+                .with_sighash_policy(SighashPolicy::ANY)
+                .finalize_spends()
+                .is_ok());
+        }
+    }
 }

--- a/pczt/src/roles/signer/mod.rs
+++ b/pczt/src/roles/signer/mod.rs
@@ -16,7 +16,7 @@
 use blake2b_simd::Hash as Blake2bHash;
 use rand_core::OsRng;
 
-use ::transparent::sighash::{SIGHASH_ANYONECANPAY, SIGHASH_NONE, SIGHASH_SINGLE};
+use ::transparent::sighash::{SighashPolicy, SIGHASH_ANYONECANPAY, SIGHASH_NONE, SIGHASH_SINGLE};
 use zcash_primitives::transaction::{
     sighash::SignableInput, sighash_v5::v5_signature_hash, txid::TxIdDigester, Authorization,
     TransactionData, TxDigests, TxVersion,
@@ -51,6 +51,7 @@ pub struct Signer {
     txid_parts: TxDigests<Blake2bHash>,
     shielded_sighash: [u8; 32],
     secp: secp256k1::Secp256k1<secp256k1::SignOnly>,
+    transparent_sighash_policy: SighashPolicy,
 }
 
 impl Signer {
@@ -92,7 +93,18 @@ impl Signer {
             txid_parts,
             shielded_sighash,
             secp: secp256k1::Secp256k1::signing_only(),
+            transparent_sighash_policy: SighashPolicy::ALL_ONLY,
         })
+    }
+
+    /// Sets the sighash policy that this Signer applies to transparent inputs.
+    ///
+    /// The default is [`SighashPolicy::ALL_ONLY`]; see [`SighashPolicy`] for why the
+    /// sighash type a counterparty placed in the PCZT is only used if this Signer’s own
+    /// policy permits it.
+    pub fn with_transparent_sighash_policy(mut self, sighash_policy: SighashPolicy) -> Self {
+        self.transparent_sighash_policy = sighash_policy;
+        self
     }
 
     /// Signs the transparent spend at the given index with the given spending key.
@@ -105,17 +117,18 @@ impl Signer {
         index: usize,
         sk: &secp256k1::SecretKey,
     ) -> Result<(), Error> {
+        let sighash_policy = self.transparent_sighash_policy;
+
         let input = self
             .transparent
             .inputs_mut()
             .get_mut(index)
             .ok_or(Error::InvalidIndex)?;
 
-        // Check consistency of the input being signed.
-        // TODO
-
+        // The consistency of the input being signed, and the acceptability of its sighash
+        // type, are checked by `Input::sign_with_sighash_policy`.
         input
-            .sign(
+            .sign_with_sighash_policy(
                 index,
                 |input| {
                     v5_signature_hash(
@@ -129,6 +142,7 @@ impl Signer {
                 },
                 sk,
                 &self.secp,
+                sighash_policy,
             )
             .map_err(Error::TransparentSign)?;
 

--- a/pczt/src/roles/spend_finalizer/mod.rs
+++ b/pczt/src/roles/spend_finalizer/mod.rs
@@ -2,7 +2,9 @@
 //!
 //! - Combines partial transparent signatures into `script_sig`s.
 
-use ::transparent::sighash::{SighashPolicy, SighashType};
+use ::transparent::sighash::{
+    SighashPolicy, SighashType, SIGHASH_ANYONECANPAY, SIGHASH_NONE, SIGHASH_SINGLE,
+};
 
 use crate::Pczt;
 
@@ -49,6 +51,38 @@ impl SpendFinalizer {
         } = pczt;
 
         let mut transparent = transparent.into_parsed().map_err(Error::TransparentParse)?;
+
+        // A Signer that produces a signature leaving part of the transaction uncommitted
+        // is required to record that in `Global.tx_modifiable`. If the flags say the
+        // effects were already fixed, then the sighash type is not the product of a
+        // deliberate multi-party flow, and finalizing would yield a signature that can be
+        // lifted into a different transaction.
+        //
+        // This is a separate gate from the sighash policy, and is not relaxed by
+        // `SpendFinalizer::with_sighash_policy`. Note that the IO Finalizer clears both
+        // transparent modifiability flags whenever the transaction has shielded spends or
+        // outputs, so such a transaction is `SIGHASH_ALL`-only here.
+        for (index, input) in transparent.inputs().iter().enumerate() {
+            let sighash_type = *input.sighash_type();
+            let encoded = sighash_type.encode();
+            let signed_outputs = encoded & !SIGHASH_ANYONECANPAY;
+
+            let inconsistent =
+                // Commits to no other input, so inputs must still be modifiable.
+                (encoded & SIGHASH_ANYONECANPAY != 0 && !global.inputs_modifiable())
+                // Commits to none of the outputs, so outputs must still be modifiable.
+                || (signed_outputs == SIGHASH_NONE && !global.outputs_modifiable())
+                // The input and output pairing must have been recorded as needing to be
+                // preserved.
+                || (signed_outputs == SIGHASH_SINGLE && !global.has_sighash_single());
+
+            if inconsistent {
+                return Err(Error::InconsistentSighashType {
+                    index,
+                    sighash_type,
+                });
+            }
+        }
 
         transparent
             .finalize_spends_with_sighash_policy(sighash_policy)

--- a/pczt/src/roles/spend_finalizer/mod.rs
+++ b/pczt/src/roles/spend_finalizer/mod.rs
@@ -2,31 +2,56 @@
 //!
 //! - Combines partial transparent signatures into `script_sig`s.
 
+use ::transparent::sighash::{SighashPolicy, SighashType};
+
 use crate::Pczt;
 
 pub struct SpendFinalizer {
     pczt: Pczt,
+    sighash_policy: SighashPolicy,
 }
 
 impl SpendFinalizer {
     /// Instantiates the Spend Finalizer role with the given PCZT.
     pub fn new(pczt: Pczt) -> Self {
-        Self { pczt }
+        Self {
+            pczt,
+            sighash_policy: SighashPolicy::ALL_ONLY,
+        }
+    }
+
+    /// Sets the sighash policy that this Spend Finalizer applies to partial signatures.
+    ///
+    /// The default is [`SighashPolicy::ALL_ONLY`]; see [`SighashPolicy`] for why. Widen it
+    /// only if the surrounding protocol genuinely calls for a narrower commitment, as this
+    /// is the last point at which such a signature can be rejected before a broadcastable
+    /// transaction exists.
+    ///
+    /// Note that this does not relax the separate requirement that `Global.tx_modifiable`
+    /// record the parts of the transaction that each signature leaves uncommitted.
+    pub fn with_sighash_policy(mut self, sighash_policy: SighashPolicy) -> Self {
+        self.sighash_policy = sighash_policy;
+        self
     }
 
     /// Finalizes the spends of the PCZT.
     pub fn finalize_spends(self) -> Result<Pczt, Error> {
+        let Self {
+            pczt,
+            sighash_policy,
+        } = self;
+
         let Pczt {
             global,
             transparent,
             sapling,
             orchard,
-        } = self.pczt;
+        } = pczt;
 
         let mut transparent = transparent.into_parsed().map_err(Error::TransparentParse)?;
 
         transparent
-            .finalize_spends()
+            .finalize_spends_with_sighash_policy(sighash_policy)
             .map_err(Error::TransparentFinalize)?;
 
         Ok(Pczt {
@@ -41,6 +66,12 @@ impl SpendFinalizer {
 /// Errors that can occur while finalizing the spends of a PCZT.
 #[derive(Debug)]
 pub enum Error {
+    /// An input's sighash type leaves part of the transaction uncommitted, but
+    /// `Global.tx_modifiable` does not record that part as still modifiable.
+    InconsistentSighashType {
+        index: usize,
+        sighash_type: SighashType,
+    },
     TransparentFinalize(transparent::pczt::SpendFinalizerError),
     TransparentParse(transparent::pczt::ParseError),
 }

--- a/zcash_transparent/CHANGELOG.md
+++ b/zcash_transparent/CHANGELOG.md
@@ -18,6 +18,11 @@ workspace.
 
 ### Changed
 - `zcash_transparent::pczt`:
+  - `Input::sign` now verifies the consistency of the input before signing it,
+    returning `SignerError::InvalidInput` if the input sets a `redeem_script`
+    that its `script_pubkey` does not commit to. Previously the `redeem_script`
+    was used unchecked, both to locate the signer's pubkey and as the
+    `script_code` committed to by the signature.
   - `SignerError` has added variants:
     - `DisallowedSighashType`
     - `InvalidInput`

--- a/zcash_transparent/CHANGELOG.md
+++ b/zcash_transparent/CHANGELOG.md
@@ -18,11 +18,11 @@ workspace.
 
 ### Changed
 - `zcash_transparent::pczt`:
-  - `Input::sign` now verifies the consistency of the input before signing it,
-    returning `SignerError::InvalidInput` if the input sets a `redeem_script`
-    that its `script_pubkey` does not commit to. Previously the `redeem_script`
-    was used unchecked, both to locate the signer's pubkey and as the
-    `script_code` committed to by the signature.
+  - `Input::sign` now verifies the consistency of the input before signing it, and
+    signs only for `SighashType::ALL`. Previously the `redeem_script` was used
+    unchecked (both to locate the signer's pubkey and as the `script_code` committed
+    to by the signature), and the sighash type was taken verbatim from the PCZT. Use
+    `Input::sign_with_sighash_policy` to permit other sighash types.
   - `SignerError` has added variants:
     - `DisallowedSighashType`
     - `InvalidInput`

--- a/zcash_transparent/CHANGELOG.md
+++ b/zcash_transparent/CHANGELOG.md
@@ -23,6 +23,12 @@ workspace.
     unchecked (both to locate the signer's pubkey and as the `script_code` committed
     to by the signature), and the sighash type was taken verbatim from the PCZT. Use
     `Input::sign_with_sighash_policy` to permit other sighash types.
+  - `Bundle::finalize_spends` now requires every partial signature it uses to end in a
+    sighash-type byte matching its input's `sighash_type`, and finalizes only
+    `SighashType::ALL` signatures. Signatures that are discarded rather than placed
+    into a `script_sig` are not checked, so that a Combiner cannot block finalization
+    by contributing junk. Use `Bundle::finalize_spends_with_sighash_policy` to permit
+    other sighash types.
   - `SignerError` has added variants:
     - `DisallowedSighashType`
     - `InvalidInput`

--- a/zcash_transparent/CHANGELOG.md
+++ b/zcash_transparent/CHANGELOG.md
@@ -10,6 +10,9 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `zcash_transparent::sighash::SighashPolicy`
+
 ## [0.6.0] - 2025-10-02
 
 ### Added

--- a/zcash_transparent/CHANGELOG.md
+++ b/zcash_transparent/CHANGELOG.md
@@ -12,6 +12,18 @@ workspace.
 
 ### Added
 - `zcash_transparent::sighash::SighashPolicy`
+- `zcash_transparent::pczt`:
+  - `Input::sign_with_sighash_policy`
+  - `Bundle::finalize_spends_with_sighash_policy`
+
+### Changed
+- `zcash_transparent::pczt`:
+  - `SignerError` has added variants:
+    - `DisallowedSighashType`
+    - `InvalidInput`
+  - `SpendFinalizerError` has added variants:
+    - `DisallowedSighashType`
+    - `MismatchedSighashType`
 
 ## [0.6.0] - 2025-10-02
 

--- a/zcash_transparent/src/address.rs
+++ b/zcash_transparent/src/address.rs
@@ -13,9 +13,6 @@ use zcash_script::{
     solver,
 };
 
-#[cfg(feature = "transparent-inputs")]
-use sha2::{Digest, Sha256};
-
 /// A serialized script, used inside transparent inputs and outputs of a transaction.
 #[derive(Clone)]
 pub struct Script(pub script::Code);
@@ -189,9 +186,7 @@ impl TransparentAddress {
     /// Derives the P2PKH transparent address corresponding to the given pubkey bytes.
     #[cfg(feature = "transparent-inputs")]
     pub(crate) fn from_pubkey_bytes(pubkey: &[u8; 33]) -> Self {
-        TransparentAddress::PublicKeyHash(
-            *ripemd::Ripemd160::digest(Sha256::digest(pubkey)).as_ref(),
-        )
+        TransparentAddress::PublicKeyHash(crate::hash160(pubkey))
     }
 }
 

--- a/zcash_transparent/src/builder.rs
+++ b/zcash_transparent/src/builder.rs
@@ -22,7 +22,6 @@ use {
         sighash::{SighashType, SIGHASH_ALL},
     },
     core::iter,
-    sha2::Digest,
     zcash_encoding::CompactSize,
     zcash_script::{pattern::push_script, pv, script::Evaluable, solver},
 };
@@ -278,10 +277,7 @@ impl TransparentBuilder {
         // output may be spent.
         match TransparentAddress::from_script_pubkey(&script_pubkey) {
             Some(TransparentAddress::PublicKeyHash(hash)) => {
-                use ripemd::Ripemd160;
-                use sha2::Sha256;
-
-                if hash[..] != Ripemd160::digest(Sha256::digest(pubkey.serialize()))[..] {
+                if hash != crate::hash160(&pubkey.serialize()) {
                     return Err(Error::InvalidAddress);
                 }
             }
@@ -319,11 +315,9 @@ impl TransparentBuilder {
             .and_then(TransparentAddress::from_script_pubkey)
         {
             Some(TransparentAddress::ScriptHash(hash)) => {
-                use ripemd::Ripemd160;
-                use sha2::Sha256;
                 use zcash_script::script::Evaluable;
 
-                if hash[..] != Ripemd160::digest(Sha256::digest(redeem_script.to_bytes()))[..] {
+                if hash != crate::hash160(&redeem_script.to_bytes()) {
                     return Err(Error::InvalidAddress);
                 }
             }
@@ -737,9 +731,7 @@ impl<'a> TransparentSignatureContext<'a, secp256k1::VerifyOnly> {
 mod tests {
     use super::{Error, OutPoint, SignableInput, TransparentBuilder, TxOut};
     use crate::address::TransparentAddress;
-    use ripemd::Ripemd160;
     use secp256k1::{Message, Secp256k1, SecretKey};
-    use sha2::{Digest, Sha256};
     use zcash_address::ZcashAddress;
     use zcash_protocol::value::Zatoshis;
 
@@ -751,9 +743,7 @@ mod tests {
         let secp = Secp256k1::new();
         let pk = secp256k1::PublicKey::from_secret_key(&secp, &sk);
 
-        let pk_hash_generic_array = Ripemd160::digest(Sha256::digest(pk.serialize()));
-        let pk_hash_bytes: [u8; 20] = pk_hash_generic_array.into();
-        let taddr = TransparentAddress::PublicKeyHash(pk_hash_bytes);
+        let taddr = TransparentAddress::PublicKeyHash(crate::hash160(&pk.serialize()));
 
         let txout = TxOut::new(Zatoshis::from_u64(10000).unwrap(), taddr.script().into());
 

--- a/zcash_transparent/src/lib.rs
+++ b/zcash_transparent/src/lib.rs
@@ -6,6 +6,9 @@
 
 #![no_std]
 
+use ripemd::Ripemd160;
+use sha2::{Digest, Sha256};
+
 pub mod address;
 pub mod builder;
 pub mod bundle;
@@ -18,3 +21,9 @@ mod test_vectors;
 
 #[macro_use]
 extern crate alloc;
+
+/// `RIPEMD160(SHA256(data))`: the hash by which a P2PKH `script_pubkey` commits to its
+/// pubkey, and a P2SH `script_pubkey` to its redeem script.
+pub(crate) fn hash160(data: &[u8]) -> [u8; 20] {
+    *Ripemd160::digest(Sha256::digest(data)).as_ref()
+}

--- a/zcash_transparent/src/pczt.rs
+++ b/zcash_transparent/src/pczt.rs
@@ -282,22 +282,15 @@ pub(crate) mod testing {
     use alloc::collections::BTreeMap;
     use alloc::vec::Vec;
 
-    use ripemd::Ripemd160;
-    use sha2::{Digest, Sha256};
     use zcash_protocol::{value::Zatoshis, TxId};
     use zcash_script::{
         pattern,
         script::{self, Evaluable},
     };
 
-    use crate::{address::TransparentAddress, sighash::SighashType};
+    use crate::{address::TransparentAddress, hash160, sighash::SighashType};
 
     use super::Input;
-
-    /// `RIPEMD160(SHA256(data))`.
-    pub(crate) fn hash160(data: &[u8]) -> [u8; 20] {
-        *Ripemd160::digest(Sha256::digest(data)).as_ref()
-    }
 
     /// The P2PKH `script_pubkey` paying to `pubkey`.
     pub(crate) fn p2pkh(pubkey: &[u8; 33]) -> script::FromChain {

--- a/zcash_transparent/src/pczt.rs
+++ b/zcash_transparent/src/pczt.rs
@@ -274,3 +274,81 @@ impl Bip32Derivation {
         }
     }
 }
+
+#[cfg(test)]
+pub(crate) mod testing {
+    //! Helpers shared between the tests of this module's submodules.
+
+    use alloc::collections::BTreeMap;
+    use alloc::vec::Vec;
+
+    use ripemd::Ripemd160;
+    use sha2::{Digest, Sha256};
+    use zcash_protocol::{value::Zatoshis, TxId};
+    use zcash_script::{
+        pattern,
+        script::{self, Evaluable},
+    };
+
+    use crate::{address::TransparentAddress, sighash::SighashType};
+
+    use super::Input;
+
+    /// `RIPEMD160(SHA256(data))`.
+    pub(crate) fn hash160(data: &[u8]) -> [u8; 20] {
+        *Ripemd160::digest(Sha256::digest(data)).as_ref()
+    }
+
+    /// The P2PKH `script_pubkey` paying to `pubkey`.
+    pub(crate) fn p2pkh(pubkey: &[u8; 33]) -> script::FromChain {
+        TransparentAddress::PublicKeyHash(hash160(pubkey))
+            .script()
+            .weaken()
+    }
+
+    /// The P2SH `script_pubkey` committing to `redeem_script`.
+    pub(crate) fn p2sh(redeem_script: &script::FromChain) -> script::FromChain {
+        TransparentAddress::ScriptHash(hash160(&redeem_script.to_bytes()))
+            .script()
+            .weaken()
+    }
+
+    /// A bare `required`-of-`pubkeys.len()` P2MS script.
+    pub(crate) fn p2ms(required: u8, pubkeys: &[&[u8; 33]]) -> script::FromChain {
+        let pubkeys = pubkeys.iter().map(|pubkey| &pubkey[..]).collect::<Vec<_>>();
+        script::Component(pattern::check_multisig(required, &pubkeys, false).expect("valid"))
+            .weaken()
+    }
+
+    /// A bare P2PK script.
+    pub(crate) fn p2pk(pubkey: &[u8; 33]) -> script::FromChain {
+        script::Component(pattern::pay_to_pubkey(pubkey).expect("valid").to_vec()).weaken()
+    }
+
+    /// An input spending a coin with the given script, carrying no signatures.
+    pub(crate) fn input(
+        script_pubkey: script::FromChain,
+        redeem_script: Option<script::FromChain>,
+        sighash_type: SighashType,
+    ) -> Input {
+        Input {
+            prevout_txid: TxId::from_bytes([0; 32]),
+            prevout_index: 0,
+            sequence: None,
+            required_time_lock_time: None,
+            required_height_lock_time: None,
+            script_sig: None,
+            value: Zatoshis::const_from_u64(1_000_000),
+            script_pubkey,
+            redeem_script,
+            partial_signatures: BTreeMap::new(),
+            sighash_type,
+            bip32_derivation: BTreeMap::new(),
+            ripemd160_preimages: BTreeMap::new(),
+            sha256_preimages: BTreeMap::new(),
+            hash160_preimages: BTreeMap::new(),
+            hash256_preimages: BTreeMap::new(),
+            proprietary: BTreeMap::new(),
+        }
+    }
+}

--- a/zcash_transparent/src/pczt/signer.rs
+++ b/zcash_transparent/src/pczt/signer.rs
@@ -4,15 +4,22 @@ use zcash_script::solver;
 
 use crate::{
     address::{Script, TransparentAddress},
-    sighash::SignableInput,
+    sighash::{SighashPolicy, SighashType, SignableInput},
 };
+
+use super::VerifyError;
 
 impl super::Input {
     /// Signs the transparent spend with the given spend authorizing key.
     ///
-    /// It is the caller's responsibility to perform any semantic validity checks on the
-    /// PCZT (for example, comfirming that the change amounts are correct) before calling
-    /// this method.
+    /// This checks the consistency of the input being signed (in particular, that any
+    /// `redeem_script` really is the script committed to by `script_pubkey`), but it is
+    /// the caller’s responsibility to perform any semantic validity checks on the rest of
+    /// the PCZT (for example, confirming that the change amounts are correct) before
+    /// calling this method.
+    ///
+    /// Only [`SighashType::ALL`] is signed for; use
+    /// [`Input::sign_with_sighash_policy`] to sign with a wider policy.
     ///
     /// Returns an error if the spend authorizing key does not match any pubkey involved
     /// with spend control of the input's spent coin. The supported script formats are:
@@ -29,6 +36,28 @@ impl super::Input {
     where
         F: FnOnce(SignableInput) -> [u8; 32],
     {
+        self.sign_with_sighash_policy(index, calculate_sighash, sk, secp, SighashPolicy::ALL_ONLY)
+    }
+
+    /// Signs the transparent spend with the given spend authorizing key, if the input’s
+    /// sighash type is permitted by `sighash_policy`. See [`SighashPolicy`] for why that
+    /// is a decision for the Signer rather than for whoever supplied the PCZT.
+    ///
+    /// Otherwise behaves exactly as [`Input::sign`], which should be preferred.
+    pub fn sign_with_sighash_policy<C: secp256k1::Signing, F>(
+        &mut self,
+        index: usize,
+        calculate_sighash: F,
+        sk: &secp256k1::SecretKey,
+        secp: &secp256k1::Secp256k1<C>,
+        sighash_policy: SighashPolicy,
+    ) -> Result<(), SignerError>
+    where
+        F: FnOnce(SignableInput) -> [u8; 32],
+    {
+        // TODO: Enforced in a subsequent commit.
+        let _ = sighash_policy;
+
         let pubkey = sk.public_key(secp).serialize();
         let p2pkh_addr = TransparentAddress::from_pubkey_bytes(&pubkey);
 
@@ -86,7 +115,156 @@ impl super::Input {
 /// Errors that can occur while signing a transparent input in a PCZT.
 #[derive(Debug)]
 pub enum SignerError {
+    /// The input's `sighash_type` is not permitted by the Signer's [`SighashPolicy`].
+    DisallowedSighashType(SighashType),
+    /// The input being signed is not internally consistent.
+    InvalidInput(VerifyError),
     /// The provided `sk` does not match any pubkey involved with spend control of the
     /// input's spent coin.
     WrongSpendingKey,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SighashPolicy, SighashType, SignerError, VerifyError};
+    use crate::pczt::{
+        testing::{input, p2ms, p2pk, p2pkh, p2sh},
+        Input,
+    };
+
+    /// Every sighash type other than `SighashType::ALL`.
+    const NON_ALL_TYPES: [SighashType; 5] = [
+        SighashType::NONE,
+        SighashType::SINGLE,
+        SighashType::ALL_ANYONECANPAY,
+        SighashType::NONE_ANYONECANPAY,
+        SighashType::SINGLE_ANYONECANPAY,
+    ];
+
+    fn secret_key(i: u8) -> secp256k1::SecretKey {
+        secp256k1::SecretKey::from_slice(&[i; 32]).expect("valid")
+    }
+
+    fn pubkey(sk: &secp256k1::SecretKey) -> [u8; 33] {
+        sk.public_key(&secp256k1::Secp256k1::signing_only())
+            .serialize()
+    }
+
+    fn sign(
+        input: &mut Input,
+        sk: &secp256k1::SecretKey,
+        sighash_policy: SighashPolicy,
+    ) -> Result<(), SignerError> {
+        input.sign_with_sighash_policy(
+            0,
+            |_| [0; 32],
+            sk,
+            &secp256k1::Secp256k1::signing_only(),
+            sighash_policy,
+        )
+    }
+
+    #[test]
+    fn sign_rejects_unmatched_redeem_script() {
+        let sk = secret_key(1);
+        // A `redeem_script` that the signer does control, but that the coin being spent
+        // does not commit to. Without a check, this is both searched for the signer's
+        // pubkey and committed to by the sighash.
+        let redeem_script = p2ms(1, &[&pubkey(&sk)]);
+        let other_script = p2ms(1, &[&pubkey(&secret_key(2))]);
+
+        let mut input = input(p2sh(&other_script), Some(redeem_script), SighashType::ALL);
+
+        assert!(matches!(
+            sign(&mut input, &sk, SighashPolicy::ALL_ONLY),
+            Err(SignerError::InvalidInput(VerifyError::WrongRedeemScript)),
+        ));
+        assert!(input.partial_signatures.is_empty());
+    }
+
+    #[test]
+    fn sign_rejects_redeem_script_on_p2pkh() {
+        let sk = secret_key(1);
+        let mut input = input(
+            p2pkh(&pubkey(&sk)),
+            Some(p2ms(1, &[&pubkey(&sk)])),
+            SighashType::ALL,
+        );
+
+        assert!(matches!(
+            sign(&mut input, &sk, SighashPolicy::ALL_ONLY),
+            Err(SignerError::InvalidInput(VerifyError::NotP2sh)),
+        ));
+        assert!(input.partial_signatures.is_empty());
+    }
+
+    #[test]
+    fn sign_accepts_matching_redeem_script() {
+        let sk = secret_key(1);
+        let redeem_script = p2ms(1, &[&pubkey(&sk)]);
+        let mut input = input(p2sh(&redeem_script), Some(redeem_script), SighashType::ALL);
+
+        assert!(sign(&mut input, &sk, SighashPolicy::ALL_ONLY).is_ok());
+        assert!(input.partial_signatures.contains_key(&pubkey(&sk)));
+    }
+
+    #[test]
+    fn sign_accepts_p2pkh() {
+        let sk = secret_key(1);
+        let mut input = input(p2pkh(&pubkey(&sk)), None, SighashType::ALL);
+
+        assert!(sign(&mut input, &sk, SighashPolicy::ALL_ONLY).is_ok());
+        assert!(input.partial_signatures.contains_key(&pubkey(&sk)));
+    }
+
+    /// `Input::verify` does not recognise bare P2PK `script_pubkey`s, but `Input::sign`
+    /// supports them.
+    #[test]
+    fn sign_accepts_bare_p2pk() {
+        let sk = secret_key(1);
+        let mut input = input(p2pk(&pubkey(&sk)), None, SighashType::ALL);
+
+        assert!(sign(&mut input, &sk, SighashPolicy::ALL_ONLY).is_ok());
+        assert!(input.partial_signatures.contains_key(&pubkey(&sk)));
+    }
+
+    /// `Input::verify` does not recognise bare P2MS `script_pubkey`s, but `Input::sign`
+    /// supports them.
+    #[test]
+    fn sign_accepts_bare_p2ms() {
+        let sk = secret_key(1);
+        let mut input = input(
+            p2ms(1, &[&pubkey(&sk), &pubkey(&secret_key(2))]),
+            None,
+            SighashType::ALL,
+        );
+
+        assert!(sign(&mut input, &sk, SighashPolicy::ALL_ONLY).is_ok());
+        assert!(input.partial_signatures.contains_key(&pubkey(&sk)));
+    }
+
+    #[test]
+    fn sign_rejects_non_all_sighash_types_by_default() {
+        let sk = secret_key(1);
+        for sighash_type in NON_ALL_TYPES {
+            let mut input = input(p2pkh(&pubkey(&sk)), None, sighash_type);
+
+            match sign(&mut input, &sk, SighashPolicy::ALL_ONLY) {
+                Err(SignerError::DisallowedSighashType(t)) => assert_eq!(t, sighash_type),
+                r => panic!("expected {sighash_type:?} to be refused, got {r:?}"),
+            }
+            assert!(input.partial_signatures.is_empty());
+        }
+    }
+
+    #[test]
+    fn sign_accepts_non_all_sighash_types_under_explicit_policy() {
+        let sk = secret_key(1);
+        for sighash_type in NON_ALL_TYPES {
+            let mut input = input(p2pkh(&pubkey(&sk)), None, sighash_type);
+
+            assert!(sign(&mut input, &sk, SighashPolicy::ANY).is_ok());
+            assert!(input.partial_signatures.contains_key(&pubkey(&sk)));
+        }
+    }
 }

--- a/zcash_transparent/src/pczt/signer.rs
+++ b/zcash_transparent/src/pczt/signer.rs
@@ -55,8 +55,11 @@ impl super::Input {
     where
         F: FnOnce(SignableInput) -> [u8; 32],
     {
-        // TODO: Enforced in a subsequent commit.
-        let _ = sighash_policy;
+        // The sighash type reaches us from whoever gave us this PCZT, so it is our
+        // policy, not theirs, that decides whether to produce such a signature.
+        if !sighash_policy.permits(self.sighash_type) {
+            return Err(SignerError::DisallowedSighashType(self.sighash_type));
+        }
 
         // The `redeem_script` reaches us from whoever gave us this PCZT, and below we
         // both search it for our pubkey and commit to it in the sighash. Check first

--- a/zcash_transparent/src/pczt/signer.rs
+++ b/zcash_transparent/src/pczt/signer.rs
@@ -58,6 +58,18 @@ impl super::Input {
         // TODO: Enforced in a subsequent commit.
         let _ = sighash_policy;
 
+        // The `redeem_script` reaches us from whoever gave us this PCZT, and below we
+        // both search it for our pubkey and commit to it in the sighash. Check first
+        // that it really is the script that the coin being spent commits to.
+        match self.verify() {
+            // `Input::verify` only recognises P2PKH and P2SH `script_pubkey`s, whereas
+            // signing additionally supports the bare P2PK and P2MS scripts below. Those
+            // have no `redeem_script` to check.
+            Err(VerifyError::UnsupportedScriptPubkey) if self.redeem_script.is_none() => Ok(()),
+            r => r,
+        }
+        .map_err(SignerError::InvalidInput)?;
+
         let pubkey = sk.public_key(secp).serialize();
         let p2pkh_addr = TransparentAddress::from_pubkey_bytes(&pubkey);
 

--- a/zcash_transparent/src/pczt/spend_finalizer.rs
+++ b/zcash_transparent/src/pczt/spend_finalizer.rs
@@ -1,9 +1,8 @@
-use ripemd::Ripemd160;
-use sha2::{Digest, Sha256};
 use zcash_script::{pattern::push_script, pv, script, solver};
 
 use crate::{
     address::TransparentAddress,
+    hash160,
     sighash::{SighashPolicy, SighashType},
 };
 
@@ -53,7 +52,7 @@ impl super::Bundle {
                         }
                         .and_then(|(pubkey, sig_bytes)| {
                             // Check that the signature is for this input.
-                            if hash[..] != Ripemd160::digest(Sha256::digest(pubkey))[..] {
+                            if hash != hash160(pubkey) {
                                 Err(SpendFinalizerError::UnexpectedSignatures)
                             } else {
                                 check_sighash_type(sig_bytes, input.sighash_type, sighash_policy)?;

--- a/zcash_transparent/src/pczt/spend_finalizer.rs
+++ b/zcash_transparent/src/pczt/spend_finalizer.rs
@@ -2,10 +2,18 @@ use ripemd::Ripemd160;
 use sha2::{Digest, Sha256};
 use zcash_script::{pattern::push_script, pv, script, solver};
 
-use crate::address::TransparentAddress;
+use crate::{
+    address::TransparentAddress,
+    sighash::{SighashPolicy, SighashType},
+};
 
 impl super::Bundle {
     /// Finalizes the spends for this bundle.
+    ///
+    /// Every partial signature that is used commits to the transaction in full: a
+    /// signature whose sighash type is not [`SighashType::ALL`] is refused, as is one
+    /// whose sighash type does not match that of the input it is being applied to. Use
+    /// [`Bundle::finalize_spends_with_sighash_policy`] to finalize with a wider policy.
     ///
     /// Returns an error if any spend uses an unsupported script format. The supported
     /// script formats are:
@@ -13,6 +21,24 @@ impl super::Bundle {
     /// - P2SH with one of these redeem script formats:
     ///   - P2MS
     pub fn finalize_spends(&mut self) -> Result<(), SpendFinalizerError> {
+        self.finalize_spends_with_sighash_policy(SighashPolicy::ALL_ONLY)
+    }
+
+    /// Finalizes the spends for this bundle, accepting any partial signature whose
+    /// sighash type is permitted by `sighash_policy`. See [`SighashPolicy`] for why that
+    /// is a decision for the Spend Finalizer rather than for whoever supplied the
+    /// signature.
+    ///
+    /// Otherwise behaves exactly as [`Bundle::finalize_spends`], which should be
+    /// preferred: this is the last point at which such a signature can be rejected before
+    /// a broadcastable transaction exists.
+    pub fn finalize_spends_with_sighash_policy(
+        &mut self,
+        sighash_policy: SighashPolicy,
+    ) -> Result<(), SpendFinalizerError> {
+        // TODO: Enforced in a subsequent commit.
+        let _ = sighash_policy;
+
         // For each input, the Spend Finalizer determines if the input has enough data to
         // pass validation. If it does, it must construct the `script_sig` and place it
         // into the PCZT input. If `script_sig` is empty for an input, the field should
@@ -130,6 +156,11 @@ impl super::Bundle {
 /// Errors that can occur while finalizing the transparent inputs of a PCZT bundle.
 #[derive(Debug)]
 pub enum SpendFinalizerError {
+    /// A partial signature's sighash type is not permitted by the Spend Finalizer's
+    /// [`SighashPolicy`].
+    DisallowedSighashType(SighashType),
+    /// A partial signature's sighash type does not match that of the input it applies to.
+    MismatchedSighashType,
     /// `script_pubkey` is a P2SH script, but `redeem_script` is not set.
     MissingRedeemScript,
     /// `script_pubkey` is a P2SH script, but `redeem_script` is too long for a `PushData`.
@@ -146,4 +177,139 @@ pub enum SpendFinalizerError {
     UnsupportedScriptPubkey,
     /// The `redeem_script` kind is unsupported.
     UnsupportedRedeemScript,
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    use super::{SighashPolicy, SighashType, SpendFinalizerError};
+    use crate::{
+        pczt::{
+            testing::{input, p2ms, p2pkh, p2sh},
+            Bundle, Input,
+        },
+        sighash::{SIGHASH_ALL, SIGHASH_NONE},
+    };
+
+    /// A pubkey-shaped byte string. The Spend Finalizer never checks that a pubkey is a
+    /// point on the curve, so these do not need to be real.
+    fn pubkey(i: u8) -> [u8; 33] {
+        let mut pubkey = [i; 33];
+        pubkey[0] = 0x02;
+        pubkey
+    }
+
+    /// A signature-shaped byte string ending in `hash_type`. The Spend Finalizer never
+    /// verifies a signature, so this does not need to be a real one.
+    fn signature(hash_type: u8) -> Vec<u8> {
+        vec![0xde, 0xad, 0xbe, 0xef, hash_type]
+    }
+
+    /// A P2PKH input signed by `pubkey(1)`.
+    fn p2pkh_input(sighash_type: SighashType, signature: Vec<u8>) -> Input {
+        let mut input = input(p2pkh(&pubkey(1)), None, sighash_type);
+        input.partial_signatures.insert(pubkey(1), signature);
+        input
+    }
+
+    /// A 2-of-3 P2SH-P2MS input, signed by the pubkeys named by the given indices.
+    fn p2ms_input(sighash_type: SighashType, signatures: &[(u8, u8)]) -> Input {
+        let pubkeys = [pubkey(1), pubkey(2), pubkey(3)];
+        let redeem_script = p2ms(2, &[&pubkeys[0], &pubkeys[1], &pubkeys[2]]);
+        let mut input = input(p2sh(&redeem_script), Some(redeem_script), sighash_type);
+        for (i, hash_type) in signatures {
+            input
+                .partial_signatures
+                .insert(pubkey(*i), signature(*hash_type));
+        }
+        input
+    }
+
+    fn finalize(input: Input, sighash_policy: SighashPolicy) -> Result<(), SpendFinalizerError> {
+        Bundle {
+            inputs: vec![input],
+            outputs: vec![],
+        }
+        .finalize_spends_with_sighash_policy(sighash_policy)
+    }
+
+    #[test]
+    fn finalize_accepts_p2pkh() {
+        let input = p2pkh_input(SighashType::ALL, signature(SIGHASH_ALL));
+        assert!(finalize(input, SighashPolicy::ALL_ONLY).is_ok());
+    }
+
+    #[test]
+    fn finalize_accepts_multisig() {
+        let input = p2ms_input(SighashType::ALL, &[(1, SIGHASH_ALL), (2, SIGHASH_ALL)]);
+        assert!(finalize(input, SighashPolicy::ALL_ONLY).is_ok());
+    }
+
+    /// The PCZT format requires a Spend Finalizer to reject a signature that does not
+    /// match the sighash type of the input it applies to.
+    #[test]
+    fn finalize_rejects_mismatched_sighash_type() {
+        let input = p2pkh_input(SighashType::ALL, signature(SIGHASH_NONE));
+        assert!(matches!(
+            finalize(input, SighashPolicy::ALL_ONLY),
+            Err(SpendFinalizerError::MismatchedSighashType),
+        ));
+    }
+
+    #[test]
+    fn finalize_rejects_mismatched_sighash_type_in_multisig() {
+        let input = p2ms_input(SighashType::ALL, &[(1, SIGHASH_ALL), (2, SIGHASH_NONE)]);
+        assert!(matches!(
+            finalize(input, SighashPolicy::ALL_ONLY),
+            Err(SpendFinalizerError::MismatchedSighashType),
+        ));
+    }
+
+    #[test]
+    fn finalize_rejects_non_all_sighash_type_by_default() {
+        let input = p2pkh_input(SighashType::NONE, signature(SIGHASH_NONE));
+        match finalize(input, SighashPolicy::ALL_ONLY) {
+            Err(SpendFinalizerError::DisallowedSighashType(t)) => {
+                assert_eq!(t, SighashType::NONE)
+            }
+            r => panic!("expected SIGHASH_NONE to be refused, got {r:?}"),
+        }
+    }
+
+    #[test]
+    fn finalize_accepts_non_all_sighash_type_under_explicit_policy() {
+        let input = p2pkh_input(SighashType::NONE, signature(SIGHASH_NONE));
+        assert!(finalize(input, SighashPolicy::ANY).is_ok());
+    }
+
+    #[test]
+    fn finalize_rejects_empty_signature() {
+        let input = p2pkh_input(SighashType::ALL, vec![]);
+        assert!(matches!(
+            finalize(input, SighashPolicy::ALL_ONLY),
+            Err(SpendFinalizerError::InvalidSignature),
+        ));
+    }
+
+    #[test]
+    fn finalize_rejects_unparsable_sighash_type() {
+        let input = p2pkh_input(SighashType::ALL, signature(0x05));
+        assert!(matches!(
+            finalize(input, SighashPolicy::ALL_ONLY),
+            Err(SpendFinalizerError::InvalidSignature),
+        ));
+    }
+
+    /// A signature that is discarded rather than placed into the `script_sig` is not
+    /// checked, so that a Combiner cannot block finalization by contributing junk.
+    #[test]
+    fn finalize_ignores_discarded_multisig_signature() {
+        let input = p2ms_input(
+            SighashType::ALL,
+            &[(1, SIGHASH_ALL), (2, SIGHASH_ALL), (3, 0x05)],
+        );
+        assert!(finalize(input, SighashPolicy::ALL_ONLY).is_ok());
+    }
 }

--- a/zcash_transparent/src/pczt/spend_finalizer.rs
+++ b/zcash_transparent/src/pczt/spend_finalizer.rs
@@ -36,9 +36,6 @@ impl super::Bundle {
         &mut self,
         sighash_policy: SighashPolicy,
     ) -> Result<(), SpendFinalizerError> {
-        // TODO: Enforced in a subsequent commit.
-        let _ = sighash_policy;
-
         // For each input, the Spend Finalizer determines if the input has enough data to
         // pass validation. If it does, it must construct the `script_sig` and place it
         // into the PCZT input. If `script_sig` is empty for an input, the field should
@@ -59,6 +56,8 @@ impl super::Bundle {
                             if hash[..] != Ripemd160::digest(Sha256::digest(pubkey))[..] {
                                 Err(SpendFinalizerError::UnexpectedSignatures)
                             } else {
+                                check_sighash_type(sig_bytes, input.sighash_type, sighash_policy)?;
+
                                 // P2PKH scriptSig
                                 input.script_sig = Some(script::Component(vec![
                                     pv::push_value(sig_bytes).expect("short enough"),
@@ -105,6 +104,12 @@ impl super::Bundle {
 
                                     // If we have a signature from this pubkey, use it.
                                     if let Some(sig) = input.partial_signatures.get(&pubkey) {
+                                        check_sighash_type(
+                                            sig,
+                                            input.sighash_type,
+                                            sighash_policy,
+                                        )?;
+
                                         // Valid signatures always fit into `PushData`s.
                                         script_sig.push(
                                             pv::push_value(sig)
@@ -151,6 +156,31 @@ impl super::Bundle {
 
         Ok(())
     }
+}
+
+/// Checks the trailing sighash-type byte of a partial signature that is about to be
+/// placed into a `script_sig`.
+fn check_sighash_type(
+    sig_bytes: &[u8],
+    expected: SighashType,
+    sighash_policy: SighashPolicy,
+) -> Result<(), SpendFinalizerError> {
+    let (hash_type, _) = sig_bytes
+        .split_last()
+        .ok_or(SpendFinalizerError::InvalidSignature)?;
+    let hash_type = SighashType::parse(*hash_type).ok_or(SpendFinalizerError::InvalidSignature)?;
+
+    // The PCZT format requires a Spend Finalizer to fail to finalize an input whose
+    // signatures do not match its `sighash_type`.
+    if hash_type != expected {
+        return Err(SpendFinalizerError::MismatchedSighashType);
+    }
+
+    if !sighash_policy.permits(hash_type) {
+        return Err(SpendFinalizerError::DisallowedSighashType(hash_type));
+    }
+
+    Ok(())
 }
 
 /// Errors that can occur while finalizing the transparent inputs of a PCZT bundle.

--- a/zcash_transparent/src/pczt/updater.rs
+++ b/zcash_transparent/src/pczt/updater.rs
@@ -4,7 +4,7 @@ use ripemd::Ripemd160;
 use sha2::{Digest, Sha256};
 use zcash_script::script::{self, Evaluable};
 
-use crate::address::TransparentAddress;
+use crate::{address::TransparentAddress, hash160};
 
 use super::{Bip32Derivation, Bundle, Input, Output};
 
@@ -71,7 +71,7 @@ impl InputUpdater<'_> {
         if let Some(TransparentAddress::ScriptHash(hash)) =
             TransparentAddress::from_script_from_chain(&self.0.script_pubkey)
         {
-            if hash[..] == Ripemd160::digest(Sha256::digest(redeem_script.to_bytes()))[..] {
+            if hash == hash160(&redeem_script.to_bytes()) {
                 self.0.redeem_script = Some(redeem_script);
                 Ok(())
             } else {
@@ -101,8 +101,7 @@ impl InputUpdater<'_> {
 
     /// Stores the given value along with `key = RIPEMD160(SHA256(value))`.
     pub fn set_hash160_preimage(&mut self, value: Vec<u8>) {
-        let hash = Ripemd160::digest(Sha256::digest(&value));
-        self.0.hash160_preimages.insert(hash.into(), value);
+        self.0.hash160_preimages.insert(hash160(&value), value);
     }
 
     /// Stores the given value along with `key = SHA256(SHA256(value))`.
@@ -129,7 +128,7 @@ impl OutputUpdater<'_> {
         if let Some(TransparentAddress::ScriptHash(hash)) =
             TransparentAddress::from_script_pubkey(&self.0.script_pubkey)
         {
-            if hash[..] == Ripemd160::digest(Sha256::digest(redeem_script.to_bytes()))[..] {
+            if hash == hash160(&redeem_script.to_bytes()) {
                 self.0.redeem_script = Some(redeem_script);
                 Ok(())
             } else {

--- a/zcash_transparent/src/pczt/verify.rs
+++ b/zcash_transparent/src/pczt/verify.rs
@@ -1,8 +1,6 @@
-use ripemd::Ripemd160;
-use sha2::{Digest, Sha256};
 use zcash_script::script::Evaluable;
 
-use crate::address::TransparentAddress;
+use crate::{address::TransparentAddress, hash160};
 
 impl super::Input {
     /// Verifies the consistency of this transparent input.
@@ -17,7 +15,7 @@ impl super::Input {
             }
             Some(TransparentAddress::ScriptHash(hash)) => {
                 if let Some(redeem_script) = self.redeem_script() {
-                    if hash[..] != Ripemd160::digest(Sha256::digest(redeem_script.to_bytes()))[..] {
+                    if hash != hash160(&redeem_script.to_bytes()) {
                         return Err(VerifyError::WrongRedeemScript);
                     }
                 }
@@ -42,7 +40,7 @@ impl super::Output {
             }
             Some(TransparentAddress::ScriptHash(hash)) => {
                 if let Some(redeem_script) = self.redeem_script() {
-                    if hash[..] != Ripemd160::digest(Sha256::digest(redeem_script.to_bytes()))[..] {
+                    if hash != hash160(&redeem_script.to_bytes()) {
                         return Err(VerifyError::WrongRedeemScript);
                     }
                 }

--- a/zcash_transparent/src/sighash.rs
+++ b/zcash_transparent/src/sighash.rs
@@ -43,6 +43,73 @@ impl SighashType {
     }
 }
 
+/// A set of [ZIP 244] sighash types.
+///
+/// A signature that does not use [`SighashType::ALL`] does not commit to some part of the
+/// transaction that it authorizes: a `SIGHASH_NONE` signature commits to none of the
+/// outputs, and a `SIGHASH_ANYONECANPAY` signature commits to no other input. Such a
+/// signature can be lifted out of the transaction it was created for and reused in a
+/// different one, so an entity that signs or finalizes on a user’s behalf should only
+/// produce or accept one when the surrounding protocol calls for it.
+///
+/// This type is how that decision is made explicit: the default is
+/// [`SighashPolicy::ALL_ONLY`], and a wider policy has to be opted into.
+///
+/// [ZIP 244]: https://zips.z.cash/zip-0244#s-2a-hash-type
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SighashPolicy(u8);
+
+impl Default for SighashPolicy {
+    fn default() -> Self {
+        Self::ALL_ONLY
+    }
+}
+
+impl SighashPolicy {
+    /// The empty policy, permitting no sighash type at all.
+    ///
+    /// Use [`SighashPolicy::permitting`] to build up a policy from this.
+    pub const EMPTY: Self = Self(0);
+
+    /// Permits only [`SighashType::ALL`].
+    ///
+    /// This is the default policy, and the only one under which a signature is guaranteed
+    /// to commit to every input and output of the transaction it authorizes.
+    pub const ALL_ONLY: Self = Self::EMPTY.permitting(SighashType::ALL);
+
+    /// Permits every [ZIP 244] sighash type.
+    ///
+    /// Only use this if the surrounding protocol needs signatures that do not commit to
+    /// the whole transaction, and it is the protocol rather than the counterparty that
+    /// decides which sighash type each input uses.
+    ///
+    /// [ZIP 244]: https://zips.z.cash/zip-0244#s-2a-hash-type
+    pub const ANY: Self = Self::ALL_ONLY
+        .permitting(SighashType::NONE)
+        .permitting(SighashType::SINGLE)
+        .permitting(SighashType::ALL_ANYONECANPAY)
+        .permitting(SighashType::NONE_ANYONECANPAY)
+        .permitting(SighashType::SINGLE_ANYONECANPAY);
+
+    /// Returns the bit representing `hash_type` within the policy.
+    const fn bit(hash_type: SighashType) -> u8 {
+        // `SighashType` is correct by construction, so the masked value is always one of
+        // `SIGHASH_ALL`, `SIGHASH_NONE`, or `SIGHASH_SINGLE`, i.e. 1, 2, or 3;
+        // `SIGHASH_ANYONECANPAY` shifts it into the upper half of the mask.
+        1 << ((hash_type.0 & !SIGHASH_ANYONECANPAY) - 1 + (hash_type.0 >> 7) * 3)
+    }
+
+    /// Returns a policy permitting everything this policy permits, and `hash_type`.
+    pub const fn permitting(self, hash_type: SighashType) -> Self {
+        Self(self.0 | Self::bit(hash_type))
+    }
+
+    /// Returns whether this policy permits `hash_type`.
+    pub const fn permits(&self, hash_type: SighashType) -> bool {
+        (self.0 & Self::bit(hash_type)) != 0
+    }
+}
+
 /// Additional context that is needed to compute signature hashes
 /// for transactions that include transparent inputs or outputs.
 pub trait TransparentAuthorizingContext: Authorization {
@@ -85,5 +152,71 @@ impl<'a> SignableInput<'a> {
             script_pubkey,
             value,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SighashPolicy, SighashType};
+
+    /// Every sighash type that [`SighashType::parse`] accepts.
+    const EVERY_TYPE: [SighashType; 6] = [
+        SighashType::ALL,
+        SighashType::NONE,
+        SighashType::SINGLE,
+        SighashType::ALL_ANYONECANPAY,
+        SighashType::NONE_ANYONECANPAY,
+        SighashType::SINGLE_ANYONECANPAY,
+    ];
+
+    #[test]
+    fn every_type_has_a_distinct_bit() {
+        let mut seen = 0;
+        for hash_type in EVERY_TYPE {
+            let bit = SighashPolicy::bit(hash_type);
+            assert_eq!(seen & bit, 0, "{hash_type:?} collides with an earlier type");
+            seen |= bit;
+        }
+        assert_eq!(seen, SighashPolicy::ANY.0);
+    }
+
+    #[test]
+    fn empty_permits_nothing() {
+        for hash_type in EVERY_TYPE {
+            assert!(!SighashPolicy::EMPTY.permits(hash_type));
+        }
+    }
+
+    #[test]
+    fn all_only_permits_only_all() {
+        for hash_type in EVERY_TYPE {
+            assert_eq!(
+                SighashPolicy::ALL_ONLY.permits(hash_type),
+                hash_type == SighashType::ALL,
+            );
+        }
+    }
+
+    #[test]
+    fn any_permits_everything() {
+        for hash_type in EVERY_TYPE {
+            assert!(SighashPolicy::ANY.permits(hash_type));
+        }
+    }
+
+    #[test]
+    fn permitting_adds_exactly_one_type() {
+        let policy = SighashPolicy::ALL_ONLY.permitting(SighashType::NONE_ANYONECANPAY);
+        for hash_type in EVERY_TYPE {
+            assert_eq!(
+                policy.permits(hash_type),
+                hash_type == SighashType::ALL || hash_type == SighashType::NONE_ANYONECANPAY,
+            );
+        }
+    }
+
+    #[test]
+    fn default_is_all_only() {
+        assert_eq!(SighashPolicy::default(), SighashPolicy::ALL_ONLY);
     }
 }


### PR DESCRIPTION
Three coupled defence-in-depth gaps on the PCZT transparent spend-authorization
path, surfaced during a wallet review. Nothing on that path semantically
authenticated the input being signed.

1. **Unverified `redeem_script`.** `Input::sign` took
   `script_code = redeem_script.unwrap_or(script_pubkey)`, then both searched it
   for the signer’s pubkey and committed to it in the sighash, without checking
   `hash160(redeem_script) == script_pubkey`. `Input::verify` already implements
   exactly that check, but the signing path never called it, and the role-layer
   hook for it in `Signer::sign_transparent` was an unimplemented `// TODO`.

2. **Attacker-chosen sighash type.** `Input::sign` used `self.sighash_type`
   verbatim, and `SighashType::parse` accepts all six ZIP 244 variants. A hostile
   Creator or Updater could therefore set `SIGHASH_NONE | SIGHASH_ANYONECANPAY`
   and obtain a signature committing to neither the outputs nor the other inputs
   — one that can be lifted into a different transaction.

3. **The Spend Finalizer enforced nothing.** `Bundle::finalize_spends` copied
   each partial signature — trailing sighash byte included — into the
   `script_sig` without inspecting it, despite the field documentation in
   `pczt.rs` already stating that “Spend Finalizers must fail to finalize inputs
   which have signatures that do not match this sighash type”.

The in-tree builder always uses `SighashType::ALL`, so single-wallet flows were
never exploitable. The exposure is to third-party multi-party PCZT signers
relying on the library to be safe by default.

## Approach

A new `zcash_transparent::sighash::SighashPolicy` — a set of permitted sighash
types, defaulting to `ALL_ONLY` — is the single opt-in mechanism. The four
existing entry points (`Input::sign`, `Bundle::finalize_spends`,
`Signer::sign_transparent`, `SpendFinalizer::finalize_spends`) keep their
signatures and become `ALL`-only; policy-taking variants sit alongside them.

Two deliberate choices worth a reviewer’s attention:

- **The redeem-script check lives in `Input::sign`, not at the role layer.**
  `pczt::roles::low_level_signer` hands out `&mut transparent::pczt::Bundle` and
  calls `Input::sign` directly, so a role-layer-only check would be bypassable.
  The `// TODO` in `Signer::sign_transparent` is therefore closed by a comment
  pointing at that check rather than by a second call.

  `Input::verify` cannot be called unconditionally from `sign`, though: it
  resolves the `script_pubkey` through `TransparentAddress::from_script_pubkey`,
  which returns `None` for the bare P2PK and P2MS scripts that `Input::sign`
  explicitly supports. So `sign` tolerates exactly
  `VerifyError::UnsupportedScriptPubkey`, and only when there is no
  `redeem_script` to check. Two tests guard that tolerance.

- **The Spend Finalizer also gates on `Global.tx_modifiable`**, independently of
  the sighash policy — `SighashPolicy::ANY` does not relax it. A Signer that
  produces a signature leaving part of the transaction uncommitted is required
  to record that in `tx_modifiable`; if the flags say the effects were already
  fixed, then the sighash type is not the product of a deliberate multi-party
  flow. This lives in the `pczt` role rather than in `zcash_transparent` because
  `tx_modifiable` is a PCZT-global field that the transparent bundle has no
  access to.

  It has real teeth: the IO Finalizer clears both transparent modifiability
  flags whenever the transaction has shielded spends or outputs, so any shielded
  PCZT is `SIGHASH_ALL`-only at finalization regardless of policy.

## Commits

Tests land before their fixes, so the history contains a point at which they
fail and each fix can be judged by which failures it clears.

| commit | failing tests |
| --- | --- |
| `zcash_transparent: Add `SighashPolicy`` | — |
| `… Add failing tests for the PCZT transparent gaps` | 12 |
| `… Verify a PCZT transparent input before signing it` | 9 |
| `… Sign a PCZT transparent input only for SIGHASH_ALL` | 7 |
| `… Check the sighash type of each finalized signature` | 1 |
| `pczt: Reject a sighash type inconsistent with `Global.tx_modifiable`` | 0 |

A final commit collapses the ten inlined copies of `RIPEMD160(SHA256(_))` in
`zcash_transparent` into one `pub(crate)` helper; it is independent of the rest
and can be dropped if unwanted.

## Testing

Unit tests in `zcash_transparent` construct hostile inputs directly (the `Input`
fields are `pub(crate)`), and a role-level suite in `pczt/src/roles.rs` drives
the whole Creator → IO Finalizer → Signer → Spend Finalizer path over a
transparent-only PCZT, so the IO Finalizer short-circuits the shielded work and
no proving keys are built. `pczt/tests/end_to_end.rs` is untouched and is the
regression guard for the honest P2PKH and P2SH-multisig flows.

## Base

Draft because this branch is built on a base ~1,945 commits behind `main` and
does not currently merge cleanly — eight files conflict. It needs a rebase onto
current `main` before it is mergeable; the diff here is otherwise complete.
