### PR TITLE
zcash_client_backend: Persist the transparent outputs detected by block scanning

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -10,6 +10,22 @@ workspace.
 
 ## [Unreleased]
 
+### Changed
+- `zcash_client_backend::data_api::WalletWrite::put_blocks` is now documented as
+  atomic: an implementation must apply the whole batch of blocks or none of it,
+  and a caller may assume after an error that nothing was persisted. An
+  implementation that applies blocks one at a time must be updated.
+
+### Fixed
+- `zcash_client_backend::data_api::WalletWrite::put_blocks` now records the
+  transparent outputs of each scanned transaction that pay a wallet account, and
+  queues each such outpoint for transparent spend detection. Transparent outputs
+  detected by `zcash_client_backend::scanning::full::scan_block` were previously
+  discarded when the scanned blocks were persisted, and were recovered only when
+  complete transaction data reached
+  `zcash_client_backend::data_api::wallet::decrypt_and_store_transaction`.
+  Transparent spends are still not detected during block scanning.
+
 ## [0.24.0] - 2026-08-18
 
 ### Added

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -3874,6 +3874,15 @@ pub trait WalletWrite:
     /// along with the note commitments that were detected when scanning the block for transactions
     /// pertaining to this wallet.
     ///
+    /// Each scanned transaction's shielded outputs and transparent outputs that pay a wallet
+    /// account are recorded as received. Outputs the wallet sent to an external recipient are
+    /// not; those are recorded when complete transaction data reaches
+    /// [`wallet::decrypt_and_store_transaction`].
+    ///
+    /// The operation is atomic: implementations must apply the whole batch or none of it. After
+    /// an error the caller may assume that no part of any block in `blocks` was persisted, and
+    /// that the call may be retried.
+    ///
     /// ### Arguments
     /// - `from_state` must be the chain state for the block height prior to the first
     ///   block in `blocks`.

--- a/zcash_client_backend/src/data_api/ll/wallet.rs
+++ b/zcash_client_backend/src/data_api/ll/wallet.rs
@@ -1077,7 +1077,7 @@ where
         tx_ref,
         &wallet_transparent_outputs,
         #[cfg(feature = "transparent-inputs")]
-        |wallet_db, output| wallet_db.put_transparent_output(output, observed_height, false),
+        observed_height,
         #[cfg(feature = "transparent-inputs")]
         |account_id, t_key_scope| {
             gap_update_set.insert((account_id, t_key_scope));
@@ -1386,21 +1386,76 @@ where
     Ok(())
 }
 
+/// Records the wallet's receipt of `output` if its recipient address belongs to a wallet
+/// account, and queues the resulting outpoint for transparent spend detection.
+///
+/// An output whose recipient address belongs to no wallet account is ignored; recording such an
+/// output as a send is the caller's responsibility.
+///
+/// `observation_height` is the height as of which the output was observed: the height of the
+/// containing block for an output discovered in a mined block, or the caller's best estimate of
+/// the chain tip for one discovered in an unmined transaction. The output is never recorded as
+/// known-unspent, because neither observing it in a block nor receiving complete data for the
+/// transaction that created it establishes that it is still a member of the UTXO set; only a
+/// query of that set can do so.
+///
+/// `on_received` is invoked with the receiving account and key scope when the output is recorded,
+/// so that a caller which does not otherwise track address use can extend the transparent address
+/// gap for that account.
+#[cfg(feature = "transparent-inputs")]
+fn put_received_transparent_output<DbT>(
+    wallet_db: &mut DbT,
+    tx_ref: <DbT as LowLevelWalletRead>::TxRef,
+    output: &WalletTransparentOutput<<DbT as LowLevelWalletRead>::AccountId>,
+    observation_height: BlockHeight,
+    mut on_received: impl FnMut(<DbT as LowLevelWalletRead>::AccountId, TransparentKeyScope),
+) -> Result<(), <DbT as LowLevelWalletRead>::Error>
+where
+    DbT: LowLevelWalletWrite,
+{
+    if output.recipient_account().is_none() {
+        return Ok(());
+    }
+
+    let (account_id, _) = wallet_db.put_transparent_output(output, observation_height, false)?;
+
+    if let Some(t_key_scope) = output.recipient_key_scope() {
+        on_received(account_id, t_key_scope);
+    }
+
+    // Queue this outpoint for explicit transparent-spend detection.
+    //
+    // Unlike shielded notes -- whose spends are detected naturally during
+    // scanning via nullifier matching -- transparent spends are only found
+    // when the wallet already knows which outpoints to watch. For receives at
+    // ordinary transparent addresses this is handled by indexer-driven address
+    // watches, but for receives at ephemeral addresses (e.g. the middle hop of
+    // a ZIP 320 / TEX flow) there is no ongoing watch. A purely-transparent
+    // spend of such an output would otherwise go undetected. This is especially
+    // a problem in wallet recovery, where transactions can be processed out of
+    // order: queuing here ensures the spend is detected even when the receive
+    // side is processed first.
+    wallet_db.queue_transparent_spend_detection(
+        *output.recipient_address(),
+        tx_ref,
+        output.outpoint().n(),
+    )?;
+
+    Ok(())
+}
+
+/// Records both sides of each transparent output of a transaction: the wallet's receipt of
+/// those outputs that pay one of its accounts, and, for each output that names a funding
+/// account, the corresponding sent output.
+///
+/// `observation_height` is the height as of which the outputs were observed; see
+/// [`put_received_transparent_output`].
 fn put_transparent_outputs<DbT, P>(
     wallet_db: &mut DbT,
     params: &P,
     tx_ref: <DbT as LowLevelWalletRead>::TxRef,
     outputs: &[WalletTransparentOutput<<DbT as LowLevelWalletRead>::AccountId>],
-    #[cfg(feature = "transparent-inputs")] put_received_output: impl Fn(
-        &mut DbT,
-        &WalletTransparentOutput<<DbT as LowLevelWalletRead>::AccountId>,
-    ) -> Result<
-        (
-            <DbT as LowLevelWalletRead>::AccountId,
-            std::option::Option<TransparentKeyScope>,
-        ),
-        <DbT as LowLevelWalletRead>::Error,
-    >,
+    #[cfg(feature = "transparent-inputs")] observation_height: BlockHeight,
     #[cfg(feature = "transparent-inputs")] mut on_received: impl FnMut(
         <DbT as LowLevelWalletRead>::AccountId,
         TransparentKeyScope,
@@ -1414,32 +1469,13 @@ where
         // Receive side: record the output as received whenever its recipient
         // address belongs to a wallet account.
         #[cfg(feature = "transparent-inputs")]
-        if output.recipient_account().is_some() {
-            let (account_id, _) = put_received_output(wallet_db, output)?;
-
-            if let Some(t_key_scope) = output.recipient_key_scope() {
-                on_received(account_id, t_key_scope);
-            }
-
-            // Queue this outpoint for explicit transparent-spend detection.
-            //
-            // Unlike shielded notes -- whose spends are detected naturally
-            // during scanning via nullifier matching -- transparent spends are
-            // only found when the wallet already knows which outpoints to
-            // watch. For receives at ordinary transparent addresses this is
-            // handled by indexer-driven address watches, but for receives at
-            // ephemeral addresses (e.g. the middle hop of a ZIP 320 / TEX
-            // flow) there is no ongoing watch. A purely-transparent spend of
-            // such an output would otherwise go undetected. This is
-            // especially a problem in wallet recovery, where transactions can
-            // be processed out of order: queuing here ensures the spend is
-            // detected even when the receive side is processed first.
-            wallet_db.queue_transparent_spend_detection(
-                *output.recipient_address(),
-                tx_ref,
-                output.outpoint().n(),
-            )?;
-        }
+        put_received_transparent_output(
+            wallet_db,
+            tx_ref,
+            output,
+            observation_height,
+            &mut on_received,
+        )?;
 
         // Send side: record the output as sent for the wallet account that
         // funded the transaction, if any. If the recipient is also a wallet

--- a/zcash_client_backend/src/data_api/ll/wallet.rs
+++ b/zcash_client_backend/src/data_api/ll/wallet.rs
@@ -406,7 +406,10 @@ where
                 .queue_tx_retrieval(std::iter::once(tx.txid()), None)
                 .map_err(PutBlocksError::Storage)?;
 
-            // Mark notes as spent and remove them from the scanning cache
+            // Mark notes as spent and remove them from the scanning cache. Block scanning does
+            // not yet detect transparent spends, so no prevouts are available here.
+            // TODO: Pass the scanned transparent spends once the scanner reports them.
+            // https://github.com/zcash/librustzcash/issues/2395
             let _ = mark_notes_spent(
                 wallet_db,
                 tx_ref,
@@ -505,6 +508,24 @@ where
                 |_account_id| (),
             )
             .map_err(PutBlocksError::Storage)?;
+
+            // Record the transparent outputs of the transaction that pay this wallet. As for
+            // the shielded pools above, only the receive side is recorded here; the sent
+            // outputs of a transaction the wallet funded are recorded when the complete
+            // transaction data arrives via `put_decrypted_tx`, which this scan has queued for
+            // retrieval. The gap-address regeneration that follows the block loop observes
+            // these receives, so no separate notification is needed.
+            #[cfg(feature = "transparent-inputs")]
+            for output in tx.transparent_outputs() {
+                put_received_transparent_output(
+                    wallet_db,
+                    tx_ref,
+                    output,
+                    block.height(),
+                    |_, _| (),
+                )
+                .map_err(PutBlocksError::Storage)?;
+            }
         }
 
         // Insert the new nullifiers from this block into the nullifier map, unless the caller

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -5,7 +5,9 @@ use std::{
 
 use assert_matches::assert_matches;
 
+use nonempty::NonEmpty;
 use sapling::zip32::ExtendedSpendingKey;
+use subtle::ConditionallySelectable;
 use transparent::{
     address::{Script, TransparentAddress},
     bundle::{Authorized, Bundle, OutPoint, TxIn, TxOut},
@@ -16,7 +18,7 @@ use zcash_keys::{
     keys::{UnifiedAddressRequest, transparent::gap_limits::GapLimits},
 };
 use zcash_primitives::{
-    block::BlockHash,
+    block::{Block, BlockHash, BlockHeaderData},
     transaction::{Transaction, TransactionData, TxVersion, fees::zip317},
 };
 use zcash_protocol::{
@@ -31,7 +33,6 @@ use {
     crate::{
         data_api::{
             AccountBirthday,
-            chain::ChainState,
             wallet::{self, SpendingKeys},
         },
         wallet::TransparentAddressSource,
@@ -46,8 +47,9 @@ use {
 use super::TestAccount;
 use crate::{
     data_api::{
-        Account as _, AccountBalance, Balance, CoinbaseFilter, InputSource as _, MaxSpendMode,
-        TargetValue, WalletRead as _, WalletTest as _, WalletWrite,
+        Account as _, AccountBalance, Balance, BlockMetadata, CoinbaseFilter, InputSource as _,
+        MaxSpendMode, ScannedBlock, TargetValue, WalletRead, WalletTest as _, WalletWrite,
+        chain::ChainState,
         testing::{
             AddressType, DataStoreFactory, ShieldedPool, TestBuilder, TestCache, TestState,
             single_output_change_strategy,
@@ -61,6 +63,10 @@ use crate::{
         },
     },
     fees::{ChangeValue, StandardFeeRule, TransparentChangePolicy},
+    scanning::{
+        Nullifiers, ScanningKeys,
+        full::{decrypt_block, scan_block},
+    },
     wallet::{Exposure, OvkPolicy, WalletTransparentOutput},
 };
 
@@ -2323,6 +2329,273 @@ where
         st.wallet_mut()
             .mark_transparent_addresses_exposed(&[(unknown, BlockHeight::from(1))])
             .is_err()
+    );
+}
+
+/// Constructs a fake transparent-only transaction paying `value` to `taddr`.
+///
+/// The transaction spends an arbitrary outpoint, so it is not structurally a coinbase
+/// transaction. The `lock_time` parameter has no consensus meaning here; distinct values may be
+/// used to give otherwise-identical transactions distinct txids.
+fn fake_transparent_payment_tx(
+    lock_time: u32,
+    value: Zatoshis,
+    taddr: &TransparentAddress,
+) -> Transaction {
+    let bundle = Bundle {
+        vin: vec![TxIn::from_parts(OutPoint::fake(), Script::default(), 0)],
+        vout: vec![TxOut::new(value, taddr.script().into())],
+        authorization: Authorized,
+    };
+
+    TransactionData::<zcash_primitives::transaction::Authorized>::from_parts(
+        TxVersion::V5,
+        BranchId::Nu5,
+        lock_time,
+        BlockHeight::from(0),
+        #[cfg(all(zcash_unstable = "nu7", feature = "zip-233"))]
+        Zatoshis::ZERO,
+        Some(bundle),
+        None,
+        None,
+        None,
+    )
+    .freeze()
+    .unwrap()
+}
+
+/// Returns the default external transparent receiver of the given account.
+fn wallet_taddr<DbT>(wallet: &DbT, account_id: <DbT as WalletRead>::AccountId) -> TransparentAddress
+where
+    DbT: WalletRead,
+    <DbT as WalletRead>::Error: std::fmt::Debug,
+{
+    *wallet
+        .get_last_generated_address_matching(account_id, UnifiedAddressRequest::AllAvailableKeys)
+        .unwrap()
+        .unwrap()
+        .transparent()
+        .unwrap()
+}
+
+/// Builds a block at `height` whose coinbase transaction is followed by a transparent-only
+/// transaction paying `value` to `taddr`, scans it, and returns the scanned block together with
+/// the outpoint of the payment.
+///
+/// Placing the payment behind the coinbase keeps the output it creates out of the coinbase
+/// maturity rule. `lock_time` has no consensus meaning here; distinct values give the payment
+/// transactions of otherwise-identical blocks distinct txids.
+fn scan_transparent_payment_block<DbT>(
+    wallet: &DbT,
+    network: &LocalNetwork,
+    account_id: <DbT as WalletRead>::AccountId,
+    height: BlockHeight,
+    lock_time: u32,
+    value: Zatoshis,
+    taddr: &TransparentAddress,
+) -> (ScannedBlock<<DbT as WalletRead>::AccountId>, OutPoint)
+where
+    DbT: WalletRead,
+    <DbT as WalletRead>::Error: std::fmt::Debug,
+    <DbT as WalletRead>::AccountId:
+        ConditionallySelectable + Default + Ord + std::hash::Hash + Send + Sync + 'static,
+{
+    /// The block subsidy is immaterial to what is under test; any value the miner may claim
+    /// will do.
+    const MINER_REWARD: Zatoshis = Zatoshis::const_from_u64(625_000_000);
+    const MINER_ADDR: TransparentAddress = TransparentAddress::PublicKeyHash([0xf5; 20]);
+
+    let payment = fake_transparent_payment_tx(lock_time, value, taddr);
+    let outpoint = OutPoint::new(payment.txid().into(), 0);
+    let block = Block::from_parts(
+        BlockHeaderData {
+            version: 4,
+            prev_block: BlockHash([0; 32]),
+            merkle_root: [0; 32],
+            final_sapling_root: [0; 32],
+            time: 0,
+            bits: 0,
+            nonce: [0; 32],
+            solution: vec![],
+        }
+        .freeze()
+        .unwrap(),
+        NonEmpty::from((
+            fake_transparent_coinbase_tx(lock_time, MINER_REWARD, &MINER_ADDR),
+            vec![payment],
+        )),
+        height,
+    );
+
+    // The block is scanned in isolation, so the note commitment trees are treated as empty as
+    // of the immediately preceding block. The block contains no shielded outputs, so they
+    // remain empty afterwards.
+    let prior_block_metadata = BlockMetadata::from_parts(
+        height - 1,
+        BlockHash([0; 32]),
+        Some(0),
+        #[cfg(feature = "orchard")]
+        Some(0),
+        #[cfg(feature = "orchard")]
+        Some(0),
+    );
+
+    let scanning_keys =
+        ScanningKeys::from_account_ufvks(wallet.get_unified_full_viewing_keys().unwrap());
+    let (header, vtx) = decrypt_block(network, block, &scanning_keys);
+    let scanned = scan_block(
+        network,
+        height,
+        &header,
+        vtx,
+        &scanning_keys,
+        &Nullifiers::empty(),
+        Some(&prior_block_metadata),
+        |addr| {
+            wallet
+                .get_transparent_address_metadata(account_id, addr)
+                .map(|meta| meta.map(|m| (account_id, m.source().scope())))
+        },
+    )
+    .expect("scanning the block succeeds");
+
+    // The scanner must have detected the payment, and nothing from the coinbase.
+    assert_matches!(
+        scanned
+            .transactions()
+            .iter()
+            .flat_map(|wtx| wtx.transparent_outputs())
+            .collect::<Vec<_>>()
+            .as_slice(),
+        [output] if output.outpoint() == &outpoint && output.txout().value() == value
+    );
+
+    (scanned, outpoint)
+}
+
+/// Scans a full block containing a transparent output that pays a wallet address, and verifies
+/// that persisting the scanned block via [`WalletWrite::put_blocks`] records that output as a
+/// UTXO belonging to the wallet.
+pub fn scan_full_block_persists_transparent_outputs<DSF>(dsf: DSF)
+where
+    DSF: DataStoreFactory,
+    <<DSF as DataStoreFactory>::DataStore as WalletRead>::AccountId:
+        ConditionallySelectable + Default + Ord + std::hash::Hash + Send + Sync + 'static,
+{
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(dsf)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let account = st.test_account().unwrap();
+    let account_id = account.id();
+    let h = account.birthday().height() + 1;
+    let taddr = wallet_taddr(st.wallet(), account_id);
+
+    st.wallet_mut().update_chain_tip(h).unwrap();
+
+    // The wallet must not already know of any output at this address.
+    assert_matches!(
+        st.wallet().get_transparent_balances(
+            account_id,
+            TargetHeight::from(h + 1),
+            ConfirmationsPolicy::MIN,
+        ),
+        Ok(balances) if balances.is_empty()
+    );
+
+    let value = Zatoshis::const_from_u64(100000);
+    let network = *st.network();
+    let (scanned, outpoint) =
+        scan_transparent_payment_block(st.wallet(), &network, account_id, h, 1, value, &taddr);
+
+    st.wallet_mut()
+        .put_blocks(&ChainState::empty(h - 1, BlockHash([0; 32])), vec![scanned])
+        .unwrap();
+
+    // The scanned output must now be a UTXO of the wallet.
+    let target_height = TargetHeight::from(h + 1);
+    assert_matches!(
+        st.wallet()
+            .get_unspent_transparent_output(&outpoint, target_height),
+        Ok(Some(ret))
+        if ret.txout().value() == value && ret.mined_height() == Some(h)
+    );
+    assert_matches!(
+        st.wallet().get_spendable_transparent_outputs(
+            &taddr,
+            target_height,
+            ConfirmationsPolicy::MIN,
+            CoinbaseFilter::AllTransparentOutputs,
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
+        ).as_deref(),
+        Ok([ret]) if ret.outpoint() == &outpoint
+    );
+    assert_matches!(
+        st.wallet().get_transparent_balances(
+            account_id,
+            target_height,
+            ConfirmationsPolicy::MIN,
+        ),
+        Ok(balances) if balances.get(&taddr).map(|(_, b)| b.spendable_value()) == Some(value)
+    );
+}
+
+/// Verifies that the transparent outputs written while persisting a batch of scanned blocks are
+/// rolled back along with the rest of the batch when a later block in the batch is rejected.
+///
+/// The batch is made to fail by leaving a gap between its two blocks, which
+/// [`WalletWrite::put_blocks`] rejects only after the first block has been written.
+pub fn put_blocks_rolls_back_transparent_outputs<DSF>(dsf: DSF)
+where
+    DSF: DataStoreFactory,
+    <<DSF as DataStoreFactory>::DataStore as WalletRead>::AccountId:
+        ConditionallySelectable + Default + Ord + std::hash::Hash + Send + Sync + 'static,
+{
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(dsf)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let account = st.test_account().unwrap();
+    let account_id = account.id();
+    let h = account.birthday().height() + 1;
+    let taddr = wallet_taddr(st.wallet(), account_id);
+
+    st.wallet_mut().update_chain_tip(h + 2).unwrap();
+
+    let value = Zatoshis::const_from_u64(100000);
+    let network = *st.network();
+    let (first, first_outpoint) =
+        scan_transparent_payment_block(st.wallet(), &network, account_id, h, 1, value, &taddr);
+    let (discontinuous, discontinuous_outpoint) =
+        scan_transparent_payment_block(st.wallet(), &network, account_id, h + 2, 2, value, &taddr);
+
+    assert_matches!(
+        st.wallet_mut().put_blocks(
+            &ChainState::empty(h - 1, BlockHash([0; 32])),
+            vec![first, discontinuous],
+        ),
+        Err(_)
+    );
+
+    // Neither block's output may have been committed: the first block's writes must have been
+    // rolled back along with the failure of the second.
+    let target_height = TargetHeight::from(h + 3);
+    for outpoint in [&first_outpoint, &discontinuous_outpoint] {
+        assert_matches!(
+            st.wallet()
+                .get_unspent_transparent_output(outpoint, target_height),
+            Ok(None)
+        );
+    }
+    assert_matches!(
+        st.wallet().get_transparent_balances(
+            account_id,
+            target_height,
+            ConfirmationsPolicy::MIN,
+        ),
+        Ok(balances) if balances.is_empty()
     );
 }
 

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -32,6 +32,11 @@ workspace.
   a pre-Sapling zcashd wallet — left the wallet without a chain tip, so every
   transaction was silently deferred to the post-import rescan and counted
   under `transactions_without_wallet_relevance`.
+- `WalletDb::put_blocks` records the transparent outputs of each scanned
+  transaction that pay a wallet account, and queues each such outpoint for
+  transparent spend detection. Transparent outputs detected by
+  `zcash_client_backend::scanning::full::scan_block` were previously discarded
+  when the scanned blocks were persisted.
 
 ## [0.22.0] - 2026-08-18
 

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -2938,6 +2938,20 @@ mod tests {
         );
     }
 
+    #[test]
+    fn scan_full_block_persists_transparent_outputs() {
+        zcash_client_backend::data_api::testing::transparent::scan_full_block_persists_transparent_outputs(
+            TestDbFactory::default(),
+        );
+    }
+
+    #[test]
+    fn put_blocks_rolls_back_transparent_outputs() {
+        zcash_client_backend::data_api::testing::transparent::put_blocks_rolls_back_transparent_outputs(
+            TestDbFactory::default(),
+        );
+    }
+
     /// Re-storing a transparent output with an unknown mined height (`None`) must not discard
     /// the mined height already recorded for its transaction. A `None` height means "we do not
     /// yet know this to have been mined" — for example, an output re-observed via the mempool


### PR DESCRIPTION
Closes #2984.

`scanning::full::scan_block` detects the transparent outputs of a block that pay a wallet account, but `put_blocks` recorded only the shielded ones, so those outputs were discarded when the scanned blocks were persisted. `WalletTx::transparent_outputs` had no non-test caller in either crate. A wallet that scans full blocks recovered them only later, when complete transaction data reached `decrypt_and_store_transaction`.

### Commits

- **Extract the transparent receive path into its own helper.** `put_transparent_outputs` handled both sides of a transaction's transparent outputs; only the receive half applies where the wallet's involvement is known from scanning alone, so it moves into `put_received_transparent_output`. The `put_received_output` closure existed only to bind the observation height and the known-unspent flag; the height is now a parameter, and the flag — `false` at every call site — is documented on the helper. No behavior change.
- **Persist the transparent outputs detected by block scanning.** `put_blocks_rows` records each scanned transaction's transparent outputs that pay a wallet account and queues each outpoint for transparent spend detection.

### Design notes

**Receive side only.** `put_blocks_rows` passes `funding_account: None` and `params: None` to `put_shielded_outputs`, so sent outputs are deliberately deferred to the enhancement path, and the scan queues every wallet transaction for retrieval. The transparent write follows the same convention. Recording sends here would require threading network parameters through the `pub` `put_blocks_rows` signature, for records that `put_decrypted_tx` writes anyway.

**Gap addresses need no new plumbing.** `v_address_uses` unions `transparent_received_outputs`, so the `find_involved_accounts` → `generate_transparent_gap_addresses` loop that already runs after the block loop observes these receives.

**Atomicity.** Per the four questions in `CLAUDE.md`: the operation issues many writes; they must land together; both new statements are idempotent upserts (`ON CONFLICT DO UPDATE` / `DO NOTHING`), so a retry repairs rather than diverges; and every call propagates with `?` inside the transaction `WalletDb::put_blocks` already opens. `WalletWrite::put_blocks` had no atomicity sentence in its rustdoc, so this adds one, along with a statement of which outputs it records.

### Testing

Two tests in `data_api::testing::transparent`, registered in `zcash_client_sqlite`:

- `scan_full_block_persists_transparent_outputs` builds a block whose coinbase is followed by a transparent payment to the wallet, runs it through the real `decrypt_block` / `scan_block` / `put_blocks` path, and asserts the UTXO is queryable. Confirmed to fail without the fix (`assertion failed: Ok(None) does not match Ok(Some(ret))`).
- `put_blocks_rolls_back_transparent_outputs` is the failure-path test: two blocks with a height gap, so the second is rejected after the first has been written, asserting that neither output persisted.

Verified locally: `cargo fmt --check`; `clippy --all-features --all-targets -D warnings` on both crates; `cargo check` across five `zcash_client_backend` and four `zcash_client_sqlite` feature states; `git rebase --exec` confirming each commit builds on its own; and the full `zcash_client_sqlite --all-features` suite (576 passed, 0 failed).

### Not in scope

Transparent spend detection during scanning remains unimplemented (#2395); `WalletTx` has no spend representation, so the prevouts passed to `mark_notes_spent` stay empty, now with a `TODO` pointing at that issue. See https://github.com/zcash/librustzcash/issues/2395 for what will need to change here once the scanner reports spends.

---
Prepared with Claude Code assistance.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
