### PR TITLE
zcash_primitives: use as_chunks for the fixed-size witness path chunks

### DIFF
--- a/zcash_client_sqlite/src/zewif.rs
+++ b/zcash_client_sqlite/src/zewif.rs
@@ -1640,7 +1640,7 @@ mod tests {
     use std::collections::BTreeMap;
     use tempfile::NamedTempFile;
     use zcash_client_backend::{
-        data_api::{Account as _, AccountPurpose, AccountSource, WalletRead},
+        data_api::{AccountPurpose, AccountSource, WalletRead},
         wallet::Exposure,
     };
     use zcash_keys::{

--- a/zcash_primitives/src/merkle_tree.rs
+++ b/zcash_primitives/src/merkle_tree.rs
@@ -249,11 +249,12 @@ pub fn merkle_path_from_slice<Node: HashSer, const DEPTH: u8>(
     witness = &witness[1..];
 
     // Begin to construct the authentication path
-    let iter = witness.chunks_exact(33);
-    witness = iter.remainder();
+    let (chunks, remainder) = witness.as_chunks::<33>();
+    witness = remainder;
 
     // The vector works in reverse
-    let auth_path = iter
+    let auth_path = chunks
+        .iter()
         .rev()
         .map(|bytes| {
             // Length of inner vector should be the length of a Pedersen hash


### PR DESCRIPTION
Rust 1.98's clippy denies chunks_exact with a constant chunk size (clippy::chunks_exact_to_as_chunks), failing every stable-clippy CI job. slice::as_chunks is stable as of the MSRV (1.88).