### PR TITLE
MOB-1751: Add shared cross-chain payment URI parser

### DIFF
--- a/.github/helpers/check-dep-graph.py
+++ b/.github/helpers/check-dep-graph.py
@@ -9,6 +9,7 @@ CRATES_IN_GRAPH = set([
     'eip681',
     'equihash',
     'f4jumble',
+    'payment_uri',
     'zcash_address',
     'zcash_encoding',
     'zcash_protocol',

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3177,6 +3177,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
+name = "payment_uri"
+version = "0.1.0"
+dependencies = [
+ "bech32",
+ "bs58",
+ "eip681",
+ "percent-encoding",
+]
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3184,6 +3184,7 @@ dependencies = [
  "bs58",
  "eip681",
  "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3184,6 +3184,7 @@ dependencies = [
  "bs58",
  "eip681",
  "percent-encoding",
+ "proptest",
  "serde_json",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "components/eip681",
     "components/equihash",
     "components/f4jumble",
+    "components/payment_uri",
     "components/zcash_address",
     "components/zcash_encoding",
     "components/zcash_protocol",
@@ -35,6 +36,7 @@ categories = ["cryptography::cryptocurrencies"]
 # part of a public API, and which can be updated without a SemVer bump.
 [workspace.dependencies]
 # Intra-workspace dependencies
+eip681 = { version = "0.1.0", path = "components/eip681" }
 equihash = { version = "0.3", path = "components/equihash", default-features = false }
 zcash_address = { version = "0.13.0", path = "components/zcash_address", default-features = false }
 zcash_client_backend = { version = "0.24.0", path = "zcash_client_backend", default-features = false }

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ graph TB
             eip681
             equihash
             f4jumble
+            payment_uri
             zcash_encoding
         end
     end
@@ -119,6 +120,7 @@ graph TB
 
     zcash_primitives --> equihash
     zcash_address --> f4jumble
+    payment_uri --> eip681
 
     %% zcash_client_backend --> orchard
     %% pczt --> orchard
@@ -161,6 +163,7 @@ graph TB
     click equihash "https://docs.rs/equihash/" _blank
     click f4jumble "https://docs.rs/f4jumble/" _blank
     click orchard "https://docs.rs/orchard/" _blank
+    click payment_uri "https://docs.rs/payment_uri/" _blank
     click pczt "https://docs.rs/pczt/" _blank
     click sapling-crypto "https://docs.rs/sapling-crypto/" _blank
     click zcash_address "https://docs.rs/zcash_address/" _blank
@@ -232,6 +235,7 @@ graph TB
 
 #### Utilities & Common Dependencies
 
+* `payment_uri`: Parsing and validation for cross-chain payment request URIs
 * `f4jumble`: Encoding for Unified addresses
 * `zcash_encoding`: Bitcoin-derived transaction encoding utilities for Zcash
 * `equihash`: Proof-of-work protocol implementation

--- a/components/payment_uri/CHANGELOG.md
+++ b/components/payment_uri/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this library will be documented in this file.
+
+## [0.1.0] - PLANNED
+
+- Initial release!

--- a/components/payment_uri/Cargo.toml
+++ b/components/payment_uri/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "payment_uri"
+description = "Parsing and validation for cross-chain payment request URIs"
+version = "0.1.0"
+authors = ["Harry <110472914+Cosmos-Harry@users.noreply.github.com>"]
+homepage = "https://github.com/zcash/librustzcash"
+repository.workspace = true
+readme = "README.md"
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+categories.workspace = true
+
+[dependencies]
+bech32.workspace = true
+bs58.workspace = true
+eip681.workspace = true
+percent-encoding.workspace = true
+
+[lints]
+workspace = true

--- a/components/payment_uri/Cargo.toml
+++ b/components/payment_uri/Cargo.toml
@@ -16,6 +16,11 @@ bech32.workspace = true
 bs58.workspace = true
 eip681.workspace = true
 percent-encoding.workspace = true
+serde_json = { workspace = true, optional = true }
+
+[features]
+## Exposes the versioned JSON representation used by foreign-language bindings.
+json = ["dep:serde_json"]
 
 [lints]
 workspace = true

--- a/components/payment_uri/Cargo.toml
+++ b/components/payment_uri/Cargo.toml
@@ -18,6 +18,9 @@ eip681.workspace = true
 percent-encoding.workspace = true
 serde_json = { workspace = true, optional = true }
 
+[dev-dependencies]
+proptest.workspace = true
+
 [features]
 ## Exposes the versioned JSON representation used by foreign-language bindings.
 json = ["dep:serde_json"]

--- a/components/payment_uri/README.md
+++ b/components/payment_uri/README.md
@@ -1,0 +1,11 @@
+# payment_uri
+
+This crate parses payment request URIs used by Bitcoin, Ethereum-compatible
+chains, Litecoin, and Solana. It validates protocol syntax and addresses while
+leaving wallet-specific asset allowlists and user-interface decisions to the
+calling application.
+
+## License
+
+Licensed under either the Apache License, Version 2.0 or the MIT license, at
+your option.

--- a/components/payment_uri/src/bitcoin.rs
+++ b/components/payment_uri/src/bitcoin.rs
@@ -22,6 +22,17 @@ pub enum Network {
     Regtest,
 }
 
+impl Network {
+    /// Returns the lowercase name used in this crate's versioned JSON representation.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Mainnet => "mainnet",
+            Self::Testnet => "testnet",
+            Self::Regtest => "regtest",
+        }
+    }
+}
+
 /// A validated Bitcoin or Litecoin on-chain payment request.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UtxoPaymentRequest {

--- a/components/payment_uri/src/bitcoin.rs
+++ b/components/payment_uri/src/bitcoin.rs
@@ -1,8 +1,56 @@
+//! Bitcoin and Litecoin on-chain payment requests.
+//!
+//! Bitcoin URIs implement the on-chain subset of [BIP 321], the modern replacement for the
+//! original [BIP 21]. Litecoin URIs follow Litecoin Core's own BIP-21-compatible convention
+//! (case-sensitive parameter keys, and its own base58 version bytes), rather than BIP 321.
+//!
+//! Only the on-chain payment fields (`amount`, `label`, `message`) are implemented. BIP 321
+//! also defines a number of alternate-payment-method and privacy extensions this module does
+//! not implement -- `lightning` (BOLT 11 invoices), `lno` (BOLT 12 offers), `pay` (BIP 351
+//! private payments), `sp` (BIP 352 silent payments), `bc`/`tb` (segwit fallback addresses),
+//! and `pop`/`req-pop` (proof-of-payment callbacks). None of those are supported, but per the
+//! `req-` convention both BIPs define, an unsupported parameter is only fatal to the request
+//! when it is marked required (`req-lno=...`); as a plain optional parameter (`lightning=...`)
+//! it is safely ignored, the same as any other wallet that hasn't implemented that extension.
+//!
+//! [BIP 21]: https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki
+//! [BIP 321]: https://github.com/bitcoin/bips/blob/master/bip-0321.mediawiki
+
 use std::collections::HashSet;
 
 use crate::{DecimalAmount, Error, decode};
 
 const MAX_FRACTIONAL_DIGITS: usize = 8;
+
+/// Length in bytes of the RIPEMD160(SHA256(...)) hash carried by a legacy P2PKH or P2SH address,
+/// after the leading version byte.
+const HASH160_LEN: usize = 20;
+
+/// Base58Check version byte for a Bitcoin mainnet P2PKH address ("1..."). See [BIP 13].
+///
+/// [BIP 13]: https://github.com/bitcoin/bips/blob/master/bip-0013.mediawiki
+const BITCOIN_MAINNET_P2PKH: u8 = 0;
+/// Base58Check version byte for a Bitcoin mainnet P2SH address ("3..."). See [BIP 13].
+///
+/// [BIP 13]: https://github.com/bitcoin/bips/blob/master/bip-0013.mediawiki
+const BITCOIN_MAINNET_P2SH: u8 = 5;
+/// Base58Check version byte for a Bitcoin testnet/regtest P2PKH address ("m.../n...").
+const BITCOIN_TESTNET_P2PKH: u8 = 111;
+/// Base58Check version byte for a Bitcoin testnet/regtest P2SH address ("2...").
+const BITCOIN_TESTNET_P2SH: u8 = 196;
+
+/// Base58Check version byte for a Litecoin mainnet P2PKH address ("L...").
+const LITECOIN_MAINNET_P2PKH: u8 = 48;
+/// Base58Check version byte for a Litecoin mainnet P2SH address ("M..."), current form.
+const LITECOIN_MAINNET_P2SH: u8 = 50;
+/// Base58Check version byte for a Litecoin mainnet P2SH address, legacy form ("3...").
+///
+/// Litecoin Core still accepts this on decode for backward compatibility with addresses
+/// generated before the switch to [`LITECOIN_MAINNET_P2SH`]; it collides with
+/// [`BITCOIN_MAINNET_P2SH`], since Litecoin originally reused Bitcoin's P2SH prefix.
+const LITECOIN_MAINNET_P2SH_LEGACY: u8 = 5;
+/// Base58Check version byte for a Litecoin testnet P2PKH address ("Q...").
+const LITECOIN_TESTNET_P2PKH: u8 = 58;
 
 #[derive(Clone, Copy)]
 pub(crate) enum Currency {
@@ -70,6 +118,19 @@ impl UtxoPaymentRequest {
     }
 }
 
+/// Parses and validates a `bitcoin:` or `litecoin:` on-chain payment request.
+///
+/// Examples of accepted input:
+/// - `bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo`
+/// - `bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?amount=20.3&label=Luke-Jr`
+/// - `litecoin:LT2KVaAy1ppRuxRgrS5RNU3vBsy7RibPeA?amount=1.25&message=Coffee`
+///
+/// Examples of rejected input:
+/// - `bitcoin:` (missing recipient)
+/// - `bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?amount=42&amount=42` (duplicate parameter,
+///   even when the values agree)
+/// - `bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?req-somethingunknown=1` (unimplemented
+///   required extension)
 pub(crate) fn parse(input: &str, currency: Currency) -> Result<UtxoPaymentRequest, Error> {
     let (_, payload) = input.split_once(':').ok_or(Error::MissingScheme)?;
     let (address, query) = payload
@@ -143,15 +204,22 @@ fn validate_address(address: &str, currency: Currency) -> Result<Network, Error>
     let [version, payload @ ..] = decoded.as_slice() else {
         return Err(Error::InvalidAddress(address.to_owned()));
     };
-    if payload.len() != 20 {
+    if payload.len() != HASH160_LEN {
         return Err(Error::InvalidAddress(address.to_owned()));
     }
 
     match (currency, *version) {
-        (Currency::Bitcoin, 0 | 5) | (Currency::Litecoin, 5 | 48 | 50) => Ok(Network::Mainnet),
-        (Currency::Bitcoin, 111 | 196) | (Currency::Litecoin, 58 | 111 | 196) => {
-            Ok(Network::Testnet)
-        }
+        (Currency::Bitcoin, BITCOIN_MAINNET_P2PKH | BITCOIN_MAINNET_P2SH)
+        | (
+            Currency::Litecoin,
+            LITECOIN_MAINNET_P2SH_LEGACY | LITECOIN_MAINNET_P2PKH | LITECOIN_MAINNET_P2SH,
+        ) => Ok(Network::Mainnet),
+        (Currency::Bitcoin, BITCOIN_TESTNET_P2PKH | BITCOIN_TESTNET_P2SH)
+        | (
+            Currency::Litecoin,
+            // Litecoin also accepts Bitcoin's testnet prefixes outright, in addition to its own.
+            LITECOIN_TESTNET_P2PKH | BITCOIN_TESTNET_P2PKH | BITCOIN_TESTNET_P2SH,
+        ) => Ok(Network::Testnet),
         _ => Err(Error::InvalidAddress(address.to_owned())),
     }
 }

--- a/components/payment_uri/src/bitcoin.rs
+++ b/components/payment_uri/src/bitcoin.rs
@@ -1,0 +1,146 @@
+use std::collections::HashSet;
+
+use crate::{DecimalAmount, Error, decode};
+
+const MAX_FRACTIONAL_DIGITS: usize = 8;
+
+#[derive(Clone, Copy)]
+pub(crate) enum Currency {
+    Bitcoin,
+    Litecoin,
+}
+
+/// The network encoded by a Bitcoin or Litecoin address.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum Network {
+    /// The production network.
+    Mainnet,
+    /// A public test network.
+    Testnet,
+    /// A local regression-test network.
+    Regtest,
+}
+
+/// A validated Bitcoin or Litecoin on-chain payment request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UtxoPaymentRequest {
+    address: String,
+    network: Network,
+    amount: Option<DecimalAmount>,
+    label: Option<String>,
+    message: Option<String>,
+}
+
+impl UtxoPaymentRequest {
+    /// Returns the validated recipient address.
+    pub fn address(&self) -> &str {
+        &self.address
+    }
+
+    /// Returns the network encoded by the recipient address.
+    pub fn network(&self) -> Network {
+        self.network
+    }
+
+    /// Returns the requested amount in BTC or LTC display units.
+    pub fn amount(&self) -> Option<&DecimalAmount> {
+        self.amount.as_ref()
+    }
+
+    /// Returns the decoded recipient label, if provided.
+    pub fn label(&self) -> Option<&str> {
+        self.label.as_deref()
+    }
+
+    /// Returns the decoded payment message, if provided.
+    pub fn message(&self) -> Option<&str> {
+        self.message.as_deref()
+    }
+}
+
+pub(crate) fn parse(input: &str, currency: Currency) -> Result<UtxoPaymentRequest, Error> {
+    let (_, payload) = input.split_once(':').ok_or(Error::MissingScheme)?;
+    let (address, query) = payload
+        .split_once('?')
+        .map_or((payload, None), |(a, q)| (a, Some(q)));
+    if address.is_empty() {
+        return Err(Error::MissingRecipient);
+    }
+    let network = validate_address(address, currency)?;
+
+    let mut amount = None;
+    let mut label = None;
+    let mut message = None;
+    let mut seen = HashSet::new();
+
+    for parameter in query.into_iter().flat_map(|query| query.split('&')) {
+        let (raw_key, raw_value) = parameter.split_once('=').unwrap_or((parameter, ""));
+        let normalized = match currency {
+            Currency::Bitcoin => raw_key.to_ascii_lowercase(),
+            Currency::Litecoin => raw_key.to_owned(),
+        };
+        let (required, key) = normalized
+            .strip_prefix("req-")
+            .map_or((false, normalized.as_str()), |key| (true, key));
+
+        if matches!(key, "amount" | "label" | "message") && !seen.insert(key.to_owned()) {
+            return Err(Error::DuplicateParameter(key.to_owned()));
+        }
+
+        match key {
+            "amount" => {
+                let parsed = DecimalAmount::parse(raw_value)?;
+                if parsed.atomic_value(MAX_FRACTIONAL_DIGITS).is_none() {
+                    return Err(Error::InvalidAmount(raw_value.to_owned()));
+                }
+                amount = Some(parsed);
+            }
+            "label" => label = Some(decode(raw_value)?),
+            "message" => message = Some(decode(raw_value)?),
+            _ if required => {
+                return Err(Error::UnsupportedRequiredParameter(raw_key.to_owned()));
+            }
+            _ => {}
+        }
+    }
+
+    Ok(UtxoPaymentRequest {
+        address: address.to_owned(),
+        network,
+        amount,
+        label,
+        message,
+    })
+}
+
+fn validate_address(address: &str, currency: Currency) -> Result<Network, Error> {
+    if let Ok((hrp, _, _)) = bech32::segwit::decode(address) {
+        let network = match (currency, hrp.as_str()) {
+            (Currency::Bitcoin, "bc") | (Currency::Litecoin, "ltc") => Network::Mainnet,
+            (Currency::Bitcoin, "tb") | (Currency::Litecoin, "tltc") => Network::Testnet,
+            (Currency::Bitcoin, "bcrt") | (Currency::Litecoin, "rltc") => Network::Regtest,
+            _ => return Err(Error::InvalidAddress(address.to_owned())),
+        };
+        return Ok(network);
+    }
+
+    let decoded = bs58::decode(address)
+        .with_check(None)
+        .into_vec()
+        .map_err(|_| Error::InvalidAddress(address.to_owned()))?;
+    let [version, payload @ ..] = decoded.as_slice() else {
+        return Err(Error::InvalidAddress(address.to_owned()));
+    };
+    if payload.len() != 20 {
+        return Err(Error::InvalidAddress(address.to_owned()));
+    }
+
+    match (currency, *version) {
+        (Currency::Bitcoin, 0 | 5) | (Currency::Litecoin, 5 | 48 | 50) => Ok(Network::Mainnet),
+        (Currency::Bitcoin, 111 | 196) | (Currency::Litecoin, 58 | 111 | 196) => {
+            Ok(Network::Testnet)
+        }
+        _ => Err(Error::InvalidAddress(address.to_owned())),
+    }
+}

--- a/components/payment_uri/src/lib.rs
+++ b/components/payment_uri/src/lib.rs
@@ -257,3 +257,115 @@ fn decode(value: &str) -> Result<String, Error> {
         .map(|decoded| decoded.into_owned())
         .map_err(|_| Error::InvalidEncoding(value.to_owned()))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[test]
+    fn decimal_amount_accepts_well_formed_values() {
+        for valid in ["0", "1", "20.3", "0.00000001", "000123", "1.0", "10.00"] {
+            let parsed = DecimalAmount::parse(valid).unwrap_or_else(|_| {
+                panic!("expected {valid:?} to parse");
+            });
+            assert_eq!(parsed.as_str(), valid);
+        }
+    }
+
+    #[test]
+    fn decimal_amount_rejects_malformed_values() {
+        for invalid in [
+            "",       // empty
+            ".",      // neither a whole nor fractional part
+            ".5",     // missing whole part
+            "1.",     // missing fractional part after the dot
+            "-1",     // sign not permitted
+            "+1",     // sign not permitted
+            "1e5",    // scientific notation not permitted
+            "1,5",    // comma is not a valid separator
+            "1.5.5",  // more than one decimal point
+            " 1",     // leading whitespace
+            "1 ",     // trailing whitespace
+            "1_000",  // digit-group separators not permitted
+            "0x1",    // hex not permitted
+            "\u{0}1", // embedded NUL
+        ] {
+            assert!(
+                DecimalAmount::parse(invalid).is_err(),
+                "expected {invalid:?} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn decimal_amount_fractional_digits_counts_only_the_fraction() {
+        assert_eq!(DecimalAmount::parse("5").unwrap().fractional_digits(), 0);
+        assert_eq!(DecimalAmount::parse("5.1").unwrap().fractional_digits(), 1);
+        assert_eq!(
+            DecimalAmount::parse("5.12345678")
+                .unwrap()
+                .fractional_digits(),
+            8
+        );
+    }
+
+    #[test]
+    fn decimal_amount_atomic_value_rejects_excess_precision() {
+        let amount = DecimalAmount::parse("1.123").unwrap();
+        assert_eq!(amount.atomic_value(3), Some(1_123));
+        assert_eq!(amount.atomic_value(2), None);
+    }
+
+    #[test]
+    fn decimal_amount_atomic_value_rejects_overflow() {
+        // u64::MAX is 18446744073709551615 (20 digits); this whole part alone already exceeds it
+        // before considering the *8 scale needed for 8 decimal places.
+        let amount = DecimalAmount::parse("99999999999999999999").unwrap();
+        assert_eq!(amount.atomic_value(8), None);
+    }
+
+    proptest! {
+        /// Any digit string this crate's own grammar accepts round-trips through `parse` and
+        /// `as_str` byte-for-byte -- parsing must not normalize, reformat, or lose precision.
+        #[test]
+        fn decimal_amount_round_trips_through_parse(
+            whole in "[0-9]{1,10}",
+            fraction in proptest::option::of("[0-9]{1,8}"),
+        ) {
+            let text = match &fraction {
+                Some(f) => format!("{whole}.{f}"),
+                None => whole.clone(),
+            };
+            let parsed = DecimalAmount::parse(&text).expect("well-formed by construction");
+            prop_assert_eq!(parsed.as_str(), text.as_str());
+        }
+
+        /// Any value with no more fractional digits than `decimal_places`, and a whole part small
+        /// enough not to overflow once scaled, must produce an atomic value satisfying the basic
+        /// arithmetic identity `atomic == whole * 10^decimal_places + fraction_padded`.
+        #[test]
+        fn decimal_amount_atomic_value_matches_arithmetic_identity(
+            whole in 0u64..1_000_000_000,
+            fraction_digits in 0usize..=8,
+        ) {
+            let decimal_places = 8;
+            let fraction: u64 = if fraction_digits == 0 { 0 } else { 12_345_678 % 10u64.pow(fraction_digits as u32) };
+            let text = if fraction_digits == 0 {
+                whole.to_string()
+            } else {
+                format!("{whole}.{fraction:0fraction_digits$}")
+            };
+            let parsed = DecimalAmount::parse(&text).expect("well-formed by construction");
+            let expected = whole * 10u64.pow(decimal_places) + fraction * 10u64.pow((decimal_places as usize - fraction_digits) as u32);
+            prop_assert_eq!(parsed.atomic_value(decimal_places as usize), Some(expected));
+        }
+
+        /// Any string containing a byte outside `[0-9.]` must be rejected -- parsing must never
+        /// panic on arbitrary bytes, including non-UTF-8-adjacent and adversarial input.
+        #[test]
+        fn decimal_amount_never_panics_on_arbitrary_strings(s in ".*") {
+            let _ = DecimalAmount::parse(&s);
+        }
+    }
+}

--- a/components/payment_uri/src/lib.rs
+++ b/components/payment_uri/src/lib.rs
@@ -1,0 +1,177 @@
+//! Typed parsing for payment request URIs used by supported cross-chain assets.
+//!
+//! The parser validates protocol syntax and address encodings. Applications
+//! remain responsible for deciding which chains and token contracts they
+//! support and for requiring user confirmation before payment.
+
+mod bitcoin;
+mod solana;
+
+use core::fmt;
+
+pub use bitcoin::{Network, UtxoPaymentRequest};
+pub use solana::{SolanaRequest, SolanaTransactionRequest, SolanaTransferRequest};
+
+/// A non-negative decimal amount represented without floating-point loss.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DecimalAmount(String);
+
+impl DecimalAmount {
+    fn parse(value: &str) -> Result<Self, Error> {
+        let (whole, fraction) = value
+            .split_once('.')
+            .map_or((value, None), |(w, f)| (w, Some(f)));
+        if whole.is_empty()
+            || !whole.bytes().all(|byte| byte.is_ascii_digit())
+            || fraction.is_some_and(|digits| {
+                digits.is_empty() || !digits.bytes().all(|byte| byte.is_ascii_digit())
+            })
+        {
+            return Err(Error::InvalidAmount(value.to_owned()));
+        }
+        Ok(Self(value.to_owned()))
+    }
+
+    /// Returns the exact decimal text encoded by the URI.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Returns the number of digits following the decimal point.
+    pub fn fractional_digits(&self) -> usize {
+        self.0.split_once('.').map_or(0, |(_, digits)| digits.len())
+    }
+
+    fn atomic_value(&self, decimal_places: usize) -> Option<u64> {
+        if self.fractional_digits() > decimal_places {
+            return None;
+        }
+        let (whole, fraction) = self.0.split_once('.').unwrap_or((&self.0, ""));
+        let scale = 10_u64.checked_pow(decimal_places.try_into().ok()?)?;
+        let whole = whole.parse::<u64>().ok()?.checked_mul(scale)?;
+        let fractional_digits = fraction.len();
+        let fraction = fraction.parse::<u64>().unwrap_or(0);
+        let padding = 10_u64.checked_pow((decimal_places - fractional_digits).try_into().ok()?)?;
+        whole.checked_add(fraction.checked_mul(padding)?)
+    }
+}
+
+impl fmt::Display for DecimalAmount {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// A parsed payment request.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum PaymentRequest {
+    /// A Bitcoin on-chain payment request following the on-chain subset of BIP 321.
+    Bitcoin(UtxoPaymentRequest),
+    /// An EIP-681 transaction request.
+    Ethereum(eip681::TransactionRequest),
+    /// A Litecoin payment request using Litecoin Core's BIP-21-compatible format.
+    Litecoin(UtxoPaymentRequest),
+    /// A Solana Pay transfer or interactive transaction request.
+    Solana(SolanaRequest),
+}
+
+impl PaymentRequest {
+    /// Parses and validates a supported payment request URI.
+    pub fn parse(input: &str) -> Result<Self, Error> {
+        let (scheme, payload) = input.split_once(':').ok_or(Error::MissingScheme)?;
+        if scheme.eq_ignore_ascii_case("bitcoin") {
+            bitcoin::parse(input, bitcoin::Currency::Bitcoin).map(Self::Bitcoin)
+        } else if scheme.eq_ignore_ascii_case("litecoin") {
+            bitcoin::parse(input, bitcoin::Currency::Litecoin).map(Self::Litecoin)
+        } else if scheme.eq_ignore_ascii_case("ethereum") {
+            eip681::TransactionRequest::parse(&format!("ethereum:{payload}"))
+                .map(Self::Ethereum)
+                .map_err(Error::Ethereum)
+        } else if scheme.eq_ignore_ascii_case("solana") {
+            solana::parse(input).map(Self::Solana)
+        } else {
+            Err(Error::UnsupportedScheme(scheme.to_owned()))
+        }
+    }
+}
+
+/// A payment request parsing or validation error.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Error {
+    /// The input has no URI scheme delimiter.
+    MissingScheme,
+    /// The URI scheme is not supported.
+    UnsupportedScheme(String),
+    /// A payment recipient is required but missing.
+    MissingRecipient,
+    /// An address is malformed for the selected protocol.
+    InvalidAddress(String),
+    /// A decimal amount is malformed or exceeds protocol precision.
+    InvalidAmount(String),
+    /// A single-value parameter occurs more than once.
+    DuplicateParameter(String),
+    /// A required parameter is not implemented by this parser.
+    UnsupportedRequiredParameter(String),
+    /// A percent-encoded parameter is malformed or is not UTF-8.
+    InvalidEncoding(String),
+    /// An interactive transaction endpoint is not an absolute HTTPS URL in canonical form.
+    InvalidTransactionLink(String),
+    /// The delegated EIP-681 parser rejected the request.
+    Ethereum(eip681::error::Error),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingScheme => f.write_str("payment request is missing a URI scheme"),
+            Self::UnsupportedScheme(scheme) => {
+                write!(f, "unsupported payment URI scheme: {scheme}")
+            }
+            Self::MissingRecipient => f.write_str("payment request is missing a recipient"),
+            Self::InvalidAddress(address) => write!(f, "invalid payment address: {address}"),
+            Self::InvalidAmount(amount) => write!(f, "invalid payment amount: {amount}"),
+            Self::DuplicateParameter(key) => write!(f, "duplicate payment parameter: {key}"),
+            Self::UnsupportedRequiredParameter(key) => {
+                write!(f, "unsupported required payment parameter: {key}")
+            }
+            Self::InvalidEncoding(value) => write!(f, "invalid URI encoding: {value}"),
+            Self::InvalidTransactionLink(link) => {
+                write!(f, "invalid interactive transaction link: {link}")
+            }
+            Self::Ethereum(error) => write!(f, "invalid EIP-681 request: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Ethereum(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+fn decode(value: &str) -> Result<String, Error> {
+    let bytes = value.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' {
+            if index + 2 >= bytes.len()
+                || !bytes[index + 1].is_ascii_hexdigit()
+                || !bytes[index + 2].is_ascii_hexdigit()
+            {
+                return Err(Error::InvalidEncoding(value.to_owned()));
+            }
+            index += 3;
+        } else {
+            index += 1;
+        }
+    }
+    percent_encoding::percent_decode_str(value)
+        .decode_utf8()
+        .map(|decoded| decoded.into_owned())
+        .map_err(|_| Error::InvalidEncoding(value.to_owned()))
+}

--- a/components/payment_uri/src/lib.rs
+++ b/components/payment_uri/src/lib.rs
@@ -9,8 +9,15 @@ mod solana;
 
 use core::fmt;
 
+#[cfg(feature = "json")]
+use serde_json::{Value, json};
+
 pub use bitcoin::{Network, UtxoPaymentRequest};
 pub use solana::{SolanaRequest, SolanaTransactionRequest, SolanaTransferRequest};
+
+#[cfg(feature = "json")]
+/// Version of the JSON representation returned by [`parse_to_json`].
+pub const JSON_VERSION: u8 = 1;
 
 /// A non-negative decimal amount represented without floating-point loss.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -93,6 +100,85 @@ impl PaymentRequest {
         } else {
             Err(Error::UnsupportedScheme(scheme.to_owned()))
         }
+    }
+
+    #[cfg(feature = "json")]
+    fn to_json(&self) -> Value {
+        match self {
+            Self::Bitcoin(request) => utxo_json("bitcoin", request),
+            Self::Ethereum(request) => ethereum_json(request),
+            Self::Litecoin(request) => utxo_json("litecoin", request),
+            Self::Solana(SolanaRequest::Transfer(request)) => json!({
+                "version": JSON_VERSION,
+                "type": "solana_transfer",
+                "recipient": request.recipient(),
+                "amount": request.amount().map(DecimalAmount::as_str),
+                "spl_token": request.spl_token(),
+                "references": request.references(),
+                "label": request.label(),
+                "message": request.message(),
+                "memo": request.memo(),
+            }),
+            Self::Solana(SolanaRequest::Transaction(request)) => json!({
+                "version": JSON_VERSION,
+                "type": "solana_transaction",
+                "link": request.link(),
+            }),
+        }
+    }
+}
+
+/// Parses a payment request and returns its versioned JSON representation.
+#[cfg(feature = "json")]
+pub fn parse_to_json(input: &str) -> Result<String, Error> {
+    PaymentRequest::parse(input).map(|request| request.to_json().to_string())
+}
+
+#[cfg(feature = "json")]
+fn utxo_json(request_type: &str, request: &UtxoPaymentRequest) -> Value {
+    json!({
+        "version": JSON_VERSION,
+        "type": request_type,
+        "address": request.address(),
+        "network": match request.network() {
+            Network::Mainnet => "mainnet",
+            Network::Testnet => "testnet",
+            Network::Regtest => "regtest",
+        },
+        "amount": request.amount().map(DecimalAmount::as_str),
+        "label": request.label(),
+        "message": request.message(),
+    })
+}
+
+#[cfg(feature = "json")]
+fn ethereum_json(request: &eip681::TransactionRequest) -> Value {
+    match request {
+        eip681::TransactionRequest::NativeRequest(request) => json!({
+            "version": JSON_VERSION,
+            "type": "ethereum_native",
+            "schema_prefix": request.schema_prefix(),
+            "has_pay": request.has_pay(),
+            "chain_id": request.chain_id().map(|value| value.to_string()),
+            "recipient_address": request.recipient_address(),
+            "value_hex": request.value_atomic().map(|value| format!("{value:#x}")),
+            "gas_limit_hex": request.gas_limit().map(|value| format!("{value:#x}")),
+            "gas_price_hex": request.gas_price().map(|value| format!("{value:#x}")),
+        }),
+        eip681::TransactionRequest::Erc20Request(request) => json!({
+            "version": JSON_VERSION,
+            "type": "ethereum_erc20",
+            "schema_prefix": request.schema_prefix(),
+            "has_pay": request.has_pay(),
+            "chain_id": request.chain_id().map(|value| value.to_string()),
+            "token_contract_address": request.token_contract_address(),
+            "recipient_address": request.recipient_address(),
+            "value_hex": format!("{:#x}", request.value_atomic()),
+        }),
+        eip681::TransactionRequest::Unrecognised(_) => json!({
+            "version": JSON_VERSION,
+            "type": "ethereum_unrecognised",
+        }),
     }
 }
 

--- a/components/payment_uri/src/lib.rs
+++ b/components/payment_uri/src/lib.rs
@@ -361,11 +361,22 @@ mod tests {
             prop_assert_eq!(parsed.atomic_value(decimal_places as usize), Some(expected));
         }
 
-        /// Any string containing a byte outside `[0-9.]` must be rejected -- parsing must never
-        /// panic on arbitrary bytes, including non-UTF-8-adjacent and adversarial input.
+        /// Never panics on arbitrary input, and its accept/reject decision always matches the
+        /// grammar `parse` itself documents: one or more digits, optionally followed by `.` and
+        /// one or more digits, nothing else. Since `s` is any string at all, most generated
+        /// cases are malformed and must be rejected, but proptest can and does occasionally
+        /// generate a well-formed one (e.g. plain digit strings) by chance -- those must still
+        /// be *accepted*, so the assertion has to check both directions rather than assuming
+        /// arbitrary input is always invalid.
         #[test]
-        fn decimal_amount_never_panics_on_arbitrary_strings(s in ".*") {
-            let _ = DecimalAmount::parse(&s);
+        fn decimal_amount_matches_its_documented_grammar_for_arbitrary_strings(s in ".*") {
+            let well_formed = {
+                let (whole, fraction) = s.split_once('.').map_or((s.as_str(), None), |(w, f)| (w, Some(f)));
+                !whole.is_empty()
+                    && whole.bytes().all(|b| b.is_ascii_digit())
+                    && fraction.is_none_or(|f| !f.is_empty() && f.bytes().all(|b| b.is_ascii_digit()))
+            };
+            prop_assert_eq!(DecimalAmount::parse(&s).is_ok(), well_formed);
         }
     }
 }

--- a/components/payment_uri/src/lib.rs
+++ b/components/payment_uri/src/lib.rs
@@ -140,11 +140,7 @@ fn utxo_json(request_type: &str, request: &UtxoPaymentRequest) -> Value {
         "version": JSON_VERSION,
         "type": request_type,
         "address": request.address(),
-        "network": match request.network() {
-            Network::Mainnet => "mainnet",
-            Network::Testnet => "testnet",
-            Network::Regtest => "regtest",
-        },
+        "network": request.network().as_str(),
         "amount": request.amount().map(DecimalAmount::as_str),
         "label": request.label(),
         "message": request.message(),

--- a/components/payment_uri/src/lib.rs
+++ b/components/payment_uri/src/lib.rs
@@ -361,22 +361,16 @@ mod tests {
             prop_assert_eq!(parsed.atomic_value(decimal_places as usize), Some(expected));
         }
 
-        /// Never panics on arbitrary input, and its accept/reject decision always matches the
-        /// grammar `parse` itself documents: one or more digits, optionally followed by `.` and
-        /// one or more digits, nothing else. Since `s` is any string at all, most generated
-        /// cases are malformed and must be rejected, but proptest can and does occasionally
-        /// generate a well-formed one (e.g. plain digit strings) by chance -- those must still
-        /// be *accepted*, so the assertion has to check both directions rather than assuming
-        /// arbitrary input is always invalid.
+        /// Must never panic on arbitrary input. This is deliberately the only property checked
+        /// here: the round-trip test above already proves well-formed input is accepted
+        /// correctly, and `decimal_amount_rejects_malformed_values` already proves specific
+        /// malformed cases are rejected. Checking accept/reject correctness for fully arbitrary
+        /// strings would need an oracle for "is this well-formed", and the only accurate oracle
+        /// for this exact grammar is a reimplementation of parse's own logic -- which wouldn't
+        /// catch a bug shared by both copies, so it isn't worth the duplication.
         #[test]
-        fn decimal_amount_matches_its_documented_grammar_for_arbitrary_strings(s in ".*") {
-            let well_formed = {
-                let (whole, fraction) = s.split_once('.').map_or((s.as_str(), None), |(w, f)| (w, Some(f)));
-                !whole.is_empty()
-                    && whole.bytes().all(|b| b.is_ascii_digit())
-                    && fraction.is_none_or(|f| !f.is_empty() && f.bytes().all(|b| b.is_ascii_digit()))
-            };
-            prop_assert_eq!(DecimalAmount::parse(&s).is_ok(), well_formed);
+        fn decimal_amount_never_panics_on_arbitrary_strings(s in ".*") {
+            let _ = DecimalAmount::parse(&s);
         }
     }
 }

--- a/components/payment_uri/src/solana.rs
+++ b/components/payment_uri/src/solana.rs
@@ -1,0 +1,168 @@
+use std::collections::HashSet;
+
+use crate::{DecimalAmount, Error, decode};
+
+const SOL_DECIMAL_PLACES: usize = 9;
+const PUBLIC_KEY_BYTES: usize = 32;
+
+/// A parsed Solana Pay request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum SolanaRequest {
+    /// A non-interactive SOL or SPL Token transfer request.
+    Transfer(SolanaTransferRequest),
+    /// An interactive HTTPS transaction request.
+    Transaction(SolanaTransactionRequest),
+}
+
+/// A validated Solana Pay transfer request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SolanaTransferRequest {
+    recipient: String,
+    amount: Option<DecimalAmount>,
+    spl_token: Option<String>,
+    references: Vec<String>,
+    label: Option<String>,
+    message: Option<String>,
+    memo: Option<String>,
+}
+
+impl SolanaTransferRequest {
+    /// Returns the recipient's base58-encoded public key.
+    pub fn recipient(&self) -> &str {
+        &self.recipient
+    }
+
+    /// Returns the amount in SOL or SPL Token display units.
+    pub fn amount(&self) -> Option<&DecimalAmount> {
+        self.amount.as_ref()
+    }
+
+    /// Returns the SPL Token mint, or `None` for native SOL.
+    pub fn spl_token(&self) -> Option<&str> {
+        self.spl_token.as_deref()
+    }
+
+    /// Returns the ordered reference keys attached to the request.
+    pub fn references(&self) -> &[String] {
+        &self.references
+    }
+
+    /// Returns the decoded request label.
+    pub fn label(&self) -> Option<&str> {
+        self.label.as_deref()
+    }
+
+    /// Returns the decoded request message.
+    pub fn message(&self) -> Option<&str> {
+        self.message.as_deref()
+    }
+
+    /// Returns the decoded public memo to include in the transaction.
+    pub fn memo(&self) -> Option<&str> {
+        self.memo.as_deref()
+    }
+}
+
+/// A validated interactive Solana Pay transaction request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SolanaTransactionRequest {
+    link: String,
+}
+
+impl SolanaTransactionRequest {
+    /// Returns the decoded absolute HTTPS endpoint.
+    pub fn link(&self) -> &str {
+        &self.link
+    }
+}
+
+pub(crate) fn parse(input: &str) -> Result<SolanaRequest, Error> {
+    let (_, payload) = input.split_once(':').ok_or(Error::MissingScheme)?;
+    let decoded_payload = decode(payload)?;
+    if is_https_url(&decoded_payload) {
+        if payload.contains('?') {
+            return Err(Error::InvalidTransactionLink(payload.to_owned()));
+        }
+        return Ok(SolanaRequest::Transaction(SolanaTransactionRequest {
+            link: decoded_payload,
+        }));
+    }
+
+    let (recipient, query) = payload
+        .split_once('?')
+        .map_or((payload, None), |(r, q)| (r, Some(q)));
+    validate_public_key(recipient)?;
+
+    let mut amount = None;
+    let mut spl_token = None;
+    let mut references = vec![];
+    let mut label = None;
+    let mut message = None;
+    let mut memo = None;
+    let mut seen = HashSet::new();
+
+    for parameter in query.into_iter().flat_map(|query| query.split('&')) {
+        let (key, value) = parameter.split_once('=').unwrap_or((parameter, ""));
+        if matches!(key, "amount" | "spl-token" | "label" | "message" | "memo") && !seen.insert(key)
+        {
+            return Err(Error::DuplicateParameter(key.to_owned()));
+        }
+        match key {
+            "amount" => amount = Some(DecimalAmount::parse(value)?),
+            "spl-token" => {
+                validate_public_key(value)?;
+                spl_token = Some(value.to_owned());
+            }
+            "reference" => {
+                validate_public_key(value)?;
+                references.push(value.to_owned());
+            }
+            "label" => label = Some(decode(value)?),
+            "message" => message = Some(decode(value)?),
+            "memo" => memo = Some(decode(value)?),
+            _ => {}
+        }
+    }
+
+    if let Some(amount) = amount.as_ref()
+        && spl_token.is_none()
+        && amount.atomic_value(SOL_DECIMAL_PLACES).is_none()
+    {
+        return Err(Error::InvalidAmount(amount.to_string()));
+    }
+
+    Ok(SolanaRequest::Transfer(SolanaTransferRequest {
+        recipient: recipient.to_owned(),
+        amount,
+        spl_token,
+        references,
+        label,
+        message,
+        memo,
+    }))
+}
+
+fn validate_public_key(value: &str) -> Result<(), Error> {
+    let decoded = bs58::decode(value)
+        .into_vec()
+        .map_err(|_| Error::InvalidAddress(value.to_owned()))?;
+    if decoded.len() == PUBLIC_KEY_BYTES {
+        Ok(())
+    } else {
+        Err(Error::InvalidAddress(value.to_owned()))
+    }
+}
+
+fn is_https_url(value: &str) -> bool {
+    let Some((scheme, remainder)) = value.split_once("://") else {
+        return false;
+    };
+    scheme.eq_ignore_ascii_case("https")
+        && remainder
+            .split(['/', '?', '#'])
+            .next()
+            .is_some_and(|authority| {
+                !authority.is_empty() && !authority.chars().any(char::is_whitespace)
+            })
+}

--- a/components/payment_uri/src/solana.rs
+++ b/components/payment_uri/src/solana.rs
@@ -1,9 +1,29 @@
+//! Solana Pay transfer and interactive transaction requests.
+//!
+//! Implements the [Solana Pay specification]: non-interactive `solana:<recipient>?...` transfer
+//! requests (native SOL or an SPL token, identified by its mint address), and interactive
+//! `solana:<https-url>` transaction requests, which this crate parses and categorizes but does
+//! not itself act on -- consumers decide whether to follow an interactive link.
+//!
+//! A transaction-request link only needs percent-encoding when it would otherwise contain
+//! characters (like a literal `?` introducing its own query string) that would be ambiguous
+//! against the outer `solana:` URI's own grammar; a bare link with no query component does not.
+//! Both forms appear as valid examples in the spec itself.
+//!
+//! Unlike BIP-21/BIP-321, which explicitly define query parameter keys as case-insensitive
+//! (Bitcoin) or case-sensitive (Litecoin), the Solana Pay spec says nothing about the case
+//! sensitivity of its keys -- it only ever shows them in lowercase. This module treats them as
+//! case-sensitive (no normalization is applied), matching the spec's own examples literally;
+//! `Amount=1` is therefore an unrecognised key, not a match for `amount`.
+//!
+//! [Solana Pay specification]: https://github.com/solana-foundation/solana-pay/blob/master/SPEC.md
+
 use std::collections::HashSet;
 
 use crate::{DecimalAmount, Error, decode};
 
 const SOL_DECIMAL_PLACES: usize = 9;
-const PUBLIC_KEY_BYTES: usize = 32;
+const PUBLIC_KEY_BYTES_LEN: usize = 32;
 
 /// A parsed Solana Pay request.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -77,6 +97,22 @@ impl SolanaTransactionRequest {
     }
 }
 
+/// Parses and validates a `solana:` transfer or interactive transaction request.
+///
+/// Examples of accepted input:
+/// - `solana:mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?amount=1&label=Michael` (native SOL)
+/// - `solana:mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?amount=0.01&spl-token=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
+///   (SPL token transfer)
+/// - `solana:https://example.com/solana-pay` (interactive request, no query string, no
+///   escaping needed)
+/// - `solana:https%3A%2F%2Fexample.com%2Fsolana-pay%3Forder%3D12345` (interactive request
+///   whose own query string is percent-encoded so it doesn't collide with the outer URI)
+///
+/// Examples of rejected input:
+/// - `solana:https://example.com/solana-pay?order=12345` (an interactive link with an
+///   unescaped `?` is ambiguous with the outer URI's own query string, so it must be
+///   percent-encoded as above instead)
+/// - a `recipient`, `spl-token`, or `reference` value that isn't a well-formed base58 public key
 pub(crate) fn parse(input: &str) -> Result<SolanaRequest, Error> {
     let (_, payload) = input.split_once(':').ok_or(Error::MissingScheme)?;
     let decoded_payload = decode(payload)?;
@@ -147,7 +183,7 @@ fn validate_public_key(value: &str) -> Result<(), Error> {
     let decoded = bs58::decode(value)
         .into_vec()
         .map_err(|_| Error::InvalidAddress(value.to_owned()))?;
-    if decoded.len() == PUBLIC_KEY_BYTES {
+    if decoded.len() == PUBLIC_KEY_BYTES_LEN {
         Ok(())
     } else {
         Err(Error::InvalidAddress(value.to_owned()))

--- a/components/payment_uri/tests/parse.rs
+++ b/components/payment_uri/tests/parse.rs
@@ -348,14 +348,15 @@ fn rejects_adversarial_input() {
         );
     }
 
-    // Two separate large-input cases, checked only for non-panic/non-hang: a query string
-    // this pathological (no '&' separators at all, just one huge repeated key=value blob)
-    // and an oversized single-field payload aren't values a fixed always_invalid list can
-    // assert a single Err/Ok answer for as confidently as the hand-picked cases above, but
-    // they must not panic or take unreasonable time either way.
-    let _ =
-        PaymentRequest::parse(&"bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?amount=".repeat(10_000));
-    let _ = PaymentRequest::parse(&format!("solana:{}", "a".repeat(100_000)));
+    // Two large, fixed (non-random) inputs -- rejected deterministically, same as the list
+    // above, but kept separate because the point of including them is performance/hang safety
+    // (no '&' separators at all in the first, a 100KB single field in the second), not the
+    // specific rejection reason.
+    assert!(
+        PaymentRequest::parse(&"bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?amount=".repeat(10_000))
+            .is_err()
+    );
+    assert!(PaymentRequest::parse(&format!("solana:{}", "a".repeat(100_000))).is_err());
 
     // These three are *not* rejected, and that's correct, not a gap: emoji are legitimate
     // free-form label text; a NUL byte in a link's hostname doesn't make the link syntactically

--- a/components/payment_uri/tests/parse.rs
+++ b/components/payment_uri/tests/parse.rs
@@ -84,6 +84,109 @@ fn delegates_ethereum_to_eip681() {
     assert!(matches!(request, PaymentRequest::Ethereum(_)));
 }
 
+#[test]
+fn rejects_bitcoin_address_with_bad_checksum() {
+    // Last character changed from the valid address used elsewhere in this file, breaking the
+    // base58check checksum while staying within the base58 alphabet.
+    assert!(PaymentRequest::parse("bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mX").is_err());
+}
+
+#[test]
+fn rejects_bitcoin_address_with_invalid_characters() {
+    // '0', 'O', 'I', 'l' are excluded from the base58 alphabet.
+    assert!(PaymentRequest::parse("bitcoin:0IOl0000000000000000000000000000").is_err());
+}
+
+#[test]
+fn rejects_address_from_the_wrong_currency() {
+    // A real Litecoin address (version byte 48) is not a valid Bitcoin address.
+    assert!(PaymentRequest::parse("bitcoin:LT2KVaAy1ppRuxRgrS5RNU3vBsy7RibPeA?amount=1").is_err());
+    // A real Bitcoin bech32 address (hrp "bc") is not a valid Litecoin address.
+    assert!(
+        PaymentRequest::parse("litecoin:bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4?amount=1")
+            .is_err()
+    );
+}
+
+#[test]
+fn rejects_missing_recipient() {
+    assert!(PaymentRequest::parse("bitcoin:?amount=1").is_err());
+}
+
+#[test]
+fn rejects_negative_and_non_numeric_amounts() {
+    let base = "bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo";
+    assert!(PaymentRequest::parse(&format!("{base}?amount=-1")).is_err());
+    assert!(PaymentRequest::parse(&format!("{base}?amount=1e5")).is_err());
+    assert!(PaymentRequest::parse(&format!("{base}?amount=")).is_err());
+    assert!(PaymentRequest::parse(&format!("{base}?amount=abc")).is_err());
+}
+
+#[test]
+fn rejects_amount_with_too_many_fractional_digits() {
+    let base = "bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo";
+    // Bitcoin/Litecoin cap fractional precision at 8 digits (satoshis/litoshis).
+    assert!(PaymentRequest::parse(&format!("{base}?amount=1.123456789")).is_err());
+    assert!(PaymentRequest::parse(&format!("{base}?amount=1.12345678")).is_ok());
+}
+
+#[test]
+fn rejects_amount_that_overflows_atomic_value() {
+    let base = "bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo";
+    // Too many digits to parse as u64 at all.
+    assert!(PaymentRequest::parse(&format!("{base}?amount=999999999999999999999")).is_err());
+    // Parses as u64, but overflows once scaled by 10^8 (satoshi precision).
+    assert!(PaymentRequest::parse(&format!("{base}?amount=200000000000000000")).is_err());
+}
+
+#[test]
+fn litecoin_parameter_matching_is_case_sensitive_per_bip21() {
+    // Unlike Bitcoin (BIP-321, case-insensitive keys), Litecoin follows the original
+    // case-sensitive BIP-21. "AMOUNT" is therefore a distinct, unrecognised key: it neither
+    // collides with "amount" as a duplicate nor is treated as the amount itself.
+    let request =
+        PaymentRequest::parse("litecoin:LT2KVaAy1ppRuxRgrS5RNU3vBsy7RibPeA?amount=1&AMOUNT=2")
+            .unwrap();
+    let PaymentRequest::Litecoin(request) = request else {
+        panic!("expected Litecoin request");
+    };
+    assert_eq!(request.amount().unwrap().as_str(), "1");
+
+    // Case-sensitivity cuts the other way for `req-`, too: an uppercase "REQ-" prefix is not
+    // recognised as a required extension, so an unsupported one is silently ignored rather
+    // than rejected the way lowercase "req-unknown" is for Bitcoin.
+    assert!(
+        PaymentRequest::parse("litecoin:LT2KVaAy1ppRuxRgrS5RNU3vBsy7RibPeA?REQ-unknown=true")
+            .is_ok()
+    );
+    assert!(
+        PaymentRequest::parse("litecoin:LT2KVaAy1ppRuxRgrS5RNU3vBsy7RibPeA?req-unknown=true")
+            .is_err()
+    );
+}
+
+#[test]
+fn does_not_panic_on_adversarial_input() {
+    let adversarial = [
+        "",
+        "bitcoin:",
+        "bitcoin:%",
+        "bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?amount=%",
+        "bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?req-=true",
+        "solana:",
+        "solana:\u{0}",
+        "ethereum:",
+        &"bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?amount=".repeat(10_000),
+        "🦀:not-a-real-scheme",
+    ];
+    for input in adversarial {
+        // The only contract under test is "does not panic"; every one of these is expected to
+        // be rejected, but that's incidental -- a future relaxation that lets one parse
+        // successfully would still be fine as long as it doesn't do so by panicking.
+        let _ = PaymentRequest::parse(input);
+    }
+}
+
 #[cfg(feature = "json")]
 #[test]
 fn encodes_a_versioned_binding_representation() {

--- a/components/payment_uri/tests/parse.rs
+++ b/components/payment_uri/tests/parse.rs
@@ -1,4 +1,12 @@
-use payment_uri::{Network, PaymentRequest, SolanaRequest};
+use payment_uri::{Error, Network, PaymentRequest, SolanaRequest};
+
+/// Parses `input` and returns the [`Error`] it must produce, panicking if it instead succeeds.
+fn err(input: &str) -> Error {
+    match PaymentRequest::parse(input) {
+        Ok(_) => panic!("expected {input:?} to be rejected"),
+        Err(e) => e,
+    }
+}
 
 #[test]
 fn parses_bitcoin_request() {
@@ -16,10 +24,10 @@ fn parses_bitcoin_request() {
 
 #[test]
 fn rejects_unsupported_required_bitcoin_extension() {
-    assert!(
-        PaymentRequest::parse("bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?req-unknown=true")
-            .is_err()
-    );
+    assert!(matches!(
+        err("bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?req-unknown=true"),
+        Error::UnsupportedRequiredParameter(key) if key == "req-unknown"
+    ));
 }
 
 #[test]
@@ -27,10 +35,51 @@ fn rejects_duplicate_bitcoin_amount_parameter() {
     // Bitcoin (BIP-321) parameter keys are case-insensitive, so "AMOUNT" collides with "amount"
     // as a duplicate rather than being treated as a distinct, unrecognised key -- contrast with
     // Litecoin's case-sensitive behavior below.
+    assert!(matches!(
+        err("bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?amount=1&AMOUNT=2"),
+        Error::DuplicateParameter(key) if key == "amount"
+    ));
+}
+
+// The following two duplicate-parameter vectors are BIP-321's own "Invalid Payment Request URIs"
+// examples (using this file's known-valid address in place of the BIP's own example address,
+// which the BIP notes is deliberately checksum-invalid "to prevent accidental transactions").
+#[test]
+fn rejects_duplicate_bitcoin_label_per_bip321_example() {
+    assert!(matches!(
+        err("bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?label=Luke-Jr&label=Matt"),
+        Error::DuplicateParameter(key) if key == "label"
+    ));
+}
+
+#[test]
+fn rejects_duplicate_bitcoin_amount_per_bip321_example_even_with_matching_values() {
+    // BIP-321 explicitly calls out that a duplicate is invalid even when both occurrences carry
+    // the same value -- it is not just a conflict-detection convenience.
+    assert!(matches!(
+        err("bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?amount=42&amount=42"),
+        Error::DuplicateParameter(key) if key == "amount"
+    ));
+}
+
+#[test]
+fn ignores_unimplemented_optional_bip321_extensions_but_rejects_them_when_required() {
+    // BIP-321 defines several alternate-payment-method extensions this crate deliberately does
+    // not implement (lightning invoices, BOLT 12 offers, silent payments, segwit fallback
+    // addresses, proof-of-payment). As plain optional parameters they must be safely ignorable
+    // by a wallet that doesn't support them...
     assert!(
-        PaymentRequest::parse("bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?amount=1&AMOUNT=2")
-            .is_err()
+        PaymentRequest::parse(
+            "bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?lightning=lnbc420bogusinvoice"
+        )
+        .is_ok()
     );
+    // ...but marked `req-`, the same unimplemented extension must make the whole URI invalid,
+    // per the `req-` contract both BIP-21 and BIP-321 define.
+    assert!(matches!(
+        err("bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?req-lno=lno1bogusoffer"),
+        Error::UnsupportedRequiredParameter(key) if key == "req-lno"
+    ));
 }
 
 #[test]
@@ -75,15 +124,45 @@ fn parses_solana_native_and_spl_transfer_requests() {
 }
 
 #[test]
-fn categorizes_solana_transaction_requests_without_treating_them_as_transfers() {
-    let request =
-        PaymentRequest::parse("solana:https%3A%2F%2Fexample.com%2Fsolana-pay%3Forder%3D12345")
-            .unwrap();
-    let PaymentRequest::Solana(SolanaRequest::Transaction(request)) = request else {
+fn parses_solana_transaction_link() {
+    // Two forms from the Solana Pay spec's own examples: a bare link with no query string
+    // needs no escaping, while one with a query string must be percent-encoded so its `?`
+    // doesn't collide with the outer `solana:` URI's own grammar.
+    let bare = PaymentRequest::parse("solana:https://example.com/solana-pay").unwrap();
+    let PaymentRequest::Solana(SolanaRequest::Transaction(bare)) = bare else {
         panic!("expected Solana transaction request");
     };
-    assert_eq!(request.link(), "https://example.com/solana-pay?order=12345");
-    assert!(PaymentRequest::parse("solana:https://example.com/solana-pay?order=12345").is_err());
+    assert_eq!(bare.link(), "https://example.com/solana-pay");
+
+    let encoded =
+        PaymentRequest::parse("solana:https%3A%2F%2Fexample.com%2Fsolana-pay%3Forder%3D12345")
+            .unwrap();
+    let PaymentRequest::Solana(SolanaRequest::Transaction(encoded)) = encoded else {
+        panic!("expected Solana transaction request");
+    };
+    assert_eq!(encoded.link(), "https://example.com/solana-pay?order=12345");
+}
+
+#[test]
+fn rejects_unescaped_solana_transaction_link_with_query_string() {
+    assert!(matches!(
+        err("solana:https://example.com/solana-pay?order=12345"),
+        Error::InvalidTransactionLink(link) if link == "https://example.com/solana-pay?order=12345"
+    ));
+}
+
+#[test]
+fn rejects_solana_request_with_invalid_public_key() {
+    // "0OIl" are excluded from the base58 alphabet used by Solana public keys, same as Bitcoin.
+    assert!(matches!(
+        err("solana:not-a-valid-base58-pubkey0OIl"),
+        Error::InvalidAddress(_)
+    ));
+    // Valid base58, but the wrong length to be a 32-byte Ed25519 public key.
+    assert!(matches!(
+        err("solana:mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?spl-token=tooshort"),
+        Error::InvalidAddress(_)
+    ));
 }
 
 #[test]
@@ -91,52 +170,115 @@ fn delegates_ethereum_to_eip681() {
     let request =
         PaymentRequest::parse("ethereum:0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359?value=1e18")
             .unwrap();
-    assert!(matches!(request, PaymentRequest::Ethereum(_)));
+    let PaymentRequest::Ethereum(request) = request else {
+        panic!("expected Ethereum request");
+    };
+    let native = request.as_native().expect("expected a native ETH transfer");
+    assert_eq!(
+        native.recipient_address(),
+        "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359"
+    );
+    assert_eq!(
+        native.value_atomic(),
+        Some(eip681::U256::from(1_000_000_000_000_000_000u64))
+    );
+}
+
+#[test]
+fn wraps_ethereum_parse_errors() {
+    assert!(matches!(err("ethereum:not-an-address"), Error::Ethereum(_)));
 }
 
 #[test]
 fn rejects_bitcoin_address_with_bad_checksum() {
     // Last character changed from the valid address used elsewhere in this file, breaking the
     // base58check checksum while staying within the base58 alphabet.
-    assert!(PaymentRequest::parse("bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mX").is_err());
+    assert!(matches!(
+        err("bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mX"),
+        Error::InvalidAddress(addr) if addr == "1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mX"
+    ));
 }
 
 #[test]
 fn rejects_bitcoin_address_with_invalid_characters() {
     // '0', 'O', 'I', 'l' are excluded from the base58 alphabet.
-    assert!(PaymentRequest::parse("bitcoin:0IOl0000000000000000000000000000").is_err());
+    assert!(matches!(
+        err("bitcoin:0IOl0000000000000000000000000000"),
+        Error::InvalidAddress(addr) if addr == "0IOl0000000000000000000000000000"
+    ));
 }
 
 #[test]
 fn rejects_address_from_the_wrong_currency() {
     // A real Litecoin address (version byte 48) is not a valid Bitcoin address.
-    assert!(PaymentRequest::parse("bitcoin:LT2KVaAy1ppRuxRgrS5RNU3vBsy7RibPeA?amount=1").is_err());
+    assert!(matches!(
+        err("bitcoin:LT2KVaAy1ppRuxRgrS5RNU3vBsy7RibPeA?amount=1"),
+        Error::InvalidAddress(addr) if addr == "LT2KVaAy1ppRuxRgrS5RNU3vBsy7RibPeA"
+    ));
     // A real Bitcoin bech32 address (hrp "bc") is not a valid Litecoin address.
-    assert!(
-        PaymentRequest::parse("litecoin:bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4?amount=1")
-            .is_err()
-    );
+    assert!(matches!(
+        err("litecoin:bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4?amount=1"),
+        Error::InvalidAddress(addr) if addr == "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"
+    ));
 }
 
 #[test]
 fn rejects_missing_recipient() {
-    assert!(PaymentRequest::parse("bitcoin:?amount=1").is_err());
+    assert!(matches!(err("bitcoin:?amount=1"), Error::MissingRecipient));
+}
+
+#[test]
+fn rejects_input_without_a_scheme() {
+    assert!(matches!(err("not-a-uri-at-all"), Error::MissingScheme));
+}
+
+#[test]
+fn rejects_unsupported_scheme() {
+    assert!(matches!(
+        err("dogecoin:D5tSf59fmS6WTv60ug7Mo4vD5rMkKtFqTP"),
+        Error::UnsupportedScheme(scheme) if scheme == "dogecoin"
+    ));
+}
+
+#[test]
+fn rejects_invalid_percent_encoding() {
+    let base = "bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo";
+    // 'z' is not a hex digit, so "%zz" is not a valid percent-encoded byte.
+    assert!(matches!(
+        err(&format!("{base}?label=%zz")),
+        Error::InvalidEncoding(value) if value == "%zz"
+    ));
+    // A '%' with fewer than two following characters can't be a complete escape sequence.
+    assert!(matches!(
+        err(&format!("{base}?label=abc%4")),
+        Error::InvalidEncoding(value) if value == "abc%4"
+    ));
 }
 
 #[test]
 fn rejects_negative_and_non_numeric_amounts() {
     let base = "bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo";
-    assert!(PaymentRequest::parse(&format!("{base}?amount=-1")).is_err());
-    assert!(PaymentRequest::parse(&format!("{base}?amount=1e5")).is_err());
-    assert!(PaymentRequest::parse(&format!("{base}?amount=")).is_err());
-    assert!(PaymentRequest::parse(&format!("{base}?amount=abc")).is_err());
+    for (query, expected) in [
+        ("amount=-1", "-1"),
+        ("amount=1e5", "1e5"),
+        ("amount=", ""),
+        ("amount=abc", "abc"),
+    ] {
+        assert!(matches!(
+            err(&format!("{base}?{query}")),
+            Error::InvalidAmount(value) if value == expected
+        ));
+    }
 }
 
 #[test]
 fn rejects_amount_with_too_many_fractional_digits() {
     let base = "bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo";
     // Bitcoin/Litecoin cap fractional precision at 8 digits (satoshis/litoshis).
-    assert!(PaymentRequest::parse(&format!("{base}?amount=1.123456789")).is_err());
+    assert!(matches!(
+        err(&format!("{base}?amount=1.123456789")),
+        Error::InvalidAmount(value) if value == "1.123456789"
+    ));
     assert!(PaymentRequest::parse(&format!("{base}?amount=1.12345678")).is_ok());
 }
 
@@ -144,9 +286,15 @@ fn rejects_amount_with_too_many_fractional_digits() {
 fn rejects_amount_that_overflows_atomic_value() {
     let base = "bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo";
     // Too many digits to parse as u64 at all.
-    assert!(PaymentRequest::parse(&format!("{base}?amount=999999999999999999999")).is_err());
+    assert!(matches!(
+        err(&format!("{base}?amount=999999999999999999999")),
+        Error::InvalidAmount(value) if value == "999999999999999999999"
+    ));
     // Parses as u64, but overflows once scaled by 10^8 (satoshi precision).
-    assert!(PaymentRequest::parse(&format!("{base}?amount=200000000000000000")).is_err());
+    assert!(matches!(
+        err(&format!("{base}?amount=200000000000000000")),
+        Error::InvalidAmount(value) if value == "200000000000000000"
+    ));
 }
 
 #[test]
@@ -169,10 +317,10 @@ fn litecoin_parameter_matching_is_case_sensitive_per_bip21() {
         PaymentRequest::parse("litecoin:LT2KVaAy1ppRuxRgrS5RNU3vBsy7RibPeA?REQ-unknown=true")
             .is_ok()
     );
-    assert!(
-        PaymentRequest::parse("litecoin:LT2KVaAy1ppRuxRgrS5RNU3vBsy7RibPeA?req-unknown=true")
-            .is_err()
-    );
+    assert!(matches!(
+        err("litecoin:LT2KVaAy1ppRuxRgrS5RNU3vBsy7RibPeA?req-unknown=true"),
+        Error::UnsupportedRequiredParameter(key) if key == "req-unknown"
+    ));
 }
 
 #[test]
@@ -185,9 +333,18 @@ fn does_not_panic_on_adversarial_input() {
         "bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?req-=true",
         "solana:",
         "solana:\u{0}",
+        "solana:mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?reference=\\..\\..\\etc\\passwd",
+        "solana:mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?label=\u{1F600}\u{1F600}\u{1F600}",
+        "solana:https://exa\u{0}mple.com",
+        "solana:HTTPS://EXAMPLE.COM/SOLANA-PAY",
         "ethereum:",
+        "ethereum:\u{0}",
         &"bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?amount=".repeat(10_000),
+        &format!("solana:{}", "a".repeat(100_000)),
         "🦀:not-a-real-scheme",
+        "bitcoin://1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo",
+        ":",
+        "::::",
     ];
     for input in adversarial {
         // The only contract under test is "does not panic"; every one of these is expected to

--- a/components/payment_uri/tests/parse.rs
+++ b/components/payment_uri/tests/parse.rs
@@ -324,8 +324,8 @@ fn litecoin_parameter_matching_is_case_sensitive_per_bip21() {
 }
 
 #[test]
-fn does_not_panic_on_adversarial_input() {
-    let adversarial = [
+fn rejects_adversarial_input() {
+    let always_invalid = [
         "",
         "bitcoin:",
         "bitcoin:%",
@@ -334,24 +334,44 @@ fn does_not_panic_on_adversarial_input() {
         "solana:",
         "solana:\u{0}",
         "solana:mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?reference=\\..\\..\\etc\\passwd",
-        "solana:mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?label=\u{1F600}\u{1F600}\u{1F600}",
-        "solana:https://exa\u{0}mple.com",
-        "solana:HTTPS://EXAMPLE.COM/SOLANA-PAY",
         "ethereum:",
         "ethereum:\u{0}",
-        &"bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?amount=".repeat(10_000),
-        &format!("solana:{}", "a".repeat(100_000)),
         "🦀:not-a-real-scheme",
         "bitcoin://1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo",
         ":",
         "::::",
     ];
-    for input in adversarial {
-        // The only contract under test is "does not panic"; every one of these is expected to
-        // be rejected, but that's incidental -- a future relaxation that lets one parse
-        // successfully would still be fine as long as it doesn't do so by panicking.
-        let _ = PaymentRequest::parse(input);
+    for input in always_invalid {
+        assert!(
+            PaymentRequest::parse(input).is_err(),
+            "expected {input:?} to be rejected"
+        );
     }
+
+    // Two separate large-input cases, checked only for non-panic/non-hang: a query string
+    // this pathological (no '&' separators at all, just one huge repeated key=value blob)
+    // and an oversized single-field payload aren't values a fixed always_invalid list can
+    // assert a single Err/Ok answer for as confidently as the hand-picked cases above, but
+    // they must not panic or take unreasonable time either way.
+    let _ =
+        PaymentRequest::parse(&"bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?amount=".repeat(10_000));
+    let _ = PaymentRequest::parse(&format!("solana:{}", "a".repeat(100_000)));
+
+    // These three are *not* rejected, and that's correct, not a gap: emoji are legitimate
+    // free-form label text; a NUL byte in a link's hostname doesn't make the link syntactically
+    // invalid by this crate's own contract (it parses and categorizes a transaction-request
+    // link, it doesn't itself resolve or connect to it -- see solana.rs's module doc); and
+    // URI schemes are case-insensitive per RFC 3986, so an uppercase "HTTPS" is exactly as
+    // valid as lowercase. Each is still asserted Ok here so a future change to any of this
+    // reasoning is a deliberate decision, not a silent regression.
+    assert!(
+        PaymentRequest::parse(
+            "solana:mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?label=\u{1F600}\u{1F600}\u{1F600}"
+        )
+        .is_ok()
+    );
+    assert!(PaymentRequest::parse("solana:https://exa\u{0}mple.com").is_ok());
+    assert!(PaymentRequest::parse("solana:HTTPS://EXAMPLE.COM/SOLANA-PAY").is_ok());
 }
 
 #[cfg(feature = "json")]

--- a/components/payment_uri/tests/parse.rs
+++ b/components/payment_uri/tests/parse.rs
@@ -83,3 +83,30 @@ fn delegates_ethereum_to_eip681() {
             .unwrap();
     assert!(matches!(request, PaymentRequest::Ethereum(_)));
 }
+
+#[cfg(feature = "json")]
+#[test]
+fn encodes_a_versioned_binding_representation() {
+    let encoded = payment_uri::parse_to_json(
+        "bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?amount=20.3&label=Luke-Jr",
+    )
+    .unwrap();
+    let value: serde_json::Value = serde_json::from_str(&encoded).unwrap();
+
+    assert_eq!(value["version"], payment_uri::JSON_VERSION);
+    assert_eq!(value["type"], "bitcoin");
+    assert_eq!(value["amount"], "20.3");
+
+    let encoded = payment_uri::parse_to_json(
+        "ethereum:0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359?value=1e18",
+    )
+    .unwrap();
+    let value: serde_json::Value = serde_json::from_str(&encoded).unwrap();
+
+    assert_eq!(value["type"], "ethereum_native");
+    assert_eq!(
+        value["recipient_address"],
+        "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359"
+    );
+    assert_eq!(value["value_hex"], "0xde0b6b3a7640000");
+}

--- a/components/payment_uri/tests/parse.rs
+++ b/components/payment_uri/tests/parse.rs
@@ -1,0 +1,85 @@
+use payment_uri::{Network, PaymentRequest, SolanaRequest};
+
+#[test]
+fn parses_bitcoin_request_and_rejects_unsafe_extensions() {
+    let request = PaymentRequest::parse(
+        "bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?amount=20.3&label=Luke-Jr",
+    )
+    .unwrap();
+    let PaymentRequest::Bitcoin(request) = request else {
+        panic!("expected Bitcoin request");
+    };
+    assert_eq!(request.network(), Network::Mainnet);
+    assert_eq!(request.amount().unwrap().as_str(), "20.3");
+    assert_eq!(request.label(), Some("Luke-Jr"));
+
+    assert!(
+        PaymentRequest::parse("bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?req-unknown=true")
+            .is_err()
+    );
+    assert!(
+        PaymentRequest::parse("bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?amount=1&AMOUNT=2")
+            .is_err()
+    );
+}
+
+#[test]
+fn parses_litecoin_request_with_a_valid_litecoin_address() {
+    let request = PaymentRequest::parse(
+        "litecoin:LT2KVaAy1ppRuxRgrS5RNU3vBsy7RibPeA?amount=1.25&message=Coffee",
+    )
+    .unwrap();
+    let PaymentRequest::Litecoin(request) = request else {
+        panic!("expected Litecoin request");
+    };
+    assert_eq!(request.network(), Network::Mainnet);
+    assert_eq!(request.amount().unwrap().as_str(), "1.25");
+    assert_eq!(request.message(), Some("Coffee"));
+}
+
+#[test]
+fn parses_solana_native_and_spl_transfer_requests() {
+    let native = PaymentRequest::parse(
+        "solana:mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?amount=1&label=Michael",
+    )
+    .unwrap();
+    let PaymentRequest::Solana(SolanaRequest::Transfer(native)) = native else {
+        panic!("expected Solana transfer");
+    };
+    assert_eq!(native.amount().unwrap().as_str(), "1");
+    assert_eq!(native.label(), Some("Michael"));
+    assert_eq!(native.spl_token(), None);
+
+    let spl = PaymentRequest::parse(
+        "solana:mvines9iiHiQTysrwkJjGf2gb9Ex9jXJX8ns3qwf2kN?amount=0.01&spl-token=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    )
+    .unwrap();
+    let PaymentRequest::Solana(SolanaRequest::Transfer(spl)) = spl else {
+        panic!("expected SPL transfer");
+    };
+    assert_eq!(spl.amount().unwrap().as_str(), "0.01");
+    assert_eq!(
+        spl.spl_token(),
+        Some("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v")
+    );
+}
+
+#[test]
+fn categorizes_solana_transaction_requests_without_treating_them_as_transfers() {
+    let request =
+        PaymentRequest::parse("solana:https%3A%2F%2Fexample.com%2Fsolana-pay%3Forder%3D12345")
+            .unwrap();
+    let PaymentRequest::Solana(SolanaRequest::Transaction(request)) = request else {
+        panic!("expected Solana transaction request");
+    };
+    assert_eq!(request.link(), "https://example.com/solana-pay?order=12345");
+    assert!(PaymentRequest::parse("solana:https://example.com/solana-pay?order=12345").is_err());
+}
+
+#[test]
+fn delegates_ethereum_to_eip681() {
+    let request =
+        PaymentRequest::parse("ethereum:0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359?value=1e18")
+            .unwrap();
+    assert!(matches!(request, PaymentRequest::Ethereum(_)));
+}

--- a/components/payment_uri/tests/parse.rs
+++ b/components/payment_uri/tests/parse.rs
@@ -1,7 +1,7 @@
 use payment_uri::{Network, PaymentRequest, SolanaRequest};
 
 #[test]
-fn parses_bitcoin_request_and_rejects_unsafe_extensions() {
+fn parses_bitcoin_request() {
     let request = PaymentRequest::parse(
         "bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?amount=20.3&label=Luke-Jr",
     )
@@ -12,11 +12,21 @@ fn parses_bitcoin_request_and_rejects_unsafe_extensions() {
     assert_eq!(request.network(), Network::Mainnet);
     assert_eq!(request.amount().unwrap().as_str(), "20.3");
     assert_eq!(request.label(), Some("Luke-Jr"));
+}
 
+#[test]
+fn rejects_unsupported_required_bitcoin_extension() {
     assert!(
         PaymentRequest::parse("bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?req-unknown=true")
             .is_err()
     );
+}
+
+#[test]
+fn rejects_duplicate_bitcoin_amount_parameter() {
+    // Bitcoin (BIP-321) parameter keys are case-insensitive, so "AMOUNT" collides with "amount"
+    // as a duplicate rather than being treated as a distinct, unrecognised key -- contrast with
+    // Litecoin's case-sensitive behavior below.
     assert!(
         PaymentRequest::parse("bitcoin:1FsSia9rv4NeEwvJ2GvXrX7LyxYspbN2mo?amount=1&AMOUNT=2")
             .is_err()


### PR DESCRIPTION
## Summary

- add a typed payment_uri crate for Bitcoin, Litecoin, Ethereum, and Solana payment requests
- delegate Ethereum parsing and categorization to the existing eip681 crate without changing its parser logic
- expose one versioned binding representation for every supported scheme
- validate Bitcoin and Litecoin addresses, Solana public keys, exact decimal amounts, duplicate parameters, and required extensions
- keep wallet asset allowlisting and token precision checks in consuming apps

Bitcoin implements the on-chain subset of BIP 321. Litecoin follows Litecoin Core compatible BIP-21 behavior. Solana follows the Solana Pay transfer and transaction-request specification.

NEAR is intentionally excluded because no normative NEAR payment URI standard was found.

## Testing

- cargo test -p payment_uri --all-features
- cargo check -p payment_uri --no-default-features
- cargo clippy -p payment_uri --all-features --all-targets -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc -p payment_uri --all-features --no-deps

Authored with OpenAI Codex.