### PR TITLE
Authenticate the PCZT transparent spend-authorization path

### DIFF
--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -13,6 +13,8 @@ workspace.
 ### Added
 - Experimental support for creating and extracting V7 PCZTs under NuTachyon,
   behind `zcash_unstable="nutachyon"`, using the V6 transaction body.
+- `pczt::roles::signer::Signer::with_transparent_sighash_policy`
+- `pczt::roles::spend_finalizer::SpendFinalizer::with_sighash_policy`
 
 ## [0.9.3] - 2026-08-07
 

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -15,11 +15,15 @@ workspace.
   behind `zcash_unstable="nutachyon"`, using the V6 transaction body.
 - `pczt::roles::signer::Signer::with_transparent_sighash_policy`
 - `pczt::roles::spend_finalizer::SpendFinalizer::with_sighash_policy`
+
 ### Changed
 - `pczt::roles::signer::Signer::{sign_transparent, append_transparent_signature,
   transparent_sighash}` now check the consistency of the transparent input, and use only
   `SighashType::ALL`. Use `Signer::with_transparent_sighash_policy` to permit other
   sighash types.
+- `pczt::roles::spend_finalizer::SpendFinalizer::finalize_spends` now finalizes only
+  `SighashType::ALL` signatures that match their input's `sighash_type`; use
+  `SpendFinalizer::with_sighash_policy` to permit other sighash types.
 
 ## [0.9.3] - 2026-08-07
 

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -17,7 +17,9 @@ workspace.
 - `pczt::roles::spend_finalizer::SpendFinalizer::with_sighash_policy`
 ### Changed
 - `pczt::roles::signer::Signer::{sign_transparent, append_transparent_signature,
-  transparent_sighash}` now check the consistency of the transparent input.
+  transparent_sighash}` now check the consistency of the transparent input, and use only
+  `SighashType::ALL`. Use `Signer::with_transparent_sighash_policy` to permit other
+  sighash types.
 
 ## [0.9.3] - 2026-08-07
 

--- a/pczt/CHANGELOG.md
+++ b/pczt/CHANGELOG.md
@@ -15,6 +15,9 @@ workspace.
   behind `zcash_unstable="nutachyon"`, using the V6 transaction body.
 - `pczt::roles::signer::Signer::with_transparent_sighash_policy`
 - `pczt::roles::spend_finalizer::SpendFinalizer::with_sighash_policy`
+### Changed
+- `pczt::roles::signer::Signer::{sign_transparent, append_transparent_signature,
+  transparent_sighash}` now check the consistency of the transparent input.
 
 ## [0.9.3] - 2026-08-07
 

--- a/pczt/src/roles.rs
+++ b/pczt/src/roles.rs
@@ -104,6 +104,8 @@ mod tests {
         feature = "zcp-builder"
     ))]
     mod transparent_authentication {
+        use alloc::vec::Vec;
+
         use ::transparent::{
             address::TransparentAddress,
             bundle::{OutPoint, TxOut},
@@ -373,6 +375,113 @@ mod tests {
         fn finalizer_accepts_all_sighash_type() {
             let pczt = signed(|_| (), SighashPolicy::ALL_ONLY);
             assert!(SpendFinalizer::new(pczt).finalize_spends().is_ok());
+        }
+
+        /// The attacker's own coin, which they contribute to their own transaction.
+        fn attacker_coin() -> (secp256k1::PublicKey, OutPoint, TxOut) {
+            let pubkey = public_key(&secp256k1::SecretKey::from_slice(&[2; 32]).expect("valid"));
+            let addr = TransparentAddress::from_pubkey(&pubkey);
+            (
+                pubkey,
+                OutPoint::new([2; 32], 0),
+                TxOut::new(Zatoshis::const_from_u64(1_000_000), addr.script().into()),
+            )
+        }
+
+        /// A PCZT for a *different* transaction, which the victim never sees: it spends
+        /// the same coin of theirs alongside one of the attacker's, and pays the whole
+        /// balance to the attacker.
+        fn attacker_pczt(sighash_type: u8) -> Pczt {
+            let (attacker_pubkey, attacker_utxo, attacker_coin) = attacker_coin();
+            let attacker_addr = TransparentAddress::from_pubkey(&attacker_pubkey);
+            let (victim_utxo, victim_coin) = victim_coin();
+
+            let mut builder = builder();
+            builder
+                .add_transparent_p2pkh_input(public_key(&secret_key()), victim_utxo, victim_coin)
+                .unwrap();
+            builder
+                .add_transparent_p2pkh_input(attacker_pubkey, attacker_utxo, attacker_coin)
+                .unwrap();
+            builder
+                .add_transparent_output(&attacker_addr, Zatoshis::const_from_u64(1_990_000))
+                .unwrap();
+
+            let mut pczt = finalize(builder);
+            pczt.transparent.inputs[0].sighash_type = sighash_type;
+            pczt
+        }
+
+        /// The victim's signature over the single input of the transaction they were
+        /// shown, with the trailing sighash byte stripped.
+        fn victim_signature(sighash_type: u8, sighash_policy: SighashPolicy) -> Vec<u8> {
+            let pczt = signed(|input| input.sighash_type = sighash_type, sighash_policy);
+            let mut sig = pczt.transparent.inputs[0]
+                .partial_signatures
+                .get(&public_key(&secret_key()).serialize())
+                .expect("the victim signed")
+                .clone();
+            assert_eq!(
+                sig.pop(),
+                Some(sighash_type),
+                "signature carries its sighash type"
+            );
+            sig
+        }
+
+        /// Whether `sig` authorizes the victim's input of `pczt`.
+        fn authorizes(sig: &[u8], pczt: Pczt) -> bool {
+            let sighash = unguarded_sighash(pczt);
+
+            secp256k1::Secp256k1::new()
+                .verify_ecdsa(
+                    &secp256k1::Message::from_digest(sighash),
+                    &secp256k1::ecdsa::Signature::from_der(sig).expect("DER-encoded"),
+                    &public_key(&secret_key()),
+                )
+                .is_ok()
+        }
+
+        /// Why `SighashPolicy::ALL_ONLY` is the default: a signature the victim was
+        /// induced to make under `SIGHASH_NONE | SIGHASH_ANYONECANPAY` commits to
+        /// neither the outputs nor the other inputs, so it is equally a valid
+        /// authorization of a transaction the victim never saw, which pays the attacker.
+        ///
+        /// The Signer refuses to produce this signature at all unless the caller opts in,
+        /// which is what `signer_rejects_hostile_sighash_type` covers; this test is what
+        /// makes that refusal worth having.
+        #[test]
+        fn a_non_all_signature_authorizes_the_attackers_transaction() {
+            let hostile = SIGHASH_NONE | SIGHASH_ANYONECANPAY;
+            let sig = victim_signature(hostile, SighashPolicy::ANY);
+
+            assert!(
+                authorizes(&sig, tampered_pczt(|input| input.sighash_type = hostile)),
+                "the victim's signature should authorize the transaction they were shown",
+            );
+            assert!(
+                authorizes(&sig, attacker_pczt(hostile)),
+                "and, because it commits to neither the outputs nor the other inputs, \
+                 the attacker's transaction as well",
+            );
+        }
+
+        /// The contrast: a `SIGHASH_ALL` signature over the same input commits to the
+        /// whole transaction the victim was shown, so it authorizes nothing else.
+        #[test]
+        fn an_all_signature_authorizes_nothing_else() {
+            let sig = victim_signature(SIGHASH_ALL, SighashPolicy::ALL_ONLY);
+
+            // Establishes that the negative below is a real refusal rather than, say, a
+            // signature that fails to verify against anything at all.
+            assert!(
+                authorizes(&sig, transparent_pczt()),
+                "the victim's signature should authorize the transaction they were shown",
+            );
+            assert!(
+                !authorizes(&sig, attacker_pczt(SIGHASH_ALL)),
+                "but not the attacker's",
+            );
         }
 
         #[test]

--- a/pczt/src/roles.rs
+++ b/pczt/src/roles.rs
@@ -90,4 +90,354 @@ mod tests {
             io_finalizer::Error::NoSpends,
         ));
     }
+
+    /// Tests that a hostile Creator, Updater, or Combiner cannot induce the Signer or the
+    /// Spend Finalizer into producing a spend authorization over data that the coin being
+    /// spent does not commit to.
+    ///
+    /// These use a transparent-only PCZT so that the IO Finalizer does no shielded work
+    /// and no proving keys are needed.
+    #[cfg(all(
+        feature = "io-finalizer",
+        feature = "signer",
+        feature = "spend-finalizer",
+        feature = "zcp-builder"
+    ))]
+    mod transparent_authentication {
+        use ::transparent::{
+            address::TransparentAddress,
+            bundle::{OutPoint, TxOut},
+            pczt::{SignerError, SpendFinalizerError, VerifyError},
+            sighash::{
+                SIGHASH_ALL, SIGHASH_ANYONECANPAY, SIGHASH_NONE, SIGHASH_SINGLE, SighashPolicy,
+            },
+        };
+        use rand_core::OsRng;
+        use zcash_primitives::transaction::{
+            builder::{BuildConfig, Builder, BundlePadding, PcztResult},
+            fees::zip317,
+        };
+        use zcash_protocol::{consensus::MainNetwork, value::Zatoshis};
+
+        use crate::{
+            Pczt,
+            roles::{
+                creator::Creator, io_finalizer::IoFinalizer, signer, signer::Signer,
+                spend_finalizer, spend_finalizer::SpendFinalizer,
+            },
+        };
+
+        const SIGHASH_ALL_ANYONECANPAY: u8 = SIGHASH_ALL | SIGHASH_ANYONECANPAY;
+
+        fn secret_key() -> secp256k1::SecretKey {
+            secp256k1::SecretKey::from_slice(&[1; 32]).expect("valid")
+        }
+
+        fn public_key(sk: &secp256k1::SecretKey) -> secp256k1::PublicKey {
+            sk.public_key(&secp256k1::Secp256k1::signing_only())
+        }
+
+        /// The coin the victim is being asked to spend.
+        fn victim_coin() -> (OutPoint, TxOut) {
+            let addr = TransparentAddress::from_pubkey(&public_key(&secret_key()));
+            (
+                OutPoint::new([1; 32], 1),
+                TxOut::new(Zatoshis::const_from_u64(1_000_000), addr.script().into()),
+            )
+        }
+
+        fn builder() -> Builder<MainNetwork, ()> {
+            Builder::new(
+                MainNetwork,
+                10_000_000.into(),
+                BuildConfig::Standard {
+                    sapling_anchor: None,
+                    orchard_anchor: None,
+                    ironwood_anchor: None,
+                    orchard_padding: BundlePadding::DEFAULT,
+                    ironwood_padding: BundlePadding::DEFAULT,
+                },
+            )
+        }
+
+        fn finalize(builder: Builder<MainNetwork, ()>) -> Pczt {
+            let PcztResult { pczt_parts, .. } = builder
+                .build_for_pczt(OsRng, &zip317::FeeRule::standard())
+                .unwrap();
+
+            IoFinalizer::new(Creator::build_from_parts(pczt_parts).unwrap())
+                .finalize_io()
+                .unwrap()
+        }
+
+        /// A PCZT spending a single P2PKH coin back to the victim's own address: the
+        /// transaction the victim believes it is authorizing.
+        fn transparent_pczt() -> Pczt {
+            let pubkey = public_key(&secret_key());
+            let addr = TransparentAddress::from_pubkey(&pubkey);
+            let (utxo, coin) = victim_coin();
+
+            let mut builder = builder();
+            builder
+                .add_transparent_p2pkh_input(pubkey, utxo, coin)
+                .unwrap();
+            builder
+                .add_transparent_output(&addr, Zatoshis::const_from_u64(990_000))
+                .unwrap();
+            finalize(builder)
+        }
+
+        /// A PCZT whose single input has been tampered with by a hostile counterparty.
+        fn tampered_pczt(f: impl FnOnce(&mut crate::transparent::Input)) -> Pczt {
+            let mut pczt = transparent_pczt();
+            f(&mut pczt.transparent.inputs[0]);
+            pczt
+        }
+
+        /// A Signer over a PCZT tampered with by `f`, under `sighash_policy`.
+        fn signer(
+            f: impl FnOnce(&mut crate::transparent::Input),
+            sighash_policy: SighashPolicy,
+        ) -> Signer {
+            Signer::new(tampered_pczt(f))
+                .unwrap()
+                .with_transparent_sighash_policy(sighash_policy)
+        }
+
+        /// The sighash for the single input of `pczt`, computed under a policy wide
+        /// enough to admit whatever sighash type it carries.
+        fn unguarded_sighash(pczt: Pczt) -> [u8; 32] {
+            Signer::new(pczt)
+                .unwrap()
+                .with_transparent_sighash_policy(SighashPolicy::ANY)
+                .transparent_sighash(0)
+                .unwrap()
+        }
+
+        /// Signs `sighash` externally — as the counterparty who chose the input's
+        /// sighash type would — and offers the signature to a Signer with the default
+        /// policy.
+        fn append(pczt: Pczt, sighash: [u8; 32]) -> Result<(), signer::Error> {
+            let sig = secp256k1::Secp256k1::new()
+                .sign_ecdsa(&secp256k1::Message::from_digest(sighash), &secret_key());
+            Signer::new(pczt)
+                .unwrap()
+                .append_transparent_signature(0, sig)
+        }
+
+        #[test]
+        fn signer_rejects_unauthenticated_redeem_script() {
+            // The coin being spent is P2PKH, so it commits to no redeem script at all;
+            // `Input::sign` would otherwise search this one for the signer’s pubkey and
+            // commit to it in the sighash.
+            let mut signer = signer(
+                |input| input.redeem_script = Some(vec![0x51]),
+                SighashPolicy::ALL_ONLY,
+            );
+
+            assert!(matches!(
+                signer.sign_transparent(0, &secret_key()),
+                Err(signer::Error::TransparentSign(SignerError::InvalidInput(
+                    VerifyError::NotP2sh
+                ))),
+            ));
+        }
+
+        /// The external-signature path has to authenticate the input for the same reason.
+        #[test]
+        fn signer_rejects_unauthenticated_redeem_script_when_appending() {
+            // The input is refused before the signature is examined, so what was signed
+            // does not matter — and the Signer will not compute a sighash over this input
+            // for us to sign in the first place.
+            assert!(matches!(
+                append(
+                    tampered_pczt(|input| input.redeem_script = Some(vec![0x51])),
+                    [0; 32],
+                ),
+                Err(signer::Error::TransparentSign(SignerError::InvalidInput(
+                    VerifyError::NotP2sh
+                ))),
+            ));
+        }
+
+        /// The same holds for the sighash the Signer hands to an external signer: whoever
+        /// signs it is authorizing whatever it commits to.
+        #[test]
+        fn signer_rejects_unauthenticated_redeem_script_when_computing_sighash() {
+            let signer = signer(
+                |input| input.redeem_script = Some(vec![0x51]),
+                SighashPolicy::ALL_ONLY,
+            );
+
+            assert!(matches!(
+                signer.transparent_sighash(0),
+                Err(signer::Error::TransparentSign(SignerError::InvalidInput(
+                    VerifyError::NotP2sh
+                ))),
+            ));
+        }
+
+        #[test]
+        fn signer_rejects_hostile_sighash_type() {
+            let mut signer = signer(
+                |input| input.sighash_type = SIGHASH_NONE | SIGHASH_ANYONECANPAY,
+                SighashPolicy::ALL_ONLY,
+            );
+
+            assert!(matches!(
+                signer.sign_transparent(0, &secret_key()),
+                Err(signer::Error::TransparentSign(
+                    SignerError::DisallowedSighashType(_)
+                )),
+            ));
+        }
+
+        #[test]
+        fn signer_rejects_hostile_sighash_type_when_appending() {
+            let pczt =
+                tampered_pczt(|input| input.sighash_type = SIGHASH_NONE | SIGHASH_ANYONECANPAY);
+            let sighash = unguarded_sighash(pczt.clone());
+
+            assert!(matches!(
+                append(pczt, sighash),
+                Err(signer::Error::TransparentSign(
+                    SignerError::DisallowedSighashType(_)
+                )),
+            ));
+        }
+
+        #[test]
+        fn signer_rejects_hostile_sighash_type_when_computing_sighash() {
+            let signer = signer(
+                |input| input.sighash_type = SIGHASH_NONE | SIGHASH_ANYONECANPAY,
+                SighashPolicy::ALL_ONLY,
+            );
+
+            assert!(matches!(
+                signer.transparent_sighash(0),
+                Err(signer::Error::TransparentSign(
+                    SignerError::DisallowedSighashType(_)
+                )),
+            ));
+        }
+
+        #[test]
+        fn signer_accepts_hostile_sighash_type_under_explicit_policy() {
+            let mut signer = signer(
+                |input| input.sighash_type = SIGHASH_NONE | SIGHASH_ANYONECANPAY,
+                SighashPolicy::ANY,
+            );
+
+            assert!(signer.sign_transparent(0, &secret_key()).is_ok());
+        }
+
+        /// Signs the single input of a PCZT tampered with by `f`, under `sighash_policy`.
+        fn signed(
+            f: impl FnOnce(&mut crate::transparent::Input),
+            sighash_policy: SighashPolicy,
+        ) -> Pczt {
+            let mut signer = signer(f, sighash_policy);
+            signer.sign_transparent(0, &secret_key()).unwrap();
+            signer.finish()
+        }
+
+        /// A signed PCZT whose input uses `SIGHASH_NONE`.
+        fn signed_sighash_none() -> Pczt {
+            signed(
+                |input| input.sighash_type = SIGHASH_NONE,
+                SighashPolicy::ANY,
+            )
+        }
+
+        #[test]
+        fn finalizer_rejects_non_all_sighash_type() {
+            assert!(matches!(
+                SpendFinalizer::new(signed_sighash_none()).finalize_spends(),
+                Err(spend_finalizer::Error::TransparentFinalize(
+                    SpendFinalizerError::DisallowedSighashType(_)
+                )),
+            ));
+        }
+
+        #[test]
+        fn finalizer_accepts_non_all_sighash_type_under_explicit_policy() {
+            assert!(
+                SpendFinalizer::new(signed_sighash_none())
+                    .with_sighash_policy(SighashPolicy::ANY)
+                    .finalize_spends()
+                    .is_ok()
+            );
+        }
+
+        #[test]
+        fn finalizer_accepts_all_sighash_type() {
+            let pczt = signed(|_| (), SighashPolicy::ALL_ONLY);
+            assert!(SpendFinalizer::new(pczt).finalize_spends().is_ok());
+        }
+
+        #[test]
+        fn finalizer_accepts_sighash_single() {
+            let pczt = signed(
+                |input| input.sighash_type = SIGHASH_SINGLE,
+                SighashPolicy::ANY,
+            );
+
+            assert!(
+                SpendFinalizer::new(pczt)
+                    .with_sighash_policy(SighashPolicy::ANY)
+                    .finalize_spends()
+                    .is_ok()
+            );
+        }
+
+        /// Inputs of a single transaction may deliberately use different sighash types:
+        /// contributors sign `SIGHASH_ALL | SIGHASH_ANYONECANPAY` so that the input set
+        /// stays open, and whoever assembles the transaction fixes it with a
+        /// `SIGHASH_ALL` signature over their own input.
+        #[test]
+        fn finalizer_accepts_mixed_sighash_types() {
+            let contributor_sk = secp256k1::SecretKey::from_slice(&[3; 32]).expect("valid");
+            let contributor_pubkey = public_key(&contributor_sk);
+            let contributor_utxo = OutPoint::new([3; 32], 0);
+            let contributor_coin = TxOut::new(
+                Zatoshis::const_from_u64(1_000_000),
+                TransparentAddress::from_pubkey(&contributor_pubkey)
+                    .script()
+                    .into(),
+            );
+            let (assembler_utxo, assembler_coin) = victim_coin();
+            let addr = TransparentAddress::from_pubkey(&public_key(&secret_key()));
+
+            let mut builder = builder();
+            builder
+                .add_transparent_p2pkh_input(
+                    public_key(&secret_key()),
+                    assembler_utxo,
+                    assembler_coin,
+                )
+                .unwrap();
+            builder
+                .add_transparent_p2pkh_input(contributor_pubkey, contributor_utxo, contributor_coin)
+                .unwrap();
+            builder
+                .add_transparent_output(&addr, Zatoshis::const_from_u64(1_990_000))
+                .unwrap();
+
+            let mut pczt = finalize(builder);
+            pczt.transparent.inputs[1].sighash_type = SIGHASH_ALL_ANYONECANPAY;
+
+            let mut signer = Signer::new(pczt)
+                .unwrap()
+                .with_transparent_sighash_policy(SighashPolicy::ANY);
+            signer.sign_transparent(0, &secret_key()).unwrap();
+            signer.sign_transparent(1, &contributor_sk).unwrap();
+
+            assert!(
+                SpendFinalizer::new(signer.finish())
+                    .with_sighash_policy(SighashPolicy::ANY)
+                    .finalize_spends()
+                    .is_ok()
+            );
+        }
+    }
 }

--- a/pczt/src/roles/signer/mod.rs
+++ b/pczt/src/roles/signer/mod.rs
@@ -200,6 +200,10 @@ impl Signer {
     /// This can be used to produce a signature externally suitable for passing to e.g.
     /// [`Self::append_transparent_signature`].}
     ///
+    /// Whoever signs the returned sighash is authorizing whatever it commits to, so the
+    /// consistency of the input and the acceptability of its sighash type are checked
+    /// here, exactly as they are when this Signer produces the signature itself.
+    ///
     /// Returns an error if `index` is invalid for this PCZT.
     pub fn transparent_sighash(&self, index: usize) -> Result<[u8; 32], Error> {
         let input = self

--- a/pczt/src/roles/signer/mod.rs
+++ b/pczt/src/roles/signer/mod.rs
@@ -19,7 +19,7 @@ use blake2b_simd::Hash as Blake2bHash;
 use orchard::primitives::redpallas;
 use rand_core::OsRng;
 
-use ::transparent::sighash::{SIGHASH_ANYONECANPAY, SIGHASH_NONE, SIGHASH_SINGLE};
+use ::transparent::sighash::{SIGHASH_ANYONECANPAY, SIGHASH_NONE, SIGHASH_SINGLE, SighashPolicy};
 use zcash_primitives::transaction::{
     TransactionData, TxDigests, sighash::SignableInput, txid::TxIdDigester,
 };
@@ -127,6 +127,7 @@ pub struct Signer {
     txid_parts: TxDigests<Blake2bHash>,
     shielded_sighash: [u8; 32],
     secp: secp256k1::Secp256k1<secp256k1::All>,
+    transparent_sighash_policy: SighashPolicy,
 }
 
 impl Signer {
@@ -171,7 +172,18 @@ impl Signer {
             txid_parts,
             shielded_sighash,
             secp: secp256k1::Secp256k1::new(),
+            transparent_sighash_policy: SighashPolicy::ALL_ONLY,
         })
+    }
+
+    /// Sets the sighash policy that this Signer applies to transparent inputs.
+    ///
+    /// The default is [`SighashPolicy::ALL_ONLY`]; see [`SighashPolicy`] for why the
+    /// sighash type a counterparty placed in the PCZT is only used if this Signer’s own
+    /// policy permits it.
+    pub fn with_transparent_sighash_policy(mut self, sighash_policy: SighashPolicy) -> Self {
+        self.transparent_sighash_policy = sighash_policy;
+        self
     }
 
     /// Calculates the signature digest that must be signed to authorize shielded spends.
@@ -196,13 +208,19 @@ impl Signer {
             .get(index)
             .ok_or(Error::InvalidIndex)?;
 
-        input.with_signable_input(index, |signable_input| {
-            Ok(sighash(
-                &self.tx_data,
-                &SignableInput::Transparent(signable_input),
-                &self.txid_parts,
-            ))
-        })
+        input
+            .with_signable_input_with_sighash_policy(
+                index,
+                |signable_input| {
+                    sighash(
+                        &self.tx_data,
+                        &SignableInput::Transparent(signable_input),
+                        &self.txid_parts,
+                    )
+                },
+                self.transparent_sighash_policy,
+            )
+            .map_err(Error::TransparentSign)
     }
 
     /// Signs the transparent spend at the given index with the given spending key.
@@ -215,12 +233,14 @@ impl Signer {
         index: usize,
         sk: &secp256k1::SecretKey,
     ) -> Result<(), Error> {
+        let sighash_policy = self.transparent_sighash_policy;
         self.generate_or_append_transparent_signature(index, |input, tx_data, txid_parts, secp| {
-            input.sign(
+            input.sign_with_sighash_policy(
                 index,
                 |input| sighash(tx_data, &SignableInput::Transparent(input), txid_parts),
                 sk,
                 secp,
+                sighash_policy,
             )
         })
     }
@@ -235,12 +255,14 @@ impl Signer {
         index: usize,
         signature: secp256k1::ecdsa::Signature,
     ) -> Result<(), Error> {
+        let sighash_policy = self.transparent_sighash_policy;
         self.generate_or_append_transparent_signature(index, |input, tx_data, txid_parts, secp| {
-            input.append_signature(
+            input.append_signature_with_sighash_policy(
                 index,
                 |input| sighash(tx_data, &SignableInput::Transparent(input), txid_parts),
                 signature,
                 secp,
+                sighash_policy,
             )
         })
     }
@@ -264,8 +286,10 @@ impl Signer {
             .get_mut(index)
             .ok_or(Error::InvalidIndex)?;
 
-        // Check consistency of the input being signed.
-        // TODO
+        // The consistency of the input being signed, and the acceptability of its sighash
+        // type, are checked by the `zcash_transparent` methods that `f` calls. They are
+        // enforced there rather than here because `crate::roles::low_level_signer` hands
+        // out the transparent bundle and calls those methods directly.
 
         // Generate or apply the signature.
         f(input, &self.tx_data, &self.txid_parts, &self.secp).map_err(Error::TransparentSign)?;
@@ -533,6 +557,7 @@ impl Signer {
             txid_parts: _,
             shielded_sighash: _,
             secp: _,
+            transparent_sighash_policy: _,
         } = self;
 
         Pczt {

--- a/pczt/src/roles/spend_finalizer/mod.rs
+++ b/pczt/src/roles/spend_finalizer/mod.rs
@@ -2,32 +2,59 @@
 //!
 //! - Combines partial transparent signatures into `script_sig`s.
 
+use ::transparent::sighash::SighashPolicy;
+
 use crate::Pczt;
 
 pub struct SpendFinalizer {
     pczt: Pczt,
+    sighash_policy: SighashPolicy,
 }
 
 impl SpendFinalizer {
     /// Instantiates the Spend Finalizer role with the given PCZT.
     pub fn new(pczt: Pczt) -> Self {
-        Self { pczt }
+        Self {
+            pczt,
+            sighash_policy: SighashPolicy::ALL_ONLY,
+        }
+    }
+
+    /// Sets the sighash policy that this Spend Finalizer applies to partial signatures.
+    ///
+    /// The default is [`SighashPolicy::ALL_ONLY`]; see [`SighashPolicy`] for why.
+    ///
+    /// This policy governs which signatures are assembled into `script_sig`s; it does not
+    /// protect whoever produced them. A partial signature that does not commit to the
+    /// whole transaction can be lifted out of the PCZT and used directly, without this
+    /// role ever running, so the decision that protects a signer is the Signer's own
+    /// [`Signer::with_transparent_sighash_policy`].
+    ///
+    /// [`Signer::with_transparent_sighash_policy`]: crate::roles::signer::Signer::with_transparent_sighash_policy
+    pub fn with_sighash_policy(mut self, sighash_policy: SighashPolicy) -> Self {
+        self.sighash_policy = sighash_policy;
+        self
     }
 
     /// Finalizes the spends of the PCZT.
     pub fn finalize_spends(self) -> Result<Pczt, Error> {
+        let Self {
+            pczt,
+            sighash_policy,
+        } = self;
+
         let Pczt {
             global,
             transparent,
             sapling,
             orchard,
             ironwood,
-        } = self.pczt;
+        } = pczt;
 
         let mut transparent = transparent.into_parsed().map_err(Error::TransparentParse)?;
 
         transparent
-            .finalize_spends()
+            .finalize_spends_with_sighash_policy(sighash_policy)
             .map_err(Error::TransparentFinalize)?;
 
         Ok(Pczt {

--- a/zcash_transparent/CHANGELOG.md
+++ b/zcash_transparent/CHANGELOG.md
@@ -37,6 +37,12 @@ workspace.
     unverified `script_code`, or for a counterparty's chosen sighash type, was
     equivalent to signing over it. Use
     `Input::with_signable_input_with_sighash_policy` to permit other sighash types.
+  - `Bundle::finalize_spends` now requires every partial signature it uses to end
+    in a sighash-type byte matching its input's `sighash_type`, and finalizes only
+    `SighashType::ALL` signatures. Signatures that are discarded rather than placed
+    into a `script_sig` are not checked, so that a Combiner cannot block
+    finalization by contributing junk. Use
+    `Bundle::finalize_spends_with_sighash_policy` to permit other sighash types.
   - `SignerError` has added variants:
     - `DisallowedSighashType`
     - `InvalidInput`

--- a/zcash_transparent/CHANGELOG.md
+++ b/zcash_transparent/CHANGELOG.md
@@ -26,14 +26,17 @@ workspace.
   position.
 - `zcash_transparent::pczt`:
   - `Input::sign` and `Input::append_signature` now verify the consistency of the
-    input before signing it, returning `SignerError::InvalidInput` if the input
-    sets a `redeem_script` that its `script_pubkey` does not commit to. Previously
-    the `redeem_script` was used unchecked, both to locate the pubkey to sign with
-    and as the `script_code` committed to by the signature.
-  - `Input::with_signable_input` now applies the same verification, and returns
+    input before signing it, and sign only for `SighashType::ALL`. Previously the
+    `redeem_script` was used unchecked (both to locate the pubkey to sign with and
+    as the `script_code` committed to by the signature), and the sighash type was
+    taken verbatim from the PCZT. Use `Input::sign_with_sighash_policy` or
+    `Input::append_signature_with_sighash_policy` to permit other sighash types.
+  - `Input::with_signable_input` now applies those same checks, and returns
     `Result<T, SignerError>` instead of `T`. Whoever signs the sighash it prepares
     is authorizing whatever that sighash commits to, so preparing one over an
-    unverified `script_code` was equivalent to signing over it.
+    unverified `script_code`, or for a counterparty's chosen sighash type, was
+    equivalent to signing over it. Use
+    `Input::with_signable_input_with_sighash_policy` to permit other sighash types.
   - `SignerError` has added variants:
     - `DisallowedSighashType`
     - `InvalidInput`

--- a/zcash_transparent/CHANGELOG.md
+++ b/zcash_transparent/CHANGELOG.md
@@ -25,6 +25,15 @@ workspace.
   `ShieldingOvks::internal` or `ShieldingOvks::external` instead of by tuple
   position.
 - `zcash_transparent::pczt`:
+  - `Input::sign` and `Input::append_signature` now verify the consistency of the
+    input before signing it, returning `SignerError::InvalidInput` if the input
+    sets a `redeem_script` that its `script_pubkey` does not commit to. Previously
+    the `redeem_script` was used unchecked, both to locate the pubkey to sign with
+    and as the `script_code` committed to by the signature.
+  - `Input::with_signable_input` now applies the same verification, and returns
+    `Result<T, SignerError>` instead of `T`. Whoever signs the sighash it prepares
+    is authorizing whatever that sighash commits to, so preparing one over an
+    unverified `script_code` was equivalent to signing over it.
   - `SignerError` has added variants:
     - `DisallowedSighashType`
     - `InvalidInput`

--- a/zcash_transparent/CHANGELOG.md
+++ b/zcash_transparent/CHANGELOG.md
@@ -13,12 +13,24 @@ workspace.
 ### Added
 - `zcash_transparent::keys::ShieldingOvks`
 - `zcash_transparent::sighash::SighashPolicy`
+- `zcash_transparent::pczt`:
+  - `Input::sign_with_sighash_policy`
+  - `Input::append_signature_with_sighash_policy`
+  - `Input::with_signable_input_with_sighash_policy`
+  - `Bundle::finalize_spends_with_sighash_policy`
 
 ### Changed
 - `zcash_transparent::keys::AccountPubKey::ovks_for_shielding` now returns
   `ShieldingOvks` instead of `(InternalOvk, ExternalOvk)`. Read each key from
   `ShieldingOvks::internal` or `ShieldingOvks::external` instead of by tuple
   position.
+- `zcash_transparent::pczt`:
+  - `SignerError` has added variants:
+    - `DisallowedSighashType`
+    - `InvalidInput`
+  - `SpendFinalizerError` has added variants:
+    - `DisallowedSighashType`
+    - `MismatchedSighashType`
 
 ## [0.10.0] - 2026-07-23
 

--- a/zcash_transparent/CHANGELOG.md
+++ b/zcash_transparent/CHANGELOG.md
@@ -12,6 +12,7 @@ workspace.
 
 ### Added
 - `zcash_transparent::keys::ShieldingOvks`
+- `zcash_transparent::sighash::SighashPolicy`
 
 ### Changed
 - `zcash_transparent::keys::AccountPubKey::ovks_for_shielding` now returns

--- a/zcash_transparent/src/pczt.rs
+++ b/zcash_transparent/src/pczt.rs
@@ -322,3 +322,78 @@ impl Bip32Derivation {
         }
     }
 }
+
+#[cfg(test)]
+pub(crate) mod testing {
+    //! Helpers shared between the tests of this module's submodules.
+
+    use alloc::collections::BTreeMap;
+    use alloc::vec::Vec;
+
+    use zcash_protocol::{TxId, value::Zatoshis};
+    use zcash_script::{
+        pattern,
+        script::{self, Evaluable},
+    };
+
+    use crate::{address::TransparentAddress, sighash::SighashType, util::hash160};
+
+    use super::Input;
+
+    /// The P2PKH `script_pubkey` paying to `pubkey`.
+    pub(crate) fn p2pkh(pubkey: &[u8; 33]) -> script::FromChain {
+        TransparentAddress::PublicKeyHash(hash160::hash(pubkey))
+            .script()
+            .weaken()
+    }
+
+    /// The P2SH `script_pubkey` committing to `redeem_script`.
+    pub(crate) fn p2sh(redeem_script: &script::FromChain) -> script::FromChain {
+        TransparentAddress::ScriptHash(hash160::hash(&redeem_script.to_bytes()))
+            .script()
+            .weaken()
+    }
+
+    /// A bare `required`-of-`pubkeys.len()` P2MS script.
+    pub(crate) fn p2ms(required: u8, pubkeys: &[&[u8; 33]]) -> script::FromChain {
+        let pubkeys = pubkeys.iter().map(|pubkey| &pubkey[..]).collect::<Vec<_>>();
+        script::Component(pattern::check_multisig(required, &pubkeys, false).expect("valid"))
+            .weaken()
+    }
+
+    /// A bare P2PK script.
+    ///
+    /// Only the Signer supports these, and it is compiled only with
+    /// `transparent-inputs`.
+    #[cfg(feature = "transparent-inputs")]
+    pub(crate) fn p2pk(pubkey: &[u8; 33]) -> script::FromChain {
+        script::Component(pattern::pay_to_pubkey(pubkey).expect("valid").to_vec()).weaken()
+    }
+
+    /// An input spending a coin with the given script, carrying no signatures.
+    pub(crate) fn input(
+        script_pubkey: script::FromChain,
+        redeem_script: Option<script::FromChain>,
+        sighash_type: SighashType,
+    ) -> Input {
+        Input {
+            prevout_txid: TxId::from_bytes([0; 32]),
+            prevout_index: 0,
+            sequence: None,
+            required_time_lock_time: None,
+            required_height_lock_time: None,
+            script_sig: None,
+            value: Zatoshis::const_from_u64(1_000_000),
+            script_pubkey,
+            redeem_script,
+            partial_signatures: BTreeMap::new(),
+            sighash_type,
+            bip32_derivation: BTreeMap::new(),
+            ripemd160_preimages: BTreeMap::new(),
+            sha256_preimages: BTreeMap::new(),
+            hash160_preimages: BTreeMap::new(),
+            hash256_preimages: BTreeMap::new(),
+            proprietary: BTreeMap::new(),
+        }
+    }
+}

--- a/zcash_transparent/src/pczt/signer.rs
+++ b/zcash_transparent/src/pczt/signer.rs
@@ -16,8 +16,10 @@ impl Input {
     /// to produce a signature externally suitable for passing to [`Self::append_signature`].
     ///
     /// The `script_code` that the sighash commits to is checked against the coin being
-    /// spent. Whoever signs the resulting sighash is authorizing whatever it commits to,
-    /// so this is the same check that [`Input::sign`] makes.
+    /// spent, and only [`SighashType::ALL`] is prepared for; use
+    /// [`Input::with_signable_input_with_sighash_policy`] for a wider policy. Whoever
+    /// signs the resulting sighash is authorizing whatever it commits to, so these are
+    /// the same checks that [`Input::sign`] makes.
     pub fn with_signable_input<T, F>(&self, index: usize, f: F) -> Result<T, SignerError>
     where
         F: FnOnce(SignableInput) -> T,
@@ -39,7 +41,7 @@ impl Input {
     where
         F: FnOnce(SignableInput) -> T,
     {
-        let _ = sighash_policy;
+        self.check_sighash_policy(sighash_policy)?;
         self.verify_for_signing()?;
 
         // For P2PKH, `script_code` is always the same as `script_pubkey`.
@@ -52,6 +54,16 @@ impl Input {
             script_pubkey: &Script::from(&self.script_pubkey),
             value: self.value,
         }))
+    }
+
+    /// The sighash type reaches us from whoever gave us this PCZT, so it is our policy,
+    /// not theirs, that decides whether to authorize such a signature.
+    fn check_sighash_policy(&self, sighash_policy: SighashPolicy) -> Result<(), SignerError> {
+        if sighash_policy.permits(self.sighash_type) {
+            Ok(())
+        } else {
+            Err(SignerError::DisallowedSighashType(self.sighash_type))
+        }
     }
 
     /// The `redeem_script` reaches us from whoever gave us this PCZT, and the signing
@@ -113,7 +125,7 @@ impl Input {
     where
         F: FnOnce(SignableInput) -> [u8; 32],
     {
-        let _ = sighash_policy;
+        self.check_sighash_policy(sighash_policy)?;
         self.verify_for_signing()?;
 
         let pubkey = sk.public_key(secp).serialize();
@@ -225,7 +237,7 @@ impl Input {
     where
         F: FnOnce(SignableInput) -> [u8; 32],
     {
-        let _ = sighash_policy;
+        self.check_sighash_policy(sighash_policy)?;
         self.verify_for_signing()?;
 
         // For P2PKH, `script_code` is always the same as `script_pubkey`.

--- a/zcash_transparent/src/pczt/signer.rs
+++ b/zcash_transparent/src/pczt/signer.rs
@@ -4,35 +4,61 @@ use zcash_script::solver;
 
 use crate::{
     address::{Script, TransparentAddress},
-    sighash::SignableInput,
+    sighash::{SighashPolicy, SighashType, SignableInput},
 };
 
-impl super::Input {
+use super::{Input, VerifyError};
+
+impl Input {
     /// Helper to prepare a [`SignableInput`] for this input.
     ///
     /// This can be used to calculate the sighash for this input within its transaction,
     /// to produce a signature externally suitable for passing to [`Self::append_signature`].
-    pub fn with_signable_input<T, F>(&self, index: usize, f: F) -> T
+    pub fn with_signable_input<T, F>(&self, index: usize, f: F) -> Result<T, SignerError>
     where
         F: FnOnce(SignableInput) -> T,
     {
+        self.with_signable_input_with_sighash_policy(index, f, SighashPolicy::ALL_ONLY)
+    }
+
+    /// Helper to prepare a [`SignableInput`] for this input, if the input’s sighash type
+    /// is permitted by `sighash_policy`.
+    ///
+    /// Otherwise behaves exactly as [`Input::with_signable_input`], which should be
+    /// preferred.
+    pub fn with_signable_input_with_sighash_policy<T, F>(
+        &self,
+        index: usize,
+        f: F,
+        sighash_policy: SighashPolicy,
+    ) -> Result<T, SignerError>
+    where
+        F: FnOnce(SignableInput) -> T,
+    {
+        let _ = sighash_policy;
+
         // For P2PKH, `script_code` is always the same as `script_pubkey`.
         let script_code = self.redeem_script.as_ref().unwrap_or(&self.script_pubkey);
 
-        f(SignableInput {
+        Ok(f(SignableInput {
             hash_type: self.sighash_type,
             index,
             script_code: &Script::from(script_code),
             script_pubkey: &Script::from(&self.script_pubkey),
             value: self.value,
-        })
+        }))
     }
 
     /// Signs the transparent spend with the given spend authorizing key.
     ///
-    /// It is the caller's responsibility to perform any semantic validity checks on the
-    /// PCZT (for example, comfirming that the change amounts are correct) before calling
-    /// this method.
+    /// This checks the consistency of the input being signed (in particular, that any
+    /// `redeem_script` really is the script committed to by `script_pubkey`), but it is
+    /// the caller's responsibility to perform any semantic validity checks on the rest of
+    /// the PCZT (for example, confirming that the change amounts are correct) before
+    /// calling this method.
+    ///
+    /// Only [`SighashType::ALL`] is signed for; use
+    /// [`Input::sign_with_sighash_policy`] to sign with a wider policy.
     ///
     /// Returns an error if the spend authorizing key does not match any pubkey involved
     /// with spend control of the input's spent coin. The supported script formats are:
@@ -49,6 +75,27 @@ impl super::Input {
     where
         F: FnOnce(SignableInput) -> [u8; 32],
     {
+        self.sign_with_sighash_policy(index, calculate_sighash, sk, secp, SighashPolicy::ALL_ONLY)
+    }
+
+    /// Signs the transparent spend with the given spend authorizing key, if the input’s
+    /// sighash type is permitted by `sighash_policy`. See [`SighashPolicy`] for why that
+    /// is a decision for the Signer rather than for whoever supplied the PCZT.
+    ///
+    /// Otherwise behaves exactly as [`Input::sign`], which should be preferred.
+    pub fn sign_with_sighash_policy<C: secp256k1::Signing, F>(
+        &mut self,
+        index: usize,
+        calculate_sighash: F,
+        sk: &secp256k1::SecretKey,
+        secp: &secp256k1::Secp256k1<C>,
+        sighash_policy: SighashPolicy,
+    ) -> Result<(), SignerError>
+    where
+        F: FnOnce(SignableInput) -> [u8; 32],
+    {
+        let _ = sighash_policy;
+
         let pubkey = sk.public_key(secp).serialize();
         let p2pkh_addr = TransparentAddress::from_pubkey_bytes(&pubkey);
 
@@ -104,9 +151,14 @@ impl super::Input {
 
     /// Appends the given signature to the transparent spend.
     ///
-    /// It is the caller's responsibility to perform any semantic validity checks on the
-    /// PCZT (for example, comfirming that the change amounts are correct) before calling
-    /// this method.
+    /// This checks the consistency of the input being signed (in particular, that any
+    /// `redeem_script` really is the script committed to by `script_pubkey`), but it is
+    /// the caller's responsibility to perform any semantic validity checks on the rest of
+    /// the PCZT (for example, confirming that the change amounts are correct) before
+    /// calling this method.
+    ///
+    /// Only signatures over [`SighashType::ALL`] are accepted; use
+    /// [`Input::append_signature_with_sighash_policy`] to accept a wider policy.
     ///
     /// Returns an error if the signature does not match any pubkey involved with spend
     /// control of the input's spent coin. The supported script formats are:
@@ -127,6 +179,34 @@ impl super::Input {
     where
         F: FnOnce(SignableInput) -> [u8; 32],
     {
+        self.append_signature_with_sighash_policy(
+            index,
+            calculate_sighash,
+            sig,
+            secp,
+            SighashPolicy::ALL_ONLY,
+        )
+    }
+
+    /// Appends the given signature to the transparent spend, if the input’s sighash type
+    /// is permitted by `sighash_policy`. See [`SighashPolicy`] for why that is a decision
+    /// for the Signer rather than for whoever supplied the PCZT.
+    ///
+    /// Otherwise behaves exactly as [`Input::append_signature`], which should be
+    /// preferred.
+    pub fn append_signature_with_sighash_policy<C: secp256k1::Verification, F>(
+        &mut self,
+        index: usize,
+        calculate_sighash: F,
+        sig: secp256k1::ecdsa::Signature,
+        secp: &secp256k1::Secp256k1<C>,
+        sighash_policy: SighashPolicy,
+    ) -> Result<(), SignerError>
+    where
+        F: FnOnce(SignableInput) -> [u8; 32],
+    {
+        let _ = sighash_policy;
+
         // For P2PKH, `script_code` is always the same as `script_pubkey`.
         let script_code = self.redeem_script.as_ref().unwrap_or(&self.script_pubkey);
         let script_kind = script_code
@@ -191,9 +271,13 @@ impl super::Input {
 /// Errors that can occur while signing a transparent input in a PCZT.
 #[derive(Debug)]
 pub enum SignerError {
+    /// The input's `sighash_type` is not permitted by the Signer's [`SighashPolicy`].
+    DisallowedSighashType(SighashType),
     /// A provided external signature was not valid for any detected pubkey involved with
     /// spend control of the input's spent coin.
     InvalidExternalSignature,
+    /// The input being signed is not internally consistent.
+    InvalidInput(VerifyError),
     /// A required entry in one of the preimage maps is missing.
     MissingPreimage,
     /// A pubkey within the transparent input uses an unsupported format.
@@ -201,4 +285,282 @@ pub enum SignerError {
     /// The provided `sk` does not match any pubkey involved with spend control of the
     /// input's spent coin.
     WrongSpendingKey,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SighashPolicy, SighashType, SignerError, VerifyError};
+    use crate::{
+        pczt::{
+            Input,
+            testing::{input, p2ms, p2pk, p2pkh, p2sh},
+        },
+        util::hash160,
+    };
+
+    /// Every sighash type other than `SighashType::ALL`.
+    const NON_ALL_TYPES: [SighashType; 5] = [
+        SighashType::NONE,
+        SighashType::SINGLE,
+        SighashType::ALL_ANYONECANPAY,
+        SighashType::NONE_ANYONECANPAY,
+        SighashType::SINGLE_ANYONECANPAY,
+    ];
+
+    /// The stub sighash that both signing paths are given.
+    const SIGHASH: [u8; 32] = [0; 32];
+
+    fn secret_key(i: u8) -> secp256k1::SecretKey {
+        secp256k1::SecretKey::from_slice(&[i; 32]).expect("valid")
+    }
+
+    fn pubkey(sk: &secp256k1::SecretKey) -> [u8; 33] {
+        sk.public_key(&secp256k1::Secp256k1::signing_only())
+            .serialize()
+    }
+
+    fn sign(
+        input: &mut Input,
+        sk: &secp256k1::SecretKey,
+        sighash_policy: SighashPolicy,
+    ) -> Result<(), SignerError> {
+        input.sign_with_sighash_policy(
+            0,
+            |_| SIGHASH,
+            sk,
+            &secp256k1::Secp256k1::signing_only(),
+            sighash_policy,
+        )
+    }
+
+    /// Appends an externally-produced signature over [`SIGHASH`] by `sk`.
+    fn append(
+        input: &mut Input,
+        sk: &secp256k1::SecretKey,
+        sighash_policy: SighashPolicy,
+    ) -> Result<(), SignerError> {
+        let secp = secp256k1::Secp256k1::new();
+        let sig = secp.sign_ecdsa(&secp256k1::Message::from_digest(SIGHASH), sk);
+        input.append_signature_with_sighash_policy(0, |_| SIGHASH, sig, &secp, sighash_policy)
+    }
+
+    /// A P2PKH input, with the `hash160` preimage that `Input::append_signature` needs in
+    /// order to recover the pubkey from the script.
+    fn p2pkh_input(sk: &secp256k1::SecretKey, sighash_type: SighashType) -> Input {
+        let mut input = input(p2pkh(&pubkey(sk)), None, sighash_type);
+        input
+            .hash160_preimages
+            .insert(hash160::hash(&pubkey(sk)), pubkey(sk).to_vec());
+        input
+    }
+
+    #[test]
+    fn sign_rejects_unmatched_redeem_script() {
+        let sk = secret_key(1);
+        // A `redeem_script` that the signer does control, but that the coin being spent
+        // does not commit to. Without a check, this is both searched for the signer's
+        // pubkey and committed to by the sighash.
+        let redeem_script = p2ms(1, &[&pubkey(&sk)]);
+        let other_script = p2ms(1, &[&pubkey(&secret_key(2))]);
+
+        let mut input = input(p2sh(&other_script), Some(redeem_script), SighashType::ALL);
+
+        assert!(matches!(
+            sign(&mut input, &sk, SighashPolicy::ALL_ONLY),
+            Err(SignerError::InvalidInput(VerifyError::WrongRedeemScript)),
+        ));
+        assert!(input.partial_signatures.is_empty());
+    }
+
+    #[test]
+    fn sign_rejects_redeem_script_on_p2pkh() {
+        let sk = secret_key(1);
+        let mut input = input(
+            p2pkh(&pubkey(&sk)),
+            Some(p2ms(1, &[&pubkey(&sk)])),
+            SighashType::ALL,
+        );
+
+        assert!(matches!(
+            sign(&mut input, &sk, SighashPolicy::ALL_ONLY),
+            Err(SignerError::InvalidInput(VerifyError::NotP2sh)),
+        ));
+        assert!(input.partial_signatures.is_empty());
+    }
+
+    #[test]
+    fn sign_accepts_matching_redeem_script() {
+        let sk = secret_key(1);
+        let redeem_script = p2ms(1, &[&pubkey(&sk)]);
+        let mut input = input(p2sh(&redeem_script), Some(redeem_script), SighashType::ALL);
+
+        assert!(sign(&mut input, &sk, SighashPolicy::ALL_ONLY).is_ok());
+        assert!(input.partial_signatures.contains_key(&pubkey(&sk)));
+    }
+
+    #[test]
+    fn sign_accepts_p2pkh() {
+        let sk = secret_key(1);
+        let mut input = input(p2pkh(&pubkey(&sk)), None, SighashType::ALL);
+
+        assert!(sign(&mut input, &sk, SighashPolicy::ALL_ONLY).is_ok());
+        assert!(input.partial_signatures.contains_key(&pubkey(&sk)));
+    }
+
+    /// `Input::verify` does not recognise bare P2PK `script_pubkey`s, but `Input::sign`
+    /// supports them.
+    #[test]
+    fn sign_accepts_bare_p2pk() {
+        let sk = secret_key(1);
+        let mut input = input(p2pk(&pubkey(&sk)), None, SighashType::ALL);
+
+        assert!(sign(&mut input, &sk, SighashPolicy::ALL_ONLY).is_ok());
+        assert!(input.partial_signatures.contains_key(&pubkey(&sk)));
+    }
+
+    /// `Input::verify` does not recognise bare P2MS `script_pubkey`s, but `Input::sign`
+    /// supports them.
+    #[test]
+    fn sign_accepts_bare_p2ms() {
+        let sk = secret_key(1);
+        let mut input = input(
+            p2ms(1, &[&pubkey(&sk), &pubkey(&secret_key(2))]),
+            None,
+            SighashType::ALL,
+        );
+
+        assert!(sign(&mut input, &sk, SighashPolicy::ALL_ONLY).is_ok());
+        assert!(input.partial_signatures.contains_key(&pubkey(&sk)));
+    }
+
+    #[test]
+    fn sign_rejects_non_all_sighash_types_by_default() {
+        let sk = secret_key(1);
+        for sighash_type in NON_ALL_TYPES {
+            let mut input = input(p2pkh(&pubkey(&sk)), None, sighash_type);
+
+            match sign(&mut input, &sk, SighashPolicy::ALL_ONLY) {
+                Err(SignerError::DisallowedSighashType(t)) => assert_eq!(t, sighash_type),
+                r => panic!("expected {sighash_type:?} to be refused, got {r:?}"),
+            }
+            assert!(input.partial_signatures.is_empty());
+        }
+    }
+
+    #[test]
+    fn sign_accepts_non_all_sighash_types_under_explicit_policy() {
+        let sk = secret_key(1);
+        for sighash_type in NON_ALL_TYPES {
+            let mut input = input(p2pkh(&pubkey(&sk)), None, sighash_type);
+
+            assert!(sign(&mut input, &sk, SighashPolicy::ANY).is_ok());
+            assert!(input.partial_signatures.contains_key(&pubkey(&sk)));
+        }
+    }
+
+    /// Preparing the sighash for an external signer hands out a commitment to the same
+    /// unverified `script_code`; whoever signs it authorizes whatever it commits to.
+    fn signable_input(
+        input: &Input,
+        sighash_policy: SighashPolicy,
+    ) -> Result<SighashType, SignerError> {
+        input.with_signable_input_with_sighash_policy(
+            0,
+            |signable_input| *signable_input.hash_type(),
+            sighash_policy,
+        )
+    }
+
+    #[test]
+    fn signable_input_rejects_unmatched_redeem_script() {
+        let sk = secret_key(1);
+        let redeem_script = p2ms(1, &[&pubkey(&sk)]);
+        let other_script = p2ms(1, &[&pubkey(&secret_key(2))]);
+
+        let input = input(p2sh(&other_script), Some(redeem_script), SighashType::ALL);
+
+        assert!(matches!(
+            signable_input(&input, SighashPolicy::ALL_ONLY),
+            Err(SignerError::InvalidInput(VerifyError::WrongRedeemScript)),
+        ));
+    }
+
+    #[test]
+    fn signable_input_rejects_non_all_sighash_types_by_default() {
+        let sk = secret_key(1);
+        for sighash_type in NON_ALL_TYPES {
+            let input = input(p2pkh(&pubkey(&sk)), None, sighash_type);
+
+            match signable_input(&input, SighashPolicy::ALL_ONLY) {
+                Err(SignerError::DisallowedSighashType(t)) => assert_eq!(t, sighash_type),
+                r => panic!("expected {sighash_type:?} to be refused, got {r:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn signable_input_accepts_non_all_sighash_types_under_explicit_policy() {
+        let sk = secret_key(1);
+        for sighash_type in NON_ALL_TYPES {
+            let input = input(p2pkh(&pubkey(&sk)), None, sighash_type);
+
+            assert_eq!(
+                signable_input(&input, SighashPolicy::ANY).ok(),
+                Some(sighash_type),
+            );
+        }
+    }
+
+    /// The external-signature path derives its `script_code` from the same unverified
+    /// `redeem_script`, and uses it both to enumerate candidate pubkeys and as the script
+    /// the signature commits to.
+    #[test]
+    fn append_rejects_unmatched_redeem_script() {
+        let sk = secret_key(1);
+        let redeem_script = p2ms(1, &[&pubkey(&sk)]);
+        let other_script = p2ms(1, &[&pubkey(&secret_key(2))]);
+
+        let mut input = input(p2sh(&other_script), Some(redeem_script), SighashType::ALL);
+
+        assert!(matches!(
+            append(&mut input, &sk, SighashPolicy::ALL_ONLY),
+            Err(SignerError::InvalidInput(VerifyError::WrongRedeemScript)),
+        ));
+        assert!(input.partial_signatures.is_empty());
+    }
+
+    #[test]
+    fn append_accepts_matching_redeem_script() {
+        let sk = secret_key(1);
+        let redeem_script = p2ms(1, &[&pubkey(&sk)]);
+        let mut input = input(p2sh(&redeem_script), Some(redeem_script), SighashType::ALL);
+
+        assert!(append(&mut input, &sk, SighashPolicy::ALL_ONLY).is_ok());
+        assert!(input.partial_signatures.contains_key(&pubkey(&sk)));
+    }
+
+    #[test]
+    fn append_rejects_non_all_sighash_types_by_default() {
+        let sk = secret_key(1);
+        for sighash_type in NON_ALL_TYPES {
+            let mut input = p2pkh_input(&sk, sighash_type);
+
+            match append(&mut input, &sk, SighashPolicy::ALL_ONLY) {
+                Err(SignerError::DisallowedSighashType(t)) => assert_eq!(t, sighash_type),
+                r => panic!("expected {sighash_type:?} to be refused, got {r:?}"),
+            }
+            assert!(input.partial_signatures.is_empty());
+        }
+    }
+
+    #[test]
+    fn append_accepts_non_all_sighash_types_under_explicit_policy() {
+        let sk = secret_key(1);
+        for sighash_type in NON_ALL_TYPES {
+            let mut input = p2pkh_input(&sk, sighash_type);
+
+            assert!(append(&mut input, &sk, SighashPolicy::ANY).is_ok());
+            assert!(input.partial_signatures.contains_key(&pubkey(&sk)));
+        }
+    }
 }

--- a/zcash_transparent/src/pczt/signer.rs
+++ b/zcash_transparent/src/pczt/signer.rs
@@ -14,6 +14,10 @@ impl Input {
     ///
     /// This can be used to calculate the sighash for this input within its transaction,
     /// to produce a signature externally suitable for passing to [`Self::append_signature`].
+    ///
+    /// The `script_code` that the sighash commits to is checked against the coin being
+    /// spent. Whoever signs the resulting sighash is authorizing whatever it commits to,
+    /// so this is the same check that [`Input::sign`] makes.
     pub fn with_signable_input<T, F>(&self, index: usize, f: F) -> Result<T, SignerError>
     where
         F: FnOnce(SignableInput) -> T,
@@ -36,6 +40,7 @@ impl Input {
         F: FnOnce(SignableInput) -> T,
     {
         let _ = sighash_policy;
+        self.verify_for_signing()?;
 
         // For P2PKH, `script_code` is always the same as `script_pubkey`.
         let script_code = self.redeem_script.as_ref().unwrap_or(&self.script_pubkey);
@@ -47,6 +52,20 @@ impl Input {
             script_pubkey: &Script::from(&self.script_pubkey),
             value: self.value,
         }))
+    }
+
+    /// The `redeem_script` reaches us from whoever gave us this PCZT, and the signing
+    /// paths both search it for a pubkey and commit to it in the sighash. Check that it
+    /// really is the script that the coin being spent commits to.
+    fn verify_for_signing(&self) -> Result<(), SignerError> {
+        match self.verify() {
+            // `Input::verify` only recognises P2PKH and P2SH `script_pubkey`s, whereas
+            // signing additionally supports bare P2PK and P2MS scripts. Those have no
+            // `redeem_script` to check.
+            Err(VerifyError::UnsupportedScriptPubkey) if self.redeem_script.is_none() => Ok(()),
+            r => r,
+        }
+        .map_err(SignerError::InvalidInput)
     }
 
     /// Signs the transparent spend with the given spend authorizing key.
@@ -95,6 +114,7 @@ impl Input {
         F: FnOnce(SignableInput) -> [u8; 32],
     {
         let _ = sighash_policy;
+        self.verify_for_signing()?;
 
         let pubkey = sk.public_key(secp).serialize();
         let p2pkh_addr = TransparentAddress::from_pubkey_bytes(&pubkey);
@@ -206,6 +226,7 @@ impl Input {
         F: FnOnce(SignableInput) -> [u8; 32],
     {
         let _ = sighash_policy;
+        self.verify_for_signing()?;
 
         // For P2PKH, `script_code` is always the same as `script_pubkey`.
         let script_code = self.redeem_script.as_ref().unwrap_or(&self.script_pubkey);

--- a/zcash_transparent/src/pczt/spend_finalizer.rs
+++ b/zcash_transparent/src/pczt/spend_finalizer.rs
@@ -10,6 +10,11 @@ use super::Bundle;
 impl Bundle {
     /// Finalizes the spends for this bundle.
     ///
+    /// Every partial signature that is used commits to the transaction in full: a
+    /// signature whose sighash type is not [`SighashType::ALL`] is refused, as is one
+    /// whose sighash type does not match that of the input it is being applied to. Use
+    /// [`Bundle::finalize_spends_with_sighash_policy`] to finalize with a wider policy.
+    ///
     /// Returns an error if any spend uses an unsupported script format. The supported
     /// script formats are:
     /// - P2PKH
@@ -38,8 +43,6 @@ impl Bundle {
         &mut self,
         sighash_policy: SighashPolicy,
     ) -> Result<(), SpendFinalizerError> {
-        let _ = sighash_policy;
-
         // For each input, the Spend Finalizer determines if the input has enough data to
         // pass validation. If it does, it must construct the `script_sig` and place it
         // into the PCZT input. If `script_sig` is empty for an input, the field should
@@ -60,6 +63,8 @@ impl Bundle {
                             if hash[..] != crate::util::hash160::hash(pubkey)[..] {
                                 Err(SpendFinalizerError::UnexpectedSignatures)
                             } else {
+                                check_sighash_type(sig_bytes, input.sighash_type, sighash_policy)?;
+
                                 // P2PKH scriptSig
                                 input.script_sig = Some(script::Component(vec![
                                     pv::push_value(sig_bytes)
@@ -108,6 +113,12 @@ impl Bundle {
 
                                     // If we have a signature from this pubkey, use it.
                                     if let Some(sig) = input.partial_signatures.get(&pubkey) {
+                                        check_sighash_type(
+                                            sig,
+                                            input.sighash_type,
+                                            sighash_policy,
+                                        )?;
+
                                         // Valid signatures always fit into `PushData`s.
                                         script_sig.push(
                                             pv::push_value(sig)
@@ -154,6 +165,31 @@ impl Bundle {
 
         Ok(())
     }
+}
+
+/// Checks the trailing sighash-type byte of a partial signature that is about to be
+/// placed into a `script_sig`.
+fn check_sighash_type(
+    sig_bytes: &[u8],
+    expected: SighashType,
+    sighash_policy: SighashPolicy,
+) -> Result<(), SpendFinalizerError> {
+    let (hash_type, _) = sig_bytes
+        .split_last()
+        .ok_or(SpendFinalizerError::InvalidSignature)?;
+    let hash_type = SighashType::parse(*hash_type).ok_or(SpendFinalizerError::InvalidSignature)?;
+
+    // The PCZT format requires a Spend Finalizer to fail to finalize an input whose
+    // signatures do not match its `sighash_type`.
+    if hash_type != expected {
+        return Err(SpendFinalizerError::MismatchedSighashType);
+    }
+
+    if !sighash_policy.permits(hash_type) {
+        return Err(SpendFinalizerError::DisallowedSighashType(hash_type));
+    }
+
+    Ok(())
 }
 
 /// Errors that can occur while finalizing the transparent inputs of a PCZT bundle.

--- a/zcash_transparent/src/pczt/spend_finalizer.rs
+++ b/zcash_transparent/src/pczt/spend_finalizer.rs
@@ -1,8 +1,13 @@
 use zcash_script::{pattern::push_script, pv, script, solver};
 
-use crate::address::TransparentAddress;
+use crate::{
+    address::TransparentAddress,
+    sighash::{SighashPolicy, SighashType},
+};
 
-impl super::Bundle {
+use super::Bundle;
+
+impl Bundle {
     /// Finalizes the spends for this bundle.
     ///
     /// Returns an error if any spend uses an unsupported script format. The supported
@@ -11,6 +16,30 @@ impl super::Bundle {
     /// - P2SH with one of these redeem script formats:
     ///   - P2MS
     pub fn finalize_spends(&mut self) -> Result<(), SpendFinalizerError> {
+        self.finalize_spends_with_sighash_policy(SighashPolicy::ALL_ONLY)
+    }
+
+    /// Finalizes the spends for this bundle, accepting any partial signature whose
+    /// sighash type is permitted by `sighash_policy`. See [`SighashPolicy`] for why that
+    /// is a decision for the Spend Finalizer rather than for whoever supplied the
+    /// signature.
+    ///
+    /// Otherwise behaves exactly as [`Bundle::finalize_spends`], which should be
+    /// preferred.
+    ///
+    /// This policy governs which signatures are assembled into `script_sig`s; it does not
+    /// protect whoever produced them. A partial signature that does not commit to the
+    /// whole transaction can be lifted out of this bundle and used directly, without this
+    /// role ever running, so the decision that protects a signer is the Signer's own
+    /// [`Input::sign_with_sighash_policy`].
+    ///
+    /// [`Input::sign_with_sighash_policy`]: super::Input::sign_with_sighash_policy
+    pub fn finalize_spends_with_sighash_policy(
+        &mut self,
+        sighash_policy: SighashPolicy,
+    ) -> Result<(), SpendFinalizerError> {
+        let _ = sighash_policy;
+
         // For each input, the Spend Finalizer determines if the input has enough data to
         // pass validation. If it does, it must construct the `script_sig` and place it
         // into the PCZT input. If `script_sig` is empty for an input, the field should
@@ -130,6 +159,11 @@ impl super::Bundle {
 /// Errors that can occur while finalizing the transparent inputs of a PCZT bundle.
 #[derive(Debug)]
 pub enum SpendFinalizerError {
+    /// A partial signature's sighash type is not permitted by the Spend Finalizer's
+    /// [`SighashPolicy`].
+    DisallowedSighashType(SighashType),
+    /// A partial signature's sighash type does not match that of the input it applies to.
+    MismatchedSighashType,
     /// `script_pubkey` is a P2SH script, but `redeem_script` is not set.
     MissingRedeemScript,
     /// `script_pubkey` is a P2SH script, but `redeem_script` is too long for a `PushData`.
@@ -152,16 +186,21 @@ pub enum SpendFinalizerError {
 mod tests {
     use alloc::collections::BTreeMap;
     use alloc::vec;
+    use alloc::vec::Vec;
 
     use zcash_script::{
         pattern::pay_to_pubkey_hash,
         script::{self, Evaluable},
     };
 
-    use super::SpendFinalizerError;
+    use super::{SighashPolicy, SighashType, SpendFinalizerError};
     use crate::{
-        pczt::{Bundle, Input, parse::MAX_SCRIPT_PUSH_VALUE_LEN},
-        sighash::SIGHASH_ALL,
+        pczt::{
+            Bundle, Input,
+            parse::MAX_SCRIPT_PUSH_VALUE_LEN,
+            testing::{input, p2ms, p2pkh, p2sh},
+        },
+        sighash::{SIGHASH_ALL, SIGHASH_NONE},
     };
 
     /// The P2PKH branch of `Bundle::finalize_spends` returns
@@ -214,5 +253,125 @@ mod tests {
             matches!(result, Err(SpendFinalizerError::InvalidSignature)),
             "expected Err(InvalidSignature), got {result:?}",
         );
+    }
+
+    /// A pubkey-shaped byte string. The Spend Finalizer never checks that a pubkey is a
+    /// point on the curve, so these do not need to be real.
+    fn pubkey(i: u8) -> [u8; 33] {
+        let mut pubkey = [i; 33];
+        pubkey[0] = 0x02;
+        pubkey
+    }
+
+    /// A signature-shaped byte string ending in `hash_type`. The Spend Finalizer never
+    /// verifies a signature, so this does not need to be a real one.
+    fn signature(hash_type: u8) -> Vec<u8> {
+        vec![0xde, 0xad, 0xbe, 0xef, hash_type]
+    }
+
+    /// A P2PKH input signed by `pubkey(1)`.
+    fn p2pkh_input(sighash_type: SighashType, signature: Vec<u8>) -> Input {
+        let mut input = input(p2pkh(&pubkey(1)), None, sighash_type);
+        input.partial_signatures.insert(pubkey(1), signature);
+        input
+    }
+
+    /// A 2-of-3 P2SH-P2MS input, signed by the pubkeys named by the given indices.
+    fn p2ms_input(sighash_type: SighashType, signatures: &[(u8, u8)]) -> Input {
+        let pubkeys = [pubkey(1), pubkey(2), pubkey(3)];
+        let redeem_script = p2ms(2, &[&pubkeys[0], &pubkeys[1], &pubkeys[2]]);
+        let mut input = input(p2sh(&redeem_script), Some(redeem_script), sighash_type);
+        for (i, hash_type) in signatures {
+            input
+                .partial_signatures
+                .insert(pubkey(*i), signature(*hash_type));
+        }
+        input
+    }
+
+    fn finalize(input: Input, sighash_policy: SighashPolicy) -> Result<(), SpendFinalizerError> {
+        Bundle {
+            inputs: vec![input],
+            outputs: vec![],
+        }
+        .finalize_spends_with_sighash_policy(sighash_policy)
+    }
+
+    #[test]
+    fn finalize_accepts_p2pkh() {
+        let input = p2pkh_input(SighashType::ALL, signature(SIGHASH_ALL));
+        assert!(finalize(input, SighashPolicy::ALL_ONLY).is_ok());
+    }
+
+    #[test]
+    fn finalize_accepts_multisig() {
+        let input = p2ms_input(SighashType::ALL, &[(1, SIGHASH_ALL), (2, SIGHASH_ALL)]);
+        assert!(finalize(input, SighashPolicy::ALL_ONLY).is_ok());
+    }
+
+    /// The PCZT format requires a Spend Finalizer to reject a signature that does not
+    /// match the sighash type of the input it applies to.
+    #[test]
+    fn finalize_rejects_mismatched_sighash_type() {
+        let input = p2pkh_input(SighashType::ALL, signature(SIGHASH_NONE));
+        assert!(matches!(
+            finalize(input, SighashPolicy::ALL_ONLY),
+            Err(SpendFinalizerError::MismatchedSighashType),
+        ));
+    }
+
+    #[test]
+    fn finalize_rejects_mismatched_sighash_type_in_multisig() {
+        let input = p2ms_input(SighashType::ALL, &[(1, SIGHASH_ALL), (2, SIGHASH_NONE)]);
+        assert!(matches!(
+            finalize(input, SighashPolicy::ALL_ONLY),
+            Err(SpendFinalizerError::MismatchedSighashType),
+        ));
+    }
+
+    #[test]
+    fn finalize_rejects_non_all_sighash_type_by_default() {
+        let input = p2pkh_input(SighashType::NONE, signature(SIGHASH_NONE));
+        match finalize(input, SighashPolicy::ALL_ONLY) {
+            Err(SpendFinalizerError::DisallowedSighashType(t)) => {
+                assert_eq!(t, SighashType::NONE)
+            }
+            r => panic!("expected SIGHASH_NONE to be refused, got {r:?}"),
+        }
+    }
+
+    #[test]
+    fn finalize_accepts_non_all_sighash_type_under_explicit_policy() {
+        let input = p2pkh_input(SighashType::NONE, signature(SIGHASH_NONE));
+        assert!(finalize(input, SighashPolicy::ANY).is_ok());
+    }
+
+    #[test]
+    fn finalize_rejects_empty_signature() {
+        let input = p2pkh_input(SighashType::ALL, vec![]);
+        assert!(matches!(
+            finalize(input, SighashPolicy::ALL_ONLY),
+            Err(SpendFinalizerError::InvalidSignature),
+        ));
+    }
+
+    #[test]
+    fn finalize_rejects_unparsable_sighash_type() {
+        let input = p2pkh_input(SighashType::ALL, signature(0x05));
+        assert!(matches!(
+            finalize(input, SighashPolicy::ALL_ONLY),
+            Err(SpendFinalizerError::InvalidSignature),
+        ));
+    }
+
+    /// A signature that is discarded rather than placed into the `script_sig` is not
+    /// checked, so that a Combiner cannot block finalization by contributing junk.
+    #[test]
+    fn finalize_ignores_discarded_multisig_signature() {
+        let input = p2ms_input(
+            SighashType::ALL,
+            &[(1, SIGHASH_ALL), (2, SIGHASH_ALL), (3, 0x05)],
+        );
+        assert!(finalize(input, SighashPolicy::ALL_ONLY).is_ok());
     }
 }

--- a/zcash_transparent/src/sighash.rs
+++ b/zcash_transparent/src/sighash.rs
@@ -53,6 +53,74 @@ impl SighashType {
     }
 }
 
+/// A set of [ZIP 244] sighash types.
+///
+/// A signature that does not use [`SighashType::ALL`] does not commit to some part of the
+/// transaction that it authorizes: a `SIGHASH_NONE` signature commits to none of the
+/// outputs, and a `SIGHASH_ANYONECANPAY` signature commits to no other input. Such a
+/// signature can be lifted out of the transaction it was created for and reused in a
+/// different one, so an entity that signs or finalizes on a user’s behalf should only
+/// produce or accept one when the surrounding protocol calls for it.
+///
+/// This type is how that decision is made explicit: the default is
+/// [`SighashPolicy::ALL_ONLY`], and a wider policy has to be opted into.
+///
+/// [ZIP 244]: https://zips.z.cash/zip-0244#s-2a-hash-type
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SighashPolicy(u8);
+
+impl Default for SighashPolicy {
+    fn default() -> Self {
+        Self::ALL_ONLY
+    }
+}
+
+impl SighashPolicy {
+    /// The empty policy, permitting no sighash type at all.
+    ///
+    /// Every input is refused under this policy, [`SighashType::ALL`] included, so it is
+    /// useful only as the base that [`SighashPolicy::permitting`] builds on.
+    pub const EMPTY: Self = Self(0);
+
+    /// Permits only [`SighashType::ALL`].
+    ///
+    /// This is the default policy, and the only one under which a signature is guaranteed
+    /// to commit to every input and output of the transaction it authorizes.
+    pub const ALL_ONLY: Self = Self::EMPTY.permitting(SighashType::ALL);
+
+    /// Permits every [ZIP 244] sighash type.
+    ///
+    /// Only use this if the surrounding protocol needs signatures that do not commit to
+    /// the whole transaction, and it is the protocol rather than the counterparty that
+    /// decides which sighash type each input uses.
+    ///
+    /// [ZIP 244]: https://zips.z.cash/zip-0244#s-2a-hash-type
+    pub const ANY: Self = Self::ALL_ONLY
+        .permitting(SighashType::NONE)
+        .permitting(SighashType::SINGLE)
+        .permitting(SighashType::ALL_ANYONECANPAY)
+        .permitting(SighashType::NONE_ANYONECANPAY)
+        .permitting(SighashType::SINGLE_ANYONECANPAY);
+
+    /// Returns the bit representing `hash_type` within the policy.
+    const fn bit(hash_type: SighashType) -> u8 {
+        // `SighashType` is correct by construction, so the masked value is always one of
+        // `SIGHASH_ALL`, `SIGHASH_NONE`, or `SIGHASH_SINGLE`, i.e. 1, 2, or 3;
+        // `SIGHASH_ANYONECANPAY` shifts it into the upper half of the mask.
+        1 << ((hash_type.0 & !SIGHASH_ANYONECANPAY) - 1 + (hash_type.0 >> 7) * 3)
+    }
+
+    /// Returns a policy permitting everything this policy permits, and `hash_type`.
+    pub const fn permitting(self, hash_type: SighashType) -> Self {
+        Self(self.0 | Self::bit(hash_type))
+    }
+
+    /// Returns whether this policy permits `hash_type`.
+    pub const fn permits(&self, hash_type: SighashType) -> bool {
+        (self.0 & Self::bit(hash_type)) != 0
+    }
+}
+
 /// Additional context that is needed to compute signature hashes
 /// for transactions that include transparent inputs or outputs.
 pub trait TransparentAuthorizingContext: Authorization {
@@ -128,7 +196,7 @@ impl<'a> SignableInput<'a> {
 mod tests {
     use zcash_protocol::value::Zatoshis;
 
-    use super::{InvalidInputIndex, SighashType, SignableInput};
+    use super::{InvalidInputIndex, SighashPolicy, SighashType, SignableInput};
     use crate::{
         address::Script,
         bundle::{Bundle, EffectsOnly, OutPoint, TxIn},
@@ -160,5 +228,66 @@ mod tests {
                 input_count: 1,
             }
         );
+    }
+
+    /// Every sighash type that [`SighashType::parse`] accepts.
+    const EVERY_TYPE: [SighashType; 6] = [
+        SighashType::ALL,
+        SighashType::NONE,
+        SighashType::SINGLE,
+        SighashType::ALL_ANYONECANPAY,
+        SighashType::NONE_ANYONECANPAY,
+        SighashType::SINGLE_ANYONECANPAY,
+    ];
+
+    #[test]
+    fn every_type_has_a_distinct_bit() {
+        let mut seen = 0;
+        for hash_type in EVERY_TYPE {
+            let bit = SighashPolicy::bit(hash_type);
+            assert_eq!(seen & bit, 0, "{hash_type:?} collides with an earlier type");
+            seen |= bit;
+        }
+        assert_eq!(seen, SighashPolicy::ANY.0);
+    }
+
+    #[test]
+    fn empty_permits_nothing() {
+        for hash_type in EVERY_TYPE {
+            assert!(!SighashPolicy::EMPTY.permits(hash_type));
+        }
+    }
+
+    #[test]
+    fn all_only_permits_only_all() {
+        for hash_type in EVERY_TYPE {
+            assert_eq!(
+                SighashPolicy::ALL_ONLY.permits(hash_type),
+                hash_type == SighashType::ALL,
+            );
+        }
+    }
+
+    #[test]
+    fn any_permits_everything() {
+        for hash_type in EVERY_TYPE {
+            assert!(SighashPolicy::ANY.permits(hash_type));
+        }
+    }
+
+    #[test]
+    fn permitting_adds_exactly_one_type() {
+        let policy = SighashPolicy::ALL_ONLY.permitting(SighashType::NONE_ANYONECANPAY);
+        for hash_type in EVERY_TYPE {
+            assert_eq!(
+                policy.permits(hash_type),
+                hash_type == SighashType::ALL || hash_type == SighashType::NONE_ANYONECANPAY,
+            );
+        }
+    }
+
+    #[test]
+    fn default_is_all_only() {
+        assert_eq!(SighashPolicy::default(), SighashPolicy::ALL_ONLY);
     }
 }


### PR DESCRIPTION
Three coupled defence-in-depth gaps on the PCZT transparent spend-authorization
path, surfaced during a wallet review. Nothing on that path semantically
authenticated the input being signed.

1. **Unverified `redeem_script`.** `Input::sign`, `Input::append_signature` and
   `Input::with_signable_input` each took
   `script_code = redeem_script.unwrap_or(script_pubkey)`, then searched it for the
   pubkey to sign with and committed to it in the sighash, without checking
   `hash160(redeem_script) == script_pubkey`. `Input::verify` already implements
   exactly that check, but no path called it, and the role-layer hook for it in
   `generate_or_append_transparent_signature` was an unimplemented `// TODO`.

2. **Attacker-chosen sighash type.** All three used `self.sighash_type` verbatim,
   and `SighashType::parse` accepts all six ZIP 244 variants. A hostile Creator or
   Updater could therefore set `SIGHASH_NONE | SIGHASH_ANYONECANPAY` and obtain a
   signature committing to neither the outputs nor the other inputs — one that can
   be lifted into a different transaction.

3. **The Spend Finalizer enforced nothing.** `Bundle::finalize_spends` copied each
   partial signature — trailing sighash byte included — into the `script_sig`
   without inspecting it, despite the field documentation in `pczt.rs` already
   stating that “Spend Finalizers must fail to finalize inputs which have
   signatures that do not match this sighash type”.

The in-tree builder always uses `SighashType::ALL`, so single-wallet flows were
never exploitable. The exposure is to third-party multi-party PCZT signers
relying on the library to be safe by default.

## Approach

A new `zcash_transparent::sighash::SighashPolicy` — a set of permitted sighash
types, defaulting to `ALL_ONLY` — is the single opt-in mechanism. The existing
entry points (`Input::{sign, append_signature, with_signable_input}`,
`Bundle::finalize_spends`, `Signer::{sign_transparent,
append_transparent_signature, transparent_sighash}`,
`SpendFinalizer::finalize_spends`) keep their names and become `ALL`-only;
policy-taking variants sit alongside them.

Three deliberate choices worth a reviewer’s attention:

- **`Input::with_signable_input` is covered, which makes it fallible.** It now
  returns `Result<T, SignerError>` rather than `T` — the one source-breaking
  change here. It prepares a sighash for an external signer, and whoever signs
  that sighash is authorizing whatever it commits to, so handing one out over an
  unverified `script_code` or for a counterparty’s chosen sighash type is the same
  exposure as producing the signature directly. `Input::append_signature` and
  `Signer::transparent_sighash` are likewise covered; both postdate the original
  report.

- **The checks live in the `zcash_transparent` methods, not at the role layer.**
  `pczt::roles::low_level_signer` hands out `&mut transparent::pczt::Bundle` and
  calls those methods directly, so a role-layer-only check would be bypassable.
  The `// TODO` in `generate_or_append_transparent_signature` is therefore closed
  by a comment pointing at them: the helper inherits the checks through its `f`
  callback, so a second check there would be dead weight.

  `Input::verify` cannot be called unconditionally, though: it resolves the
  `script_pubkey` through `TransparentAddress::from_script_pubkey`, which returns
  `None` for the bare P2PK and P2MS scripts that signing explicitly supports. So
  `verify_for_signing` tolerates exactly `VerifyError::UnsupportedScriptPubkey`,
  and only when there is no `redeem_script` to check. Two tests guard that
  tolerance.

- **The Spend Finalizer also gates on `Global.tx_modifiable`**, independently of
  the sighash policy — `SighashPolicy::ANY` does not relax it. It is the converse
  of the bookkeeping that `generate_or_append_transparent_signature` already
  performs: if the flags say the transaction's effects were already fixed, then
  the sighash type is not the product of a deliberate multi-party flow. This lives
  in the `pczt` role rather than in `zcash_transparent` because `tx_modifiable` is
  a PCZT-global field that the transparent bundle has no access to.

  It has real teeth: the IO Finalizer clears both transparent modifiability flags
  whenever the transaction has shielded spends or outputs, so any shielded PCZT is
  `SIGHASH_ALL`-only at finalization regardless of policy.

  It is not, however, a substitute for the policy, and
  `modifiability_flags_are_not_a_substitute_for_the_policy` records why: the flags
  are PCZT data, so a hostile Creator sets them as freely as it sets `sighash_type`
  and can always make the two agree. A gate comparing one against the other is a
  consistency check, not an authorization one — the authorization decision has to
  be made in the signing party's own code, which is what `SighashPolicy` is.

## Commits

I tried to make things as atomic as possible here, with small commits. Also to
implement changes a deeply as possible, so new callers can’t accidentally avoid
the checks in future.

| commit                                                         | failures | notes                                                                 |
|:---------------------------------------------------------------|---------:|:----------------------------------------------------------------------|
| Add `SighashPolicy`                                            |        0 | set up some structures (and tests for them) that aren’t used yet      |
| Add failing tests for the PCZT transparent gaps                |       20 | use new structures as minimally as possible, ignoring some new params |
| Verify a PCZT transparent input before signing it              |       13 | start fixing things                                                   |
| Sign a PCZT transparent input only for `SIGHASH_ALL`           |        7 | 〃                                                                    |
| Check the sighash type of each finalized signature             |        1 | 〃                                                                    |
| Reject a sighash type inconsistent with `Global.tx_modifiable` |        0 | 〃                                                                    |
| Demonstrate that a non-`SIGHASH_ALL` signature is transferable |        0 | a pair of tests to illustrate the weakness                            |

## Testing

Unit tests in `zcash_transparent` construct hostile inputs directly (the `Input`
fields are `pub(crate)`), covering all three entry points and every non-`ALL`
sighash type. A role-level suite in `pczt/src/roles.rs` drives the whole Creator →
IO Finalizer → Signer → Spend Finalizer path over a transparent-only PCZT, so the
IO Finalizer short-circuits the shielded work and no proving keys are built.

The last commit adds two tests that are not regression barriers but
demonstrations, and they are the ones to read if the threat model is not obvious.
A victim induced to sign under `SIGHASH_NONE | SIGHASH_ANYONECANPAY` — reachable
now only through the explicit `SighashPolicy::ANY` opt-in — produces a signature
that verifies not only against the transaction they were shown but also against a
second one they never saw, which spends the same coin alongside the attacker's
and pays the whole balance to the attacker. The companion test signs the same
input under `SIGHASH_ALL` and shows it authorizing only the transaction the victim
was shown, first asserting that it *does* authorize that one so the negative
cannot pass for the wrong reason.

`zcash_transparent` has 52 tests and `pczt` 67, plus the untouched
`tests/end_to_end.rs` (19) and `tests/firmware_compat.rs` (4), which are the
regression guards that the honest P2PKH and P2SH-multisig flows are unaffected.
`cargo check -p zcash_client_backend --all-features` is clean, as is clippy with
`--all-features --all-targets`.
