### PR TITLE
zcash_client_sqlite: only gate spendability on unscanned ranges at or below the anchor

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -17,6 +17,18 @@ workspace.
   previously conflated with `transactions_without_wallet_relevance`.
 
 ### Fixed
+- Notes in the note commitment tree shard at the chain tip are no longer
+  reported as unspendable, and excluded from note selection, merely because
+  `WalletWrite::update_chain_tip` has queued a scan range (between the
+  previously scanned height and the new chain tip) that has not yet been
+  scanned. Only unscanned ranges that begin at or below the anchor height can
+  affect the witness of a note at the anchor, so only those now disqualify a
+  note whose witness has not been stabilized. Previously, every advance of the
+  chain tip caused the spendable balance of every non-stabilized note in the
+  tip shard to drop to zero until the tip range was scanned, so that a spend
+  proposed against a just-reported balance could fail with
+  `InsufficientFunds { available: 0 }`. The wallet summary and note selection
+  now share the same shard scan state query, so they cannot disagree on this.
 - Reading back a stored unmined transaction with a zero expiry height (such as
   a coinbase transaction imported from a zcashd wallet before any chain scan)
   no longer fails with a "Consensus branch ID not known" error. When neither a

--- a/zcash_client_sqlite/src/testing/pool.rs
+++ b/zcash_client_sqlite/src/testing/pool.rs
@@ -2,28 +2,46 @@
 //!
 //! Generalised for sharing across the Sapling and Orchard implementations.
 
-use core::num::NonZeroU32;
+use core::num::{NonZeroU8, NonZeroU32};
+use std::convert::Infallible;
+
+use incrementalmerkletree::frontier::Frontier;
+use zcash_primitives::block::BlockHash;
 
 use crate::{
     SAPLING_TABLES_PREFIX,
     error::SqliteClientError,
     testing::{BlockCache, db::TestDbFactory},
-};
-use zcash_client_backend::data_api::{
-    WalletWrite,
-    anchor_retention::AnchorRetentionInterval,
-    chain::{ChainState, error::Error},
-    testing::{
-        AddressType,
-        pool::{InputTrust, ShieldedPoolTester, dsl::TestDsl},
-        sapling::SaplingPoolTester,
+    wallet::{
+        common::unscanned_tip_exists,
+        get_target_and_anchor_heights,
+        scanning::{priority_code, suggest_scan_ranges},
     },
+};
+use zcash_client_backend::{
+    data_api::{
+        Account as _, TargetValue, WalletWrite,
+        anchor_retention::AnchorRetentionInterval,
+        chain::{ChainState, CommitmentTreeRoot, error::Error},
+        scanning::{ScanPriority, spanning_tree::testing::scan_range},
+        testing::{
+            AddressType, InitialChainState, TestBuilder,
+            pool::{
+                InputTrust, ShieldedPoolTester,
+                dsl::{TestDsl, TestScenario},
+            },
+            sapling::SaplingPoolTester,
+        },
+        wallet::{ConfirmationsPolicy, TargetHeight},
+    },
+    fees::StandardFeeRule,
+    wallet::OvkPolicy,
 };
 
 #[cfg(feature = "transparent-inputs")]
 use rusqlite::named_params;
 use zcash_protocol::{
-    consensus::{NetworkUpgrade, Parameters},
+    consensus::{BlockHeight, NetworkUpgrade, Parameters},
     value::Zatoshis,
 };
 #[cfg(feature = "orchard")]
@@ -1020,5 +1038,304 @@ pub(crate) fn proposal_records_and_serializes_proposed_version() {
     zcash_client_backend::data_api::testing::pool::proposal_records_and_serializes_proposed_version(
         TestDbFactory::default(),
         BlockCache::new(),
+    );
+}
+
+/// Builds a wallet whose birthday lies within the second (incomplete) note commitment tree
+/// shard of each pool, with the first shard having been completed ten blocks before the
+/// birthday. This is the steady state of a wallet on a live chain: the completed prior shard
+/// gives `update_chain_tip` a tip shard to complete, so that advancing the chain tip queues a
+/// `ChainTip` range rather than the `Historic` range used for linear scanning.
+fn tip_shard_scenario<T: ShieldedPoolTester>() -> TestDsl<TestScenario<T, BlockCache, TestDbFactory>>
+{
+    // The frontiers at the block prior to the birthday sit 1234 notes into the second shard.
+    let frontier_tree_size: u32 = (0x1 << 16) + 1234;
+    let builder = TestBuilder::new()
+        .with_data_store_factory(TestDbFactory::default())
+        .with_block_cache(BlockCache::new())
+        .with_initial_chain_state(|rng, network| {
+            let birthday_height = network.activation_height(NetworkUpgrade::Nu5).unwrap() + 76;
+            let shard_end_height = birthday_height - 10;
+
+            let (prior_sapling_roots, sapling_initial_tree) =
+                Frontier::random_with_prior_subtree_roots(
+                    rng,
+                    frontier_tree_size.into(),
+                    NonZeroU8::new(16).unwrap(),
+                );
+            let prior_sapling_roots = prior_sapling_roots
+                .into_iter()
+                .map(|root| CommitmentTreeRoot::from_parts(shard_end_height, root))
+                .collect::<Vec<_>>();
+
+            #[cfg(feature = "orchard")]
+            let (prior_orchard_roots, orchard_initial_tree) =
+                Frontier::random_with_prior_subtree_roots(
+                    rng,
+                    frontier_tree_size.into(),
+                    NonZeroU8::new(16).unwrap(),
+                );
+            #[cfg(feature = "orchard")]
+            let prior_orchard_roots = prior_orchard_roots
+                .into_iter()
+                .map(|root| CommitmentTreeRoot::from_parts(shard_end_height, root))
+                .collect::<Vec<_>>();
+
+            InitialChainState {
+                chain_state: ChainState::new(
+                    birthday_height - 1,
+                    BlockHash([0; 32]),
+                    sapling_initial_tree,
+                    #[cfg(feature = "orchard")]
+                    orchard_initial_tree,
+                    #[cfg(feature = "orchard")]
+                    Frontier::empty(),
+                ),
+                prior_sapling_roots,
+                #[cfg(feature = "orchard")]
+                prior_orchard_roots,
+            }
+        })
+        .with_account_having_current_birthday();
+
+    TestDsl::from(builder).build::<T>()
+}
+
+/// Receives a single note into the (incomplete) tip shard and scans the block containing it,
+/// so that the wallet is scanned to its view of the chain tip. Checks that the note is not
+/// stabilized and is spendable according to both the wallet summary and note selection, and
+/// returns the height at which it was received.
+fn receive_note_in_tip_shard<T: ShieldedPoolTester + ShieldedPoolPersistence>(
+    st: &mut TestDsl<TestScenario<T, BlockCache, TestDbFactory>>,
+    value: Zatoshis,
+) -> BlockHeight {
+    let account_id = st.get_account().id();
+    let (h, _, _) = st.add_a_single_note_checking_balance(value);
+
+    // The note is in the (incomplete) tip shard and has not been stabilized, so its
+    // spendability is governed by the shard scan state.
+    let witness_stabilized: bool = st
+        .wallet()
+        .conn()
+        .query_row(
+            &format!(
+                "SELECT witness_stabilized FROM {}_received_notes",
+                T::TABLES_PREFIX
+            ),
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(!witness_stabilized);
+
+    // Scanned to the tip: the note is spendable at one confirmation, both according to the
+    // wallet summary and to note selection.
+    assert_eq!(
+        st.get_spendable_balance(account_id, ConfirmationsPolicy::MIN),
+        value
+    );
+    let spendable = T::select_spendable_notes(
+        st,
+        account_id,
+        TargetValue::AtLeast(value),
+        TargetHeight::from(h + 1),
+        ConfirmationsPolicy::MIN,
+        &[],
+    )
+    .unwrap();
+    assert_eq!(spendable.len(), 1);
+
+    h
+}
+
+/// Advances the wallet's view of the chain tip by `blocks` without scanning, and asserts that
+/// a `ChainTip` range beginning just above the previously scanned height was queued.
+fn advance_chain_tip_without_scanning<T: ShieldedPoolTester + ShieldedPoolPersistence>(
+    st: &mut TestDsl<TestScenario<T, BlockCache, TestDbFactory>>,
+    max_scanned: BlockHeight,
+    blocks: u32,
+) -> BlockHeight {
+    let new_tip = max_scanned + blocks;
+    st.wallet_mut().update_chain_tip(new_tip).unwrap();
+
+    let queued = suggest_scan_ranges(st.wallet().conn(), ScanPriority::ChainTip).unwrap();
+    assert_eq!(
+        queued,
+        vec![scan_range(
+            (max_scanned + 1).into()..(new_tip + 1).into(),
+            ScanPriority::ChainTip
+        )]
+    );
+
+    // The premise of the fix: `update_chain_tip` raises the target height to `new_tip + 1` but
+    // creates no checkpoints, and the anchor is clamped to the newest checkpoint at or below
+    // `target - min_confirmations`, so it remains at the old scan frontier, strictly below the
+    // start of the queued `ChainTip` range.
+    let (target_height, anchor_height) =
+        get_target_and_anchor_heights(st.wallet().conn(), ConfirmationsPolicy::default().trusted())
+            .unwrap()
+            .expect("chain tip and anchor are known");
+    assert_eq!(target_height, TargetHeight::from(new_tip + 1));
+    assert_eq!(anchor_height, max_scanned);
+    assert!(anchor_height < queued[0].block_range().start);
+
+    new_tip
+}
+
+/// Asserts that the per-pool gate (`unscanned_tip_exists`, shared by the wallet summary and
+/// note selection), the wallet summary's spendable balance, and note selection all agree on
+/// whether the wallet's single note is spendable under `policy`.
+fn assert_gates_agree<T: ShieldedPoolTester + ShieldedPoolPersistence>(
+    st: &TestDsl<TestScenario<T, BlockCache, TestDbFactory>>,
+    policy: ConfirmationsPolicy,
+    value: Zatoshis,
+    expect_spendable: bool,
+) {
+    let account_id = st.get_account().id();
+    let (target_height, anchor_height) =
+        get_target_and_anchor_heights(st.wallet().conn(), policy.trusted())
+            .unwrap()
+            .expect("chain tip and anchor are known");
+
+    let tip_unscanned =
+        unscanned_tip_exists(st.wallet().conn(), anchor_height, T::TABLES_PREFIX).unwrap();
+    assert_eq!(tip_unscanned, !expect_spendable);
+
+    let (expected_spendable, expected_pending) = if expect_spendable {
+        (value, Zatoshis::ZERO)
+    } else {
+        (Zatoshis::ZERO, value)
+    };
+    assert_eq!(
+        st.get_spendable_balance(account_id, policy),
+        expected_spendable
+    );
+    assert_eq!(
+        st.get_pending_shielded_balance(account_id, policy),
+        expected_pending
+    );
+
+    let spendable = T::select_spendable_notes(
+        st,
+        account_id,
+        TargetValue::AtLeast(value),
+        target_height,
+        policy,
+        &[],
+    )
+    .unwrap();
+    assert_eq!(spendable.len(), usize::from(expect_spendable));
+    if let Some(note) = spendable.first() {
+        assert_eq!(T::note_value(note.note()), value);
+    }
+}
+
+/// A non-stabilized note in the tip shard remains spendable, both according to the wallet
+/// summary and to note selection, after the wallet's view of the chain tip is advanced without
+/// the intervening blocks having been scanned. The `ChainTip` range queued by `update_chain_tip`
+/// lies entirely above the anchor and so cannot affect the witness at the anchor.
+///
+/// This is the mobile-wallet failure mode in which the UI reports a spendable balance and a
+/// subsequent proposal fails with `InsufficientFunds { available: 0 }`.
+pub(crate) fn tip_shard_notes_remain_spendable_after_chain_tip_update<
+    T: ShieldedPoolTester + ShieldedPoolPersistence,
+>() {
+    let mut st = tip_shard_scenario::<T>();
+    let account = st.get_account();
+    let account_id = account.id();
+
+    let value = Zatoshis::const_from_u64(100_000);
+    let h = receive_note_in_tip_shard(&mut st, value);
+
+    // Advance the chain tip without scanning; the tip-shard `ChainTip` range now overlaps the
+    // note's shard, but begins above the anchor.
+    advance_chain_tip_without_scanning(&mut st, h, 50);
+
+    // The per-pool gate, the summary and note selection all still report the note as
+    // spendable. The default policy requires more confirmations than the minimum, which the
+    // note has (relative to the advanced tip) even though it did not at the time it was
+    // scanned.
+    for policy in [ConfirmationsPolicy::MIN, ConfirmationsPolicy::default()] {
+        assert_gates_agree(&st, policy, value, true);
+    }
+
+    // A transfer proposal therefore succeeds.
+    let to = T::sk_default_address(&T::sk(&[0xf5; 32]));
+    let proposal = st
+        .propose_standard_transfer::<Infallible>(
+            account_id,
+            StandardFeeRule::Zip317,
+            ConfirmationsPolicy::default(),
+            &to,
+            Zatoshis::const_from_u64(60_000),
+            None,
+            None,
+            T::SHIELDED_PROTOCOL,
+        )
+        .unwrap();
+    assert_eq!(proposal.steps().len(), 1);
+    assert_eq!(
+        proposal
+            .steps()
+            .head
+            .shielded_inputs()
+            .map(|i| i.notes().len()),
+        Some(1)
+    );
+
+    // Executing the proposal (which constructs the witness at the anchor) also succeeds.
+    st.create_proposed_transactions::<Infallible, _, Infallible, _>(
+        account.usk(),
+        OvkPolicy::Sender,
+        &proposal,
+    )
+    .unwrap();
+}
+
+/// An unscanned range that begins at or below the anchor height still renders a non-stabilized
+/// note in the affected shard unspendable, according to both the wallet summary and note
+/// selection, since it may contain note commitments that are part of the tree state at the
+/// anchor.
+pub(crate) fn unscanned_range_below_anchor_blocks_spendability<
+    T: ShieldedPoolTester + ShieldedPoolPersistence,
+>() {
+    let mut st = tip_shard_scenario::<T>();
+
+    let value = Zatoshis::const_from_u64(100_000);
+    let h = receive_note_in_tip_shard(&mut st, value);
+    advance_chain_tip_without_scanning(&mut st, h, 50);
+    assert_gates_agree(&st, ConfirmationsPolicy::MIN, value, true);
+
+    // Simulate the state following a rewind in which the block at the anchor height (the block
+    // in which the note was received) must be re-verified: the scan queue entry covering that
+    // block is marked `Verify`, so a range starting at or below the anchor is now unscanned.
+    let updated = st
+        .wallet()
+        .conn()
+        .execute(
+            "UPDATE scan_queue SET priority = :priority
+             WHERE block_range_start <= :height AND block_range_end > :height",
+            rusqlite::named_params![
+                ":priority": priority_code(&ScanPriority::Verify),
+                ":height": u32::from(h),
+            ],
+        )
+        .unwrap();
+    assert_eq!(updated, 1);
+
+    // The per-pool gate, the summary and note selection all now report the note as not
+    // spendable.
+    for policy in [ConfirmationsPolicy::MIN, ConfirmationsPolicy::default()] {
+        assert_gates_agree(&st, policy, value, false);
+    }
+
+    // A transfer proposal therefore fails for lack of spendable funds.
+    let to = T::sk_default_address(&T::sk(&[0xf5; 32]));
+    st.expect_insufficient_funds_with(
+        &to,
+        Zatoshis::const_from_u64(60_000),
+        ConfirmationsPolicy::default(),
+        Zatoshis::ZERO,
+        Zatoshis::const_from_u64(70_000),
     );
 }

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -2767,35 +2767,15 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
     {
         let TableConstants { table_prefix, .. } = table_constants::<SqliteClientError>(protocol)?;
 
-        // If the shard containing the anchor height contains any unscanned ranges that start
-        // below or including that height, none of our shielded balance is currently spendable.
-        #[tracing::instrument(skip_all)]
-        fn is_any_spendable(
-            conn: &rusqlite::Connection,
-            anchor_height: BlockHeight,
-            table_prefix: &'static str,
-        ) -> Result<bool, SqliteClientError> {
-            conn.query_row(
-                &format!(
-                    "SELECT NOT EXISTS(
-                         SELECT 1 FROM v_{table_prefix}_shard_unscanned_ranges
-                         WHERE :anchor_height
-                            BETWEEN subtree_start_height
-                            AND IFNULL(subtree_end_height, :anchor_height)
-                         AND block_range_start <= :anchor_height
-                     )"
-                ),
-                named_params![":anchor_height": u32::from(anchor_height)],
-                |row| row.get::<_, bool>(0),
-            )
-            .map_err(|e| e.into())
-        }
+        // If the shard containing the anchor height contains any unscanned ranges relevant at
+        // the anchor (see `common::shard_scan_ranges_at_anchor`), none of our shielded balance
+        // is currently spendable. This is the same check that note selection performs.
+        let any_spendable = anchor_height.map_or(Ok(false), |h| {
+            common::unscanned_tip_exists(tx, h, table_prefix).map(|unscanned| !unscanned)
+        })?;
 
         let trusted_height =
             target_height.saturating_sub(u32::from(confirmations_policy.trusted()));
-
-        let any_spendable =
-            anchor_height.map_or(Ok(false), |h| is_any_spendable(tx, h, table_prefix))?;
 
         let mut stmt_select_notes = tx.prepare_cached(&format!(
             "SELECT accounts.uuid, rn.id, rn.value, rn.is_change, rn.recipient_key_scope,
@@ -2809,7 +2789,7 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
              FROM {table_prefix}_received_notes rn
              INNER JOIN accounts ON accounts.id = rn.account_id
              INNER JOIN transactions t ON t.id_tx = rn.transaction_id
-             LEFT OUTER JOIN v_{table_prefix}_shards_scan_state scan_state
+             LEFT OUTER JOIN ({shard_scan_state}) scan_state
                 ON rn.commitment_tree_position >= scan_state.start_position
                 AND rn.commitment_tree_position < scan_state.end_position_exclusive
              LEFT OUTER JOIN transparent_received_output_spends ros
@@ -2824,10 +2804,14 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
              GROUP BY rn.id",
             common::tx_unexpired_condition("t"),
             common::spent_notes_clause(table_prefix),
+            shard_scan_state = common::shard_scan_state_at_anchor(table_prefix),
         ))?;
 
         let mut rows = stmt_select_notes.query(named_params![
             ":target_height": u32::from(target_height),
+            // With no anchor, the shard scan state is empty and every non-stabilized note
+            // is reported as pending spendability, consistent with `any_spendable`.
+            ":anchor_height": anchor_height.map(u32::from),
         ])?;
         while let Some(row) = rows.next()? {
             let account = AccountUuid(row.get::<_, Uuid>("uuid")?);
@@ -2846,9 +2830,13 @@ pub(crate) fn get_wallet_summary<P: consensus::Parameters>(
                 .map(KeyScope::decode)
                 .transpose()?;
 
-            // If `max_priority` is null, this means that the note is not positioned; the note
-            // will not be spendable, so we assign the scan priority to `ChainTip` as a priority
-            // that is greater than `Scanned`
+            // If `max_priority` is null, this means that the note is not positioned (or that no
+            // anchor is available); the note will not be spendable, so we assign the scan
+            // priority to `ChainTip` as a priority that is greater than `Scanned`. Otherwise it
+            // is the maximum priority among the scan ranges overlapping the note's shard that
+            // begin at or below the anchor height; see `common::shard_scan_state_at_anchor` for
+            // why ranges above the anchor are excluded, and note that the identical gate is
+            // applied by note selection.
             let max_priority_raw = row.get::<_, Option<i64>>("max_priority")?;
             let max_priority = max_priority_raw.map_or_else(
                 || Ok(ScanPriority::ChainTip),

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -144,26 +144,81 @@ pub(crate) fn spent_notes_clause(table_prefix: &str) -> String {
     )
 }
 
-fn unscanned_tip_exists(
+/// Returns a SQL subquery selecting the rows of `v_{table_prefix}_shard_scan_ranges` whose
+/// `block_range_start` is at or below `:anchor_height`.
+///
+/// This is the single definition of which scan queue entries can affect a witness at the anchor;
+/// every spendability gate ([`unscanned_tip_exists`], [`shard_scan_state_at_anchor`],
+/// [`shard_unscanned_ranges_at_anchor`]) is built from it so that [`get_wallet_summary`] and note
+/// selection cannot disagree.
+///
+/// A witness depends only on the tree state at the anchor, i.e. on blocks at or below it, all of
+/// which have been scanned (the anchor is clamped to a checkpoint, and checkpoints exist only for
+/// scanned blocks). A range starting above the anchor — e.g. the `ChainTip` range queued by
+/// [`update_chain_tip`] before any of it is scanned — therefore must not disqualify notes, even
+/// though it overlaps the tip shard. A range starting at or below the anchor may cover blocks
+/// that are part of the tree at the anchor, and still disqualifies the shards it overlaps.
+///
+/// The parent query must bind `:anchor_height`; if it is `NULL`, the subquery yields no rows.
+///
+/// [`update_chain_tip`]: crate::wallet::scanning::update_chain_tip
+/// [`get_wallet_summary`]: crate::wallet::get_wallet_summary
+pub(crate) fn shard_scan_ranges_at_anchor(table_prefix: &str) -> String {
+    format!(
+        "SELECT * FROM v_{table_prefix}_shard_scan_ranges
+         WHERE block_range_start <= :anchor_height"
+    )
+}
+
+/// Returns a SQL subquery computing, per shard, the maximum priority of the scan queue entries
+/// selected by [`shard_scan_ranges_at_anchor`]. A note whose shard's `max_priority` exceeds
+/// `Scanned` (or is `NULL`, when no anchor is bound) has no available witness.
+pub(crate) fn shard_scan_state_at_anchor(table_prefix: &str) -> String {
+    format!(
+        "SELECT
+             start_position,
+             end_position_exclusive,
+             MAX(priority) AS max_priority
+         FROM ({})
+         GROUP BY start_position, end_position_exclusive",
+        shard_scan_ranges_at_anchor(table_prefix)
+    )
+}
+
+/// [`shard_scan_ranges_at_anchor`] restricted to unscanned entries ending after the wallet
+/// birthday, i.e. `v_{table_prefix}_shard_unscanned_ranges` restricted to the anchor.
+pub(crate) fn shard_unscanned_ranges_at_anchor(table_prefix: &str) -> String {
+    format!(
+        "SELECT * FROM ({})
+         WHERE priority > {}
+         AND block_range_end > (SELECT MIN(birthday_height) FROM accounts)",
+        shard_scan_ranges_at_anchor(table_prefix),
+        priority_code(&ScanPriority::Scanned),
+    )
+}
+
+/// Returns whether the shard containing the anchor height has unscanned entries at or below the
+/// anchor. Every witness needs the tree frontier at the anchor, so if that shard is incomplete
+/// no non-stabilized note of the pool is spendable.
+pub(crate) fn unscanned_tip_exists(
     conn: &Connection,
     anchor_height: BlockHeight,
     table_prefix: &'static str,
-) -> Result<bool, rusqlite::Error> {
-    // v_sapling_shard_unscanned_ranges only returns ranges ending on or after wallet birthday, so
-    // we don't need to refer to the birthday in this query.
+) -> Result<bool, SqliteClientError> {
     conn.query_row(
         &format!(
             "SELECT EXISTS (
-                 SELECT 1 FROM v_{table_prefix}_shard_unscanned_ranges range
-                 WHERE range.block_range_start <= :anchor_height
-                 AND :anchor_height BETWEEN
+                 SELECT 1 FROM ({}) range
+                 WHERE :anchor_height BETWEEN
                     range.subtree_start_height
                     AND IFNULL(range.subtree_end_height, :anchor_height)
-             )"
+             )",
+            shard_unscanned_ranges_at_anchor(table_prefix)
         ),
-        named_params![":anchor_height": u32::from(anchor_height),],
+        named_params![":anchor_height": u32::from(anchor_height)],
         |row| row.get::<_, bool>(0),
     )
+    .map_err(SqliteClientError::from)
 }
 
 /// Retrieves the set of nullifiers for "potentially spendable" notes that the wallet is tracking.
@@ -489,7 +544,7 @@ where
          FROM {table_prefix}_received_notes rn
          INNER JOIN accounts ON accounts.id = rn.account_id
          INNER JOIN transactions t ON t.id_tx = rn.transaction_id
-         LEFT OUTER JOIN v_{table_prefix}_shards_scan_state scan_state
+         LEFT OUTER JOIN ({shard_scan_state}) scan_state
             ON rn.commitment_tree_position >= scan_state.start_position
             AND rn.commitment_tree_position < scan_state.end_position_exclusive
          LEFT OUTER JOIN transparent_received_output_spends ros
@@ -511,7 +566,8 @@ where
          GROUP BY rn.id",
         tx_unexpired_condition("t"),
         spent_notes_clause(table_prefix),
-        output_eligible_condition(lock_filter, "rn")
+        output_eligible_condition(lock_filter, "rn"),
+        shard_scan_state = shard_scan_state_at_anchor(table_prefix),
     ))?;
 
     let excluded: Vec<Value> = exclude
@@ -528,11 +584,15 @@ where
 
     let account_uuid = account.0;
     let target_height_arg = u32::from(target_height);
+    // When the request carries no anchor, no shard scan state is produced and no
+    // non-stabilized note is considered to have an available witness.
+    let anchor_height_arg = note_request.anchor_height().map(u32::from);
     let min_value = u64::from(zip317::MARGINAL_FEE);
     let overridable_owners = overridable_owners_rarray(lock_filter);
     let mut sql_params: Vec<(&str, &dyn ToSql)> = vec![
         (":account_uuid", &account_uuid),
         (":target_height", &target_height_arg),
+        (":anchor_height", &anchor_height_arg),
         (":exclude", &excluded_ptr),
         (":min_value", &min_value),
     ];
@@ -575,6 +635,10 @@ where
                 tx_trusted,
                 tx_shielding_inputs_trusted,
             ) => {
+                // The shard scan priority only accounts for scan ranges that begin at or below
+                // the anchor height (see `shard_scan_state_at_anchor`); a `None` value indicates
+                // either that the note is not positioned in the tree or that no anchor was
+                // requested, in which case no witness can be produced.
                 let shard_witness_available = witness_stabilized
                     || max_shard_priority.is_some_and(|p| p <= ScanPriority::Scanned);
 
@@ -756,7 +820,7 @@ where
              FROM {table_prefix}_received_notes rn
              INNER JOIN accounts ON accounts.id = rn.account_id
              INNER JOIN transactions t ON t.id_tx = rn.transaction_id
-             LEFT OUTER JOIN v_{table_prefix}_shards_scan_state scan_state
+             LEFT OUTER JOIN ({shard_scan_state}) scan_state
                 ON rn.commitment_tree_position >= scan_state.start_position
                 AND rn.commitment_tree_position < scan_state.end_position_exclusive
              LEFT OUTER JOIN transparent_received_output_spends ros
@@ -779,8 +843,8 @@ where
              AND (
                  rn.witness_stabilized = 1
                  OR (
-                     :tip_unscanned = 0 -- the tip shard has no unscanned ranges
-                     AND scan_state.max_priority <= :scanned_priority -- the note shard is fully scanned or ignored
+                     :tip_unscanned = 0 -- the anchor shard has no unscanned ranges below the anchor
+                     AND scan_state.max_priority <= :scanned_priority -- the note shard is fully scanned or ignored below the anchor
                  )
              )
              AND rn.id NOT IN rarray(:exclude)
@@ -790,6 +854,7 @@ where
          )
          {selection_tail}",
         spent_notes_clause(table_prefix),
+        shard_scan_state = shard_scan_state_at_anchor(table_prefix),
     ))?;
 
     let excluded: Vec<Value> = exclude
@@ -937,16 +1002,16 @@ pub(crate) fn select_unspent_note_meta(
          AND commitment_tree_position IS NOT NULL
          AND rn.id NOT IN ({})
          AND NOT EXISTS (
-            SELECT 1 FROM v_{table_prefix}_shard_unscanned_ranges unscanned
-            -- select all the unscanned ranges involving the shard containing this note
+            -- select all the unscanned ranges relevant at the anchor that involve the shard
+            -- containing this note
+            SELECT 1 FROM ({}) unscanned
             WHERE rn.commitment_tree_position >= unscanned.start_position
             AND rn.commitment_tree_position < unscanned.end_position_exclusive
-            -- exclude unscanned ranges that start above the anchor height (they don't affect spendability)
-            AND unscanned.block_range_start <= :anchor_height
             -- exclude unscanned ranges that end below the wallet birthday
             AND unscanned.block_range_end > :wallet_birthday
          )",
-         spent_notes_clause(table_prefix)
+        spent_notes_clause(table_prefix),
+        shard_unscanned_ranges_at_anchor(table_prefix),
     ))?;
 
     let res = stmt

--- a/zcash_client_sqlite/src/wallet/common.rs
+++ b/zcash_client_sqlite/src/wallet/common.rs
@@ -146,23 +146,6 @@ pub(crate) fn spent_notes_clause(table_prefix: &str) -> String {
 
 /// Returns a SQL subquery selecting the rows of `v_{table_prefix}_shard_scan_ranges` whose
 /// `block_range_start` is at or below `:anchor_height`.
-///
-/// This is the single definition of which scan queue entries can affect a witness at the anchor;
-/// every spendability gate ([`unscanned_tip_exists`], [`shard_scan_state_at_anchor`],
-/// [`shard_unscanned_ranges_at_anchor`]) is built from it so that [`get_wallet_summary`] and note
-/// selection cannot disagree.
-///
-/// A witness depends only on the tree state at the anchor, i.e. on blocks at or below it, all of
-/// which have been scanned (the anchor is clamped to a checkpoint, and checkpoints exist only for
-/// scanned blocks). A range starting above the anchor — e.g. the `ChainTip` range queued by
-/// [`update_chain_tip`] before any of it is scanned — therefore must not disqualify notes, even
-/// though it overlaps the tip shard. A range starting at or below the anchor may cover blocks
-/// that are part of the tree at the anchor, and still disqualifies the shards it overlaps.
-///
-/// The parent query must bind `:anchor_height`; if it is `NULL`, the subquery yields no rows.
-///
-/// [`update_chain_tip`]: crate::wallet::scanning::update_chain_tip
-/// [`get_wallet_summary`]: crate::wallet::get_wallet_summary
 pub(crate) fn shard_scan_ranges_at_anchor(table_prefix: &str) -> String {
     format!(
         "SELECT * FROM v_{table_prefix}_shard_scan_ranges
@@ -992,7 +975,8 @@ pub(crate) fn select_unspent_note_meta(
     //
     // TODO: Deduplicate this in the future by introducing a view?
     let mut stmt = conn.prepare_cached(&format!(
-        "SELECT rn.id AS id, txid, {output_index_col},
+        "WITH unscanned_at_anchor AS ({})
+         SELECT rn.id AS id, txid, {output_index_col},
                 commitment_tree_position, value
          FROM {table_prefix}_received_notes rn
          INNER JOIN transactions ON transactions.id_tx = rn.transaction_id
@@ -1002,16 +986,15 @@ pub(crate) fn select_unspent_note_meta(
          AND commitment_tree_position IS NOT NULL
          AND rn.id NOT IN ({})
          AND NOT EXISTS (
-            -- select all the unscanned ranges relevant at the anchor that involve the shard
-            -- containing this note
-            SELECT 1 FROM ({}) unscanned
+            -- select all the unscanned ranges involving the shard containing this note
+            SELECT 1 FROM unscanned_at_anchor unscanned
             WHERE rn.commitment_tree_position >= unscanned.start_position
             AND rn.commitment_tree_position < unscanned.end_position_exclusive
             -- exclude unscanned ranges that end below the wallet birthday
             AND unscanned.block_range_end > :wallet_birthday
          )",
-        spent_notes_clause(table_prefix),
         shard_unscanned_ranges_at_anchor(table_prefix),
+        spent_notes_clause(table_prefix),
     ))?;
 
     let res = stmt

--- a/zcash_client_sqlite/src/wallet/orchard.rs
+++ b/zcash_client_sqlite/src/wallet/orchard.rs
@@ -894,6 +894,17 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn tip_shard_notes_remain_spendable_after_chain_tip_update() {
+        testing::pool::tip_shard_notes_remain_spendable_after_chain_tip_update::<OrchardPoolTester>(
+        )
+    }
+
+    #[test]
+    fn unscanned_range_below_anchor_blocks_spendability() {
+        testing::pool::unscanned_range_below_anchor_blocks_spendability::<OrchardPoolTester>()
+    }
+
+    #[test]
     fn ovk_policy_prevents_recovery_from_chain() {
         testing::pool::ovk_policy_prevents_recovery_from_chain::<OrchardPoolTester>()
     }

--- a/zcash_client_sqlite/src/wallet/sapling.rs
+++ b/zcash_client_sqlite/src/wallet/sapling.rs
@@ -599,6 +599,17 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn tip_shard_notes_remain_spendable_after_chain_tip_update() {
+        testing::pool::tip_shard_notes_remain_spendable_after_chain_tip_update::<SaplingPoolTester>(
+        )
+    }
+
+    #[test]
+    fn unscanned_range_below_anchor_blocks_spendability() {
+        testing::pool::unscanned_range_below_anchor_blocks_spendability::<SaplingPoolTester>()
+    }
+
+    #[test]
     fn ovk_policy_prevents_recovery_from_chain() {
         testing::pool::ovk_policy_prevents_recovery_from_chain::<SaplingPoolTester>()
     }


### PR DESCRIPTION
Fixes wallets reporting InsufficientFunds { available: 0 } right after showing a correct spendable balance.

Spendability gated every non-stabilized note on its shard's MAX(priority) over all overlapping scan-queue ranges. After update_chain_tip, the queued ChainTip range overlaps the tip shard but starts strictly above the anchor (which is clamped to the last checkpoint, i.e. the old scan frontier), so it cannot affect a witness at the anchor — yet it disqualified every recent note until fully scanned.

Only ranges with block_range_start <= anchor now count. The rule lives in one helper (common::shard_scan_ranges_at_anchor) that all per-pool and per-note gates, in both get_wallet_summary and note selection, are built from. No schema or API change.

Tests (Sapling/Orchard): note stays spendable across an unscanned chain-tip advance (fails with have 0 before the fix); an unscanned range at the anchor still blocks; summary and selection agree in both cases.