### PR TITLE
Drop the stale block-buffer / crypto-common pre-release pins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7393,12 +7393,10 @@ version = "0.30.1"
 dependencies = [
  "assert_matches",
  "blake2b_simd",
- "block-buffer 0.11.0-rc.3",
  "bls12_381",
  "chacha20poly1305",
  "corez",
  "criterion 0.5.1",
- "crypto-common 0.2.0-rc.1",
  "document-features",
  "equihash",
  "ff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,8 +82,6 @@ pasta_curves = "0.5"
 
 # - Transparent
 bip32 = { version = "=0.6.0-pre.1", default-features = false, features = ["alloc"] }
-block-buffer = { version = "=0.11.0-rc.3" } # later RCs require edition2024
-crypto-common = { version = "=0.2.0-rc.1" } # later RCs require edition2024
 ripemd = { version = "0.1", default-features = false }
 secp256k1 = { version = "0.29", default-features = false, features = ["alloc"] }
 transparent = { package = "zcash_transparent", version = "0.10.0", path = "zcash_transparent", default-features = false }

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -53,8 +53,6 @@ proptest = { workspace = true, optional = true }
 transparent.workspace = true
 
 # - Transparent inputs
-block-buffer.workspace = true # remove after edition2024 upgrade
-crypto-common.workspace = true # remove after edition2024 upgrade
 #   - `SecretKey` and `PublicKey` types exposed
 secp256k1 = { workspace = true, optional = true }
 


### PR DESCRIPTION
The workspace pins

```toml
block-buffer  = { version = "=0.11.0-rc.3" } # later RCs require edition2024
crypto-common = { version = "=0.2.0-rc.1" }  # later RCs require edition2024
```

and `zcash_primitives` consumes them under

```toml
block-buffer.workspace  = true # remove after edition2024 upgrade
crypto-common.workspace = true # remove after edition2024 upgrade
```

**The edition2024 upgrade has landed.** The workspace is `edition = "2024"` with
`rust-version = "1.88"`, and every current release of the crates in question —
`block-buffer 0.11.0`/`0.12.1`, `crypto-common 0.2.2`, `digest 0.11.3` —
declares `rust-version = "1.85"`. The condition the pins were waiting on is met,
and the comments say what to do about it.

Neither crate is referenced anywhere in `zcash_primitives`' source; `grep -rn
'block_buffer\|crypto_common' zcash_primitives/` is empty. They exist only to
hold the RustCrypto graph back.

### Why it is worth removing rather than leaving

`=0.2.0-rc.1` cannot coexist with the `^0.2` that `digest 0.11` requires, so any
downstream crate that pulls a released RustCrypto 0.11-era hash cannot link
librustzcash at all. We hit this building an end-to-end-encrypted messaging
stack alongside a librustzcash-backed wallet in one binary: `ed25519-dalek 3`
needs `sha2 ^0.11`, `openmls_rust_crypto` needs `hmac ^0.13`, and the resolver
fails on `crypto-common` before it gets anywhere near either.

`bip32 = "=0.6.0-pre.1"` is a separate and larger version of the same problem —
that release exact-pins `sha2 =0.11.0-pre.4`, `hmac =0.13.0-pre.4` and
`ripemd =0.2.0-pre.4` — but it is not fixable from here: iqlusioninc/crates
`main` has moved bip32 onto the released lines, and has not published, and the
same branch bumped `secp256k1-ffi` 0.29 → 0.31 which `zcash_script 0.4.5` cannot
take. That one needs a coordinated secp256k1 bump and a bip32 release; this PR
is only the part that is already unblocked.

`Cargo.lock` is regenerated in the same commit.
