### PR TITLE
Let applications declare spendability of standalone transparent imports

### DIFF
--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -10,7 +10,43 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `zcash_client_backend::data_api`:
+  - `StandaloneSpendability`, the application's declaration of whether it can
+    sign for a standalone (imported) transparent address. The wallet stores at
+    most the pubkey or redeem script for such an address, so only the
+    application can know whether it holds the secret key(s).
+  - `Balance::watch_only_value` and `Balance::add_watch_only_value`: value
+    received by transparent addresses the wallet watches but cannot sign for
+    (address-only imports, and pubkey/script imports declared `WatchOnly`).
+  - `WalletWrite::set_standalone_transparent_spendability`, which revises the
+    declared spendability of a standalone import that has key material.
+- `zcash_client_backend::wallet::TransparentAddressSource::spendability`.
+
 ### Changed
+- `zcash_client_backend::data_api`:
+  - `WalletWrite::import_standalone_transparent_pubkey`,
+    `WalletWrite::import_standalone_transparent_pubkeys`, and
+    `WalletWrite::import_standalone_transparent_script` now take a
+    `StandaloneSpendability` argument. Outputs of imports declared `WatchOnly`
+    are excluded from the `InputSource` spendable-output queries and reported
+    under `Balance::watch_only_value`; previously every pubkey or script import
+    was offered as spendable. A re-import may promote an address from
+    `WatchOnly` to `Spendable` but never downgrades it.
+  - `TransparentKeyOrigin::Imported` is now a struct variant carrying the
+    declared `spendability`.
+  - `Balance::total` now includes `Balance::watch_only_value`;
+    `Balance::spendable_value` never does. Value received by standalone
+    imports the wallet cannot sign for (including address-only imports) was
+    previously reported under `spendable_value` or
+    `value_pending_spendability`; it now moves to `watch_only_value`.
+- `zcash_client_backend::wallet`:
+  - `TransparentAddressSource::StandalonePubkey` and
+    `TransparentAddressSource::StandaloneScript` are now struct variants
+    (`{ pubkey, spendability }` and `{ redeem_script, spendability }`).
+  - `TransparentAddressMetadata::standalone_p2pkh` and
+    `TransparentAddressMetadata::standalone_script` now take a
+    `StandaloneSpendability` argument.
 - `zcash_client_backend::data_api::WalletWrite::put_blocks` is now documented as
   atomic: an implementation must apply the whole batch of blocks or none of it,
   and a caller may assume after an error that nothing was persisted. An

--- a/zcash_client_backend/src/data_api.rs
+++ b/zcash_client_backend/src/data_api.rs
@@ -144,12 +144,40 @@ pub mod zip318;
 #[cfg(any(test, feature = "test-dependencies"))]
 pub mod testing;
 
+/// Whether the application can produce signatures for a standalone (imported) transparent
+/// address.
+///
+/// The wallet stores at most the public key or redeem script for such an address; only the
+/// application knows whether it holds the corresponding secret key(s), so it must declare this
+/// at import time and may revise it later via
+/// [`WalletWrite::set_standalone_transparent_spendability`].
+///
+/// For a multisig redeem script, whether the application considers the address spendable when
+/// it holds only some of the member keys (all `n` versus at least the `required` threshold) is
+/// the application's own policy; the wallet does not inspect the script to decide.
+#[cfg(feature = "transparent-inputs")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StandaloneSpendability {
+    /// The application cannot sign for the address. Its outputs are excluded from spendable
+    /// input selection, and their value is reported under [`Balance::watch_only_value`].
+    WatchOnly,
+    /// The application can sign for the address. Its outputs are offered as spendable inputs
+    /// (subject to the wallet's confirmation policy), and their value is reported under
+    /// [`Balance::spendable_value`] or [`Balance::value_pending_spendability`].
+    Spendable,
+}
+
 /// The origin of a transparent address within a wallet.
 #[cfg(feature = "transparent-inputs")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TransparentKeyOrigin {
     /// The address was imported standalone (no HD derivation scope).
-    Imported,
+    Imported {
+        /// Whether the application has declared that it can sign for the address. An
+        /// address-only import (no pubkey or redeem script) is always
+        /// [`StandaloneSpendability::WatchOnly`].
+        spendability: StandaloneSpendability,
+    },
     /// The address was derived from the account's HD key tree.
     Derived { scope: TransparentKeyScope },
 }
@@ -217,12 +245,29 @@ pub enum MaxSpendMode {
     Everything,
 }
 /// Balance information for a value within a single pool in an account.
+///
+/// The value of a pool is partitioned into buckets. [`spendable_value`], [`locked_value`],
+/// [`change_pending_confirmation`], [`value_pending_spendability`] and [`watch_only_value`]
+/// are disjoint and sum to [`total`]; [`uneconomic_value`] is tracked separately and does not
+/// participate in the total. Of these, only [`spendable_value`] may be spent right now:
+/// [`watch_only_value`] in particular is value received by transparent addresses that the
+/// wallet watches but cannot sign for, and it never becomes spendable without the application
+/// declaring otherwise (see [`StandaloneSpendability`]).
+///
+/// [`spendable_value`]: Balance::spendable_value
+/// [`locked_value`]: Balance::locked_value
+/// [`change_pending_confirmation`]: Balance::change_pending_confirmation
+/// [`value_pending_spendability`]: Balance::value_pending_spendability
+/// [`watch_only_value`]: Balance::watch_only_value
+/// [`uneconomic_value`]: Balance::uneconomic_value
+/// [`total`]: Balance::total
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Balance {
     spendable_value: Zatoshis,
     locked_value: Zatoshis,
     change_pending_confirmation: Zatoshis,
     value_pending_spendability: Zatoshis,
+    watch_only_value: Zatoshis,
     uneconomic_value: Zatoshis,
 }
 
@@ -233,6 +278,7 @@ impl Balance {
         locked_value: Zatoshis::ZERO,
         change_pending_confirmation: Zatoshis::ZERO,
         value_pending_spendability: Zatoshis::ZERO,
+        watch_only_value: Zatoshis::ZERO,
         uneconomic_value: Zatoshis::ZERO,
     };
 
@@ -241,6 +287,7 @@ impl Balance {
             + self.locked_value
             + self.change_pending_confirmation
             + self.value_pending_spendability
+            + self.watch_only_value
             + value)
             .ok_or(BalanceError::Overflow)
     }
@@ -301,6 +348,29 @@ impl Balance {
         Ok(())
     }
 
+    /// Returns the value in the account received by transparent addresses that the wallet
+    /// watches but cannot sign for: addresses imported without key material via
+    /// `WalletWrite::import_standalone_transparent_address`, and pubkey or redeem script imports
+    /// that the application has declared [`StandaloneSpendability::WatchOnly`].
+    ///
+    /// This value is included in [`total`] but never in [`spendable_value`] or
+    /// [`value_pending_spendability`]; the outputs that comprise it are excluded from spendable
+    /// input selection.
+    ///
+    /// [`total`]: Balance::total
+    /// [`spendable_value`]: Balance::spendable_value
+    /// [`value_pending_spendability`]: Balance::value_pending_spendability
+    pub fn watch_only_value(&self) -> Zatoshis {
+        self.watch_only_value
+    }
+
+    /// Adds the specified value to the watch-only total, checking for overflow.
+    pub fn add_watch_only_value(&mut self, value: Zatoshis) -> Result<(), BalanceError> {
+        self.check_total_adding(value)?;
+        self.watch_only_value = (self.watch_only_value + value).unwrap();
+        Ok(())
+    }
+
     /// Returns the value in the account of notes that have value less than or equal to the marginal
     /// fee, and consequently cannot be spent except as a grace input.
     pub fn uneconomic_value(&self) -> Zatoshis {
@@ -313,12 +383,17 @@ impl Balance {
         Ok(())
     }
 
-    /// Returns the total value of funds represented by this [`Balance`].
+    /// Returns the total value of funds represented by this [`Balance`], including
+    /// [`watch_only_value`] that the wallet cannot spend but excluding [`uneconomic_value`].
+    ///
+    /// [`watch_only_value`]: Balance::watch_only_value
+    /// [`uneconomic_value`]: Balance::uneconomic_value
     pub fn total(&self) -> Zatoshis {
         (self.spendable_value
             + self.locked_value
             + self.change_pending_confirmation
-            + self.value_pending_spendability)
+            + self.value_pending_spendability
+            + self.watch_only_value)
             .expect("Balance cannot overflow MAX_MONEY")
     }
 }
@@ -336,6 +411,8 @@ impl core::ops::Add<Balance> for Balance {
                 .ok_or(BalanceError::Overflow)?,
             value_pending_spendability: (self.value_pending_spendability
                 + rhs.value_pending_spendability)
+                .ok_or(BalanceError::Overflow)?,
+            watch_only_value: (self.watch_only_value + rhs.watch_only_value)
                 .ok_or(BalanceError::Overflow)?,
             uneconomic_value: (self.uneconomic_value + rhs.uneconomic_value)
                 .ok_or(BalanceError::Overflow)?,
@@ -446,15 +523,18 @@ impl AccountBalance {
     /// [`value_pending_spendability`] field contains transparent funds that are not yet
     /// spendable: funds that do not yet have the number of confirmations required by the
     /// wallet's confirmation policy, and coinbase funds that have not yet reached maturity. The
-    /// [`change_pending_confirmation`] field is currently always zero, because this crate does
-    /// not yet distinguish transparent change from other transparent value awaiting
-    /// confirmation.
+    /// [`watch_only_value`] field contains transparent funds received by addresses that the
+    /// wallet watches but cannot sign for (see [`StandaloneSpendability`]); these are never
+    /// spendable regardless of confirmations. The [`change_pending_confirmation`] field is
+    /// currently always zero, because this crate does not yet distinguish transparent change
+    /// from other transparent value awaiting confirmation.
     ///
     /// [`unshielded_regular_balance`]: AccountBalance::unshielded_regular_balance
     /// [`unshielded_coinbase_balance`]: AccountBalance::unshielded_coinbase_balance
     /// [`spendable_value`]: Balance::spendable_value
     /// [`change_pending_confirmation`]: Balance::change_pending_confirmation
     /// [`value_pending_spendability`]: Balance::value_pending_spendability
+    /// [`watch_only_value`]: Balance::watch_only_value
     pub fn unshielded_balance(&self) -> Balance {
         (self.unshielded_regular_balance + self.unshielded_coinbase_balance)
             .expect("Account balance cannot overflow MAX_MONEY")
@@ -3482,11 +3562,13 @@ impl AccountBirthday {
 /// transparent rules for the purpose of balance, transaction listing, and so forth. However,
 /// transparent keys imported via `WalletWrite::import_standalone_transparent_pubkey` or
 /// `WalletWrite::import_standalone_transparent_script` (available with the
-/// `transparent-key-import` feature) break this abstraction slightly, so wallets using this API
-/// need to be cautious to enforce the invariant that the wallet either maintains access to the
-/// keys required to spend **ALL** outputs received by the account, or that it **DOES NOT** offer
-/// any spending capability for the account, i.e. the account is treated as view-only for all
-/// user-facing operations.
+/// `transparent-key-import` feature) break this abstraction slightly. The wallet cannot verify
+/// whether the application holds the secret keys for such imports, so the application must
+/// declare this per import via [`StandaloneSpendability`]; outputs of imports declared
+/// `WatchOnly` are excluded from spendable input selection and reported under
+/// [`Balance::watch_only_value`]. Wallets using this API need to be cautious to keep that
+/// declaration accurate, i.e. to declare an import `Spendable` only when they maintain access
+/// to the keys required to spend its outputs.
 ///
 /// A future change to this trait might introduce a method to "upgrade" an imported
 /// account with derivation information. See [zcash/librustzcash#1284] for details.
@@ -3691,15 +3773,27 @@ pub trait WalletWrite:
     ///
     /// The imported address will contribute to the balance of the account, but the wallet holds
     /// neither the public key (P2PKH) nor the redeem script (P2SH) from which the address was
-    /// derived, so funds received by it cannot be spent — its outputs are excluded from spendable
-    /// input selection, and it must not be included in the addresses passed to
-    /// [`propose_shielding`]. Subsequently importing the corresponding key material with
+    /// derived, so funds received by it cannot be spent: the address is always
+    /// [`StandaloneSpendability::WatchOnly`], its outputs are excluded from the selection
+    /// queries ([`get_spendable_transparent_outputs`],
+    /// [`get_spendable_transparent_outputs_for_addresses`],
+    /// [`select_spendable_transparent_outputs`], and [`get_unspent_transparent_output`]), their
+    /// value is reported under [`Balance::watch_only_value`], and the address must not be
+    /// included in the addresses passed to [`propose_shielding`].
+    /// [`set_standalone_transparent_spendability`] rejects such an address.
+    ///
+    /// Subsequently importing the corresponding key material with
     /// [`import_standalone_transparent_pubkey`] or [`import_standalone_transparent_script`]
-    /// upgrades the address in place, after which the spending limitations of those methods
-    /// apply instead.
+    /// upgrades the address in place, after which the spendability declared in that call
+    /// applies instead.
     ///
     /// [`import_standalone_transparent_pubkey`]: Self::import_standalone_transparent_pubkey
     /// [`import_standalone_transparent_script`]: Self::import_standalone_transparent_script
+    /// [`set_standalone_transparent_spendability`]: Self::set_standalone_transparent_spendability
+    /// [`get_spendable_transparent_outputs`]: InputSource::get_spendable_transparent_outputs
+    /// [`get_spendable_transparent_outputs_for_addresses`]: InputSource::get_spendable_transparent_outputs_for_addresses
+    /// [`select_spendable_transparent_outputs`]: InputSource::select_spendable_transparent_outputs
+    /// [`get_unspent_transparent_output`]: InputSource::get_unspent_transparent_output
     /// [`propose_shielding`]: crate::data_api::wallet::propose_shielding
     #[cfg(feature = "transparent-key-import")]
     fn import_standalone_transparent_address(
@@ -3716,18 +3810,44 @@ pub trait WalletWrite:
     /// associated transparent p2pkh address.
     ///
     /// The imported address will contribute to the balance of the account (for UFVK-based
-    /// accounts), but spending funds held by this address requires the associated spending keys to
-    /// be provided explicitly when calling [`create_proposed_transactions`]. By extension, calls
-    /// to [`propose_shielding`] must only include addresses for which the spending application
-    /// holds or can obtain the spending keys.
+    /// accounts). The wallet holds only the public key, so it cannot know whether the
+    /// application can sign for the address; the application declares this via
+    /// `spendability`, and may revise it later with
+    /// [`set_standalone_transparent_spendability`]:
+    ///
+    /// - [`StandaloneSpendability::Spendable`]: the address's outputs are offered by the
+    ///   selection queries ([`get_spendable_transparent_outputs`],
+    ///   [`get_spendable_transparent_outputs_for_addresses`],
+    ///   [`select_spendable_transparent_outputs`], and [`get_unspent_transparent_output`])
+    ///   subject to the wallet's confirmation policy, and their value is reported under
+    ///   [`Balance::spendable_value`] or [`Balance::value_pending_spendability`]. Spending
+    ///   them requires the associated secret key to be provided explicitly in the
+    ///   `standalone_transparent_keys` of the [`SpendingKeys`] passed to
+    ///   [`create_proposed_transactions`]; by extension, calls to [`propose_shielding`] must
+    ///   only include addresses for which the spending application holds or can obtain the
+    ///   secret keys.
+    /// - [`StandaloneSpendability::WatchOnly`]: the address's outputs are excluded from the
+    ///   selection queries, and their value is reported under [`Balance::watch_only_value`].
+    ///
+    /// Importing a pubkey whose address is already recorded as a standalone import of this
+    /// account is idempotent with respect to the key material, and may promote the address
+    /// from `WatchOnly` to `Spendable` if `spendability` is `Spendable`; it never downgrades a
+    /// `Spendable` address. Use [`set_standalone_transparent_spendability`] to downgrade.
     ///
     /// [`create_proposed_transactions`]: crate::data_api::wallet::create_proposed_transactions
     /// [`propose_shielding`]: crate::data_api::wallet::propose_shielding
+    /// [`SpendingKeys`]: crate::data_api::wallet::SpendingKeys
+    /// [`set_standalone_transparent_spendability`]: Self::set_standalone_transparent_spendability
+    /// [`get_spendable_transparent_outputs`]: InputSource::get_spendable_transparent_outputs
+    /// [`get_spendable_transparent_outputs_for_addresses`]: InputSource::get_spendable_transparent_outputs_for_addresses
+    /// [`select_spendable_transparent_outputs`]: InputSource::select_spendable_transparent_outputs
+    /// [`get_unspent_transparent_output`]: InputSource::get_unspent_transparent_output
     #[cfg(feature = "transparent-key-import")]
     fn import_standalone_transparent_pubkey(
         &mut self,
         _account: <Self as WalletRead>::AccountId,
         _pubkey: secp256k1::PublicKey,
+        _spendability: StandaloneSpendability,
     ) -> Result<(), <Self as WalletRead>::Error> {
         unimplemented!(
             "WalletWrite::import_standalone_transparent_pubkey must be overridden for wallets to use the `transparent-key-import` feature"
@@ -3736,12 +3856,14 @@ pub trait WalletWrite:
 
     /// Imports a batch of standalone transparent pubkeys into the account, adding the associated
     /// transparent p2pkh addresses. See [`import_standalone_transparent_pubkey`] for the semantics
-    /// and spending limitations that apply to each imported pubkey.
+    /// and spending limitations that apply to each imported pubkey; the single `spendability`
+    /// declaration applies to every pubkey in the batch.
     ///
     /// This is equivalent to calling [`import_standalone_transparent_pubkey`] once per pubkey, but
     /// implementations may validate the target account a single time for the whole batch. The
     /// default implementation calls [`import_standalone_transparent_pubkey`] for each pubkey; a
-    /// pubkey whose receiver address is already known to the wallet is skipped.
+    /// pubkey whose receiver address is already known to the wallet is skipped, apart from the
+    /// `WatchOnly` to `Spendable` promotion described there.
     ///
     /// [`import_standalone_transparent_pubkey`]: Self::import_standalone_transparent_pubkey
     #[cfg(feature = "transparent-key-import")]
@@ -3749,9 +3871,10 @@ pub trait WalletWrite:
         &mut self,
         account: <Self as WalletRead>::AccountId,
         pubkeys: &[secp256k1::PublicKey],
+        spendability: StandaloneSpendability,
     ) -> Result<(), <Self as WalletRead>::Error> {
         for pubkey in pubkeys {
-            self.import_standalone_transparent_pubkey(account, *pubkey)?;
+            self.import_standalone_transparent_pubkey(account, *pubkey, spendability)?;
         }
         Ok(())
     }
@@ -3760,13 +3883,40 @@ pub trait WalletWrite:
     /// adds the associated transparent p2sh address.
     ///
     /// The imported address will contribute to the balance of the account (for UFVK-based
-    /// accounts), but spending funds held by this address requires the associated spending keys to
-    /// be provided explicitly when calling [`create_proposed_transactions`]. By extension, calls
-    /// to [`propose_shielding`] must only include addresses for which the spending application
-    /// holds or can obtain the spending keys.
+    /// accounts). The wallet holds only the redeem script, so it cannot know whether the
+    /// application holds enough of the script's member keys to sign for the address; the
+    /// application declares this via `spendability`, and may revise it later with
+    /// [`set_standalone_transparent_spendability`]. Whether a multisig address counts as
+    /// spendable when only some member keys are held (all `n` versus at least the `required`
+    /// threshold) is the application's own policy.
+    ///
+    /// - [`StandaloneSpendability::Spendable`]: the address's outputs are offered by the
+    ///   selection queries ([`get_spendable_transparent_outputs`],
+    ///   [`get_spendable_transparent_outputs_for_addresses`],
+    ///   [`select_spendable_transparent_outputs`], and [`get_unspent_transparent_output`])
+    ///   subject to the wallet's confirmation policy, and their value is reported under
+    ///   [`Balance::spendable_value`] or [`Balance::value_pending_spendability`]. Spending
+    ///   them requires the member secret keys to be provided explicitly in the
+    ///   `standalone_transparent_keys` of the [`SpendingKeys`] passed to
+    ///   [`create_proposed_transactions`]; by extension, calls to [`propose_shielding`] must
+    ///   only include addresses for which the spending application holds or can obtain the
+    ///   secret keys.
+    /// - [`StandaloneSpendability::WatchOnly`]: the address's outputs are excluded from the
+    ///   selection queries, and their value is reported under [`Balance::watch_only_value`].
+    ///
+    /// Importing a script whose address is already recorded as a standalone import of this
+    /// account is idempotent with respect to the key material, and may promote the address
+    /// from `WatchOnly` to `Spendable` if `spendability` is `Spendable`; it never downgrades a
+    /// `Spendable` address. Use [`set_standalone_transparent_spendability`] to downgrade.
     ///
     /// [`create_proposed_transactions`]: crate::data_api::wallet::create_proposed_transactions
     /// [`propose_shielding`]: crate::data_api::wallet::propose_shielding
+    /// [`SpendingKeys`]: crate::data_api::wallet::SpendingKeys
+    /// [`set_standalone_transparent_spendability`]: Self::set_standalone_transparent_spendability
+    /// [`get_spendable_transparent_outputs`]: InputSource::get_spendable_transparent_outputs
+    /// [`get_spendable_transparent_outputs_for_addresses`]: InputSource::get_spendable_transparent_outputs_for_addresses
+    /// [`select_spendable_transparent_outputs`]: InputSource::select_spendable_transparent_outputs
+    /// [`get_unspent_transparent_output`]: InputSource::get_unspent_transparent_output
     ///
     /// # Spending limitations
     ///
@@ -3777,9 +3927,37 @@ pub trait WalletWrite:
         &mut self,
         _account: <Self as WalletRead>::AccountId,
         _script: zcash_script::script::Redeem,
+        _spendability: StandaloneSpendability,
     ) -> Result<(), <Self as WalletRead>::Error> {
         unimplemented!(
             "WalletWrite::import_standalone_transparent_script must be overridden for wallets to use the `transparent-key-import` feature"
+        )
+    }
+
+    /// Sets the application's declaration of whether it can sign for the given standalone
+    /// transparent address of `account`.
+    ///
+    /// The address must be a standalone import that has key material, i.e. one recorded via
+    /// [`import_standalone_transparent_pubkey`] or [`import_standalone_transparent_script`]
+    /// (possibly upgraded from an address-only import). An implementation must return an error
+    /// if the address is unknown to the wallet, belongs to a different account, is derived from
+    /// the account's HD key tree (such addresses are always spendable), or is an address-only
+    /// import (always watch-only until key material is imported).
+    ///
+    /// Unlike the import methods, this may move the address in either direction: it is the only
+    /// way to downgrade a `Spendable` address to `WatchOnly`.
+    ///
+    /// [`import_standalone_transparent_pubkey`]: Self::import_standalone_transparent_pubkey
+    /// [`import_standalone_transparent_script`]: Self::import_standalone_transparent_script
+    #[cfg(feature = "transparent-key-import")]
+    fn set_standalone_transparent_spendability(
+        &mut self,
+        _account: <Self as WalletRead>::AccountId,
+        _address: &TransparentAddress,
+        _spendability: StandaloneSpendability,
+    ) -> Result<(), <Self as WalletRead>::Error> {
+        unimplemented!(
+            "WalletWrite::set_standalone_transparent_spendability must be overridden for wallets to use the `transparent-key-import` feature"
         )
     }
 
@@ -4484,10 +4662,10 @@ pub trait WalletCommitmentTrees {
 
 /// Property tests for the [`Balance`] bucket arithmetic.
 ///
-/// These pin the accounting semantics the locked-value bucket joined: every bucket except
-/// `uneconomic_value` participates in [`Balance::total`] and in the shared overflow guard,
-/// while `uneconomic_value` is guarded only against its own overflow and never contributes
-/// to the total.
+/// These pin the accounting semantics the locked-value and watch-only buckets joined: every
+/// bucket except `uneconomic_value` participates in [`Balance::total`] and in the shared
+/// overflow guard, while `uneconomic_value` is guarded only against its own overflow and never
+/// contributes to the total.
 #[cfg(test)]
 mod balance_tests {
     use proptest::prelude::*;
@@ -4501,19 +4679,27 @@ mod balance_tests {
         Locked = 1,
         PendingChange = 2,
         PendingSpendable = 3,
-        Uneconomic = 4,
+        WatchOnly = 4,
+        Uneconomic = 5,
     }
     use Bucket::*;
 
-    const ALL_BUCKETS: [Bucket; 5] = [
+    const ALL_BUCKETS: [Bucket; 6] = [
         Spendable,
         Locked,
         PendingChange,
         PendingSpendable,
+        WatchOnly,
         Uneconomic,
     ];
     /// The buckets that participate in `Balance::total` and its overflow guard.
-    const TOTAL_BUCKETS: [Bucket; 4] = [Spendable, Locked, PendingChange, PendingSpendable];
+    const TOTAL_BUCKETS: [Bucket; 5] = [
+        Spendable,
+        Locked,
+        PendingChange,
+        PendingSpendable,
+        WatchOnly,
+    ];
 
     fn apply(balance: &mut Balance, bucket: Bucket, value: Zatoshis) -> Result<(), BalanceError> {
         match bucket {
@@ -4521,6 +4707,7 @@ mod balance_tests {
             Locked => balance.add_locked_value(value),
             PendingChange => balance.add_pending_change_value(value),
             PendingSpendable => balance.add_pending_spendable_value(value),
+            WatchOnly => balance.add_watch_only_value(value),
             Uneconomic => balance.add_uneconomic_value(value),
         }
     }
@@ -4531,6 +4718,7 @@ mod balance_tests {
             Locked => balance.locked_value(),
             PendingChange => balance.change_pending_confirmation(),
             PendingSpendable => balance.value_pending_spendability(),
+            WatchOnly => balance.watch_only_value(),
             Uneconomic => balance.uneconomic_value(),
         }
     }
@@ -4541,6 +4729,7 @@ mod balance_tests {
             Just(Locked),
             Just(PendingChange),
             Just(PendingSpendable),
+            Just(WatchOnly),
             Just(Uneconomic),
         ]
     }
@@ -4560,13 +4749,13 @@ mod balance_tests {
     proptest! {
         /// Bucket adds succeed exactly while their overflow guard permits, mutate only the
         /// requested bucket, and leave the balance untouched on failure. `total()` is always
-        /// the sum of the four participating buckets. (In particular this establishes that
+        /// the sum of the five participating buckets. (In particular this establishes that
         /// the `unwrap` inside each guarded add is unreachable.)
         #[test]
         fn add_total_consistency(adds in proptest::collection::vec(arb_add(), 0..12)) {
             let mut balance = Balance::ZERO;
             // The model: per-bucket totals, indexed by bucket discriminant.
-            let mut model = [0u64; 5];
+            let mut model = [0u64; 6];
 
             for (bucket, v) in adds {
                 let value = Zatoshis::from_u64(v).unwrap();

--- a/zcash_client_backend/src/data_api/testing.rs
+++ b/zcash_client_backend/src/data_api/testing.rs
@@ -62,8 +62,6 @@ use zcash_protocol::{
     memo::{Memo, MemoBytes},
     value::{ZatBalance, Zatoshis},
 };
-#[cfg(feature = "transparent-key-import")]
-use zcash_script::script;
 use zip32::DiversifierIndex;
 use zip321::Payment;
 #[cfg(feature = "orchard")]
@@ -79,6 +77,8 @@ use {
     pasta_curves::pallas,
     zcash_note_encryption::ShieldedOutput,
 };
+#[cfg(feature = "transparent-key-import")]
+use {super::StandaloneSpendability, zcash_script::script};
 
 use super::{
     Account, AccountBalance, AccountBirthday, AccountMeta, AccountPurpose, AccountSource,
@@ -3516,6 +3516,7 @@ impl WalletWrite for MockWalletDb {
         &mut self,
         _account: <Self as WalletRead>::AccountId,
         _address: secp256k1::PublicKey,
+        _spendability: StandaloneSpendability,
     ) -> Result<(), <Self as WalletRead>::Error> {
         todo!()
     }
@@ -3525,6 +3526,17 @@ impl WalletWrite for MockWalletDb {
         &mut self,
         _account: <Self as WalletRead>::AccountId,
         _script: script::Redeem,
+        _spendability: StandaloneSpendability,
+    ) -> Result<(), <Self as WalletRead>::Error> {
+        todo!()
+    }
+
+    #[cfg(feature = "transparent-key-import")]
+    fn set_standalone_transparent_spendability(
+        &mut self,
+        _account: <Self as WalletRead>::AccountId,
+        _address: &TransparentAddress,
+        _spendability: StandaloneSpendability,
     ) -> Result<(), <Self as WalletRead>::Error> {
         todo!()
     }

--- a/zcash_client_backend/src/data_api/testing/transparent.rs
+++ b/zcash_client_backend/src/data_api/testing/transparent.rs
@@ -32,7 +32,7 @@ use zip321::{Payment, TransactionRequest};
 use {
     crate::{
         data_api::{
-            AccountBirthday,
+            AccountBirthday, StandaloneSpendability, TransparentKeyOrigin,
             wallet::{self, SpendingKeys},
         },
         wallet::TransparentAddressSource,
@@ -1398,16 +1398,25 @@ where
         .put_received_transparent_utxo(&utxo)
         .unwrap();
 
-    // Verify the balance is reflected via get_transparent_balances.
+    // Verify the balance is reflected via get_transparent_balances, as watch-only value: the
+    // wallet holds no key material with which a spend could be constructed.
     let target_height = TargetHeight::from(height + 1);
     let balances = st
         .wallet()
         .get_transparent_balances(account_id, target_height, ConfirmationsPolicy::MIN)
         .unwrap();
-    assert_eq!(balances.get(&taddr).map(|(_, b)| b.total()), Some(value),);
+    let (origin, balance) = balances.get(&taddr).expect("address should be present");
+    assert_eq!(
+        origin,
+        &TransparentKeyOrigin::Imported {
+            spendability: StandaloneSpendability::WatchOnly
+        }
+    );
+    assert_eq!(balance.watch_only_value(), value);
+    assert_eq!(balance.spendable_value(), Zatoshis::ZERO);
+    assert_eq!(balance.total(), value);
 
-    // The output must not be offered for spending: the wallet holds no key material with
-    // which a spend could be constructed.
+    // The output must not be offered for spending.
     let utxos = st
         .wallet()
         .get_spendable_transparent_outputs(
@@ -1460,10 +1469,14 @@ where
 
     // Import the key material for each address.
     st.wallet_mut()
-        .import_standalone_transparent_pubkey(account_id, pubkey)
+        .import_standalone_transparent_pubkey(account_id, pubkey, StandaloneSpendability::Spendable)
         .unwrap();
     st.wallet_mut()
-        .import_standalone_transparent_script(account_id, redeem_script)
+        .import_standalone_transparent_script(
+            account_id,
+            redeem_script,
+            StandaloneSpendability::Spendable,
+        )
         .unwrap();
 
     // The addresses were upgraded in place: no new receivers, and each address's source
@@ -1479,7 +1492,7 @@ where
         .expect("address should be present");
     assert!(matches!(
         p2pkh_metadata.source(),
-        TransparentAddressSource::StandalonePubkey(_)
+        TransparentAddressSource::StandalonePubkey { .. }
     ));
 
     let p2sh_metadata = receivers_after
@@ -1487,7 +1500,7 @@ where
         .expect("address should be present");
     assert!(matches!(
         p2sh_metadata.source(),
-        TransparentAddressSource::StandaloneScript(_)
+        TransparentAddressSource::StandaloneScript { .. }
     ));
 }
 
@@ -1508,8 +1521,11 @@ where
     let secret_key = SecretKey::from_slice(&[1u8; 32]).expect("valid secret key");
     let pubkey = secret_key.public_key(&secp);
     assert_matches!(
-        st.wallet_mut()
-            .import_standalone_transparent_pubkey(account_id, pubkey),
+        st.wallet_mut().import_standalone_transparent_pubkey(
+            account_id,
+            pubkey,
+            StandaloneSpendability::Spendable
+        ),
         Ok(_)
     );
 }
@@ -1533,8 +1549,11 @@ where
 
     // First import
     assert_matches!(
-        st.wallet_mut()
-            .import_standalone_transparent_pubkey(account_id, pubkey),
+        st.wallet_mut().import_standalone_transparent_pubkey(
+            account_id,
+            pubkey,
+            StandaloneSpendability::Spendable
+        ),
         Ok(_)
     );
 
@@ -1546,8 +1565,11 @@ where
 
     // Second import to same account should also succeed (idempotent)
     assert_matches!(
-        st.wallet_mut()
-            .import_standalone_transparent_pubkey(account_id, pubkey),
+        st.wallet_mut().import_standalone_transparent_pubkey(
+            account_id,
+            pubkey,
+            StandaloneSpendability::Spendable
+        ),
         Ok(_)
     );
 
@@ -1565,7 +1587,7 @@ where
         .expect("address should be present");
     assert!(matches!(
         metadata.source(),
-        TransparentAddressSource::StandalonePubkey(_)
+        TransparentAddressSource::StandalonePubkey { .. }
     ));
 }
 
@@ -1588,8 +1610,11 @@ where
 
     // Import to first account
     assert_matches!(
-        st.wallet_mut()
-            .import_standalone_transparent_pubkey(account1_id, pubkey),
+        st.wallet_mut().import_standalone_transparent_pubkey(
+            account1_id,
+            pubkey,
+            StandaloneSpendability::Spendable
+        ),
         Ok(_)
     );
 
@@ -1612,8 +1637,11 @@ where
 
     // Import same pubkey to second account should fail
     assert_matches!(
-        st.wallet_mut()
-            .import_standalone_transparent_pubkey(account2_id, pubkey),
+        st.wallet_mut().import_standalone_transparent_pubkey(
+            account2_id,
+            pubkey,
+            StandaloneSpendability::Spendable
+        ),
         Err(_)
     );
 }
@@ -1639,7 +1667,7 @@ where
 
     // Import the public key.
     st.wallet_mut()
-        .import_standalone_transparent_pubkey(account_id, pubkey)
+        .import_standalone_transparent_pubkey(account_id, pubkey, StandaloneSpendability::Spendable)
         .unwrap();
 
     // Derive the P2PKH address.
@@ -1713,7 +1741,7 @@ where
 
     // Import the public key.
     st.wallet_mut()
-        .import_standalone_transparent_pubkey(account_id, pubkey)
+        .import_standalone_transparent_pubkey(account_id, pubkey, StandaloneSpendability::Spendable)
         .unwrap();
 
     // Derive the P2PKH address.
@@ -1826,8 +1854,11 @@ where
 
     // Import should succeed
     assert_matches!(
-        st.wallet_mut()
-            .import_standalone_transparent_script(account_id, redeem_script.clone()),
+        st.wallet_mut().import_standalone_transparent_script(
+            account_id,
+            redeem_script.clone(),
+            StandaloneSpendability::Spendable
+        ),
         Ok(_)
     );
 
@@ -1847,7 +1878,7 @@ where
         .expect("address should be present");
     assert!(matches!(
         metadata.source(),
-        TransparentAddressSource::StandaloneScript(_)
+        TransparentAddressSource::StandaloneScript { .. }
     ));
 }
 
@@ -1867,8 +1898,11 @@ where
 
     // First import
     assert_matches!(
-        st.wallet_mut()
-            .import_standalone_transparent_script(account_id, redeem_script.clone()),
+        st.wallet_mut().import_standalone_transparent_script(
+            account_id,
+            redeem_script.clone(),
+            StandaloneSpendability::Spendable
+        ),
         Ok(_)
     );
 
@@ -1880,8 +1914,11 @@ where
 
     // Second import to same account should also succeed (idempotent)
     assert_matches!(
-        st.wallet_mut()
-            .import_standalone_transparent_script(account_id, redeem_script.clone()),
+        st.wallet_mut().import_standalone_transparent_script(
+            account_id,
+            redeem_script.clone(),
+            StandaloneSpendability::Spendable
+        ),
         Ok(_)
     );
 
@@ -1901,7 +1938,7 @@ where
         .expect("address should be present");
     assert!(matches!(
         metadata.source(),
-        TransparentAddressSource::StandaloneScript(_)
+        TransparentAddressSource::StandaloneScript { .. }
     ));
 }
 
@@ -1921,8 +1958,11 @@ where
 
     // Import to first account
     assert_matches!(
-        st.wallet_mut()
-            .import_standalone_transparent_script(account1_id, redeem_script.clone()),
+        st.wallet_mut().import_standalone_transparent_script(
+            account1_id,
+            redeem_script.clone(),
+            StandaloneSpendability::Spendable
+        ),
         Ok(_)
     );
 
@@ -1945,8 +1985,11 @@ where
 
     // Import same redeem script to second account should fail
     assert_matches!(
-        st.wallet_mut()
-            .import_standalone_transparent_script(account2_id, redeem_script),
+        st.wallet_mut().import_standalone_transparent_script(
+            account2_id,
+            redeem_script,
+            StandaloneSpendability::Spendable
+        ),
         Err(_)
     );
 }
@@ -1970,7 +2013,11 @@ where
 
     // Import the P2SH address.
     st.wallet_mut()
-        .import_standalone_transparent_script(account_id, redeem_script.clone())
+        .import_standalone_transparent_script(
+            account_id,
+            redeem_script.clone(),
+            StandaloneSpendability::Spendable,
+        )
         .unwrap();
 
     // Derive the expected transparent address from the redeem script.
@@ -2042,7 +2089,11 @@ where
 
     // Import the P2SH address.
     st.wallet_mut()
-        .import_standalone_transparent_script(account_id, redeem_script.clone())
+        .import_standalone_transparent_script(
+            account_id,
+            redeem_script.clone(),
+            StandaloneSpendability::Spendable,
+        )
         .unwrap();
 
     // Derive the P2SH address.
@@ -2136,6 +2187,552 @@ where
             .sapling_balance()
             .change_pending_confirmation(),
         (value - fee).unwrap(),
+    );
+}
+
+/// Records a fake unspent output of `value` at `taddr` for `account_id`, mined at `height`,
+/// and returns its outpoint.
+#[cfg(feature = "transparent-key-import")]
+fn put_fake_utxo<DSF, Cache>(
+    st: &mut TestState<Cache, <DSF as DataStoreFactory>::DataStore, LocalNetwork>,
+    account_id: <<DSF as DataStoreFactory>::DataStore as WalletRead>::AccountId,
+    taddr: &TransparentAddress,
+    value: Zatoshis,
+    height: BlockHeight,
+) -> OutPoint
+where
+    DSF: DataStoreFactory,
+{
+    let outpoint = OutPoint::fake();
+    let txout = TxOut::new(value, taddr.script().into());
+    let utxo = WalletTransparentOutput::from_parts(
+        outpoint.clone(),
+        txout,
+        Some(height),
+        Some(account_id),
+        None,
+        None,
+    )
+    .unwrap();
+    st.wallet_mut()
+        .put_received_transparent_utxo(&utxo)
+        .unwrap();
+    outpoint
+}
+
+/// Scans a block at `height` paying `value` to the account's last generated HD-derived
+/// transparent address and persists it, so that the wallet has scan progress (which
+/// `get_wallet_summary` requires) and a known spendable derived balance.
+#[cfg(feature = "transparent-key-import")]
+fn scan_derived_payment_block<DSF, Cache>(
+    st: &mut TestState<Cache, <DSF as DataStoreFactory>::DataStore, LocalNetwork>,
+    account_id: <<DSF as DataStoreFactory>::DataStore as WalletRead>::AccountId,
+    height: BlockHeight,
+    value: Zatoshis,
+) where
+    DSF: DataStoreFactory,
+    <<DSF as DataStoreFactory>::DataStore as WalletRead>::AccountId:
+        ConditionallySelectable + Default + Ord + std::hash::Hash + Send + Sync + 'static,
+{
+    /// The payment is not time-locked.
+    const NO_LOCK_TIME: u32 = 0;
+
+    let derived_addr = wallet_taddr(st.wallet(), account_id);
+    let network = *st.network();
+    let (scanned, _) = scan_transparent_payment_block(
+        st.wallet(),
+        &network,
+        account_id,
+        height,
+        NO_LOCK_TIME,
+        value,
+        &derived_addr,
+    );
+    st.wallet_mut()
+        .put_blocks(
+            &ChainState::empty(height - 1, BlockHash([0; 32])),
+            vec![scanned],
+        )
+        .unwrap();
+}
+
+/// A standalone address under test, holding a single confirmed output of `value` at
+/// `outpoint`, in an account that also holds `derived_value` spendably at its HD-derived
+/// addresses.
+#[cfg(feature = "transparent-key-import")]
+struct StandaloneFixture<AccountId> {
+    account_id: AccountId,
+    taddr: TransparentAddress,
+    outpoint: OutPoint,
+    value: Zatoshis,
+    derived_value: Zatoshis,
+    target_height: TargetHeight,
+}
+
+/// Asserts that the standalone address of `fixture` is reported and offered for selection
+/// according to `spendability`:
+///
+/// - `get_transparent_balances` reports the value under `watch_only_value` (`WatchOnly`) or
+///   `spendable_value` (`Spendable`), with the matching `TransparentKeyOrigin`;
+/// - the unshielded balance of `get_wallet_summary` does the same, on top of the
+///   `derived_value` the account holds spendably at its HD-derived addresses;
+/// - `get_spendable_transparent_outputs` and `select_spendable_transparent_outputs` (restricted
+///   to the standalone address) return the output only when `Spendable`;
+/// - `get_unspent_transparent_output` at a target height returns the output only when
+///   `Spendable`.
+#[cfg(feature = "transparent-key-import")]
+fn check_standalone_spendability<DSF, Cache>(
+    st: &TestState<Cache, <DSF as DataStoreFactory>::DataStore, LocalNetwork>,
+    fixture: &StandaloneFixture<<<DSF as DataStoreFactory>::DataStore as WalletRead>::AccountId>,
+    spendability: StandaloneSpendability,
+) where
+    DSF: DataStoreFactory,
+    <<DSF as DataStoreFactory>::DataStore as WalletWrite>::UtxoRef: std::fmt::Debug,
+{
+    let StandaloneFixture {
+        account_id,
+        taddr,
+        outpoint,
+        value,
+        derived_value,
+        target_height,
+    } = fixture;
+    let (account_id, value, derived_value, target_height) =
+        (*account_id, *value, *derived_value, *target_height);
+    let (expected_spendable, expected_watch_only) = match spendability {
+        StandaloneSpendability::WatchOnly => (Zatoshis::ZERO, value),
+        StandaloneSpendability::Spendable => (value, Zatoshis::ZERO),
+    };
+
+    // Per-address balances carry the declared spendability and bucket the value accordingly.
+    let balances = st
+        .wallet()
+        .get_transparent_balances(account_id, target_height, ConfirmationsPolicy::MIN)
+        .unwrap();
+    let (origin, balance) = balances.get(taddr).expect("address should be present");
+    assert_eq!(origin, &TransparentKeyOrigin::Imported { spendability });
+    assert_eq!(balance.spendable_value(), expected_spendable);
+    assert_eq!(balance.watch_only_value(), expected_watch_only);
+    assert_eq!(balance.total(), value);
+
+    // The account-level unshielded balance agrees, over and above the derived balance.
+    let summary = st
+        .wallet()
+        .get_wallet_summary(ConfirmationsPolicy::MIN)
+        .unwrap()
+        .unwrap();
+    let unshielded = summary
+        .account_balances()
+        .get(&account_id)
+        .unwrap()
+        .unshielded_balance();
+    assert_eq!(
+        unshielded.spendable_value(),
+        (expected_spendable + derived_value).unwrap()
+    );
+    assert_eq!(unshielded.watch_only_value(), expected_watch_only);
+    assert_eq!(unshielded.total(), (value + derived_value).unwrap());
+
+    // Selection queries offer the output only when declared spendable.
+    let expected_selected: Vec<Zatoshis> = match spendability {
+        StandaloneSpendability::WatchOnly => vec![],
+        StandaloneSpendability::Spendable => vec![value],
+    };
+    let by_address = st
+        .wallet()
+        .get_spendable_transparent_outputs(
+            taddr,
+            target_height,
+            ConfirmationsPolicy::MIN,
+            CoinbaseFilter::AllTransparentOutputs,
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
+        )
+        .unwrap();
+    assert_eq!(
+        by_address.iter().map(|u| u.value()).collect::<Vec<_>>(),
+        expected_selected
+    );
+    let selected = st
+        .wallet()
+        .select_spendable_transparent_outputs(
+            account_id,
+            target_height,
+            ConfirmationsPolicy::MIN,
+            CoinbaseFilter::AllTransparentOutputs,
+            Some(std::slice::from_ref(taddr)),
+            TargetValue::AllFunds(MaxSpendMode::MaxSpendable),
+            usize::MAX,
+            &StandardFeeRule::Zip317,
+            LockFilter::Policy(&LockedInputPolicy::Exclude),
+        )
+        .unwrap();
+    assert_eq!(
+        selected.iter().map(|u| u.value()).collect::<Vec<_>>(),
+        expected_selected
+    );
+    let by_outpoint = st
+        .wallet()
+        .get_unspent_transparent_output(outpoint, target_height)
+        .unwrap();
+    assert_eq!(
+        by_outpoint.map(|u| u.value()),
+        expected_selected.first().copied()
+    );
+}
+
+/// Tests that a pubkey imported as `WatchOnly` contributes only watch-only balance and is
+/// excluded from input selection, and that
+/// [`WalletWrite::set_standalone_transparent_spendability`] moves it in both directions.
+#[cfg(feature = "transparent-key-import")]
+pub fn import_standalone_transparent_pubkey_watch_only<DSF>(dsf: DSF)
+where
+    DSF: DataStoreFactory,
+    <<DSF as DataStoreFactory>::DataStore as WalletWrite>::UtxoRef: std::fmt::Debug,
+    <<DSF as DataStoreFactory>::DataStore as WalletRead>::AccountId:
+        ConditionallySelectable + Default + Ord + std::hash::Hash + Send + Sync + 'static,
+{
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(dsf)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let account_id = st.test_account().unwrap().id();
+    let birthday = st.test_account().unwrap().birthday().height();
+
+    let secp = Secp256k1::new();
+    let secret_key = SecretKey::from_slice(&[1u8; 32]).expect("valid secret key");
+    let pubkey = secret_key.public_key(&secp);
+    let taddr = TransparentAddress::from_pubkey(&pubkey);
+
+    st.wallet_mut()
+        .import_standalone_transparent_pubkey(account_id, pubkey, StandaloneSpendability::WatchOnly)
+        .unwrap();
+
+    let height = birthday + 1000;
+    st.wallet_mut().update_chain_tip(height).unwrap();
+    let derived_value = Zatoshis::const_from_u64(100_000);
+    scan_derived_payment_block::<DSF, _>(&mut st, account_id, height, derived_value);
+    let value = Zatoshis::const_from_u64(50_000);
+    let outpoint = put_fake_utxo::<DSF, _>(&mut st, account_id, &taddr, value, height);
+    let fixture = StandaloneFixture {
+        account_id,
+        taddr,
+        outpoint,
+        value,
+        derived_value,
+        target_height: TargetHeight::from(height + 1),
+    };
+
+    check_standalone_spendability::<DSF, _>(&st, &fixture, StandaloneSpendability::WatchOnly);
+
+    // Declaring the address spendable flips every view.
+    st.wallet_mut()
+        .set_standalone_transparent_spendability(
+            account_id,
+            &fixture.taddr,
+            StandaloneSpendability::Spendable,
+        )
+        .unwrap();
+    check_standalone_spendability::<DSF, _>(&st, &fixture, StandaloneSpendability::Spendable);
+
+    // And back again.
+    st.wallet_mut()
+        .set_standalone_transparent_spendability(
+            account_id,
+            &fixture.taddr,
+            StandaloneSpendability::WatchOnly,
+        )
+        .unwrap();
+    check_standalone_spendability::<DSF, _>(&st, &fixture, StandaloneSpendability::WatchOnly);
+}
+
+/// Tests that a multisig redeem script imported as `WatchOnly` contributes only watch-only
+/// balance and is excluded from input selection, and that
+/// [`WalletWrite::set_standalone_transparent_spendability`] moves it in both directions.
+#[cfg(feature = "transparent-key-import")]
+pub fn import_standalone_transparent_script_watch_only<DSF>(dsf: DSF)
+where
+    DSF: DataStoreFactory,
+    <<DSF as DataStoreFactory>::DataStore as WalletWrite>::UtxoRef: std::fmt::Debug,
+    <<DSF as DataStoreFactory>::DataStore as WalletRead>::AccountId:
+        ConditionallySelectable + Default + Ord + std::hash::Hash + Send + Sync + 'static,
+{
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(dsf)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let account_id = st.test_account().unwrap().id();
+    let birthday = st.test_account().unwrap().birthday().height();
+
+    let (redeem_script, _) = build_test_redeem_script();
+    let taddr =
+        TransparentAddress::from_script_pubkey(&sh(&redeem_script)).expect("valid P2SH address");
+
+    st.wallet_mut()
+        .import_standalone_transparent_script(
+            account_id,
+            redeem_script,
+            StandaloneSpendability::WatchOnly,
+        )
+        .unwrap();
+
+    let height = birthday + 1000;
+    st.wallet_mut().update_chain_tip(height).unwrap();
+    let derived_value = Zatoshis::const_from_u64(100_000);
+    scan_derived_payment_block::<DSF, _>(&mut st, account_id, height, derived_value);
+    let value = Zatoshis::const_from_u64(50_000);
+    let outpoint = put_fake_utxo::<DSF, _>(&mut st, account_id, &taddr, value, height);
+    let fixture = StandaloneFixture {
+        account_id,
+        taddr,
+        outpoint,
+        value,
+        derived_value,
+        target_height: TargetHeight::from(height + 1),
+    };
+
+    check_standalone_spendability::<DSF, _>(&st, &fixture, StandaloneSpendability::WatchOnly);
+
+    st.wallet_mut()
+        .set_standalone_transparent_spendability(
+            account_id,
+            &fixture.taddr,
+            StandaloneSpendability::Spendable,
+        )
+        .unwrap();
+    check_standalone_spendability::<DSF, _>(&st, &fixture, StandaloneSpendability::Spendable);
+
+    st.wallet_mut()
+        .set_standalone_transparent_spendability(
+            account_id,
+            &fixture.taddr,
+            StandaloneSpendability::WatchOnly,
+        )
+        .unwrap();
+    check_standalone_spendability::<DSF, _>(&st, &fixture, StandaloneSpendability::WatchOnly);
+}
+
+/// Tests that re-importing a standalone pubkey may promote it from `WatchOnly` to
+/// `Spendable`, but never downgrades it.
+#[cfg(feature = "transparent-key-import")]
+pub fn import_standalone_transparent_pubkey_reimport_promotes<DSF>(dsf: DSF)
+where
+    DSF: DataStoreFactory,
+{
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(dsf)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let account_id = st.test_account().unwrap().id();
+
+    let secp = Secp256k1::new();
+    let secret_key = SecretKey::from_slice(&[1u8; 32]).expect("valid secret key");
+    let pubkey = secret_key.public_key(&secp);
+    let taddr = TransparentAddress::from_pubkey(&pubkey);
+
+    let spendability_of =
+        |st: &TestState<(), <DSF as DataStoreFactory>::DataStore, LocalNetwork>| {
+            st.wallet()
+                .get_transparent_receivers(account_id, false, true)
+                .unwrap()
+                .get(&taddr)
+                .expect("address should be present")
+                .source()
+                .spendability()
+        };
+
+    st.wallet_mut()
+        .import_standalone_transparent_pubkey(account_id, pubkey, StandaloneSpendability::WatchOnly)
+        .unwrap();
+    assert_eq!(
+        spendability_of(&st),
+        Some(StandaloneSpendability::WatchOnly)
+    );
+
+    // Re-importing as spendable promotes the address.
+    st.wallet_mut()
+        .import_standalone_transparent_pubkey(account_id, pubkey, StandaloneSpendability::Spendable)
+        .unwrap();
+    assert_eq!(
+        spendability_of(&st),
+        Some(StandaloneSpendability::Spendable)
+    );
+
+    // Re-importing as watch-only does not downgrade it.
+    st.wallet_mut()
+        .import_standalone_transparent_pubkey(account_id, pubkey, StandaloneSpendability::WatchOnly)
+        .unwrap();
+    assert_eq!(
+        spendability_of(&st),
+        Some(StandaloneSpendability::Spendable)
+    );
+}
+
+/// Tests that [`WalletWrite::set_standalone_transparent_spendability`] rejects addresses
+/// that are not standalone imports with key material: an HD-derived address of the account,
+/// an address-only import, and an address unknown to the wallet.
+#[cfg(feature = "transparent-key-import")]
+pub fn set_standalone_transparent_spendability_rejects_non_standalone<DSF>(dsf: DSF)
+where
+    DSF: DataStoreFactory,
+{
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(dsf)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let account = st.test_account().cloned().unwrap();
+    let account_id = account.id();
+
+    // An HD-derived address is always spendable; its marker cannot be set.
+    let (derived_addr, _) = account.usk().default_transparent_address();
+    assert_matches!(
+        st.wallet_mut().set_standalone_transparent_spendability(
+            account_id,
+            &derived_addr,
+            StandaloneSpendability::WatchOnly,
+        ),
+        Err(_)
+    );
+
+    // An address-only import is always watch-only; its marker cannot be set.
+    let secp = Secp256k1::new();
+    let secret_key = SecretKey::from_slice(&[1u8; 32]).expect("valid secret key");
+    let address_only = TransparentAddress::from_pubkey(&secret_key.public_key(&secp));
+    st.wallet_mut()
+        .import_standalone_transparent_address(account_id, address_only)
+        .unwrap();
+    assert_matches!(
+        st.wallet_mut().set_standalone_transparent_spendability(
+            account_id,
+            &address_only,
+            StandaloneSpendability::Spendable,
+        ),
+        Err(_)
+    );
+
+    // An address the wallet has never seen.
+    let unknown_key = SecretKey::from_slice(&[2u8; 32]).expect("valid secret key");
+    let unknown_addr = TransparentAddress::from_pubkey(&unknown_key.public_key(&secp));
+    assert_matches!(
+        st.wallet_mut().set_standalone_transparent_spendability(
+            account_id,
+            &unknown_addr,
+            StandaloneSpendability::Spendable,
+        ),
+        Err(_)
+    );
+}
+
+/// Tests that the metadata returned by [`WalletRead::get_transparent_receivers`] carries the
+/// declared spendability of pubkey and script imports, and reports address-only imports as
+/// watch-only.
+#[cfg(feature = "transparent-key-import")]
+pub fn get_transparent_receivers_reports_spendability<DSF>(dsf: DSF)
+where
+    DSF: DataStoreFactory,
+{
+    let mut st = TestBuilder::new()
+        .with_data_store_factory(dsf)
+        .with_account_from_sapling_activation(BlockHash([0; 32]))
+        .build();
+
+    let account_id = st.test_account().unwrap().id();
+    let secp = Secp256k1::new();
+
+    let spendable_key = SecretKey::from_slice(&[1u8; 32]).expect("valid secret key");
+    let spendable_pubkey = spendable_key.public_key(&secp);
+    let spendable_addr = TransparentAddress::from_pubkey(&spendable_pubkey);
+    st.wallet_mut()
+        .import_standalone_transparent_pubkey(
+            account_id,
+            spendable_pubkey,
+            StandaloneSpendability::Spendable,
+        )
+        .unwrap();
+
+    let watch_only_key = SecretKey::from_slice(&[2u8; 32]).expect("valid secret key");
+    let watch_only_pubkey = watch_only_key.public_key(&secp);
+    let watch_only_addr = TransparentAddress::from_pubkey(&watch_only_pubkey);
+    st.wallet_mut()
+        .import_standalone_transparent_pubkey(
+            account_id,
+            watch_only_pubkey,
+            StandaloneSpendability::WatchOnly,
+        )
+        .unwrap();
+
+    let (redeem_script, _) = build_test_redeem_script();
+    let script_addr =
+        TransparentAddress::from_script_pubkey(&sh(&redeem_script)).expect("valid P2SH address");
+    st.wallet_mut()
+        .import_standalone_transparent_script(
+            account_id,
+            redeem_script.clone(),
+            StandaloneSpendability::WatchOnly,
+        )
+        .unwrap();
+
+    let address_only_key = SecretKey::from_slice(&[3u8; 32]).expect("valid secret key");
+    let address_only_addr = TransparentAddress::from_pubkey(&address_only_key.public_key(&secp));
+    st.wallet_mut()
+        .import_standalone_transparent_address(account_id, address_only_addr)
+        .unwrap();
+
+    let receivers = st
+        .wallet()
+        .get_transparent_receivers(account_id, true, true)
+        .unwrap();
+    let source_of = |addr: &TransparentAddress| {
+        receivers
+            .get(addr)
+            .expect("address should be present")
+            .source()
+            .clone()
+    };
+
+    assert_eq!(
+        source_of(&spendable_addr),
+        TransparentAddressSource::StandalonePubkey {
+            pubkey: spendable_pubkey,
+            spendability: StandaloneSpendability::Spendable,
+        }
+    );
+    assert_eq!(
+        source_of(&watch_only_addr),
+        TransparentAddressSource::StandalonePubkey {
+            pubkey: watch_only_pubkey,
+            spendability: StandaloneSpendability::WatchOnly,
+        }
+    );
+    assert_eq!(
+        source_of(&script_addr),
+        TransparentAddressSource::StandaloneScript {
+            redeem_script,
+            spendability: StandaloneSpendability::WatchOnly,
+        }
+    );
+    assert_eq!(
+        source_of(&address_only_addr),
+        TransparentAddressSource::StandaloneAddress
+    );
+    assert_eq!(
+        source_of(&address_only_addr).spendability(),
+        Some(StandaloneSpendability::WatchOnly)
+    );
+
+    // HD-derived receivers report no standalone spendability.
+    let derived = receivers
+        .iter()
+        .filter(|(_, meta)| matches!(meta.source(), TransparentAddressSource::Derived { .. }))
+        .collect::<Vec<_>>();
+    assert!(!derived.is_empty());
+    assert!(
+        derived
+            .iter()
+            .all(|(_, meta)| meta.source().spendability().is_none())
     );
 }
 

--- a/zcash_client_backend/src/data_api/wallet.rs
+++ b/zcash_client_backend/src/data_api/wallet.rs
@@ -2078,13 +2078,17 @@ where
                         utxos_spent.push(outpoint.clone());
                         builder.add_transparent_p2pkh_input(pubkey, outpoint, txout)?;
                     }
+                    // The declared spendability is deliberately not consulted here: it only
+                    // governs input selection and balance reporting. If the proposal names an
+                    // input at a standalone address, the keys supplied explicitly in
+                    // `SpendingKeys::standalone_transparent_keys` are what sign for it.
                     #[cfg(feature = "transparent-key-import")]
-                    TransparentAddressSource::StandalonePubkey(pubkey) => {
+                    TransparentAddressSource::StandalonePubkey { pubkey, .. } => {
                         utxos_spent.push(outpoint.clone());
                         builder.add_transparent_p2pkh_input(*pubkey, outpoint, txout)?;
                     }
                     #[cfg(feature = "transparent-key-import")]
-                    TransparentAddressSource::StandaloneScript(redeem_script) => {
+                    TransparentAddressSource::StandaloneScript { redeem_script, .. } => {
                         let from_chain =
                             zs_script::FromChain::parse(&zs_script::Code(redeem_script.to_bytes()))
                                 .map_err(|_| ::transparent::builder::Error::UnsupportedScript)?;
@@ -2619,9 +2623,11 @@ where
                         .expect("spending key derivation should not fail"),
                 );
             }
+            // Keys explicitly supplied for a standalone address sign for it regardless of the
+            // spendability the application declared at import time.
             #[cfg(feature = "transparent-key-import")]
-            TransparentAddressSource::StandalonePubkey(_)
-            | TransparentAddressSource::StandaloneScript(_) => {
+            TransparentAddressSource::StandalonePubkey { .. }
+            | TransparentAddressSource::StandaloneScript { .. } => {
                 let keys = spending_keys
                     .standalone_transparent_keys
                     .get(&_address)
@@ -3216,8 +3222,8 @@ where
                                 address_index,
                             } => Some((index, *scope, *address_index)),
                             #[cfg(feature = "transparent-key-import")]
-                            TransparentAddressSource::StandalonePubkey(_)
-                            | TransparentAddressSource::StandaloneScript(_)
+                            TransparentAddressSource::StandalonePubkey { .. }
+                            | TransparentAddressSource::StandaloneScript { .. }
                             | TransparentAddressSource::StandaloneAddress => None,
                         }
                     })

--- a/zcash_client_backend/src/wallet.rs
+++ b/zcash_client_backend/src/wallet.rs
@@ -28,7 +28,10 @@ use crate::{TransferType, fees::sapling as sapling_fees};
 use crate::fees::orchard as orchard_fees;
 
 #[cfg(feature = "transparent-inputs")]
-use {::transparent::keys::NonHardenedChildIndex, std::time::SystemTime};
+use {
+    crate::data_api::StandaloneSpendability, ::transparent::keys::NonHardenedChildIndex,
+    std::time::SystemTime,
+};
 
 /// A unique identifier for a shielded transaction output
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -1043,11 +1046,15 @@ impl TransparentAddressMetadata {
     #[cfg(feature = "transparent-key-import")]
     pub fn standalone_p2pkh(
         pubkey: secp256k1::PublicKey,
+        spendability: StandaloneSpendability,
         exposure: Exposure,
         next_check_time: Option<SystemTime>,
     ) -> Self {
         Self {
-            source: TransparentAddressSource::StandalonePubkey(pubkey),
+            source: TransparentAddressSource::StandalonePubkey {
+                pubkey,
+                spendability,
+            },
             exposure,
             next_check_time,
         }
@@ -1058,11 +1065,15 @@ impl TransparentAddressMetadata {
     #[cfg(feature = "transparent-key-import")]
     pub fn standalone_script(
         redeem_script: script::Redeem,
+        spendability: StandaloneSpendability,
         exposure: Exposure,
         next_check_time: Option<SystemTime>,
     ) -> Self {
         Self {
-            source: TransparentAddressSource::StandaloneScript(redeem_script),
+            source: TransparentAddressSource::StandaloneScript {
+                redeem_script,
+                spendability,
+            },
             exposure,
             next_check_time,
         }
@@ -1151,13 +1162,28 @@ pub enum TransparentAddressSource {
     /// unknown or for which the associated spending key was produced from system randomness.
     /// This variant provides the public key directly.
     #[cfg(feature = "transparent-key-import")]
-    StandalonePubkey(secp256k1::PublicKey),
+    StandalonePubkey {
+        /// The public key from which the P2PKH address was derived.
+        pubkey: secp256k1::PublicKey,
+        /// The application's declaration of whether it can sign for the address. This does
+        /// not affect transaction construction: a secret key explicitly supplied for the
+        /// address in `SpendingKeys::standalone_transparent_keys` is used to sign regardless.
+        spendability: StandaloneSpendability,
+    },
 
     /// The address was derived from a P2SH redeem_script for which derivation information is
     /// unknown.
     /// This variant provides the redeem script directly.
     #[cfg(feature = "transparent-key-import")]
-    StandaloneScript(script::Redeem),
+    StandaloneScript {
+        /// The redeem script from which the P2SH address was derived.
+        redeem_script: script::Redeem,
+        /// The application's declaration of whether it holds enough member keys to sign for
+        /// the address. This does not affect transaction construction: secret keys explicitly
+        /// supplied for the address in `SpendingKeys::standalone_transparent_keys` are used to
+        /// sign regardless.
+        spendability: StandaloneSpendability,
+    },
 
     /// The address was imported as a bare transparent address, without any associated key
     /// material. The wallet watches for outputs received by the address, but holds neither
@@ -1175,9 +1201,9 @@ impl TransparentAddressSource {
         match self {
             TransparentAddressSource::Derived { scope, .. } => Some(*scope),
             #[cfg(feature = "transparent-key-import")]
-            TransparentAddressSource::StandalonePubkey(_) => None,
+            TransparentAddressSource::StandalonePubkey { .. } => None,
             #[cfg(feature = "transparent-key-import")]
-            TransparentAddressSource::StandaloneScript(_) => None,
+            TransparentAddressSource::StandaloneScript { .. } => None,
             #[cfg(feature = "transparent-key-import")]
             TransparentAddressSource::StandaloneAddress => None,
         }
@@ -1189,9 +1215,9 @@ impl TransparentAddressSource {
         match self {
             TransparentAddressSource::Derived { address_index, .. } => Some(*address_index),
             #[cfg(feature = "transparent-key-import")]
-            TransparentAddressSource::StandalonePubkey(_) => None,
+            TransparentAddressSource::StandalonePubkey { .. } => None,
             #[cfg(feature = "transparent-key-import")]
-            TransparentAddressSource::StandaloneScript(_) => None,
+            TransparentAddressSource::StandaloneScript { .. } => None,
             #[cfg(feature = "transparent-key-import")]
             TransparentAddressSource::StandaloneAddress => None,
         }
@@ -1204,11 +1230,30 @@ impl TransparentAddressSource {
         match self {
             TransparentAddressSource::Derived { .. } => None,
             #[cfg(feature = "transparent-key-import")]
-            TransparentAddressSource::StandalonePubkey(_) => None,
+            TransparentAddressSource::StandalonePubkey { .. } => None,
             #[cfg(feature = "transparent-key-import")]
-            TransparentAddressSource::StandaloneScript(redeem_script) => Some(redeem_script),
+            TransparentAddressSource::StandaloneScript { redeem_script, .. } => Some(redeem_script),
             #[cfg(feature = "transparent-key-import")]
             TransparentAddressSource::StandaloneAddress => None,
+        }
+    }
+
+    /// Returns the application's declaration of whether it can sign for the address, if this
+    /// is a standalone (imported) address.
+    ///
+    /// Returns `None` for HD-derived addresses, which are always spendable with the account's
+    /// spending key, and `Some(StandaloneSpendability::WatchOnly)` for an address imported
+    /// without key material.
+    pub fn spendability(&self) -> Option<StandaloneSpendability> {
+        match self {
+            TransparentAddressSource::Derived { .. } => None,
+            #[cfg(feature = "transparent-key-import")]
+            TransparentAddressSource::StandalonePubkey { spendability, .. }
+            | TransparentAddressSource::StandaloneScript { spendability, .. } => {
+                Some(*spendability)
+            }
+            #[cfg(feature = "transparent-key-import")]
+            TransparentAddressSource::StandaloneAddress => Some(StandaloneSpendability::WatchOnly),
         }
     }
 }

--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -15,6 +15,37 @@ workspace.
   transactions deferred to the post-import rescan because the wallet had no
   view of the chain tip against which to store them; such transactions were
   previously conflated with `transactions_without_wallet_relevance`.
+- A `standalone_spendability` migration adds the `addresses.standalone_spendable`
+  column, recording whether the application has declared that it holds the
+  secret key material for a standalone transparent import.
+- `WalletDb` now implements `WalletWrite::set_standalone_transparent_spendability`.
+- `SqliteClientError::NotStandaloneKeyImport`, returned by
+  `set_standalone_transparent_spendability` when the address is a derived
+  address or an address imported without key material.
+- `zewif::ZewifImportReport::redeem_scripts_watch_only`: counts registered
+  P2SH redeem scripts marked watch-only because the document did not deliver
+  the spending key of every member pubkey.
+
+### Changed
+- **Existing standalone transparent imports with key material (imported
+  pubkeys and redeem scripts) are marked watch-only by the
+  `standalone_spendability` migration.** The wallet database cannot know
+  whether the application holds the corresponding secret keys, so until the
+  application calls `WalletWrite::set_standalone_transparent_spendability`
+  for each import it can sign for, the value received at those addresses is
+  reported under `Balance::watch_only_value` instead of `spendable_value`
+  (it remains part of `total`), and their outputs are no longer selected as
+  transaction inputs. Address-only imports remain unspendable, and their
+  value is now also reported as watch-only rather than spendable.
+- `WalletWrite::import_standalone_transparent_pubkey`,
+  `import_standalone_transparent_pubkeys` and
+  `import_standalone_transparent_script` take a `StandaloneSpendability`
+  argument; re-importing an already-imported pubkey or script as `Spendable`
+  promotes it, and never downgrades it.
+- `zewif::import_wallet` marks imported transparent pubkeys spendable (their
+  spending keys are decoded and verified against the pubkeys), and marks a
+  multisig redeem script spendable only when the spending key of every member
+  pubkey was imported; any other redeem script is registered watch-only.
 
 ### Fixed
 - Reading back a stored unmined transaction with a zero expiry height (such as

--- a/zcash_client_sqlite/src/error.rs
+++ b/zcash_client_sqlite/src/error.rs
@@ -246,6 +246,13 @@ pub enum SqliteClientError {
     #[cfg(feature = "transparent-key-import")]
     StandaloneImportConflict(Uuid),
 
+    /// An attempt to set the spendability of a standalone transparent import failed because the
+    /// given address is known to the wallet but is not a standalone import carrying key material:
+    /// it is either a derived address of the account (whose spendability is that of the account)
+    /// or an address imported without key material (which can never be spent from).
+    #[cfg(feature = "transparent-key-import")]
+    NotStandaloneKeyImport(TransparentAddress),
+
     /// An error returned by a [`FeeRule`] during transparent input selection. The underlying
     /// error is boxed so the storage layer does not need to know every fee rule's error type.
     ///
@@ -475,6 +482,13 @@ impl fmt::Display for SqliteClientError {
                 write!(
                     f,
                     "The given standalone transparent address is already managed by account {uuid}"
+                )
+            }
+            #[cfg(feature = "transparent-key-import")]
+            SqliteClientError::NotStandaloneKeyImport(addr) => {
+                write!(
+                    f,
+                    "The transparent address {addr:?} is not a standalone import with key material, so its spendability cannot be set"
                 )
             }
             #[cfg(feature = "transparent-inputs")]

--- a/zcash_client_sqlite/src/lib.rs
+++ b/zcash_client_sqlite/src/lib.rs
@@ -114,6 +114,9 @@ use zcash_client_backend::{
     decrypt_transaction,
 };
 
+#[cfg(feature = "transparent-key-import")]
+use zcash_client_backend::data_api::StandaloneSpendability;
+
 #[cfg(feature = "transparent-inputs")]
 use {
     crate::wallet::transparent::ephemeral::schedule_ephemeral_address_checks,
@@ -1775,8 +1778,11 @@ impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL: Clock, R:
         &mut self,
         account: <Self as WalletRead>::AccountId,
         pubkey: secp256k1::PublicKey,
+        spendability: StandaloneSpendability,
     ) -> Result<(), <Self as WalletRead>::Error> {
-        self.transactionally(|wdb| wdb.import_standalone_transparent_pubkey(account, pubkey))
+        self.transactionally(|wdb| {
+            wdb.import_standalone_transparent_pubkey(account, pubkey, spendability)
+        })
     }
 
     #[cfg(feature = "transparent-key-import")]
@@ -1784,8 +1790,11 @@ impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL: Clock, R:
         &mut self,
         account: <Self as WalletRead>::AccountId,
         pubkeys: &[secp256k1::PublicKey],
+        spendability: StandaloneSpendability,
     ) -> Result<(), <Self as WalletRead>::Error> {
-        self.transactionally(|wdb| wdb.import_standalone_transparent_pubkeys(account, pubkeys))
+        self.transactionally(|wdb| {
+            wdb.import_standalone_transparent_pubkeys(account, pubkeys, spendability)
+        })
     }
 
     #[cfg(feature = "transparent-key-import")]
@@ -1793,8 +1802,23 @@ impl<C: BorrowMut<rusqlite::Connection>, P: consensus::Parameters, CL: Clock, R:
         &mut self,
         account: <Self as WalletRead>::AccountId,
         script: zcash_script::script::Redeem,
+        spendability: StandaloneSpendability,
     ) -> Result<(), <Self as WalletRead>::Error> {
-        self.transactionally(|wdb| wdb.import_standalone_transparent_script(account, script))
+        self.transactionally(|wdb| {
+            wdb.import_standalone_transparent_script(account, script, spendability)
+        })
+    }
+
+    #[cfg(feature = "transparent-key-import")]
+    fn set_standalone_transparent_spendability(
+        &mut self,
+        account: <Self as WalletRead>::AccountId,
+        address: &TransparentAddress,
+        spendability: StandaloneSpendability,
+    ) -> Result<(), <Self as WalletRead>::Error> {
+        self.transactionally(|wdb| {
+            wdb.set_standalone_transparent_spendability(account, address, spendability)
+        })
     }
 
     fn get_next_available_address(
@@ -2161,9 +2185,16 @@ impl<P: consensus::Parameters, CL: Clock, R: RngCore> WalletWrite
         &mut self,
         account: <Self as WalletRead>::AccountId,
         pubkey: secp256k1::PublicKey,
+        spendability: StandaloneSpendability,
     ) -> Result<(), <Self as WalletRead>::Error> {
-        wallet::import_standalone_transparent_pubkey(self.conn.0, &self.params, account, pubkey)
-            .map(|_inserted| ())
+        wallet::import_standalone_transparent_pubkey(
+            self.conn.0,
+            &self.params,
+            account,
+            pubkey,
+            spendability,
+        )
+        .map(|_inserted| ())
     }
 
     #[cfg(feature = "transparent-key-import")]
@@ -2171,9 +2202,16 @@ impl<P: consensus::Parameters, CL: Clock, R: RngCore> WalletWrite
         &mut self,
         account: <Self as WalletRead>::AccountId,
         pubkeys: &[secp256k1::PublicKey],
+        spendability: StandaloneSpendability,
     ) -> Result<(), <Self as WalletRead>::Error> {
-        wallet::import_standalone_transparent_pubkeys(self.conn.0, &self.params, account, pubkeys)
-            .map(|_inserted| ())
+        wallet::import_standalone_transparent_pubkeys(
+            self.conn.0,
+            &self.params,
+            account,
+            pubkeys,
+            spendability,
+        )
+        .map(|_inserted| ())
     }
 
     #[cfg(feature = "transparent-key-import")]
@@ -2181,8 +2219,31 @@ impl<P: consensus::Parameters, CL: Clock, R: RngCore> WalletWrite
         &mut self,
         account: <Self as WalletRead>::AccountId,
         script: zcash_script::script::Redeem,
+        spendability: StandaloneSpendability,
     ) -> Result<(), <Self as WalletRead>::Error> {
-        wallet::import_standalone_transparent_script(self.conn.0, &self.params, account, script)
+        wallet::import_standalone_transparent_script(
+            self.conn.0,
+            &self.params,
+            account,
+            script,
+            spendability,
+        )
+    }
+
+    #[cfg(feature = "transparent-key-import")]
+    fn set_standalone_transparent_spendability(
+        &mut self,
+        account: <Self as WalletRead>::AccountId,
+        address: &TransparentAddress,
+        spendability: StandaloneSpendability,
+    ) -> Result<(), <Self as WalletRead>::Error> {
+        wallet::set_standalone_transparent_spendability(
+            self.conn.0,
+            &self.params,
+            account,
+            address,
+            spendability,
+        )
     }
 
     fn get_next_available_address(

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -177,6 +177,8 @@ use {
 #[cfg(feature = "transparent-key-import")]
 use {
     ::transparent::address::TransparentAddress,
+    encoding::encode_standalone_spendability,
+    zcash_client_backend::data_api::StandaloneSpendability,
     zcash_script::{descriptor::sh, script::Evaluable},
 };
 
@@ -933,7 +935,8 @@ pub(crate) fn import_standalone_transparent_address<P: consensus::Parameters>(
     Ok(rows_affected)
 }
 
-/// Imports a standalone transparent P2PKH receiver by its pubkey into the given account.
+/// Imports a standalone transparent P2PKH receiver by its pubkey into the given account, with
+/// the given application-declared spendability.
 ///
 /// Returns the number of address rows inserted: `1` when a new receiver row was added, or `0`
 /// when nothing was inserted because the receiver address was already present in the wallet.
@@ -943,11 +946,19 @@ pub(crate) fn import_standalone_transparent_pubkey<P: consensus::Parameters>(
     params: &P,
     account_uuid: AccountUuid,
     pubkey: secp256k1::PublicKey,
+    spendability: StandaloneSpendability,
 ) -> Result<usize, SqliteClientError> {
     // Resolve the account up front so an unknown account is reported explicitly, rather than
     // inferred from a zero-row INSERT.
     let account_id = get_account_ref(conn, account_uuid)?;
-    import_standalone_transparent_pubkey_inner(conn, params, account_uuid, account_id, pubkey)
+    import_standalone_transparent_pubkey_inner(
+        conn,
+        params,
+        account_uuid,
+        account_id,
+        pubkey,
+        spendability,
+    )
 }
 
 /// Imports a batch of standalone transparent P2PKH receivers by their pubkeys into the given
@@ -959,6 +970,7 @@ pub(crate) fn import_standalone_transparent_pubkeys<P: consensus::Parameters>(
     params: &P,
     account_uuid: AccountUuid,
     pubkeys: &[secp256k1::PublicKey],
+    spendability: StandaloneSpendability,
 ) -> Result<usize, SqliteClientError> {
     let account_id = get_account_ref(conn, account_uuid)?;
     let mut inserted = 0;
@@ -969,6 +981,7 @@ pub(crate) fn import_standalone_transparent_pubkeys<P: consensus::Parameters>(
             account_uuid,
             account_id,
             *pubkey,
+            spendability,
         )?;
     }
     Ok(inserted)
@@ -979,6 +992,11 @@ pub(crate) fn import_standalone_transparent_pubkeys<P: consensus::Parameters>(
 ///
 /// Returns the number of address rows inserted (`1` when a new receiver row was added, `0` when
 /// nothing was inserted because the receiver address was already present).
+///
+/// If the pubkey has already been imported into this account, re-importing it as
+/// [`StandaloneSpendability::Spendable`] promotes the existing row to spendable; a re-import as
+/// [`StandaloneSpendability::WatchOnly`] never downgrades a spendable row (use
+/// [`set_standalone_transparent_spendability`] for that).
 #[cfg(feature = "transparent-key-import")]
 fn import_standalone_transparent_pubkey_inner<P: consensus::Parameters>(
     conn: &rusqlite::Transaction,
@@ -986,23 +1004,25 @@ fn import_standalone_transparent_pubkey_inner<P: consensus::Parameters>(
     account_uuid: AccountUuid,
     account_id: AccountRef,
     pubkey: secp256k1::PublicKey,
+    spendability: StandaloneSpendability,
 ) -> Result<usize, SqliteClientError> {
-    let existing_import_account = conn
+    let existing_import: Option<(i64, Uuid)> = conn
         .query_row(
-            "SELECT accounts.uuid AS account_uuid
+            "SELECT addresses.id, accounts.uuid AS account_uuid
              FROM addresses
              JOIN accounts ON accounts.id = addresses.account_id
              WHERE imported_transparent_receiver_pubkey = :imported_transparent_receiver_pubkey",
             named_params![
                 ":imported_transparent_receiver_pubkey": pubkey.serialize()
             ],
-            |row| row.get::<_, Uuid>("account_uuid"),
+            |row| Ok((row.get("id")?, row.get("account_uuid")?)),
         )
         .optional()?;
 
-    if let Some(current) = existing_import_account {
+    if let Some((row_id, current)) = existing_import {
         if current == account_uuid.expose_uuid() {
-            // The key has already been imported; nothing to do.
+            // The key has already been imported; at most promote it to spendable.
+            promote_standalone_spendability(conn, row_id, spendability)?;
             return Ok(0);
         } else {
             return Err(SqliteClientError::StandaloneImportConflict(current));
@@ -1017,10 +1037,12 @@ fn import_standalone_transparent_pubkey_inner<P: consensus::Parameters>(
     if let Some(row_id) = standalone_address_only_row(conn, account_id, &addr_str)? {
         conn.execute(
             "UPDATE addresses
-             SET imported_transparent_receiver_pubkey = :imported_transparent_receiver_pubkey
+             SET imported_transparent_receiver_pubkey = :imported_transparent_receiver_pubkey,
+                 standalone_spendable = :standalone_spendable
              WHERE id = :id",
             named_params![
                 ":imported_transparent_receiver_pubkey": pubkey.serialize(),
+                ":standalone_spendable": encode_standalone_spendability(spendability),
                 ":id": row_id,
             ],
         )?;
@@ -1042,11 +1064,11 @@ fn import_standalone_transparent_pubkey_inner<P: consensus::Parameters>(
         r#"
         INSERT INTO addresses (
           account_id, key_scope, address, cached_transparent_receiver_address,
-          receiver_flags, imported_transparent_receiver_pubkey
+          receiver_flags, imported_transparent_receiver_pubkey, standalone_spendable
         )
         VALUES (
           :account_id, :key_scope, :address, :address,
-          :receiver_flags, :imported_transparent_receiver_pubkey
+          :receiver_flags, :imported_transparent_receiver_pubkey, :standalone_spendable
         )
         "#,
         named_params![
@@ -1054,7 +1076,8 @@ fn import_standalone_transparent_pubkey_inner<P: consensus::Parameters>(
             ":key_scope": KeyScope::Foreign.encode(),
             ":address": addr_str,
             ":receiver_flags": ReceiverFlags::P2PKH.bits(),
-            ":imported_transparent_receiver_pubkey": pubkey.serialize()
+            ":imported_transparent_receiver_pubkey": pubkey.serialize(),
+            ":standalone_spendable": encode_standalone_spendability(spendability),
         ],
     )?;
 
@@ -1063,12 +1086,20 @@ fn import_standalone_transparent_pubkey_inner<P: consensus::Parameters>(
     Ok(rows_affected)
 }
 
+/// Imports a standalone transparent P2SH receiver by its redeem script into the given account,
+/// with the given application-declared spendability.
+///
+/// If the script has already been imported into this account, re-importing it as
+/// [`StandaloneSpendability::Spendable`] promotes the existing row to spendable; a re-import as
+/// [`StandaloneSpendability::WatchOnly`] never downgrades a spendable row (use
+/// [`set_standalone_transparent_spendability`] for that).
 #[cfg(feature = "transparent-key-import")]
 pub(crate) fn import_standalone_transparent_script<P: consensus::Parameters>(
     conn: &rusqlite::Transaction,
     params: &P,
     account_uuid: AccountUuid,
     redeem_script: zcash_script::script::Redeem,
+    spendability: StandaloneSpendability,
 ) -> Result<(), SqliteClientError> {
     // Resolve the account up front so an unknown account is reported explicitly, rather than
     // inferred from a zero-row INSERT below.
@@ -1104,22 +1135,23 @@ pub(crate) fn import_standalone_transparent_script<P: consensus::Parameters>(
         )
     })?;
 
-    let existing_import_account = conn
+    let existing_import: Option<(i64, Uuid)> = conn
         .query_row(
-            "SELECT accounts.uuid AS account_uuid
+            "SELECT addresses.id, accounts.uuid AS account_uuid
              FROM addresses
              JOIN accounts ON accounts.id = addresses.account_id
              WHERE imported_transparent_receiver_script = :imported_transparent_receiver_script",
             named_params![
                 ":imported_transparent_receiver_script": &rs_bytes[..]
             ],
-            |row| row.get::<_, Uuid>("account_uuid"),
+            |row| Ok((row.get("id")?, row.get("account_uuid")?)),
         )
         .optional()?;
 
-    if let Some(current) = existing_import_account {
+    if let Some((row_id, current)) = existing_import {
         if current == account_uuid.expose_uuid() {
-            // The key has already been imported; nothing to do.
+            // The script has already been imported; at most promote it to spendable.
+            promote_standalone_spendability(conn, row_id, spendability)?;
             return Ok(());
         } else {
             return Err(SqliteClientError::StandaloneImportConflict(current));
@@ -1134,10 +1166,12 @@ pub(crate) fn import_standalone_transparent_script<P: consensus::Parameters>(
     if let Some(row_id) = standalone_address_only_row(conn, account_id, &addr_str)? {
         conn.execute(
             "UPDATE addresses
-             SET imported_transparent_receiver_script = :imported_transparent_receiver_script
+             SET imported_transparent_receiver_script = :imported_transparent_receiver_script,
+                 standalone_spendable = :standalone_spendable
              WHERE id = :id",
             named_params![
                 ":imported_transparent_receiver_script": &rs_bytes[..],
+                ":standalone_spendable": encode_standalone_spendability(spendability),
                 ":id": row_id,
             ],
         )?;
@@ -1148,11 +1182,11 @@ pub(crate) fn import_standalone_transparent_script<P: consensus::Parameters>(
         r#"
         INSERT INTO addresses (
           account_id, key_scope, address, cached_transparent_receiver_address,
-          receiver_flags, imported_transparent_receiver_script
+          receiver_flags, imported_transparent_receiver_script, standalone_spendable
         )
         VALUES (
           :account_id, :key_scope, :address, :address,
-          :receiver_flags, :imported_transparent_receiver_script
+          :receiver_flags, :imported_transparent_receiver_script, :standalone_spendable
         )
         "#,
         named_params![
@@ -1160,11 +1194,105 @@ pub(crate) fn import_standalone_transparent_script<P: consensus::Parameters>(
             ":key_scope": KeyScope::Foreign.encode(),
             ":address": addr_str,
             ":receiver_flags": ReceiverFlags::P2SH.bits(),
-            ":imported_transparent_receiver_script": &rs_bytes[..]
+            ":imported_transparent_receiver_script": &rs_bytes[..],
+            ":standalone_spendable": encode_standalone_spendability(spendability),
         ],
     )?;
 
     Ok(())
+}
+
+/// Promotes the standalone import row `row_id` to spendable if `spendability` is
+/// [`StandaloneSpendability::Spendable`]; never downgrades an already-spendable row.
+#[cfg(feature = "transparent-key-import")]
+fn promote_standalone_spendability(
+    conn: &rusqlite::Transaction,
+    row_id: i64,
+    spendability: StandaloneSpendability,
+) -> Result<(), SqliteClientError> {
+    match spendability {
+        StandaloneSpendability::WatchOnly => {}
+        StandaloneSpendability::Spendable => {
+            conn.execute(
+                "UPDATE addresses SET standalone_spendable = 1 WHERE id = :id",
+                named_params![":id": row_id],
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// Sets the application-declared spendability of a standalone transparent import.
+///
+/// The address must be a standalone import (a [`KeyScope::Foreign`] row) of the given account
+/// that carries key material (an imported pubkey or redeem script). Otherwise, the failure is
+/// diagnosed in this order:
+/// 1. an unknown account is reported as [`SqliteClientError::AccountUnknown`];
+/// 2. an address unknown to the wallet is reported as
+///    [`SqliteClientError::AddressNotRecognized`];
+/// 3. an address belonging to a different account (whatever its kind) is reported as
+///    [`SqliteClientError::StandaloneImportConflict`] with that account's identifier;
+/// 4. a derived address of the account, or an address the account imported without key
+///    material, is reported as [`SqliteClientError::NotStandaloneKeyImport`].
+#[cfg(feature = "transparent-key-import")]
+pub(crate) fn set_standalone_transparent_spendability<P: consensus::Parameters>(
+    conn: &rusqlite::Transaction,
+    params: &P,
+    account_uuid: AccountUuid,
+    address: &TransparentAddress,
+    spendability: StandaloneSpendability,
+) -> Result<(), SqliteClientError> {
+    // Resolve the account up front so an unknown account is reported explicitly, rather than
+    // being conflated with an unknown address.
+    let account_id = get_account_ref(conn, account_uuid)?;
+    let addr_str = Address::Transparent(*address).encode(params);
+
+    let updated = conn.execute(
+        "UPDATE addresses
+         SET standalone_spendable = :standalone_spendable
+         WHERE account_id = :account_id
+         AND cached_transparent_receiver_address = :address
+         AND key_scope = :key_scope
+         AND (
+             imported_transparent_receiver_pubkey IS NOT NULL
+             OR imported_transparent_receiver_script IS NOT NULL
+         )",
+        named_params![
+            ":standalone_spendable": encode_standalone_spendability(spendability),
+            ":account_id": account_id.0,
+            ":address": addr_str,
+            ":key_scope": KeyScope::Foreign.encode(),
+        ],
+    )?;
+
+    if updated == 1 {
+        return Ok(());
+    }
+
+    // Nothing matched; diagnose why. `cached_transparent_receiver_address` is unique, so at most
+    // one row can hold the address.
+    let owner: Option<Uuid> = conn
+        .query_row(
+            "SELECT accounts.uuid AS account_uuid
+             FROM addresses
+             JOIN accounts ON accounts.id = addresses.account_id
+             WHERE cached_transparent_receiver_address = :address",
+            named_params![":address": addr_str],
+            |row| row.get("account_uuid"),
+        )
+        .optional()?;
+
+    match owner {
+        None => Err(SqliteClientError::AddressNotRecognized(*address)),
+        // The address belongs to another account; report that before its kind, since the caller
+        // has no standing to alter it regardless.
+        Some(owner) if owner != account_uuid.expose_uuid() => {
+            Err(SqliteClientError::StandaloneImportConflict(owner))
+        }
+        // The account's own row did not match the UPDATE, so it is a derived address or an
+        // address-only import.
+        Some(_) => Err(SqliteClientError::NotStandaloneKeyImport(*address)),
+    }
 }
 
 pub(crate) fn get_next_available_address<P: consensus::Parameters, C: Clock>(

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -184,12 +184,20 @@ pub(super) const INDEX_ACCOUNTS_P2SH_IVK: &str =
 /// - `imported_transparent_receiver_script`: The serialized redeem script for an imported
 ///   standalone P2SH address. When present, `cached_transparent_receiver_address` holds the P2SH
 ///   address derived from this script. This is only set for imported addresses (key_scope = -1).
+/// - `standalone_spendable`: `1` if the application has declared that it holds the secret key
+///   material needed to spend outputs received at an imported standalone address, `0` (watch-only)
+///   otherwise. This is only meaningful for, and may only be `1` on, imported rows
+///   (key_scope = -1) that carry key material in one of the two preceding columns. The
+///   `standalone_spendability` migration set this to `0` on all pre-existing rows, because the
+///   wallet database cannot know which secret keys the application holds.
 ///
 /// At most one of `imported_transparent_receiver_pubkey` and
 /// `imported_transparent_receiver_script` may be set. An imported row (key_scope = -1) with
 /// neither set is a standalone transparent address imported without key material: the wallet
-/// watches for outputs received by `cached_transparent_receiver_address`, but cannot spend
-/// them unless the corresponding pubkey or redeem script is subsequently imported.
+/// watches for outputs received by `cached_transparent_receiver_address`, but can never spend
+/// them. Importing the corresponding pubkey or redeem script does not by itself make such
+/// outputs spendable: the wallet only selects them as inputs, and only counts their value as
+/// spendable, once `standalone_spendable` is `1`.
 ///
 /// [`ReceiverFlags`]: crate::wallet::encoding::ReceiverFlags
 pub(super) const TABLE_ADDRESSES: &str = r#"
@@ -207,6 +215,7 @@ CREATE TABLE "addresses" (
     transparent_receiver_next_check_time INTEGER,
     imported_transparent_receiver_pubkey BLOB,
     imported_transparent_receiver_script BLOB,
+    standalone_spendable INTEGER NOT NULL DEFAULT 0,
     UNIQUE (account_id, key_scope, diversifier_index_be),
     UNIQUE (imported_transparent_receiver_pubkey),
     UNIQUE (imported_transparent_receiver_script),
@@ -241,6 +250,15 @@ CREATE TABLE "addresses" (
     ),
     CONSTRAINT ck_addr_foreign_or_diversified CHECK (
         (diversifier_index_be IS NULL) == (key_scope = -1)
+    ),
+    -- the spendable marker may only be set on imported rows that carry key material
+    CONSTRAINT ck_addr_standalone_spendable CHECK (
+        standalone_spendable = 0 OR (
+            key_scope = -1 AND (
+                imported_transparent_receiver_pubkey IS NOT NULL
+                OR imported_transparent_receiver_script IS NOT NULL
+            )
+        )
     )
 )"#;
 pub(super) const INDEX_ADDRESSES_ACCOUNTS: &str = r#"

--- a/zcash_client_sqlite/src/wallet/encoding.rs
+++ b/zcash_client_sqlite/src/wallet/encoding.rs
@@ -19,7 +19,7 @@ use {
     super::transparent::SchedulingError,
     std::time::{Duration, SystemTime},
     transparent::keys::TransparentKeyScope,
-    zcash_client_backend::data_api::TransparentKeyOrigin,
+    zcash_client_backend::data_api::{StandaloneSpendability, TransparentKeyOrigin},
     zcash_keys::keys::AddressGenerationError,
 };
 
@@ -164,8 +164,12 @@ impl KeyScope {
         }
     }
 
+    /// Returns the [`TransparentKeyOrigin`] of an address row with this key scope.
+    ///
+    /// `standalone_spendable` is the row's `standalone_spendable` marker; it is only meaningful
+    /// for (and only ever set on) [`KeyScope::Foreign`] rows, and is ignored otherwise.
     #[cfg(feature = "transparent-inputs")]
-    pub(crate) fn as_key_origin(&self) -> TransparentKeyOrigin {
+    pub(crate) fn as_key_origin(&self, standalone_spendable: bool) -> TransparentKeyOrigin {
         match self {
             KeyScope::Zip32(scope) => TransparentKeyOrigin::Derived {
                 scope: TransparentKeyScope::from(*scope),
@@ -173,8 +177,29 @@ impl KeyScope {
             KeyScope::Ephemeral => TransparentKeyOrigin::Derived {
                 scope: TransparentKeyScope::custom(2).expect("valid scope"),
             },
-            KeyScope::Foreign => TransparentKeyOrigin::Imported,
+            KeyScope::Foreign => TransparentKeyOrigin::Imported {
+                spendability: decode_standalone_spendability(standalone_spendable),
+            },
         }
+    }
+}
+
+/// Encodes a [`StandaloneSpendability`] as the `addresses.standalone_spendable` column value.
+#[cfg(feature = "transparent-key-import")]
+pub(crate) fn encode_standalone_spendability(spendability: StandaloneSpendability) -> bool {
+    match spendability {
+        StandaloneSpendability::WatchOnly => false,
+        StandaloneSpendability::Spendable => true,
+    }
+}
+
+/// Decodes the `addresses.standalone_spendable` column value as a [`StandaloneSpendability`].
+#[cfg(feature = "transparent-inputs")]
+pub(crate) fn decode_standalone_spendability(standalone_spendable: bool) -> StandaloneSpendability {
+    if standalone_spendable {
+        StandaloneSpendability::Spendable
+    } else {
+        StandaloneSpendability::WatchOnly
     }
 }
 

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -249,7 +249,8 @@ fn sqlite_client_error_to_wallet_migration_error(e: SqliteClientError) -> Wallet
             unreachable!("we don't service transaction data requests in migrations")
         }
         #[cfg(feature = "transparent-key-import")]
-        SqliteClientError::StandaloneImportConflict(_) => {
+        SqliteClientError::StandaloneImportConflict(_)
+        | SqliteClientError::NotStandaloneKeyImport(_) => {
             unreachable!("we do not import standalone transparent addresses in migrations")
         }
         #[cfg(feature = "orchard")]

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -155,6 +155,7 @@ migration_modules!(
     spend_key_available,
     standalone_address,
     standalone_p2sh,
+    standalone_spendability,
     support_legacy_sqlite,
     support_zcashd_wallet_import,
     transparent_gap_limit_handling,
@@ -274,8 +275,8 @@ pub(super) fn all_migrations<
     //                             |  add_transparent_receiver_address_index        \
     //                             |               |                                 \
     //                             |      standalone_address               ironwood_received_notes ----------------
-    //                             |                                        /         |          \                  \
-    //                             |                     ironwood_pool_code_views     |      note_locking  fix_bad_ironwood_change_flagging
+    //                             |               |                        /         |          \                  \
+    //                             |  standalone_spendability  ironwood_pool_code_views     |      note_locking  fix_bad_ironwood_change_flagging
     //                             |                             |          \         |
     //                             |                             |           \ v_address_uses_ironwood
     //                             |                             |            \
@@ -401,6 +402,7 @@ pub(super) fn all_migrations<
         Box::new(orchard_ironwood_migration_txid_blob::Migration),
         Box::new(v_migration_transactions::Migration),
         Box::new(standalone_address::Migration),
+        Box::new(standalone_spendability::Migration),
     ]
 }
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/standalone_spendability.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/standalone_spendability.rs
@@ -1,0 +1,323 @@
+//! This migration adds the `standalone_spendable` column to the `addresses` table, recording
+//! whether the application has declared that it holds the secret key material required to spend
+//! outputs received at a standalone (`key_scope = -1`) transparent import.
+
+use std::collections::HashSet;
+
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+
+use crate::wallet::init::WalletMigrationError;
+
+use super::standalone_address;
+
+/// This migration adds the `standalone_spendable` column to the `addresses` table.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0x3f6b8e1a_7d24_4c0b_9a5e_2b1f0c8d7e63);
+
+pub(super) const DEPENDENCIES: &[Uuid] = &[standalone_address::MIGRATION_ID];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Adds the standalone_spendable column to the addresses table, recording whether the application holds the key material for a standalone transparent import."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        // Recreate the addresses table with the new column. The wallet database cannot know
+        // whether the application holds the secret keys corresponding to imported key material,
+        // so every existing standalone import is marked watch-only (`standalone_spendable = 0`);
+        // the application must reclassify the imports for which it holds the keys via
+        // `WalletWrite::set_standalone_transparent_spendability`.
+        //
+        // The new constraint permits the spendable marker only on standalone rows that carry
+        // key material: a derived address never needs the marker (its spendability is that of
+        // the account), and an address-only import has nothing to spend with.
+        transaction.execute_batch(
+            r#"
+            CREATE TABLE addresses_new (
+                id INTEGER NOT NULL PRIMARY KEY,
+                account_id INTEGER NOT NULL
+                    REFERENCES accounts(id) ON DELETE CASCADE,
+                key_scope INTEGER NOT NULL,
+                diversifier_index_be BLOB,
+                address TEXT NOT NULL,
+                transparent_child_index INTEGER,
+                cached_transparent_receiver_address TEXT,
+                exposed_at_height INTEGER,
+                receiver_flags INTEGER NOT NULL,
+                transparent_receiver_next_check_time INTEGER,
+                imported_transparent_receiver_pubkey BLOB,
+                imported_transparent_receiver_script BLOB,
+                standalone_spendable INTEGER NOT NULL DEFAULT 0,
+                UNIQUE (account_id, key_scope, diversifier_index_be),
+                UNIQUE (imported_transparent_receiver_pubkey),
+                UNIQUE (imported_transparent_receiver_script),
+                CONSTRAINT ck_addr_transparent_index_consistency CHECK (
+                    (transparent_child_index IS NULL OR diversifier_index_be < x'0000000F00000000000000')
+                    AND (
+                        -- no transparent receiver: all transparent columns are absent
+                        (
+                            cached_transparent_receiver_address IS NULL
+                            AND transparent_child_index IS NULL
+                            AND imported_transparent_receiver_pubkey IS NULL
+                            AND imported_transparent_receiver_script IS NULL
+                        )
+                        OR (
+                            cached_transparent_receiver_address IS NOT NULL
+                            -- a transparent receiver has a child index iff it was derived
+                            AND ((transparent_child_index IS NULL) == (key_scope = -1))
+                            -- at most one kind of imported key material
+                            AND NOT (
+                                imported_transparent_receiver_pubkey IS NOT NULL
+                                AND imported_transparent_receiver_script IS NOT NULL
+                            )
+                            -- imported key material appears only on imported (key_scope = -1) rows
+                            AND (
+                                key_scope = -1 OR (
+                                    imported_transparent_receiver_pubkey IS NULL
+                                    AND imported_transparent_receiver_script IS NULL
+                                )
+                            )
+                        )
+                    )
+                ),
+                CONSTRAINT ck_addr_foreign_or_diversified CHECK (
+                    (diversifier_index_be IS NULL) == (key_scope = -1)
+                ),
+                -- the spendable marker may only be set on imported rows that carry key material
+                CONSTRAINT ck_addr_standalone_spendable CHECK (
+                    standalone_spendable = 0 OR (
+                        key_scope = -1 AND (
+                            imported_transparent_receiver_pubkey IS NOT NULL
+                            OR imported_transparent_receiver_script IS NOT NULL
+                        )
+                    )
+                )
+            );
+
+            INSERT INTO addresses_new (
+                id, account_id, key_scope, diversifier_index_be, address,
+                transparent_child_index, cached_transparent_receiver_address,
+                exposed_at_height, receiver_flags, transparent_receiver_next_check_time,
+                imported_transparent_receiver_pubkey, imported_transparent_receiver_script
+            )
+            SELECT
+                id, account_id, key_scope, diversifier_index_be, address,
+                transparent_child_index, cached_transparent_receiver_address,
+                exposed_at_height, receiver_flags, transparent_receiver_next_check_time,
+                imported_transparent_receiver_pubkey, imported_transparent_receiver_script
+            FROM addresses;
+
+            PRAGMA legacy_alter_table = ON;
+
+            DROP TABLE addresses;
+            ALTER TABLE addresses_new RENAME TO addresses;
+
+            PRAGMA legacy_alter_table = OFF;
+
+            -- Recreate the existing indices
+            CREATE INDEX idx_addresses_accounts ON addresses (
+                account_id ASC
+            );
+            CREATE UNIQUE INDEX idx_addresses_cached_transparent_receiver_address ON addresses (
+                cached_transparent_receiver_address ASC
+            );
+            CREATE INDEX idx_addresses_indices ON addresses (
+                diversifier_index_be ASC
+            );
+            CREATE INDEX idx_addresses_pubkeys ON addresses (
+                imported_transparent_receiver_pubkey ASC
+            );
+            CREATE INDEX idx_addresses_t_indices ON addresses (
+                transparent_child_index ASC
+            );
+            "#,
+        )?;
+
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        Err(WalletMigrationError::CannotRevert(MIGRATION_ID))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::named_params;
+    use secrecy::Secret;
+    use tempfile::NamedTempFile;
+    use zcash_keys::keys::UnifiedSpendingKey;
+    use zcash_protocol::consensus::Network;
+
+    use crate::{
+        WalletDb,
+        testing::db::{test_clock, test_rng},
+        wallet::init::{WalletMigrator, migrations::tests::test_migrate},
+    };
+
+    use super::{DEPENDENCIES, MIGRATION_ID};
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[MIGRATION_ID]);
+    }
+
+    #[test]
+    fn migrate_marks_existing_imports_watch_only() {
+        let network = Network::TestNetwork;
+        let data_file = NamedTempFile::new().unwrap();
+        let mut db_data =
+            WalletDb::for_path(data_file.path(), network, test_clock(), test_rng()).unwrap();
+
+        let seed_bytes = vec![0xab; 32];
+
+        // Migrate to database state just prior to this migration.
+        WalletMigrator::new()
+            .with_seed(Secret::new(seed_bytes.clone()))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, DEPENDENCIES)
+            .unwrap();
+
+        // Insert a test account with a valid UFVK so post-migration checks pass.
+        let usk = UnifiedSpendingKey::from_seed(&network, &seed_bytes[..], zip32::AccountId::ZERO)
+            .unwrap();
+        let ufvk = usk.to_unified_full_viewing_key();
+        let ufvk_str = ufvk.encode(&network);
+        let uivk_str = ufvk.to_unified_incoming_viewing_key().encode(&network);
+
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO accounts (uuid, account_kind, hd_seed_fingerprint,
+                 hd_account_index, ufvk, uivk, has_spend_key, birthday_height)
+                 VALUES (X'0000000000000000000000000000AAAA', 0, X'00000000000000000000000000000000000000000000000000000000000000AB',
+                 0, :ufvk, :uivk, 1, 1)",
+                named_params![":ufvk": ufvk_str, ":uivk": uivk_str],
+            )
+            .unwrap();
+
+        let account_id: i64 = db_data
+            .conn
+            .query_row(
+                "SELECT id FROM accounts WHERE uuid = X'0000000000000000000000000000AAAA'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        // Insert the address row shapes that exist in production databases.
+
+        // 1. Derived transparent address
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO addresses (account_id, key_scope, diversifier_index_be, address,
+                 transparent_child_index, cached_transparent_receiver_address, receiver_flags)
+                 VALUES (?1, 0, X'00000000000000000000000000', 'addr_derived', 0, 't_derived', 5)",
+                [account_id],
+            )
+            .unwrap();
+
+        // 2. Standalone P2PKH import with key material
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO addresses (account_id, key_scope, address,
+                 cached_transparent_receiver_address, receiver_flags,
+                 imported_transparent_receiver_pubkey)
+                 VALUES (?1, -1, 'ttest_addr', 'ttest_addr', 1, X'0000000000000000000000000000000000000000000000000000000000000001')",
+                [account_id],
+            )
+            .unwrap();
+
+        // 3. Standalone P2SH import with key material
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO addresses (account_id, key_scope, address,
+                 cached_transparent_receiver_address, receiver_flags,
+                 imported_transparent_receiver_script)
+                 VALUES (?1, -1, 't_p2sh', 't_p2sh', 2, X'0102030405')",
+                [account_id],
+            )
+            .unwrap();
+
+        // 4. Address-only standalone import
+        db_data
+            .conn
+            .execute(
+                "INSERT INTO addresses (account_id, key_scope, address,
+                 cached_transparent_receiver_address, receiver_flags)
+                 VALUES (?1, -1, 't_addr_only', 't_addr_only', 1)",
+                [account_id],
+            )
+            .unwrap();
+
+        // Run the standalone_spendability migration.
+        WalletMigrator::new()
+            .with_seed(Secret::new(seed_bytes))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, &[MIGRATION_ID])
+            .unwrap();
+
+        // Verify all rows survived the migration, and that every one of them is marked
+        // watch-only: the migration cannot know which keys the application holds.
+        let (count, spendable_count): (i64, i64) = db_data
+            .conn
+            .query_row(
+                "SELECT COUNT(*), SUM(standalone_spendable) FROM addresses WHERE account_id = ?1",
+                [account_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(count, 4);
+        assert_eq!(spendable_count, 0);
+
+        // Standalone imports with key material may be marked spendable.
+        for addr in ["ttest_addr", "t_p2sh"] {
+            let updated = db_data
+                .conn
+                .execute(
+                    "UPDATE addresses SET standalone_spendable = 1
+                     WHERE cached_transparent_receiver_address = :addr",
+                    named_params![":addr": addr],
+                )
+                .unwrap();
+            assert_eq!(updated, 1);
+        }
+
+        // The constraint rejects the marker on derived rows and address-only imports.
+        for addr in ["t_derived", "t_addr_only"] {
+            let result = db_data.conn.execute(
+                "UPDATE addresses SET standalone_spendable = 1
+                 WHERE cached_transparent_receiver_address = :addr",
+                named_params![":addr": addr],
+            );
+            assert!(result.is_err());
+        }
+
+        // The constraint rejects a spendable derived row on insert as well.
+        let result = db_data.conn.execute(
+            "INSERT INTO addresses (account_id, key_scope, diversifier_index_be, address,
+             transparent_child_index, cached_transparent_receiver_address, receiver_flags,
+             standalone_spendable)
+             VALUES (?1, 0, X'00000000000000000100000000', 'bad_derived', 1, 'bad_derived', 1, 1)",
+            [account_id],
+        );
+        assert!(result.is_err());
+    }
+}

--- a/zcash_client_sqlite/src/wallet/transparent.rs
+++ b/zcash_client_sqlite/src/wallet/transparent.rs
@@ -22,8 +22,9 @@ use transparent::{
 use zcash_address::unified::{Ivk, Uivk};
 use zcash_client_backend::{
     data_api::{
-        Account, AccountBalance, Balance, CoinbaseFilter, OutputStatusFilter, TargetValue,
-        TransactionDataRequest, TransactionStatusFilter, TransparentBalances,
+        Account, AccountBalance, Balance, CoinbaseFilter, OutputStatusFilter,
+        StandaloneSpendability, TargetValue, TransactionDataRequest, TransactionStatusFilter,
+        TransparentBalances, TransparentKeyOrigin,
         wallet::{ConfirmationsPolicy, TargetHeight, input_selection::LockFilter},
     },
     fees::StandardFeeRule,
@@ -57,6 +58,7 @@ use zcash_script::script;
 use zip32::Scope;
 #[cfg(feature = "transparent-key-import")]
 use {
+    super::encoding::decode_standalone_spendability,
     bip32::{PublicKey, PublicKeyBytes},
     zcash_script::script::Code,
 };
@@ -185,7 +187,8 @@ pub(crate) fn get_transparent_receivers<P: consensus::Parameters>(
             imported_transparent_receiver_pubkey,
             exposed_at_height,
             transparent_receiver_next_check_time,
-            imported_transparent_receiver_script
+            imported_transparent_receiver_script,
+            standalone_spendable
          FROM addresses
          WHERE account_id = :account_id
          AND cached_transparent_receiver_address IS NOT NULL
@@ -269,6 +272,9 @@ pub(crate) fn get_transparent_receivers<P: consensus::Parameters>(
         #[cfg(feature = "transparent-key-import")]
         let imported_transparent_receiver_script_bytes: Option<Vec<u8>> =
             row.get("imported_transparent_receiver_script")?;
+        #[cfg(feature = "transparent-key-import")]
+        let spendability =
+            decode_standalone_spendability(row.get::<_, bool>("standalone_spendable")?);
 
         if let Some(taddr) = taddr {
             let p2pkh_metadata = || -> Result<TransparentAddressMetadata, SqliteClientError> {
@@ -293,6 +299,7 @@ pub(crate) fn get_transparent_receivers<P: consensus::Parameters>(
                             })?;
                             Ok(TransparentAddressMetadata::standalone_p2pkh(
                                 pubkey,
+                                spendability,
                                 exposure,
                                 next_check_time,
                             ))
@@ -333,6 +340,7 @@ pub(crate) fn get_transparent_receivers<P: consensus::Parameters>(
                         // Standalone P2SH import
                         Ok(TransparentAddressMetadata::standalone_script(
                             imported_transparent_receiver_script,
+                            spendability,
                             exposure,
                             next_check_time,
                         ))
@@ -807,7 +815,8 @@ pub(crate) fn store_address_range<P: consensus::Parameters>(
                      transparent_child_index = :transparent_child_index,
                      receiver_flags = :receiver_flags,
                      imported_transparent_receiver_pubkey = NULL,
-                     imported_transparent_receiver_script = NULL
+                     imported_transparent_receiver_script = NULL,
+                     standalone_spendable = 0
                  WHERE id = :id",
                 named_params![
                     ":account_id": account_id.0,
@@ -1306,7 +1315,9 @@ pub(crate) fn excluding_immature_coinbase_outputs(tx: &str) -> String {
 /// # Parameters
 /// - `outpoint`: The identifier for the output to be retrieved.
 /// - `target_height`: The target height of a transaction under construction that will spend the
-///   returned output. If this is `None`, no spendability checks are performed.
+///   returned output. If this is `None`, no spendability checks are performed; otherwise the
+///   output is only returned if it is unspent, unexpired, and not received at a standalone
+///   import that the application has not declared spendable.
 pub(crate) fn get_wallet_transparent_output(
     conn: &rusqlite::Connection,
     outpoint: &OutPoint,
@@ -1336,11 +1347,16 @@ pub(crate) fn get_wallet_transparent_output(
                  ({}) -- the transaction is unexpired
                  AND u.id NOT IN ({}) -- and the output is unspent
                  AND ({}) -- exclude likely-spent wallet-internal ephemeral outputs
+                 AND (
+                     addresses.key_scope != {foreign_scope}
+                     OR addresses.standalone_spendable = 1
+                 ) -- and the output is not that of a watch-only standalone import
              )
          )",
         tx_unexpired_condition("t"),
         spent_utxos_clause(),
         excluding_wallet_internal_ephemeral_outputs("u", "addresses", "t", "accounts"),
+        foreign_scope = KeyScope::Foreign.encode(),
     ))?;
 
     let txid_bytes = outpoint.hash();
@@ -1402,12 +1418,11 @@ fn spendable_transparent_outputs_query(
            -- unknown tx_index defaults to 1 (non-coinbase) to avoid false positives,
            -- so such outputs are excluded by CoinbaseOnly and included by NonCoinbaseOnly
          AND ({lock_eligible_sql}) -- the output is eligible under the lock filter
-         AND NOT (
-             addresses.key_scope = {foreign_scope}
-             AND addresses.imported_transparent_receiver_pubkey IS NULL
-             AND addresses.imported_transparent_receiver_script IS NULL
-         ) -- exclude outputs of addresses imported without key material: no
-           -- key material exists with which a spend could be constructed
+         AND (
+             addresses.key_scope != {foreign_scope}
+             OR addresses.standalone_spendable = 1
+         ) -- exclude outputs of standalone imports the application has not declared
+           -- spendable: the wallet cannot construct a spend without the secret key
          ORDER BY {order_by_sql}",
         tx_unexpired_condition_minconf_0("t"),
         spent_utxos_clause(),
@@ -1709,6 +1724,18 @@ pub(crate) fn select_spendable_transparent_outputs<P: consensus::Parameters>(
     Ok(utxos)
 }
 
+/// Returns whether outputs received at an address with the given key origin are watch-only:
+/// received at a standalone import that the application has not declared spendable.
+fn is_watch_only(key_origin: &TransparentKeyOrigin) -> bool {
+    match key_origin {
+        TransparentKeyOrigin::Derived { .. } => false,
+        TransparentKeyOrigin::Imported { spendability } => match spendability {
+            StandaloneSpendability::WatchOnly => true,
+            StandaloneSpendability::Spendable => false,
+        },
+    }
+}
+
 /// Returns a mapping from each transparent receiver associated with the specified account
 /// to its not-yet-shielded UTXO balance, including only the effects of transactions mined
 /// at a block height less than or equal to `summary_height`.
@@ -1733,7 +1760,8 @@ pub(crate) fn get_transparent_balances<P: consensus::Parameters>(
     let mut result = HashMap::new();
 
     let mut stmt_address_balances = conn.prepare(&format!(
-        "SELECT u.address, u.value_zat, u.lock_expiry_height, addresses.key_scope
+        "SELECT u.address, u.value_zat, u.lock_expiry_height, addresses.key_scope,
+                addresses.standalone_spendable
          FROM transparent_received_outputs u
          JOIN accounts ON accounts.id = u.account_id
          JOIN transactions t ON t.id_tx = u.transaction_id
@@ -1760,10 +1788,14 @@ pub(crate) fn get_transparent_balances<P: consensus::Parameters>(
         let value = Zatoshis::from_nonnegative_i64(row.get("value_zat")?)?;
         let lock_expiry_height: Option<u32> = row.get("lock_expiry_height")?;
         let key_scope_code: i64 = row.get("key_scope")?;
-        let key_origin = KeyScope::decode(key_scope_code)?.as_key_origin();
+        let standalone_spendable: bool = row.get("standalone_spendable")?;
+        let key_origin = KeyScope::decode(key_scope_code)?.as_key_origin(standalone_spendable);
 
+        let watch_only = is_watch_only(&key_origin);
         let entry = result.entry(taddr).or_insert((key_origin, Balance::ZERO));
-        if value <= zip317::MARGINAL_FEE {
+        if watch_only {
+            entry.1.add_watch_only_value(value)?;
+        } else if value <= zip317::MARGINAL_FEE {
             entry.1.add_uneconomic_value(value)?;
         } else if is_locked_at(lock_expiry_height, target_height) {
             entry.1.add_locked_value(value)?;
@@ -1782,7 +1814,7 @@ pub(crate) fn get_transparent_balances<P: consensus::Parameters>(
     // pending, so we don't check locking here.
     if min_confirmations > 0 {
         let mut stmt_address_balances = conn.prepare(&format!(
-            "SELECT u.address, u.value_zat, addresses.key_scope
+            "SELECT u.address, u.value_zat, addresses.key_scope, addresses.standalone_spendable
              FROM transparent_received_outputs u
              JOIN accounts ON accounts.id = u.account_id
              JOIN transactions t ON t.id_tx = u.transaction_id
@@ -1819,10 +1851,14 @@ pub(crate) fn get_transparent_balances<P: consensus::Parameters>(
             let taddr = TransparentAddress::decode(params, &taddr_str)?;
             let value = Zatoshis::from_nonnegative_i64(row.get("value_zat")?)?;
             let key_scope_code: i64 = row.get("key_scope")?;
-            let key_origin = KeyScope::decode(key_scope_code)?.as_key_origin();
+            let standalone_spendable: bool = row.get("standalone_spendable")?;
+            let key_origin = KeyScope::decode(key_scope_code)?.as_key_origin(standalone_spendable);
 
+            let watch_only = is_watch_only(&key_origin);
             let entry = result.entry(taddr).or_insert((key_origin, Balance::ZERO));
-            if value <= zip317::MARGINAL_FEE {
+            if watch_only {
+                entry.1.add_watch_only_value(value)?;
+            } else if value <= zip317::MARGINAL_FEE {
                 entry.1.add_uneconomic_value(value)?;
             } else {
                 entry.1.add_spendable_value(value)?;
@@ -1852,7 +1888,9 @@ pub(crate) fn add_transparent_account_balances(
         "SELECT accounts.uuid, u.lock_expiry_height, SUM(u.value_zat),
             (IFNULL(t.tx_index, 1) == 0) AS is_coinbase,
             (t.mined_height IS NOT NULL
-             AND :target_height - t.mined_height >= {COINBASE_MATURITY_BLOCKS}) AS is_mature
+             AND :target_height - t.mined_height >= {COINBASE_MATURITY_BLOCKS}) AS is_mature,
+            (addresses.key_scope = {foreign_scope}
+             AND addresses.standalone_spendable = 0) AS is_watch_only
          FROM transparent_received_outputs u
          JOIN accounts ON accounts.id = u.account_id
          JOIN transactions t ON t.id_tx = u.transaction_id
@@ -1860,10 +1898,11 @@ pub(crate) fn add_transparent_account_balances(
          WHERE ({}) -- the transaction is mined or unexpired with minconf 0
          AND u.id NOT IN ({}) -- and the received txo is unspent
          AND ({}) -- exclude likely-spent wallet-internal ephemeral outputs
-         GROUP BY accounts.uuid, lock_expiry_height, is_coinbase, is_mature",
+         GROUP BY accounts.uuid, lock_expiry_height, is_coinbase, is_mature, is_watch_only",
         tx_unexpired_condition_minconf_0("t"),
         spent_utxos_clause(),
         excluding_wallet_internal_ephemeral_outputs("u", "addresses", "t", "accounts"),
+        foreign_scope = KeyScope::Foreign.encode(),
     ))?;
 
     let mut rows = stmt_account_spendable_balances.query(named_params![
@@ -1880,13 +1919,19 @@ pub(crate) fn add_transparent_account_balances(
         })?;
         let is_coinbase: bool = row.get("is_coinbase")?;
         let is_mature: bool = row.get("is_mature")?;
+        let is_watch_only: bool = row.get("is_watch_only")?;
 
         let balance = account_balances
             .entry(account)
             .or_insert(AccountBalance::ZERO);
         if is_coinbase {
             balance.with_unshielded_coinbase_balance_mut(|bal| {
-                if value <= zip317::MARGINAL_FEE {
+                if is_watch_only {
+                    // Value received at a standalone import that the application has not
+                    // declared spendable is reported separately, regardless of its other
+                    // properties: the wallet cannot spend it at all.
+                    bal.add_watch_only_value(value)
+                } else if value <= zip317::MARGINAL_FEE {
                     bal.add_uneconomic_value(value)
                 } else if is_locked_at(lock_expiry_height, target_height) {
                     // A locked coinbase output (selected by an in-flight shielding
@@ -1903,7 +1948,9 @@ pub(crate) fn add_transparent_account_balances(
             })?;
         } else {
             balance.with_unshielded_regular_balance_mut(|bal| {
-                if value <= zip317::MARGINAL_FEE {
+                if is_watch_only {
+                    bal.add_watch_only_value(value)
+                } else if value <= zip317::MARGINAL_FEE {
                     bal.add_uneconomic_value(value)
                 } else if is_locked_at(lock_expiry_height, target_height) {
                     bal.add_locked_value(value)
@@ -1921,7 +1968,9 @@ pub(crate) fn add_transparent_account_balances(
     if min_confirmations > 0 {
         let mut stmt_account_unconfirmed_balances = conn.prepare(&format!(
             "SELECT accounts.uuid, u.lock_expiry_height, SUM(u.value_zat),
-                (IFNULL(t.tx_index, 1) == 0) AS is_coinbase
+                (IFNULL(t.tx_index, 1) == 0) AS is_coinbase,
+                (addresses.key_scope = {foreign_scope}
+                 AND addresses.standalone_spendable = 0) AS is_watch_only
              FROM transparent_received_outputs u
              JOIN accounts ON accounts.id = u.account_id
              JOIN transactions t ON t.id_tx = u.transaction_id
@@ -1940,9 +1989,10 @@ pub(crate) fn add_transparent_account_balances(
              )
              AND u.id NOT IN ({}) -- and the received txo is unspent
              AND ({}) -- exclude likely-spent wallet-internal ephemeral outputs
-             GROUP BY accounts.uuid, lock_expiry_height, is_coinbase",
+             GROUP BY accounts.uuid, lock_expiry_height, is_coinbase, is_watch_only",
             spent_utxos_clause(),
             excluding_wallet_internal_ephemeral_outputs("u", "addresses", "t", "accounts"),
+            foreign_scope = KeyScope::Foreign.encode(),
         ))?;
 
         let mut rows = stmt_account_unconfirmed_balances.query(named_params![
@@ -1958,9 +2008,12 @@ pub(crate) fn add_transparent_account_balances(
                 SqliteClientError::CorruptedData(format!("Negative UTXO value {raw_value:?}"))
             })?;
             let is_coinbase: bool = row.get("is_coinbase")?;
+            let is_watch_only: bool = row.get("is_watch_only")?;
 
             let add_pending = |bal: &mut Balance| {
-                if value <= zip317::MARGINAL_FEE {
+                if is_watch_only {
+                    bal.add_watch_only_value(value)
+                } else if value <= zip317::MARGINAL_FEE {
                     bal.add_uneconomic_value(value)
                 } else if is_locked_at(lock_expiry_height, target_height) {
                     bal.add_locked_value(value)
@@ -2473,7 +2526,8 @@ pub(crate) fn get_transparent_address_metadata<P: consensus::Parameters>(
                 imported_transparent_receiver_pubkey,
                 exposed_at_height,
                 transparent_receiver_next_check_time,
-                imported_transparent_receiver_script
+                imported_transparent_receiver_script,
+                standalone_spendable
              FROM addresses
              JOIN accounts ON addresses.account_id = accounts.id
              WHERE accounts.uuid = :account_uuid
@@ -2534,6 +2588,8 @@ pub(crate) fn get_transparent_address_metadata<P: consensus::Parameters>(
                         None => {
                             let _imported_transparent_receiver_script_bytes: Option<Vec<u8>> = row.get("imported_transparent_receiver_script")?;
                             let _pubkey_bytes = row.get::<_, Option<Vec<u8>>>("imported_transparent_receiver_pubkey")?;
+                            #[cfg(feature = "transparent-key-import")]
+                            let spendability = decode_standalone_spendability(row.get::<_, bool>("standalone_spendable")?);
 
                             let _standalone_exposure = exposed_at_height.map_or(
                                 Exposure::Unknown,
@@ -2556,6 +2612,7 @@ pub(crate) fn get_transparent_address_metadata<P: consensus::Parameters>(
 
                                     Ok(TransparentAddressMetadata::standalone_script(
                                         imported_transparent_receiver_script,
+                                        spendability,
                                         _standalone_exposure,
                                         next_check_time,
                                     ))
@@ -2569,6 +2626,7 @@ pub(crate) fn get_transparent_address_metadata<P: consensus::Parameters>(
 
                                     Ok(TransparentAddressMetadata::standalone_p2pkh(
                                         pubkey,
+                                        spendability,
                                         _standalone_exposure,
                                         next_check_time,
                                     ))
@@ -2926,7 +2984,9 @@ mod tests {
         secp256k1::{PublicKey, Secp256k1, SecretKey},
         std::collections::HashSet,
         transparent::address::TransparentAddress,
-        zcash_client_backend::data_api::{AccountBirthday, chain::ChainState},
+        zcash_client_backend::data_api::{
+            AccountBirthday, StandaloneSpendability, chain::ChainState,
+        },
         zcash_keys::{address::Address, encoding::AddressCodec},
         zcash_protocol::consensus::{NetworkUpgrade, Parameters},
     };
@@ -3869,6 +3929,7 @@ mod tests {
                     &network,
                     account_uuid,
                     pubkey,
+                    StandaloneSpendability::Spendable,
                 )
                 .unwrap();
                 prop_assert_eq!(inserted, 0);
@@ -3917,6 +3978,7 @@ mod tests {
                     &network,
                     account_uuid,
                     pubkey,
+                    StandaloneSpendability::Spendable,
                 )
                 .unwrap();
                 prop_assert_eq!(inserted, 1);
@@ -3927,6 +3989,7 @@ mod tests {
                     &network,
                     account_uuid,
                     pubkey,
+                    StandaloneSpendability::Spendable,
                 )
                 .unwrap();
                 prop_assert_eq!(reinserted, 0);
@@ -3965,8 +4028,13 @@ mod tests {
         let unknown = crate::AccountUuid::from_uuid(uuid::Uuid::from_bytes([0xff; 16]));
 
         let tx = st.wallet().db().conn.unchecked_transaction().unwrap();
-        let result =
-            crate::wallet::import_standalone_transparent_pubkey(&tx, &network, unknown, pubkey);
+        let result = crate::wallet::import_standalone_transparent_pubkey(
+            &tx,
+            &network,
+            unknown,
+            pubkey,
+            StandaloneSpendability::Spendable,
+        );
         assert!(matches!(
             result,
             Err(crate::error::SqliteClientError::AccountUnknown)
@@ -4010,6 +4078,7 @@ mod tests {
                     &network,
                     account_uuid,
                     &pubkeys,
+                    StandaloneSpendability::Spendable,
                 )
                 .unwrap();
                 prop_assert_eq!(inserted, distinct.len());
@@ -4033,6 +4102,7 @@ mod tests {
                     &network,
                     account_uuid,
                     &pubkeys,
+                    StandaloneSpendability::Spendable,
                 )
                 .unwrap();
                 prop_assert_eq!(again, 0);
@@ -4058,12 +4128,152 @@ mod tests {
         let unknown = crate::AccountUuid::from_uuid(uuid::Uuid::from_bytes([0xfe; 16]));
 
         let tx = st.wallet().db().conn.unchecked_transaction().unwrap();
-        let result =
-            crate::wallet::import_standalone_transparent_pubkeys(&tx, &network, unknown, &[pubkey]);
+        let result = crate::wallet::import_standalone_transparent_pubkeys(
+            &tx,
+            &network,
+            unknown,
+            &[pubkey],
+            StandaloneSpendability::Spendable,
+        );
         assert!(matches!(
             result,
             Err(crate::error::SqliteClientError::AccountUnknown)
         ));
+    }
+
+    /// Pins the error variant returned by `set_standalone_transparent_spendability` for each
+    /// failure case, and checks that the success path flips the column in both directions.
+    #[test]
+    #[cfg(feature = "transparent-key-import")]
+    fn set_standalone_transparent_spendability_errors() {
+        use crate::error::SqliteClientError;
+
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_account_from_sapling_activation(BlockHash([0; 32]))
+            .build();
+
+        let account_a = st.test_account().unwrap().id();
+        let network = *st.network();
+
+        // A second account, to own an import the first account has no standing over.
+        let birthday = AccountBirthday::from_parts(
+            ChainState::empty(
+                network.activation_height(NetworkUpgrade::Sapling).unwrap() - 1,
+                BlockHash([0; 32]),
+            ),
+            None,
+        );
+        let (account_b, _) = st
+            .wallet_mut()
+            .create_account("b", &Secret::new(vec![42u8; 32]), &birthday, None)
+            .unwrap();
+
+        let secp = Secp256k1::new();
+        let pubkey_a =
+            PublicKey::from_secret_key(&secp, &SecretKey::from_slice(&[0x31; 32]).unwrap());
+        let pubkey_b =
+            PublicKey::from_secret_key(&secp, &SecretKey::from_slice(&[0x32; 32]).unwrap());
+        let taddr_a = TransparentAddress::from_pubkey(&pubkey_a);
+        let taddr_b = TransparentAddress::from_pubkey(&pubkey_b);
+        let taddr_address_only = TransparentAddress::PublicKeyHash([0x33; 20]);
+        let taddr_unknown = TransparentAddress::PublicKeyHash([0x44; 20]);
+
+        let tx = st.wallet().db().conn.unchecked_transaction().unwrap();
+
+        // A derived transparent address of account A (created with the account).
+        let account_a_ref = get_account_ref(&tx, account_a).unwrap();
+        let derived_enc: String = tx
+            .query_row(
+                "SELECT cached_transparent_receiver_address FROM addresses
+                 WHERE account_id = :account_id
+                 AND key_scope = :key_scope
+                 AND cached_transparent_receiver_address IS NOT NULL
+                 LIMIT 1",
+                named_params![
+                    ":account_id": account_a_ref.0,
+                    ":key_scope": KeyScope::Zip32(zip32::Scope::External).encode(),
+                ],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let taddr_derived = TransparentAddress::decode(&network, &derived_enc).unwrap();
+
+        crate::wallet::import_standalone_transparent_pubkey(
+            &tx,
+            &network,
+            account_a,
+            pubkey_a,
+            StandaloneSpendability::WatchOnly,
+        )
+        .unwrap();
+        crate::wallet::import_standalone_transparent_pubkey(
+            &tx,
+            &network,
+            account_b,
+            pubkey_b,
+            StandaloneSpendability::WatchOnly,
+        )
+        .unwrap();
+        crate::wallet::import_standalone_transparent_address(
+            &tx,
+            &network,
+            account_a,
+            taddr_address_only,
+        )
+        .unwrap();
+
+        let set = |addr: &TransparentAddress, spendability| {
+            crate::wallet::set_standalone_transparent_spendability(
+                &tx,
+                &network,
+                account_a,
+                addr,
+                spendability,
+            )
+        };
+        let spendable_flag = |addr: &TransparentAddress| -> bool {
+            tx.query_row(
+                "SELECT standalone_spendable FROM addresses
+                 WHERE cached_transparent_receiver_address = :address",
+                named_params![":address": addr.encode(&network)],
+                |row| row.get(0),
+            )
+            .unwrap()
+        };
+
+        // Unknown address.
+        assert!(matches!(
+            set(&taddr_unknown, StandaloneSpendability::Spendable),
+            Err(SqliteClientError::AddressNotRecognized(a)) if a == taddr_unknown
+        ));
+
+        // Key-material import owned by another account.
+        assert!(matches!(
+            set(&taddr_b, StandaloneSpendability::Spendable),
+            Err(SqliteClientError::StandaloneImportConflict(owner)) if owner == account_b.expose_uuid()
+        ));
+
+        // Derived address of the caller's own account.
+        assert!(matches!(
+            set(&taddr_derived, StandaloneSpendability::Spendable),
+            Err(SqliteClientError::NotStandaloneKeyImport(a)) if a == taddr_derived
+        ));
+
+        // Address-only import of the caller's own account.
+        assert!(matches!(
+            set(&taddr_address_only, StandaloneSpendability::Spendable),
+            Err(SqliteClientError::NotStandaloneKeyImport(a)) if a == taddr_address_only
+        ));
+
+        // The success path flips the column both ways.
+        assert!(!spendable_flag(&taddr_a));
+        set(&taddr_a, StandaloneSpendability::Spendable).unwrap();
+        assert!(spendable_flag(&taddr_a));
+        set(&taddr_a, StandaloneSpendability::WatchOnly).unwrap();
+        assert!(!spendable_flag(&taddr_a));
+        // Nothing else was touched.
+        assert!(!spendable_flag(&taddr_b));
     }
 
     #[test]
@@ -4134,6 +4344,46 @@ mod tests {
     #[cfg(feature = "transparent-key-import")]
     fn test_import_standalone_transparent_pubkey_balance() {
         zcash_client_backend::data_api::testing::transparent::import_standalone_transparent_pubkey_balance(
+            TestDbFactory::default(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-key-import")]
+    fn test_import_standalone_transparent_pubkey_watch_only() {
+        zcash_client_backend::data_api::testing::transparent::import_standalone_transparent_pubkey_watch_only(
+            TestDbFactory::default(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-key-import")]
+    fn test_import_standalone_transparent_script_watch_only() {
+        zcash_client_backend::data_api::testing::transparent::import_standalone_transparent_script_watch_only(
+            TestDbFactory::default(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-key-import")]
+    fn test_import_standalone_transparent_pubkey_reimport_promotes() {
+        zcash_client_backend::data_api::testing::transparent::import_standalone_transparent_pubkey_reimport_promotes(
+            TestDbFactory::default(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-key-import")]
+    fn test_set_standalone_transparent_spendability_rejects_non_standalone() {
+        zcash_client_backend::data_api::testing::transparent::set_standalone_transparent_spendability_rejects_non_standalone(
+            TestDbFactory::default(),
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "transparent-key-import")]
+    fn test_get_transparent_receivers_reports_spendability() {
+        zcash_client_backend::data_api::testing::transparent::get_transparent_receivers_reports_spendability(
             TestDbFactory::default(),
         );
     }

--- a/zcash_client_sqlite/src/zewif.rs
+++ b/zcash_client_sqlite/src/zewif.rs
@@ -26,6 +26,11 @@
 //!    account is registered with that account (its secret half having already been
 //!    delivered to the sink), and P2SH redeem scripts recorded on imported
 //!    accounts' addresses are registered where the wallet can represent them.
+//!    Each registration declares a spendability: a pubkey whose spending key was
+//!    verified is `Spendable`; a multisig redeem script is `Spendable` only if the
+//!    spending key of every member pubkey was verified from the document (zcashd's
+//!    `ismine` rule for P2SH multisig); everything else is `WatchOnly`, and is
+//!    counted in [`ZewifImportReport::redeem_scripts_watch_only`].
 //! 5. Marks the transparent addresses recorded in the document as exposed, so
 //!    that address-based recovery includes them.
 //! 6. Stores the document's transactions: each transaction carrying raw data is
@@ -57,7 +62,7 @@
 //!   crate's decryption support) before import.
 
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     fmt,
 };
 
@@ -70,8 +75,8 @@ use rand::RngCore;
 use secrecy::{ExposeSecret, SecretVec};
 use zcash_client_backend::{
     data_api::{
-        Account as _, AccountBirthday, AccountPurpose, WalletRead, WalletWrite, Zip32Derivation,
-        chain::ChainState, wallet::decrypt_and_store_transaction,
+        Account as _, AccountBirthday, AccountPurpose, StandaloneSpendability, WalletRead,
+        WalletWrite, Zip32Derivation, chain::ChainState, wallet::decrypt_and_store_transaction,
     },
     wallet::{Exposure, TransparentAddressMetadata},
 };
@@ -529,6 +534,14 @@ pub struct ZewifImportReport {
     pub skipped_transparent_keys: Vec<SkippedTransparentKey>,
     /// The number of P2SH redeem scripts registered with imported accounts.
     pub redeem_scripts_registered: usize,
+    /// The number of registered P2SH redeem scripts that were marked watch-only
+    /// because the document did not deliver the spending keys for every member
+    /// pubkey of the multisig script. These are included in
+    /// `redeem_scripts_registered`; outputs received at them are reported in
+    /// the watch-only balance and are never selected as transaction inputs
+    /// unless the application later reclassifies them via
+    /// `WalletWrite::set_standalone_transparent_spendability`.
+    pub redeem_scripts_watch_only: usize,
     /// The number of P2SH redeem scripts recorded in the document that the
     /// wallet cannot represent (for example, non-multisig scripts).
     pub redeem_scripts_not_representable: usize,
@@ -1075,6 +1088,10 @@ where
     };
     let secp = secp256k1::Secp256k1::new();
 
+    // The serialized pubkeys whose spending keys were delivered and verified, used to decide
+    // whether a multisig redeem script is fully spendable by the wallet.
+    let mut verified_pubkeys: HashSet<Vec<u8>> = HashSet::new();
+
     for entry in store.map_or(&[][..], |s| s.transparent_keys()) {
         if !entry.pubkey().is_compressed() {
             report.skipped_transparent_keys.push(SkippedTransparentKey {
@@ -1097,11 +1114,18 @@ where
         if secret_key.public_key(&secp) != pubkey {
             return Err(ZewifImportError::TransparentKeyMismatch { address });
         }
+        verified_pubkeys.insert(pubkey.serialize().to_vec());
 
         match taddrs.owners.get(&address) {
             Some((account_uuid, _)) => {
-                wdb.import_standalone_transparent_pubkey(*account_uuid, pubkey)
-                    .map_err(ZewifImportError::Wallet)?;
+                // The spending key was delivered and verified against the pubkey, so the
+                // application (via its secret sink) holds what is needed to spend.
+                wdb.import_standalone_transparent_pubkey(
+                    *account_uuid,
+                    pubkey,
+                    StandaloneSpendability::Spendable,
+                )
+                .map_err(ZewifImportError::Wallet)?;
                 report.transparent_keys_registered += 1;
             }
             None => {
@@ -1117,8 +1141,35 @@ where
         let parsed = Redeem::parse(&Code(script_bytes.clone()));
         match parsed {
             Ok(redeem) => {
-                match wdb.import_standalone_transparent_script(*account_uuid, redeem) {
-                    Ok(()) => report.redeem_scripts_registered += 1,
+                // Following zcashd's `ismine` rule for P2SH multisig, the script is spendable
+                // only if the spending key of every member pubkey is held; any other script
+                // kind is not one the wallet can spend from.
+                //
+                // Membership is decided on the exact serialized pubkey: the set holds the
+                // 33-byte compressed encoding of each verified key, and is compared against
+                // whatever encoding the script embeds. A member pubkey in a different encoding
+                // (such as uncompressed) is deliberately treated as not held, so that the
+                // script fails safe to watch-only rather than being declared spendable on a
+                // key the wallet's spend path cannot use. Do not "fix" this by comparing
+                // key hashes.
+                let spendability = match zcash_script::solver::standard(&redeem) {
+                    Some(zcash_script::solver::ScriptKind::MultiSig { pubkeys, .. })
+                        if pubkeys
+                            .iter()
+                            .all(|pk| verified_pubkeys.contains(pk.as_slice())) =>
+                    {
+                        StandaloneSpendability::Spendable
+                    }
+                    _ => StandaloneSpendability::WatchOnly,
+                };
+                match wdb.import_standalone_transparent_script(*account_uuid, redeem, spendability)
+                {
+                    Ok(()) => {
+                        report.redeem_scripts_registered += 1;
+                        if spendability == StandaloneSpendability::WatchOnly {
+                            report.redeem_scripts_watch_only += 1;
+                        }
+                    }
                     // The wallet can only represent a subset of redeem scripts
                     // (e.g. multisig within the P2SH size limit); scripts it
                     // rejects remain recoverable from the document.
@@ -2204,6 +2255,132 @@ mod tests {
         assert_eq!(report.addresses_marked_exposed, 1);
         assert_eq!(report.addresses_not_recognized, 0);
         assert_eq!(report.addresses_never_exposed, 0);
+    }
+
+    /// Imported transparent pubkeys are marked spendable (their spending keys
+    /// were delivered and verified), and a multisig redeem script is marked
+    /// spendable only when every member pubkey's spending key was delivered.
+    #[test]
+    fn redeem_script_spendability_follows_member_keys() {
+        use rusqlite::named_params;
+        use zcash_script::{
+            descriptor::sh,
+            pattern::check_multisig,
+            script::{self, Evaluable as _},
+        };
+
+        let (_file, mut wdb) = test_wallet_db();
+        let ts = test_seed(0);
+
+        let secp = secp256k1::Secp256k1::new();
+        let held_keys: Vec<secp256k1::SecretKey> = [0x42u8, 0x43]
+            .into_iter()
+            .map(|b| secp256k1::SecretKey::from_slice(&[b; 32]).unwrap())
+            .collect();
+        let held_pubkeys: Vec<secp256k1::PublicKey> =
+            held_keys.iter().map(|sk| sk.public_key(&secp)).collect();
+        // A member key whose spending key is not delivered by the document.
+        let foreign_pubkey = secp256k1::SecretKey::from_slice(&[0x44; 32])
+            .unwrap()
+            .public_key(&secp);
+
+        let mut store = ::zewif::SecretStore::new();
+        store.add_seed(seed_entry(&ts));
+        for (sk, pk) in held_keys.iter().zip(&held_pubkeys) {
+            let mut wif_payload = vec![0xEF];
+            wif_payload.extend_from_slice(&sk.secret_bytes());
+            wif_payload.push(0x01);
+            let wif = bs58::encode(wif_payload).with_check().into_string();
+            store.add_transparent_key(::zewif::TransparentKeyEntry::new(
+                ::zewif::transparent::TransparentPubKey::from_bytes(pk.serialize().to_vec())
+                    .unwrap(),
+                ::zewif::transparent::TransparentSpendingKey::new(wif),
+            ));
+        }
+
+        let multisig = |members: &[&secp256k1::PublicKey]| -> script::Redeem {
+            let member_bytes: Vec<[u8; 33]> = members.iter().map(|pk| pk.serialize()).collect();
+            let member_refs: Vec<&[u8]> = member_bytes.iter().map(|b| &b[..]).collect();
+            script::Component(
+                check_multisig(1, &member_refs, false)
+                    .unwrap()
+                    .into_iter()
+                    .collect(),
+            )
+        };
+        let fully_held = multisig(&[&held_pubkeys[0], &held_pubkeys[1]]);
+        let partially_held = multisig(&[&held_pubkeys[0], &foreign_pubkey]);
+        let p2sh_address = |redeem: &script::Redeem| {
+            TransparentAddress::from_script_pubkey(&sh(redeem))
+                .unwrap()
+                .encode(&TEST_NETWORK)
+        };
+        let fully_held_addr = p2sh_address(&fully_held);
+        let partially_held_addr = p2sh_address(&partially_held);
+
+        let mut account = ::zewif::Account::new(::zewif::AccountViewingKey::TransparentAddressSet);
+        account.set_name("legacy");
+        account.set_birthday_height(::zewif::BlockHeight::from(2_600_000));
+        account.set_key_source(::zewif::KeySource::Derived(::zewif::DerivedKeySource::new(
+            ::zewif::SeedFingerprint::new(ts.fingerprint_encoding.clone()),
+            0x7FFF_FFFF,
+            None,
+        )));
+        for pk in &held_pubkeys {
+            let mut taddr = ::zewif::transparent::Address::new(
+                TransparentAddress::from_pubkey(pk).encode(&TEST_NETWORK),
+            );
+            taddr.set_pubkey(
+                ::zewif::transparent::TransparentPubKey::from_bytes(pk.serialize().to_vec())
+                    .unwrap(),
+            );
+            account.add_address(::zewif::Address::new(
+                ::zewif::ProtocolAddress::Transparent(taddr),
+            ));
+        }
+        for (addr, redeem) in [
+            (&fully_held_addr, &fully_held),
+            (&partially_held_addr, &partially_held),
+        ] {
+            let mut taddr = ::zewif::transparent::Address::new(addr.clone());
+            taddr.set_redeem_script(::zewif::Script::from(::zewif::Data::from(
+                redeem.to_bytes(),
+            )));
+            account.add_address(::zewif::Address::new(
+                ::zewif::ProtocolAddress::Transparent(taddr),
+            ));
+        }
+
+        let (mut doc, mut wallet) = document(::zewif::Network::Testnet);
+        wallet.add_account(account);
+        doc.add_wallet(wallet);
+        doc.set_secrets(::zewif::Secrets::Plain(store));
+
+        let mut sink = RecordingSink::default();
+        let report = import_wallet(&mut wdb, &doc, &mut sink).unwrap();
+
+        assert_eq!(report.transparent_keys_registered, 2);
+        assert_eq!(report.redeem_scripts_registered, 2);
+        assert_eq!(report.redeem_scripts_watch_only, 1);
+        assert_eq!(report.redeem_scripts_not_representable, 0);
+
+        let spendable = |addr: &str| -> bool {
+            wdb.conn
+                .query_row(
+                    "SELECT standalone_spendable FROM addresses
+                     WHERE cached_transparent_receiver_address = :address",
+                    named_params![":address": addr],
+                    |row| row.get(0),
+                )
+                .unwrap()
+        };
+        for pk in &held_pubkeys {
+            assert!(spendable(
+                &TransparentAddress::from_pubkey(pk).encode(&TEST_NETWORK)
+            ));
+        }
+        assert!(spendable(&fully_held_addr));
+        assert!(!spendable(&partially_held_addr));
     }
 
     /// An address recorded with no exposure height (for example a zcashd


### PR DESCRIPTION
Closes #3008.
[COR-1906](https://linear.app/zodl/issue/COR-1906)

## Problem

The wallet stores at most the pubkey or redeem script for a standalone (KeyScope::Foreign) transparent import, so it cannot know whether the application holds the corresponding secret keys (watch-only pubkey imports via z_importaddress <pubkey>; multisig scripts with zero, some, or all member keys held). Yet spendable_transparent_outputs_query offered every such import with key material as an input, and the balance queries excluded nothing — not even address-only imports, which were counted under spendable_value. The explicit-outpoint lookup (get_wallet_transparent_output with a target height) had no Foreign exclusion at all.

## Design

Compared with the sketch in #3008, three deliberate departures:

1. Watch-only value is reported, not dropped. New Balance::watch_only_value, included in total() and never in spendable_value (the same shape as locked_value). Address-only imports move to this bucket too, so total() is unchanged for them.
2. Spendability is a parameter of the import methods, not only a separate setter, so a caller that holds the key (z_importkey) cannot silently lose spendability on a dependency bump. WalletWrite::set_standalone_transparent_spendability exists for later promotion/demotion (e.g. after a multisig policy decision).
3. ZeWIF import sets the marker itself. It already verifies each WIF against its pubkey, so those are Spendable; multisig redeem scripts are Spendable iff every member key was imported from the document — zcashd's own ismine rule, i.e. preserving the semantics of the wallet being migrated. Runtime imports remain the application's policy (zcash/zallet#798).

## Changes

zcash_client_backend
- data_api::StandaloneSpendability { WatchOnly, Spendable }.
- import_standalone_transparent_{pubkey,pubkeys,script} take it; new WalletWrite::set_standalone_transparent_spendability.
- TransparentKeyOrigin::Imported { spendability }; TransparentAddressSource::StandalonePubkey { pubkey, spendability } / StandaloneScript { redeem_script, spendability }; TransparentAddressSource::spendability().
- Balance::watch_only_value / add_watch_only_value.
- Six new shared tests in data_api::testing::transparent.

zcash_client_sqlite
- Migration standalone_spendability: addresses.standalone_spendable, with a CHECK forbidding it on derived and address-only rows. All pre-existing standalone imports are marked watch-only; applications must reclassify via the setter (see CHANGELOG).
- Selection queries and the outpoint lookup exclude unflagged Foreign rows; all four balance statements route their value to watch_only_value.
- Foreign→derived upgrade clears the flag; address-only→key-material upgrade sets it; re-import may promote to spendable but never downgrades.
- ZeWIF import as described above; ZewifImportReport::redeem_scripts_watch_only.
- New SqliteClientError::NotStandaloneKeyImport.

## Testing

- cargo fmt --all -- --check; cargo clippy --workspace --all-features --all-targets -- -D warnings — clean.
- cargo test --release -p zcash_client_sqlite -p zcash_client_backend --all-features -- transparent standalone zewif migrations balance summary shield: 25 backend + 234 sqlite passed, 0 failed.
- Migration tests (standalone_spendability::tests::*, verify_schema), set_standalone_transparent_spendability_errors, zewif::tests::redeem_script_spendability_follows_member_keys pass.

Downstream: zallet needs to pass the flag from z_importkey/z_importaddress, reclassify existing rows at startup, and surface watch_only_value (zcash/zallet#797, zcash/zallet#798).

🤖 Generated with Claude Code

https://claude.ai/code/session_01ESqx9zBzenHwTUDjfZ8YyP

Co-Authored-By: Claude Fable 5 noreply@anthropic.com