### PR TITLE
zcash_client_sqlite: Report diverged checkpoints as typed errors

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -11,6 +11,8 @@ workspace.
 ## [Unreleased]
 
 ### Added
+- `SqliteClientError::DivergedCheckpoints`, which exposes the divergent shielded pool and the
+  requested truncation height missing from its note commitment tree checkpoints.
 - `zewif::ZewifImportReport::transactions_deferred_no_chain_tip`: counts
   transactions deferred to the post-import rescan because the wallet had no
   view of the chain tip against which to store them; such transactions were

--- a/zcash_client_sqlite/src/error.rs
+++ b/zcash_client_sqlite/src/error.rs
@@ -45,6 +45,15 @@ pub enum SqliteClientError {
     /// Decoding of a stored value from its serialized form has failed.
     CorruptedData(String),
 
+    /// A note commitment tree retains checkpoints both above and below a requested truncation
+    /// height, but has no checkpoint at that height.
+    DivergedCheckpoints {
+        /// The shielded pool whose note commitment tree has diverged checkpoints.
+        pool: ShieldedPool,
+        /// The requested truncation height missing from the tree's checkpoints.
+        height: BlockHeight,
+    },
+
     /// An error occurred decoding a protobuf message.
     Protobuf(prost::DecodeError),
 
@@ -321,6 +330,10 @@ impl fmt::Display for SqliteClientError {
             SqliteClientError::CorruptedData(reason) => {
                 write!(f, "Data DB is corrupted: {reason}")
             }
+            SqliteClientError::DivergedCheckpoints { pool, height } => write!(
+                f,
+                "Data DB is corrupted: the {pool:?} note commitment tree retains checkpoints both above and below height {height}, but none at that height to truncate to"
+            ),
             SqliteClientError::Protobuf(e) => {
                 write!(f, "Failed to parse protobuf-encoded record: {e}")
             }

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -4308,15 +4308,15 @@ fn witness_destroying_truncation_error(
 }
 
 /// Reports a [`TreeTruncation::DivergedCheckpoints`] classification for the given pool as
-/// [`SqliteClientError::CorruptedData`].
+/// [`SqliteClientError::DivergedCheckpoints`].
 fn diverged_checkpoints_error(
     pool: ShieldedPool,
     truncation_height: BlockHeight,
 ) -> SqliteClientError {
-    SqliteClientError::CorruptedData(format!(
-        "the {pool:?} note commitment tree retains checkpoints both above and below \
-         height {truncation_height}, but none at that height to truncate to"
-    ))
+    SqliteClientError::DivergedCheckpoints {
+        pool,
+        height: truncation_height,
+    }
 }
 
 /// Truncates the wallet to `truncation_height`, bringing each pool's note commitment tree
@@ -4331,7 +4331,7 @@ fn diverged_checkpoints_error(
 /// inexecutable without indicating any inconsistency in the wallet's state; this is
 /// reported as [`SqliteClientError::RequestedRewindInvalid`]. A pool classified as
 /// [`TreeTruncation::DivergedCheckpoints`] is reported as
-/// [`SqliteClientError::CorruptedData`].
+/// [`SqliteClientError::DivergedCheckpoints`].
 pub(crate) fn truncate_to_height_internal<P: consensus::Parameters>(
     conn: &rusqlite::Transaction,
     params: &P,
@@ -4779,12 +4779,12 @@ pub(crate) fn truncate_to_chain_state<P: consensus::Parameters, CL, R>(
 /// empty *and* every account in the wallet has a birthday greater than
 /// `chain_state.block_height() + 1`. Returns `Err(RewindError::DataSource(_))` with a
 /// `CorruptedData` payload if `reset_account_birthdays` contains any account UUID that is not
-/// present in the wallet, or if a pool's note commitment tree retains checkpoints that
-/// straddle the truncation height without one at it (see [`plan_tree_truncation`]); and with
-/// a `RequestedRewindInvalid` payload if discarding a pool tree's scanned state would destroy
-/// witness data for notes below the rewind target that the requeued rescan would not
-/// re-create — a valid wallet state from which the requested rewind simply cannot be
-/// executed.
+/// present in the wallet; with a `DivergedCheckpoints` payload if a pool's note commitment
+/// tree retains checkpoints that straddle the truncation height without one at it (see
+/// [`plan_tree_truncation`]); and with a `RequestedRewindInvalid` payload if discarding a pool
+/// tree's scanned state would destroy witness data for notes below the rewind target that the
+/// requeued rescan would not re-create — a valid wallet state from which the requested rewind
+/// simply cannot be executed.
 pub(crate) fn rewind_to_chain_state<P: consensus::Parameters>(
     conn: &rusqlite::Transaction,
     params: &P,
@@ -6119,8 +6119,9 @@ mod tests {
 
     use super::{
         KeyScope, ShieldedPool, TxQueryType, TxRef, account_birthday, chain_tip_height,
-        flag_previously_received_change, get_transaction, min_shared_checkpoint_height, parse_tx,
-        put_zip318_classification, queue_tx_retrieval, select_truncation_height,
+        diverged_checkpoints_error, flag_previously_received_change, get_transaction,
+        min_shared_checkpoint_height, parse_tx, put_zip318_classification, queue_tx_retrieval,
+        select_truncation_height,
     };
 
     use incrementalmerkletree::frontier::Frontier;
@@ -7269,10 +7270,21 @@ mod tests {
         );
     }
 
-    /// An Ironwood tree with checkpoints both above and below the truncation height but none
-    /// at it must still be treated as corruption: the tree cannot be truncated to the height
-    /// consistently, and its state genuinely diverges from the pools that determined that
-    /// height.
+    #[test]
+    fn diverged_checkpoints_error_preserves_pool_and_height() {
+        let height = BlockHeight::from_u32(42);
+
+        let result = diverged_checkpoints_error(ShieldedPool::Sapling, height);
+
+        assert_matches!(
+            result,
+            SqliteClientError::DivergedCheckpoints {
+                pool: ShieldedPool::Sapling,
+                height: actual_height,
+            } if actual_height == height
+        );
+    }
+
     #[test]
     #[cfg(feature = "orchard")]
     fn rewind_to_chain_state_with_straddling_ironwood_checkpoints_errors() {
@@ -7297,7 +7309,12 @@ mod tests {
 
         assert_matches!(
             result,
-            Err(RewindError::DataSource(SqliteClientError::CorruptedData(_)))
+            Err(RewindError::DataSource(
+                SqliteClientError::DivergedCheckpoints {
+                    pool: ShieldedPool::Ironwood,
+                    height,
+                }
+            )) if height == target_height
         );
     }
 

--- a/zcash_client_sqlite/src/wallet/init.rs
+++ b/zcash_client_sqlite/src/wallet/init.rs
@@ -198,6 +198,7 @@ fn sqlite_client_error_to_wallet_migration_error(e: SqliteClientError) -> Wallet
         SqliteClientError::TableNotEmpty => unreachable!("wallet already initialized"),
         SqliteClientError::BlockConflict(_)
         | SqliteClientError::NonSequentialBlocks
+        | SqliteClientError::DivergedCheckpoints { .. }
         | SqliteClientError::PutBlocksCommitmentTree { .. }
         | SqliteClientError::TruncateCommitmentTree { .. }
         | SqliteClientError::RequestedRewindInvalid { .. }


### PR DESCRIPTION
Preserve the existing diagnostic text while exposing the affected pool and truncation height to callers. See #3017

Closes #3017. The variant added here matches that issue's proposal field for field — `DivergedCheckpoints { pool: ShieldedPool, height: BlockHeight }` — and preserves the existing display text and truncation behaviour, as it asked.
