### PR TITLE
zcash_client_sqlite: stop v_transactions multiplying a sender's totals

### DIFF
--- a/zcash_client_sqlite/CHANGELOG.md
+++ b/zcash_client_sqlite/CHANGELOG.md
@@ -37,6 +37,14 @@ workspace.
   transparent spend detection. Transparent outputs detected by
   `zcash_client_backend::scanning::full::scan_block` were previously discarded
   when the scanned blocks were persisted.
+- The `v_transactions` and `v_transactions_with_pending_migrations` views no
+  longer multiply a sending account's row by the number of distinct groups the
+  transaction's outputs were received into, where a group is an account of the
+  wallet and the outputs no account of the wallet received form one further
+  group. `account_balance_delta`, `total_spent`, `total_received`,
+  `received_note_count`, `spent_note_count`, and the received-note contribution
+  to `memo_count` were each scaled by that count; `sent_note_count` reported
+  the notes of the largest single group instead of all of them.
 
 ## [0.22.0] - 2026-08-18
 

--- a/zcash_client_sqlite/src/wallet.rs
+++ b/zcash_client_sqlite/src/wallet.rs
@@ -6089,27 +6089,33 @@ mod tests {
 
     use rusqlite::{Connection, named_params};
     use sapling::zip32::ExtendedSpendingKey;
-    use secrecy::{ExposeSecret, SecretVec};
+    use secrecy::{ExposeSecret, Secret, SecretVec};
     use uuid::Uuid;
-    use zcash_client_backend::data_api::{
-        Account as _, AccountSource, TransactionDataRequest, TransactionStatus, WalletRead,
-        WalletWrite,
-        chain::{ChainState, CommitmentTreeRoot},
-        error::RewindError,
-        testing::{
-            AddressType, DataStoreFactory, FakeCompactOutput, InitialChainState, TestBuilder,
-            TestState, pool::ShieldedPoolTester, sapling::SaplingPoolTester,
+    use zcash_client_backend::{
+        data_api::{
+            Account as _, AccountBirthday, AccountSource, TransactionDataRequest,
+            TransactionStatus, WalletRead, WalletTest, WalletWrite,
+            chain::{ChainState, CommitmentTreeRoot},
+            error::RewindError,
+            testing::{
+                AddressType, DataStoreFactory, FakeCompactOutput, InitialChainState, TestBuilder,
+                TestState, pool::ShieldedPoolTester, sapling::SaplingPoolTester,
+                single_output_change_strategy,
+            },
+            wallet::{ConfirmationsPolicy, input_selection::GreedyInputSelector},
         },
-        wallet::ConfirmationsPolicy,
+        fees::StandardFeeRule,
+        wallet::OvkPolicy,
     };
     use zcash_keys::keys::UnifiedAddressRequest;
     use zcash_primitives::block::BlockHash;
     use zcash_protocol::{
         TxId,
         consensus::{BlockHeight, BranchId, MAIN_NETWORK, NetworkUpgrade, Parameters},
-        value::Zatoshis,
+        value::{ZatBalance, Zatoshis},
         zip318::{Zip318Classification, Zip318TxKind},
     };
+    use zip321::{Payment, TransactionRequest};
 
     use crate::{
         AccountUuid,
@@ -7858,5 +7864,131 @@ mod tests {
             put_zip318_classification(conn, TxRef(ABSENT), classification),
             Err(SqliteClientError::CorruptedData(_))
         );
+    }
+
+    /// A transaction's outputs may be received into several of the wallet's accounts, and into
+    /// none of them. The sending account's row in `v_transactions` must report what that account
+    /// actually spent and received, once, however many recipients the transaction has.
+    ///
+    /// Account 1 spends its single note to pay account 2, account 3, and an address outside the
+    /// wallet. The subquery that counts the notes the wallet created groups them, and grouping
+    /// them by the receiving account rather than the sending one emits one row per distinct
+    /// recipient account (outputs the wallet does not receive forming a group of their own); the
+    /// outer join then multiplies every aggregate of the sending account's row by the number of
+    /// those groups. Three groups make a threefold total, which no rounding or off-by-one can
+    /// account for.
+    #[test]
+    fn v_transactions_totals_do_not_scale_with_the_recipient_account_count() {
+        let mut st = TestBuilder::new()
+            .with_data_store_factory(TestDbFactory::default())
+            .with_block_cache(BlockCache::new())
+            .build();
+
+        // Three accounts in one wallet, so that payments between them are payments the wallet
+        // sees both halves of.
+        let seed = Secret::new(vec![0u8; 32]);
+        let birthday = AccountBirthday::from_sapling_activation(st.network(), BlockHash([0; 32]));
+        let (account1, usk1) = st
+            .wallet_mut()
+            .create_account("account1", &seed, &birthday, None)
+            .unwrap();
+        let dfvk1 = SaplingPoolTester::sk_to_fvk(SaplingPoolTester::usk_to_sk(&usk1));
+        let (account2, usk2) = st
+            .wallet_mut()
+            .create_account("account2", &seed, &birthday, None)
+            .unwrap();
+        let dfvk2 = SaplingPoolTester::sk_to_fvk(SaplingPoolTester::usk_to_sk(&usk2));
+        let (account3, usk3) = st
+            .wallet_mut()
+            .create_account("account3", &seed, &birthday, None)
+            .unwrap();
+        let dfvk3 = SaplingPoolTester::sk_to_fvk(SaplingPoolTester::usk_to_sk(&usk3));
+
+        // Fund account 1 with exactly one note, so that the spent total the view reports is a
+        // value no arithmetic over several notes could coincidentally produce.
+        let note_value = Zatoshis::const_from_u64(200_000);
+        let (h, _, _) = st.generate_next_block(&dfvk1, AddressType::DefaultExternal, note_value);
+        st.scan_cached_blocks(h, 1);
+        assert_eq!(st.get_total_balance(account1), note_value);
+
+        // One transaction paying three recipients: two of the wallet's own accounts and one
+        // address the wallet does not hold. None of the three outputs is change, so all three
+        // survive into the sent-note subquery, in three distinct groups.
+        let to_account2 = Zatoshis::const_from_u64(20_000);
+        let to_account3 = Zatoshis::const_from_u64(30_000);
+        let to_external = Zatoshis::const_from_u64(40_000);
+        let external = SaplingPoolTester::sk_default_address(&SaplingPoolTester::sk(&[0xf5; 32]));
+        let request = TransactionRequest::new(vec![
+            Payment::without_memo(
+                SaplingPoolTester::fvk_default_address(&dfvk2).to_zcash_address(st.network()),
+                to_account2,
+            ),
+            Payment::without_memo(
+                SaplingPoolTester::fvk_default_address(&dfvk3).to_zcash_address(st.network()),
+                to_account3,
+            ),
+            Payment::without_memo(external.to_zcash_address(st.network()), to_external),
+        ])
+        .unwrap();
+
+        let change_strategy = single_output_change_strategy(
+            StandardFeeRule::Zip317,
+            None,
+            SaplingPoolTester::SHIELDED_PROTOCOL,
+        );
+        let input_selector = GreedyInputSelector::new();
+        let txid = st
+            .spend(
+                &input_selector,
+                &change_strategy,
+                &usk1,
+                request,
+                OvkPolicy::Sender,
+                ConfirmationsPolicy::MIN,
+            )
+            .unwrap()[0];
+
+        let (h, _) = st.generate_next_block_including(txid);
+        st.scan_cached_blocks(h, 1);
+
+        let history = st.wallet().get_tx_history().unwrap();
+        let row_for = |account| {
+            history
+                .iter()
+                .find(|tx| tx.txid() == txid && tx.account_id() == &account)
+                .unwrap_or_else(|| panic!("{account:?} has a row for the transaction"))
+        };
+        let sender = row_for(account1);
+
+        // The one funding note, counted once.
+        assert_eq!(sender.total_spent(), note_value);
+        assert_eq!(sender.spent_note_count(), 1);
+
+        // The three outputs the wallet created for a recipient address, counted once each.
+        assert_eq!(sender.sent_note_count(), 3);
+
+        // Everything the transaction did not pay out or spend on the fee returns to account 1
+        // as change, and change is all it receives.
+        let fee = sender
+            .fee_paid()
+            .expect("the wallet created the transaction");
+        let paid_out = (to_account2 + to_account3 + to_external + fee).unwrap();
+        assert!(sender.has_change());
+        assert_eq!(sender.received_note_count(), 0);
+        assert_eq!(
+            sender.total_received(),
+            (note_value - paid_out).unwrap(),
+            "the change returned to the sending account, counted once",
+        );
+        assert_eq!(sender.account_value_delta(), -ZatBalance::from(paid_out));
+
+        // The recipient accounts' own rows are unaffected: each spent nothing and received the
+        // payment made to it.
+        for (account, paid) in [(account2, to_account2), (account3, to_account3)] {
+            let recipient = row_for(account);
+            assert_eq!(recipient.total_spent(), Zatoshis::ZERO);
+            assert_eq!(recipient.total_received(), paid);
+            assert_eq!(recipient.received_note_count(), 1);
+        }
     }
 }

--- a/zcash_client_sqlite/src/wallet/db.rs
+++ b/zcash_client_sqlite/src/wallet/db.rs
@@ -1416,12 +1416,33 @@ pub(super) fn view_migration_transactions() -> String {
 /// time, or raw bytes; `account_balance_delta` is minus the transaction's fee, every real output
 /// being internal to the account). `v_transactions` itself is unchanged; a consumer opts into
 /// the merged feed by reading this view instead.
+///
+/// Every column reference names its source table, CTE, or subquery alias. SQLite resolves a
+/// bare name against the input columns before the output aliases, so a bare name can bind a
+/// joined table's column of the same name instead of the projection it appears to repeat.
 pub(super) const VIEW_TRANSACTIONS_WITH_PENDING_MIGRATIONS: &str = "
 CREATE VIEW v_transactions_with_pending_migrations AS
-SELECT account_uuid, mined_height, txid, tx_index, expiry_height, raw, account_balance_delta,
-       total_spent, total_received, fee_paid, has_change, sent_note_count, received_note_count,
-       memo_count, block_time, expired_unmined, spent_note_count, is_shielding,
-       pool_crossing_value, trust_status, zip318_kind
+SELECT v_transactions.account_uuid           AS account_uuid,
+       v_transactions.mined_height           AS mined_height,
+       v_transactions.txid                   AS txid,
+       v_transactions.tx_index               AS tx_index,
+       v_transactions.expiry_height          AS expiry_height,
+       v_transactions.raw                    AS raw,
+       v_transactions.account_balance_delta  AS account_balance_delta,
+       v_transactions.total_spent            AS total_spent,
+       v_transactions.total_received         AS total_received,
+       v_transactions.fee_paid               AS fee_paid,
+       v_transactions.has_change             AS has_change,
+       v_transactions.sent_note_count        AS sent_note_count,
+       v_transactions.received_note_count    AS received_note_count,
+       v_transactions.memo_count             AS memo_count,
+       v_transactions.block_time             AS block_time,
+       v_transactions.expired_unmined        AS expired_unmined,
+       v_transactions.spent_note_count       AS spent_note_count,
+       v_transactions.is_shielding           AS is_shielding,
+       v_transactions.pool_crossing_value    AS pool_crossing_value,
+       v_transactions.trust_status           AS trust_status,
+       v_transactions.zip318_kind            AS zip318_kind
 FROM v_transactions
 UNION ALL
 SELECT vmt.account_uuid          AS account_uuid,
@@ -1448,6 +1469,12 @@ SELECT vmt.account_uuid          AS account_uuid,
        vmt.zip318_kind           AS zip318_kind
 FROM v_migration_transactions vmt";
 
+/// The history of transactions that affect the balance of each account in the wallet. The parent
+/// module's documentation describes the columns.
+///
+/// Every column reference names its source table, CTE, or subquery alias. SQLite resolves a
+/// bare name against the input columns before the output aliases, so a bare name can bind a
+/// joined table's column of the same name instead of the projection it appears to repeat.
 pub(super) const VIEW_TRANSACTIONS: &str = "
 CREATE VIEW v_transactions AS
 WITH
@@ -1456,7 +1483,7 @@ notes AS (
     SELECT ro.account_id              AS account_id,
            ro.transaction_id          AS transaction_id,
            ro.pool                    AS pool,
-           id_within_pool_table,
+           ro.id_within_pool_table    AS id_within_pool_table,
            ro.value                   AS value,
            ro.value                   AS received_value,
            0                          AS spent_value,
@@ -1486,7 +1513,7 @@ notes AS (
     SELECT ro.account_id              AS account_id,
            ros.transaction_id         AS transaction_id,
            ro.pool                    AS pool,
-           id_within_pool_table,
+           ro.id_within_pool_table    AS id_within_pool_table,
            -ro.value                  AS value,
            0                          AS received_value,
            ro.value                   AS spent_value,
@@ -1509,12 +1536,14 @@ notes AS (
 -- received value in but spent nothing from is a pool that value crossed into from
 -- elsewhere, which is what `pool_crossings` below is built on.
 notes_by_pool AS (
-    SELECT account_id, transaction_id, pool,
-           SUM(spent_note_count)                   AS spent_note_count,
-           SUM(received_count + change_note_count) AS received_note_count,
-           SUM(received_value)                     AS received_value
+    SELECT notes.account_id                                     AS account_id,
+           notes.transaction_id                                 AS transaction_id,
+           notes.pool                                           AS pool,
+           SUM(notes.spent_note_count)                          AS spent_note_count,
+           SUM(notes.received_count + notes.change_note_count)  AS received_note_count,
+           SUM(notes.received_value)                            AS received_value
     FROM notes
-    GROUP BY account_id, transaction_id, pool
+    GROUP BY notes.account_id, notes.transaction_id, notes.pool
 ),
 -- Obtain a count of the notes that the wallet created in each transaction,
 -- not counting change notes.
@@ -1532,7 +1561,10 @@ sent_note_counts AS (
     FROM sent_notes
     LEFT JOIN v_received_outputs ro ON sent_notes.id = ro.sent_note_id
     WHERE COALESCE(ro.is_change, 0) = 0
-    GROUP BY account_id, sent_notes.transaction_id
+    -- Group by the SENDING account. A bare `account_id` here binds `ro.account_id`, the
+    -- receiving account, because SQLite resolves a GROUP BY name against the input columns
+    -- before the output aliases.
+    GROUP BY sent_notes.from_account_id, sent_notes.transaction_id
 ),
 -- Identifies the transactions that are wallet-internal transfers moving an account's own
 -- funds between shielded pools, and reports the value that crossed. `crossing_value` is

--- a/zcash_client_sqlite/src/wallet/init/migrations.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations.rs
@@ -130,6 +130,7 @@ migration_modules!(
     fix_broken_commitment_trees,
     fix_transparent_received_outputs,
     fix_v_transactions_expired_unmined,
+    fix_v_transactions_multi_account_totals,
     full_account_ids,
     initial_setup,
     ironwood_pool_code_views,
@@ -401,6 +402,7 @@ pub(super) fn all_migrations<
         Box::new(orchard_ironwood_migration_txid_blob::Migration),
         Box::new(v_migration_transactions::Migration),
         Box::new(standalone_address::Migration),
+        Box::new(fix_v_transactions_multi_account_totals::Migration),
     ]
 }
 

--- a/zcash_client_sqlite/src/wallet/init/migrations/fix_v_transactions_multi_account_totals.rs
+++ b/zcash_client_sqlite/src/wallet/init/migrations/fix_v_transactions_multi_account_totals.rs
@@ -1,0 +1,346 @@
+//! Stops `v_transactions` from multiplying a sending account's totals.
+//!
+//! The `sent_note_counts` subquery projected `sent_notes.from_account_id AS account_id` while
+//! also joining `v_received_outputs`, which has its own `account_id`. SQLite resolves a bare name
+//! in `GROUP BY` against the input columns before the output aliases, so the grouping key was the
+//! RECEIVING account. A transaction whose sent notes were received into more than one account
+//! therefore produced one subquery row per recipient, all carrying the same sending account, and
+//! the outer join multiplied every aggregate of the sending account's row: `account_balance_delta`,
+//! `total_spent`, `total_received`, `received_note_count`, `spent_note_count`, and the received
+//! half of `memo_count` were scaled by the number of recipients, and `sent_note_count` reported
+//! the largest single recipient's share instead of the whole.
+//!
+//! Every column reference in both recreated views now names its source, so no bare name is left
+//! for that resolution order to capture. The only change in meaning is the grouping key.
+//!
+//! A view carries no data, so this migration discards nothing.
+//!
+//! `down` is deliberately a no-op, unlike the sibling view migrations that restore prior text:
+//! no supported upgrade path runs `down`, and a bug fix must not offer a path that reinstates
+//! the bug.
+
+use std::collections::HashSet;
+
+use schemerz_rusqlite::RusqliteMigration;
+use uuid::Uuid;
+
+use crate::wallet::init::WalletMigrationError;
+
+use super::{v_migration_transactions, v_transactions_zip318_kind};
+
+/// Identifies this migration in the wallet's schema-migration DAG.
+pub const MIGRATION_ID: Uuid = Uuid::from_u128(0xa7cd7bfd_2a92_4a7b_ba98_20d61893b260);
+
+/// `v_transactions_zip318_kind` created the `v_transactions` text this replaces, and
+/// `v_migration_transactions` created the `v_transactions_with_pending_migrations` text that
+/// selects from it.
+pub(super) const DEPENDENCIES: &[Uuid] = &[
+    v_transactions_zip318_kind::MIGRATION_ID,
+    v_migration_transactions::MIGRATION_ID,
+];
+
+pub(super) struct Migration;
+
+impl schemerz::Migration<Uuid> for Migration {
+    fn id(&self) -> Uuid {
+        MIGRATION_ID
+    }
+
+    fn dependencies(&self) -> HashSet<Uuid> {
+        DEPENDENCIES.iter().copied().collect()
+    }
+
+    fn description(&self) -> &'static str {
+        "Stops v_transactions from multiplying a sending account's totals by its recipient count."
+    }
+}
+
+impl RusqliteMigration for Migration {
+    type Error = WalletMigrationError;
+
+    fn up(&self, transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        transaction.execute_batch(
+            "DROP VIEW v_transactions_with_pending_migrations;
+            DROP VIEW v_transactions;
+            CREATE VIEW v_transactions AS
+            WITH
+            notes AS (
+                -- Outputs received in this transaction
+                SELECT ro.account_id              AS account_id,
+                       ro.transaction_id          AS transaction_id,
+                       ro.pool                    AS pool,
+                       ro.id_within_pool_table    AS id_within_pool_table,
+                       ro.value                   AS value,
+                       ro.value                   AS received_value,
+                       0                          AS spent_value,
+                       0                          AS spent_note_count,
+                       CASE
+                            WHEN ro.is_change THEN 1
+                            ELSE 0
+                       END AS change_note_count,
+                       CASE
+                            WHEN ro.is_change THEN 0
+                            ELSE 1
+                       END AS received_count,
+                       CASE
+                         WHEN (ro.memo IS NULL OR ro.memo = X'F6')
+                           THEN 0
+                         ELSE 1
+                       END AS memo_present,
+                       -- The wallet cannot receive transparent outputs in shielding transactions.
+                       CASE
+                         WHEN ro.pool = 0
+                           THEN 1
+                         ELSE 0
+                       END AS does_not_match_shielding
+                FROM v_received_outputs ro
+                UNION
+                -- Outputs spent in this transaction
+                SELECT ro.account_id              AS account_id,
+                       ros.transaction_id         AS transaction_id,
+                       ro.pool                    AS pool,
+                       ro.id_within_pool_table    AS id_within_pool_table,
+                       -ro.value                  AS value,
+                       0                          AS received_value,
+                       ro.value                   AS spent_value,
+                       1                          AS spent_note_count,
+                       0                          AS change_note_count,
+                       0                          AS received_count,
+                       0                          AS memo_present,
+                       -- The wallet cannot spend shielded outputs in shielding transactions.
+                       CASE
+                         WHEN ro.pool != 0
+                           THEN 1
+                         ELSE 0
+                       END AS does_not_match_shielding
+                FROM v_received_outputs ro
+                JOIN v_received_output_spends ros
+                     ON ros.pool = ro.pool
+                     AND ros.received_output_id = ro.id_within_pool_table
+            ),
+            -- What each account spent and received in each pool, per transaction. A pool the account
+            -- received value in but spent nothing from is a pool that value crossed into from
+            -- elsewhere, which is what `pool_crossings` below is built on.
+            notes_by_pool AS (
+                SELECT notes.account_id                                     AS account_id,
+                       notes.transaction_id                                 AS transaction_id,
+                       notes.pool                                           AS pool,
+                       SUM(notes.spent_note_count)                          AS spent_note_count,
+                       SUM(notes.received_count + notes.change_note_count)  AS received_note_count,
+                       SUM(notes.received_value)                            AS received_value
+                FROM notes
+                GROUP BY notes.account_id, notes.transaction_id, notes.pool
+            ),
+            -- Obtain a count of the notes that the wallet created in each transaction,
+            -- not counting change notes.
+            sent_note_counts AS (
+                SELECT sent_notes.from_account_id     AS account_id,
+                       sent_notes.transaction_id      AS transaction_id,
+                       COUNT(DISTINCT sent_notes.id)  AS sent_notes,
+                       SUM(
+                         CASE
+                           WHEN (sent_notes.memo IS NULL OR sent_notes.memo = X'F6' OR ro.transaction_id IS NOT NULL)
+                             THEN 0
+                           ELSE 1
+                         END
+                       ) AS memo_count
+                FROM sent_notes
+                LEFT JOIN v_received_outputs ro ON sent_notes.id = ro.sent_note_id
+                WHERE COALESCE(ro.is_change, 0) = 0
+                -- Group by the SENDING account. A bare `account_id` here binds `ro.account_id`, the
+                -- receiving account, because SQLite resolves a GROUP BY name against the input columns
+                -- before the output aliases.
+                GROUP BY sent_notes.from_account_id, sent_notes.transaction_id
+            ),
+            -- Identifies the transactions that are wallet-internal transfers moving an account's own
+            -- funds between shielded pools, and reports the value that crossed. `crossing_value` is
+            -- non-NULL exactly for such a transaction, so it carries both the classification and the
+            -- amount; see the `pool_crossing_value` column below.
+            pool_crossings AS (
+                SELECT notes_by_pool.account_id     AS account_id,
+                       notes_by_pool.transaction_id AS transaction_id,
+                       CASE WHEN (
+                            -- Every note spent and every output received by the wallet is shielded.
+                            SUM(CASE WHEN notes_by_pool.pool = 0 THEN notes_by_pool.spent_note_count + notes_by_pool.received_note_count ELSE 0 END) = 0
+                            -- The transaction spends at least one of the account's notes.
+                            AND SUM(notes_by_pool.spent_note_count) > 0
+                            -- At least one output was received in a pool the account spent nothing
+                            -- from, so value crossed between pools.
+                            AND SUM(CASE WHEN notes_by_pool.spent_note_count = 0 THEN notes_by_pool.received_note_count ELSE 0 END) > 0
+                            -- We do not know about any external outputs of the transaction.
+                            AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
+                       )
+                       -- The total value received in the pools the account did not spend from. The
+                       -- condition above guarantees at least one such output, so when this branch is
+                       -- taken the sum is never NULL.
+                       THEN SUM(CASE WHEN notes_by_pool.spent_note_count = 0 THEN notes_by_pool.received_value ELSE 0 END)
+                       END AS crossing_value
+                FROM notes_by_pool
+                LEFT JOIN sent_note_counts
+                     ON sent_note_counts.account_id = notes_by_pool.account_id
+                     AND sent_note_counts.transaction_id = notes_by_pool.transaction_id
+                GROUP BY notes_by_pool.account_id, notes_by_pool.transaction_id
+            ),
+            blocks_max_height AS (
+                SELECT MAX(blocks.height) AS max_height FROM blocks
+            )
+            SELECT accounts.uuid                AS account_uuid,
+                   transactions.mined_height    AS mined_height,
+                   transactions.txid            AS txid,
+                   transactions.tx_index        AS tx_index,
+                   transactions.expiry_height   AS expiry_height,
+                   transactions.raw             AS raw,
+                   SUM(notes.value)             AS account_balance_delta,
+                   SUM(notes.spent_value)       AS total_spent,
+                   SUM(notes.received_value)    AS total_received,
+                   transactions.fee             AS fee_paid,
+                   SUM(notes.change_note_count) > 0  AS has_change,
+                   MAX(COALESCE(sent_note_counts.sent_notes, 0))  AS sent_note_count,
+                   SUM(notes.received_count)         AS received_note_count,
+                   SUM(notes.memo_present) + MAX(COALESCE(sent_note_counts.memo_count, 0)) AS memo_count,
+                   blocks.time                       AS block_time,
+                   (
+                        transactions.mined_height IS NULL
+                        AND transactions.expiry_height BETWEEN 1 AND blocks_max_height.max_height
+                   ) AS expired_unmined,
+                   SUM(notes.spent_note_count) AS spent_note_count,
+                   (
+                        -- All of the wallet-spent and wallet-received notes are consistent with a
+                        -- shielding transaction.
+                        SUM(notes.does_not_match_shielding) = 0
+                        -- The transaction contains at least one wallet-spent output.
+                        AND SUM(notes.spent_note_count) > 0
+                        -- The transaction contains at least one wallet-received note.
+                        AND (SUM(notes.received_count) + SUM(notes.change_note_count)) > 0
+                        -- We do not know about any external outputs of the transaction.
+                        AND MAX(COALESCE(sent_note_counts.sent_notes, 0)) = 0
+                   ) AS is_shielding,
+                   -- The value that crossed pools, when this transaction is a wallet-internal transfer
+                   -- between shielded pools; NULL when it is not such a transfer. A transaction is one
+                   -- exactly when this column is non-NULL.
+                   pool_crossings.crossing_value AS pool_crossing_value,
+                   transactions.trust_status,
+                   transactions.zip318_kind
+            FROM notes
+            JOIN accounts ON accounts.id = notes.account_id
+            JOIN transactions ON transactions.id_tx = notes.transaction_id
+            LEFT JOIN blocks_max_height
+            LEFT JOIN blocks ON blocks.height = transactions.mined_height
+            LEFT JOIN sent_note_counts
+                 ON sent_note_counts.account_id = notes.account_id
+                 AND sent_note_counts.transaction_id = notes.transaction_id
+            LEFT JOIN pool_crossings
+                 ON pool_crossings.account_id = notes.account_id
+                 AND pool_crossings.transaction_id = notes.transaction_id
+            GROUP BY notes.account_id, notes.transaction_id;
+            CREATE VIEW v_transactions_with_pending_migrations AS
+            SELECT v_transactions.account_uuid           AS account_uuid,
+                   v_transactions.mined_height           AS mined_height,
+                   v_transactions.txid                   AS txid,
+                   v_transactions.tx_index               AS tx_index,
+                   v_transactions.expiry_height          AS expiry_height,
+                   v_transactions.raw                    AS raw,
+                   v_transactions.account_balance_delta  AS account_balance_delta,
+                   v_transactions.total_spent            AS total_spent,
+                   v_transactions.total_received         AS total_received,
+                   v_transactions.fee_paid               AS fee_paid,
+                   v_transactions.has_change             AS has_change,
+                   v_transactions.sent_note_count        AS sent_note_count,
+                   v_transactions.received_note_count    AS received_note_count,
+                   v_transactions.memo_count             AS memo_count,
+                   v_transactions.block_time             AS block_time,
+                   v_transactions.expired_unmined        AS expired_unmined,
+                   v_transactions.spent_note_count       AS spent_note_count,
+                   v_transactions.is_shielding           AS is_shielding,
+                   v_transactions.pool_crossing_value    AS pool_crossing_value,
+                   v_transactions.trust_status           AS trust_status,
+                   v_transactions.zip318_kind            AS zip318_kind
+            FROM v_transactions
+            UNION ALL
+            SELECT vmt.account_uuid          AS account_uuid,
+                   NULL                      AS mined_height,
+                   vmt.txid                  AS txid,
+                   NULL                      AS tx_index,
+                   vmt.expiry_height         AS expiry_height,
+                   NULL                      AS raw,
+                   -vmt.fee                  AS account_balance_delta,
+                   vmt.value_spent           AS total_spent,
+                   vmt.value_received        AS total_received,
+                   vmt.fee                   AS fee_paid,
+                   vmt.has_change            AS has_change,
+                   0                         AS sent_note_count,
+                   vmt.received_note_count   AS received_note_count,
+                   0                         AS memo_count,
+                   NULL                      AS block_time,
+                   (vmt.expiry_height BETWEEN 1 AND (SELECT MAX(blocks.height) FROM blocks))
+                                             AS expired_unmined,
+                   vmt.spent_note_count      AS spent_note_count,
+                   0                         AS is_shielding,
+                   vmt.pool_crossing_value   AS pool_crossing_value,
+                   NULL                      AS trust_status,
+                   vmt.zip318_kind           AS zip318_kind
+            FROM v_migration_transactions vmt;",
+        )?;
+
+        Ok(())
+    }
+
+    fn down(&self, _transaction: &rusqlite::Transaction) -> Result<(), Self::Error> {
+        // Nothing to do: no supported upgrade path runs `down`, and a bug fix must not
+        // offer a path that reinstates the bug. The corrected views satisfy every reader
+        // of the prior schema, so leaving them in place is sound.
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use secrecy::Secret;
+    use tempfile::NamedTempFile;
+    use zcash_protocol::consensus::Network;
+
+    use crate::WalletDb;
+    use crate::testing::db::{test_clock, test_rng};
+    use crate::wallet::init::WalletMigrator;
+    use crate::wallet::init::migrations::tests::test_migrate;
+
+    #[test]
+    fn migrate() {
+        test_migrate(&[super::MIGRATION_ID]);
+    }
+
+    /// Both recreated views must be QUERYABLE, not merely creatable. SQLite stores a view's
+    /// SELECT as text and does not resolve its column references until the view is used, so a
+    /// `CREATE VIEW` naming a column that does not exist succeeds and fails only later, at the
+    /// first query a client makes. Migrating cleanly is therefore not evidence that this
+    /// migration worked, and qualifying every column reference is exactly the kind of edit a
+    /// bad name survives.
+    #[test]
+    fn the_recreated_views_are_queryable() {
+        let data_file = NamedTempFile::new().unwrap();
+        let mut db_data = WalletDb::for_path(
+            data_file.path(),
+            Network::TestNetwork,
+            test_clock(),
+            test_rng(),
+        )
+        .unwrap();
+
+        WalletMigrator::new()
+            .with_seed(Secret::new(vec![0xab; 32]))
+            .ignore_seed_relevance()
+            .init_or_migrate_to(&mut db_data, &[super::MIGRATION_ID])
+            .unwrap();
+
+        for view in ["v_transactions", "v_transactions_with_pending_migrations"] {
+            // The wallet is empty, so each of these returns zero; preparing and stepping the
+            // statement is what forces SQLite to resolve the view's column references.
+            let count: i64 = db_data
+                .conn
+                .query_row(&format!("SELECT COUNT(*) FROM {view}"), [], |row| row.get(0))
+                .unwrap_or_else(|e| panic!("{view} resolves when queried: {e}"));
+
+            assert_eq!(count, 0);
+        }
+    }
+}


### PR DESCRIPTION
Closes #3019.

`v_transactions`' `sent_note_counts` subquery grouped by a bare `account_id` that SQLite resolves to the LEFT-JOINed `v_received_outputs.account_id` (input columns win over output aliases), so the grouping key was the *receiving* account while every row projected the *sender*. A transaction whose sent notes are received into more than one distinct group multiplies every aggregate of the sending account's row by the group count — `account_balance_delta`, `total_spent`, `total_received`, `received_note_count`, `spent_note_count`, and the received half of `memo_count` — while `sent_note_count` (via `MAX`) *under*-reports, returning the largest single recipient's share.

The fix is `GROUP BY sent_notes.from_account_id, sent_notes.transaction_id`, plus a migration recreating `v_transactions` and `v_transactions_with_pending_migrations` (a view holds no data, so nothing is discarded; `down` is a deliberate no-op: no supported upgrade path runs it, and a bug fix must not offer a path that reinstates the bug). Both recreated views are now fully column-qualified so no bare name remains for that resolution order to capture. The regression test constructs the three-recipient-group case and fails at exactly 3× without the fix.

One pre-existing wrinkle this migration defends against: `v_migration_transactions::up` reads the live view constant rather than a frozen copy, so editing the constant changes what that migration creates for fresh wallets. This migration depends on it, making fresh and previously-migrated wallets converge on the text `verify_schema` requires.

## Shadowing audit

Per the issue, the rest of the schema's views were audited for the same class of bug:

```
Shadowing audit
---------------

Method: for every bare column reference in a view's SQL -- and every bare name
in a `GROUP BY`, `ORDER BY` or join `ON`, where output aliases also compete --
enumerate the in-scope sources that supply that name, then adjudicate what
SQLite binds against what the author meant. Run mechanically over each view's
sources and the schema's column lists, not by eye.

Both recreated views now qualify every column reference, so no bare name is
left for that resolution order to capture. The qualification is inert: running
the old and new view text over identical data differs only where a transaction
has more than one recipient group.

The other views in `wallet/db.rs` were audited and left alone; none binds a
name to the wrong source. Two are fragile rather than wrong, and are recorded
here rather than churned:

- `v_received_outputs` reads bare `account_id` and `is_change` in its three
  shielded branches. Only the pool's received-notes table supplies either name;
  the joined `sent_notes` has neither. A future `sent_notes.account_id` would
  reproduce this same bug one level down.
- `v_{sapling,orchard,ironwood}_shard_scan_ranges` reads bare
  `subtree_start_height` in a join `ON` clause, where it binds the output alias
  because no input column carries that name -- which is the intent, via
  SQLite's alias-in-`ON` extension.
```

Two fragile-but-correct patterns worth knowing about (deliberately not churned, since neither currently misbinds): `v_received_outputs`' shielded branches use bare `account_id`/`is_change` that stay correct only because `sent_notes` happens to carry neither name — a future `sent_notes.account_id` column would reproduce this bug one level down — and the shard scan-range views rely on SQLite's alias-in-`ON` extension for `subtree_start_height`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)