### PR TITLE
zcash_client_backend: Try every ZIP 316 sender OVK when recovering outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7169,6 +7169,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "rayon",
+ "redjubjub",
  "rust_decimal",
  "sapling-crypto",
  "secp256k1",

--- a/zcash_client_backend/CHANGELOG.md
+++ b/zcash_client_backend/CHANGELOG.md
@@ -25,6 +25,14 @@ workspace.
   complete transaction data reached
   `zcash_client_backend::data_api::wallet::decrypt_and_store_transaction`.
   Transparent spends are still not detected during block scanning.
+- `zcash_client_backend::decrypt::decrypt_transaction` now attempts outgoing
+  ciphertext recovery with every outgoing viewing key an account's UFVK can
+  produce — Orchard, Sapling and transparent-derived, in both the external and
+  internal scopes — instead of only the same-pool external-scope key, and tries
+  each pool's outputs against every account instead of only those whose UFVK
+  holds that pool's key. Cross-pool sends, shielding transactions, and outputs
+  encrypted under an internal-scope OVK now recover their recipient, value and
+  memo as `zcash_client_backend::TransferType::Outgoing`.
 
 ## [0.24.0] - 2026-08-18
 

--- a/zcash_client_backend/Cargo.toml
+++ b/zcash_client_backend/Cargo.toml
@@ -154,6 +154,7 @@ jubjub.workspace = true
 proptest.workspace = true
 rand.workspace = true
 rand_chacha.workspace = true
+redjubjub.workspace = true
 shardtree = { workspace = true, features = ["test-dependencies"] }
 tempfile = "3.5.0"
 tokio = { version = "1.21.0", features = ["macros", "rt-multi-thread"] }

--- a/zcash_client_backend/src/decrypt.rs
+++ b/zcash_client_backend/src/decrypt.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use sapling::note_encryption::{PreparedIncomingViewingKey, SaplingDomain};
-use zcash_keys::keys::UnifiedFullViewingKey;
+use zcash_keys::keys::{OutgoingViewingKey, UnifiedFullViewingKey};
 use zcash_note_encryption::{try_note_decryption, try_output_recovery_with_ovk};
 use zcash_primitives::{
     transaction::Transaction, transaction::components::sapling::zip212_enforcement,
@@ -116,6 +116,44 @@ impl<A> DecryptedOutput<orchard::note::Note, A> {
     }
 }
 
+/// Returns every outgoing viewing key that a [ZIP 316]-compliant sender may have used to encrypt
+/// the outgoing ciphertexts of a transaction funded from the account that `ufvk` belongs to.
+///
+/// A sender selects one `(external, internal)` OVK pair for the entire transaction, taken from the
+/// protocol that the spent funds came from, and uses that pair for every shielded output of the
+/// transaction irrespective of the pool each output lands in; an OVK is pool-agnostic input to the
+/// outgoing-ciphertext KDF. The pool that funded a transaction cannot be determined from the
+/// transaction alone, so recovery must try each key the account is able to produce: Orchard
+/// external and internal, Sapling external and internal, and the transparent-derived pair.
+///
+/// [ZIP 316]: https://zips.z.cash/zip-0316#usage-of-outgoing-viewing-keys
+fn candidate_ovks(ufvk: &UnifiedFullViewingKey) -> Vec<OutgoingViewingKey> {
+    // Candidates are ordered by the ZIP 316 preference order of the item that produced them, with
+    // the external scope before the internal scope, so that the most likely candidate is tried
+    // first; correctness does not depend upon the order.
+    let mut ovks = Vec::with_capacity(6);
+
+    #[cfg(feature = "orchard")]
+    if let Some(fvk) = ufvk.orchard() {
+        ovks.push(fvk.to_ovk(Scope::External).into());
+        ovks.push(fvk.to_ovk(Scope::Internal).into());
+    }
+
+    if let Some(dfvk) = ufvk.sapling() {
+        ovks.push(dfvk.to_ovk(Scope::External).into());
+        ovks.push(dfvk.to_ovk(Scope::Internal).into());
+    }
+
+    #[cfg(feature = "transparent-inputs")]
+    if let Some(pubkey) = ufvk.transparent() {
+        let (internal, external) = pubkey.ovks_for_shielding();
+        ovks.push(external.as_bytes().into());
+        ovks.push(internal.as_bytes().into());
+    }
+
+    ovks
+}
+
 /// Scans a [`Transaction`] for any information that can be decrypted by the set of
 /// [`UnifiedFullViewingKey`]s.
 ///
@@ -153,51 +191,68 @@ pub fn decrypt_transaction<'a, P: consensus::Parameters, AccountId: Copy>(
     let sapling_outputs = sapling_bundle
         .iter()
         .flat_map(|bundle| {
-            ufvks
-                .iter()
-                .flat_map(|(account, ufvk)| ufvk.sapling().into_iter().map(|dfvk| (*account, dfvk)))
-                .flat_map(|(account, dfvk)| {
-                    let sapling_domain = SaplingDomain::new(zip212_enforcement);
-                    let ivk_external =
-                        PreparedIncomingViewingKey::new(&dfvk.to_ivk(Scope::External));
-                    let ivk_internal =
-                        PreparedIncomingViewingKey::new(&dfvk.to_ivk(Scope::Internal));
-                    let ovk = dfvk.fvk().ovk;
+            ufvks.iter().flat_map(|(account, ufvk)| {
+                let account = *account;
+                let sapling_domain = SaplingDomain::new(zip212_enforcement);
+                // An account can only receive a Sapling output if its UFVK has a Sapling item,
+                // but it can fund one from any pool, so outgoing recovery is attempted for
+                // every account.
+                let ivks = ufvk.sapling().map(|dfvk| {
+                    (
+                        PreparedIncomingViewingKey::new(&dfvk.to_ivk(Scope::External)),
+                        PreparedIncomingViewingKey::new(&dfvk.to_ivk(Scope::Internal)),
+                    )
+                });
+                let ovks = candidate_ovks(ufvk)
+                    .into_iter()
+                    .map(::sapling::keys::OutgoingViewingKey::from)
+                    .collect::<Vec<_>>();
 
-                    bundle
-                        .shielded_outputs()
-                        .iter()
-                        .enumerate()
-                        .flat_map(move |(index, output)| {
-                            try_note_decryption(&sapling_domain, &ivk_external, output)
-                                .map(|ret| (ret, TransferType::Incoming))
-                                .or_else(|| {
-                                    try_note_decryption(&sapling_domain, &ivk_internal, output)
-                                        .map(|ret| (ret, TransferType::AccountInternal))
-                                })
-                                .or_else(|| {
-                                    try_output_recovery_with_ovk(
-                                        &sapling_domain,
-                                        &ovk,
-                                        output,
-                                        output.cv(),
-                                        output.out_ciphertext(),
-                                    )
+                bundle
+                    .shielded_outputs()
+                    .iter()
+                    .enumerate()
+                    .flat_map(move |(index, output)| {
+                        ivks.as_ref()
+                            .and_then(|(ivk_external, ivk_internal)| {
+                                try_note_decryption(&sapling_domain, ivk_external, output)
+                                    .map(|ret| (ret, TransferType::Incoming))
+                                    .or_else(|| {
+                                        try_note_decryption(&sapling_domain, ivk_internal, output)
+                                            .map(|ret| (ret, TransferType::AccountInternal))
+                                    })
+                            })
+                            .or_else(|| {
+                                // Recovery under any candidate OVK yields `Outgoing`
+                                // unconditionally: the incoming and internal trial decryptions
+                                // above have already run and failed, so this account is not the
+                                // recipient of the output. Which candidate matched identifies
+                                // only the pool the sender spent from, not the recipient.
+                                ovks.iter()
+                                    .find_map(|ovk| {
+                                        try_output_recovery_with_ovk(
+                                            &sapling_domain,
+                                            ovk,
+                                            output,
+                                            output.cv(),
+                                            output.out_ciphertext(),
+                                        )
+                                    })
                                     .map(|ret| (ret, TransferType::Outgoing))
-                                })
-                                .into_iter()
-                                .map(move |((note, _, memo), transfer_type)| {
-                                    DecryptedOutput::new(
-                                        index,
-                                        note,
-                                        ShieldedPool::Sapling,
-                                        account,
-                                        MemoBytes::from_bytes(&memo).expect("correct length"),
-                                        transfer_type,
-                                    )
-                                })
-                        })
-                })
+                            })
+                            .into_iter()
+                            .map(move |((note, _, memo), transfer_type)| {
+                                DecryptedOutput::new(
+                                    index,
+                                    note,
+                                    ShieldedPool::Sapling,
+                                    account,
+                                    MemoBytes::from_bytes(&memo).expect("correct length"),
+                                    transfer_type,
+                                )
+                            })
+                    })
+            })
         })
         .collect();
 
@@ -217,51 +272,68 @@ pub fn decrypt_transaction<'a, P: consensus::Parameters, AccountId: Copy>(
         pool: orchard::ValuePool,
     ) -> impl Iterator<Item = DecryptedOutput<(orchard::Note, orchard::ValuePool), AccountId>> {
         let shielded_pool = crate::wallet::shielded_pool_for_value_pool(pool);
-        ufvks
-            .iter()
-            .flat_map(|(account, ufvk)| ufvk.orchard().into_iter().map(|fvk| (*account, fvk)))
-            .flat_map(move |(account, fvk)| {
-                let ivk_external =
-                    orchard::keys::PreparedIncomingViewingKey::new(&fvk.to_ivk(Scope::External));
-                let ivk_internal =
-                    orchard::keys::PreparedIncomingViewingKey::new(&fvk.to_ivk(Scope::Internal));
-                let ovk = fvk.to_ovk(Scope::External);
+        ufvks.iter().flat_map(move |(account, ufvk)| {
+            let account = *account;
+            // An account can only receive an Orchard-family output if its UFVK has an Orchard
+            // item, but it can fund one from any pool, so outgoing recovery is attempted for
+            // every account.
+            let ivks = ufvk.orchard().map(|fvk| {
+                (
+                    orchard::keys::PreparedIncomingViewingKey::new(&fvk.to_ivk(Scope::External)),
+                    orchard::keys::PreparedIncomingViewingKey::new(&fvk.to_ivk(Scope::Internal)),
+                )
+            });
+            let ovks = candidate_ovks(ufvk)
+                .into_iter()
+                .map(orchard::keys::OutgoingViewingKey::from)
+                .collect::<Vec<_>>();
 
-                bundle
-                    .actions()
-                    .iter()
-                    .enumerate()
-                    .flat_map(move |(index, action)| {
-                        let domain = NoteEncryptionDomain::<V>::for_action(action);
-                        try_note_decryption(&domain, &ivk_external, action)
-                            .map(|ret| (ret, TransferType::Incoming))
-                            .or_else(|| {
-                                try_note_decryption(&domain, &ivk_internal, action)
-                                    .map(|ret| (ret, TransferType::AccountInternal))
-                            })
-                            .or_else(|| {
-                                try_output_recovery_with_ovk(
-                                    &domain,
-                                    &ovk,
-                                    action,
-                                    action.cv_net(),
-                                    &action.encrypted_note().out_ciphertext,
-                                )
+            bundle
+                .actions()
+                .iter()
+                .enumerate()
+                .flat_map(move |(index, action)| {
+                    let domain = NoteEncryptionDomain::<V>::for_action(action);
+                    ivks.as_ref()
+                        .and_then(|(ivk_external, ivk_internal)| {
+                            try_note_decryption(&domain, ivk_external, action)
+                                .map(|ret| (ret, TransferType::Incoming))
+                                .or_else(|| {
+                                    try_note_decryption(&domain, ivk_internal, action)
+                                        .map(|ret| (ret, TransferType::AccountInternal))
+                                })
+                        })
+                        .or_else(|| {
+                            // Recovery under any candidate OVK yields `Outgoing`
+                            // unconditionally: the incoming and internal trial decryptions
+                            // above have already run and failed, so this account is not the
+                            // recipient of the output. Which candidate matched identifies only
+                            // the pool the sender spent from, not the recipient.
+                            ovks.iter()
+                                .find_map(|ovk| {
+                                    try_output_recovery_with_ovk(
+                                        &domain,
+                                        ovk,
+                                        action,
+                                        action.cv_net(),
+                                        &action.encrypted_note().out_ciphertext,
+                                    )
+                                })
                                 .map(|ret| (ret, TransferType::Outgoing))
-                            })
-                            .into_iter()
-                            .map(move |((note, _, memo), transfer_type)| {
-                                DecryptedOutput::new(
-                                    index,
-                                    (note, pool),
-                                    shielded_pool,
-                                    account,
-                                    MemoBytes::from_bytes(&memo).expect("correct length"),
-                                    transfer_type,
-                                )
-                            })
-                    })
-            })
+                        })
+                        .into_iter()
+                        .map(move |((note, _, memo), transfer_type)| {
+                            DecryptedOutput::new(
+                                index,
+                                (note, pool),
+                                shielded_pool,
+                                account,
+                                MemoBytes::from_bytes(&memo).expect("correct length"),
+                                transfer_type,
+                            )
+                        })
+                })
+        })
     }
 
     #[cfg(feature = "orchard")]
@@ -299,4 +371,418 @@ pub fn decrypt_transaction<'a, P: consensus::Parameters, AccountId: Copy>(
         #[cfg(feature = "orchard")]
         ironwood_outputs,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use rand_chacha::ChaChaRng;
+    use rand_core::{CryptoRng, RngCore, SeedableRng};
+    use sapling::{
+        note_encryption::sapling_note_encryption,
+        util::generate_random_rseed,
+        value::{NoteValue, ValueCommitTrapdoor, ValueCommitment},
+    };
+    use zcash_keys::keys::{OutgoingViewingKey, UnifiedFullViewingKey, UnifiedSpendingKey};
+    use zcash_note_encryption::Domain;
+    use zcash_primitives::transaction::{
+        Authorized, Transaction, TransactionData, TxVersion,
+        components::sapling::zip212_enforcement,
+    };
+    use zcash_protocol::{
+        consensus::{BlockHeight, BranchId, Network},
+        memo::MemoBytes,
+        value::{ZatBalance, Zatoshis},
+    };
+    use zip32::{AccountId, Scope};
+
+    use super::{SaplingDomain, TransferType, decrypt_transaction};
+
+    /// A height at which ZIP 212 is fully enforced on the test network, so that the note
+    /// plaintexts built here and the domain `decrypt_transaction` reconstructs agree.
+    const MINED_HEIGHT: u32 = 2_000_000;
+
+    const VALUE: Zatoshis = Zatoshis::const_from_u64(100_000);
+
+    /// The account whose keys are used to attempt recovery.
+    fn wallet_ufvk() -> UnifiedFullViewingKey {
+        UnifiedSpendingKey::from_seed(&Network::TestNetwork, &[0xab; 32], AccountId::ZERO)
+            .expect("seed produces a valid unified spending key")
+            .to_unified_full_viewing_key()
+    }
+
+    /// A key belonging to someone else, used to produce recipient addresses that the wallet
+    /// cannot detect with any of its incoming viewing keys.
+    fn counterparty_ufvk() -> UnifiedFullViewingKey {
+        UnifiedSpendingKey::from_seed(&Network::TestNetwork, &[0xcd; 32], AccountId::ZERO)
+            .expect("seed produces a valid unified spending key")
+            .to_unified_full_viewing_key()
+    }
+
+    /// Every outgoing viewing key that a ZIP 316-compliant sender may select for a transaction
+    /// funded from the account that `ufvk` belongs to, labelled by the item and scope it is
+    /// derived from. Derived here directly from the UFVK's items, independently of the candidate
+    /// set that `decrypt_transaction` builds.
+    fn zip316_sender_ovks(ufvk: &UnifiedFullViewingKey) -> Vec<(&'static str, OutgoingViewingKey)> {
+        let mut ovks: Vec<(&'static str, OutgoingViewingKey)> = Vec::new();
+
+        #[cfg(feature = "orchard")]
+        {
+            let fvk = ufvk.orchard().expect("UFVK has an Orchard item");
+            ovks.push(("Orchard external", fvk.to_ovk(Scope::External).into()));
+            ovks.push(("Orchard internal", fvk.to_ovk(Scope::Internal).into()));
+        }
+
+        let dfvk = ufvk.sapling().expect("UFVK has a Sapling item");
+        ovks.push(("Sapling external", dfvk.to_ovk(Scope::External).into()));
+        ovks.push(("Sapling internal", dfvk.to_ovk(Scope::Internal).into()));
+
+        #[cfg(feature = "transparent-inputs")]
+        {
+            let tfvk = ufvk.transparent().expect("UFVK has a transparent item");
+            let (internal, external) = tfvk.ovks_for_shielding();
+            // `ovks_for_shielding` returns the pair in (internal, external) order, and both halves
+            // become raw bytes as soon as they are used, so only this destructure records which is
+            // which. Pin each half against the accessor that names it, so that a swap here cannot
+            // pass by relabelling both ends consistently.
+            assert_eq!(external.as_bytes(), tfvk.external_ovk().as_bytes());
+            assert_eq!(internal.as_bytes(), tfvk.internal_ovk().as_bytes());
+            ovks.push(("transparent external", external.as_bytes().into()));
+            ovks.push(("transparent internal", internal.as_bytes().into()));
+        }
+
+        ovks
+    }
+
+    /// A 32-byte value that is not derivable from any wallet key.
+    fn foreign_ovk() -> OutgoingViewingKey {
+        OutgoingViewingKey::from([0x5a; 32])
+    }
+
+    /// Builds a v5 transaction whose sole Sapling output pays `recipient`, with the outgoing
+    /// ciphertext encrypted under `ovk`.
+    ///
+    /// The zero-knowledge proof and binding signature are dummies; neither participates in note
+    /// decryption or outgoing-ciphertext recovery.
+    fn sapling_tx_paying(
+        recipient: ::sapling::PaymentAddress,
+        ovk: OutgoingViewingKey,
+        rng: &mut (impl RngCore + CryptoRng),
+    ) -> Transaction {
+        let enforcement =
+            zip212_enforcement(&Network::TestNetwork, BlockHeight::from_u32(MINED_HEIGHT));
+        let value = NoteValue::from_raw(VALUE.into_u64());
+        let rseed = generate_random_rseed(enforcement, rng);
+        let note = ::sapling::Note::from_parts(recipient, value, rseed);
+        let cv = ValueCommitment::derive(value, ValueCommitTrapdoor::random(&mut *rng));
+        let cmu = note.cmu();
+
+        let encryptor =
+            sapling_note_encryption(Some(ovk.into()), note, MemoBytes::empty().into_bytes(), rng);
+        let ephemeral_key = SaplingDomain::epk_bytes(encryptor.epk());
+        let enc_ciphertext = encryptor.encrypt_note_plaintext();
+        let out_ciphertext = encryptor.encrypt_outgoing_plaintext(&cv, &cmu, rng);
+
+        let output = ::sapling::bundle::OutputDescription::from_parts(
+            cv,
+            cmu,
+            ephemeral_key,
+            enc_ciphertext,
+            out_ciphertext,
+            [0u8; core::mem::size_of::<::sapling::bundle::GrothProofBytes>()],
+        );
+
+        let bundle = ::sapling::Bundle::from_parts(
+            vec![],
+            vec![output],
+            ZatBalance::const_from_i64(-(VALUE.into_u64() as i64)),
+            ::sapling::bundle::Authorized {
+                binding_sig: redjubjub::Signature::from([0u8; 64]),
+            },
+        )
+        .expect("the bundle has an output");
+
+        TransactionData::<Authorized>::from_parts(
+            TxVersion::V5,
+            BranchId::Nu5,
+            0,
+            BlockHeight::from_u32(MINED_HEIGHT + 100),
+            #[cfg(all(zcash_unstable = "nu7", feature = "zip-233"))]
+            Zatoshis::ZERO,
+            None,
+            None,
+            Some(bundle),
+            None,
+        )
+        .freeze()
+        .expect("the transaction data is well-formed")
+    }
+
+    /// Recovers the wallet's view of a transaction, returning the transfer type and value of each
+    /// Sapling output that could be decrypted.
+    fn decrypt_sapling(tx: &Transaction) -> Vec<(TransferType, Zatoshis)> {
+        let mut ufvks = HashMap::new();
+        ufvks.insert(0u32, wallet_ufvk());
+
+        decrypt_transaction(
+            &Network::TestNetwork,
+            Some(BlockHeight::from_u32(MINED_HEIGHT)),
+            None,
+            tx,
+            &ufvks,
+        )
+        .sapling_outputs()
+        .iter()
+        .map(|output| (output.transfer_type(), output.note_value()))
+        .collect()
+    }
+
+    /// A Sapling output is recovered under every OVK a ZIP 316-compliant sender might have chosen
+    /// for the transaction, not only the Sapling external-scope one.
+    #[test]
+    fn sapling_output_recovered_with_every_zip316_ovk() {
+        let mut rng = ChaChaRng::seed_from_u64(0);
+        let recipient = counterparty_ufvk()
+            .sapling()
+            .expect("UFVK has a Sapling item")
+            .default_address()
+            .1;
+
+        for (label, ovk) in zip316_sender_ovks(&wallet_ufvk()) {
+            let tx = sapling_tx_paying(recipient, ovk, &mut rng);
+            assert_eq!(
+                decrypt_sapling(&tx),
+                vec![(TransferType::Outgoing, VALUE)],
+                "output encrypted under the {label} OVK was not recovered"
+            );
+        }
+    }
+
+    /// An outgoing ciphertext that no wallet key can open is not reported.
+    #[test]
+    fn sapling_output_not_recovered_with_foreign_ovk() {
+        let mut rng = ChaChaRng::seed_from_u64(1);
+        let recipient = counterparty_ufvk()
+            .sapling()
+            .expect("UFVK has a Sapling item")
+            .default_address()
+            .1;
+
+        let tx = sapling_tx_paying(recipient, foreign_ovk(), &mut rng);
+        assert_eq!(decrypt_sapling(&tx), vec![]);
+    }
+
+    /// Builds a v5 transaction whose sole Orchard action creates a note paying `recipient`, with
+    /// the outgoing ciphertext encrypted under `ovk`.
+    ///
+    /// The action's spend half is vestigial here: it carries an arbitrary nullifier, whose only
+    /// role is to seed the note's `rho`. The zero-knowledge proof and signatures are dummies;
+    /// none of them participates in note decryption or outgoing-ciphertext recovery.
+    #[cfg(feature = "orchard")]
+    fn orchard_tx_paying(
+        recipient: ::orchard::Address,
+        ovk: OutgoingViewingKey,
+        rng: &mut (impl RngCore + CryptoRng),
+    ) -> Transaction {
+        use ::orchard::{
+            Anchor, Proof,
+            bundle::{Authorized as OrchardAuthorized, BundleVersion, Flags},
+            note::{
+                ExtractedNoteCommitment, Nullifier, RandomSeed, Rho, TransmittedNoteCiphertext,
+            },
+            note_encryption::OrchardNoteEncryption,
+            primitives::redpallas::{SigningKey, SpendAuth, VerificationKey},
+            value::{NoteValue as OrchardNoteValue, ValueCommitTrapdoor, ValueCommitment},
+        };
+        use nonempty::NonEmpty;
+
+        let mut nf_bytes = [0u8; 32];
+        rng.fill_bytes(&mut nf_bytes);
+        let nf_old = loop {
+            let nf = Nullifier::from_bytes(&nf_bytes);
+            if nf.is_some().into() {
+                break nf.unwrap();
+            }
+            rng.fill_bytes(&mut nf_bytes);
+        };
+        // `Rho::from_nf_old(nf)` is `Rho(nf.inner())`, which this reproduces through the
+        // public byte encodings so that the domain reconstructed from the action's revealed
+        // nullifier matches the one the note was created under.
+        let rho = Rho::from_bytes(&nf_old.to_bytes()).expect("a nullifier is a canonical Rho");
+        let rseed = loop {
+            let mut bytes = [0u8; 32];
+            rng.fill_bytes(&mut bytes);
+            let rseed = RandomSeed::from_bytes(bytes, &rho);
+            if rseed.is_some().into() {
+                break rseed.unwrap();
+            }
+        };
+
+        let value = OrchardNoteValue::from_raw(VALUE.into_u64());
+        let note =
+            ::orchard::Note::from_parts(recipient, value, rho, rseed, ::orchard::NoteVersion::V2)
+                .expect("the note parts are consistent");
+        let cmx = ExtractedNoteCommitment::from(note.commitment());
+        let cv_net = ValueCommitment::derive(
+            OrchardNoteValue::from_raw(0) - value,
+            ValueCommitTrapdoor::from_bytes([0u8; 32]).expect("zero is a canonical scalar"),
+        );
+
+        let encryptor = OrchardNoteEncryption::new(Some(ovk.into()), note, [0u8; 512]);
+        let encrypted_note = TransmittedNoteCiphertext {
+            epk_bytes: ::orchard::note_encryption::OrchardDomain::epk_bytes(encryptor.epk()).0,
+            enc_ciphertext: encryptor.encrypt_note_plaintext(),
+            out_ciphertext: encryptor.encrypt_outgoing_plaintext(&cv_net, &cmx, rng),
+        };
+
+        let rk = loop {
+            let mut rk_bytes = [0u8; 32];
+            rng.fill_bytes(&mut rk_bytes);
+            if let Ok(sk) = SigningKey::<SpendAuth>::try_from(rk_bytes) {
+                break VerificationKey::<SpendAuth>::from(&sk);
+            }
+        };
+
+        let action = ::orchard::Action::from_parts(
+            nf_old,
+            rk,
+            cmx,
+            encrypted_note,
+            cv_net,
+            ::orchard::primitives::redpallas::Signature::from([0u8; 64]),
+        )
+        .expect("the action parts are valid");
+
+        let bundle = ::orchard::Bundle::try_from_parts(
+            NonEmpty::new(action),
+            Flags::ENABLED,
+            ZatBalance::const_from_i64(-(VALUE.into_u64() as i64)),
+            Anchor::empty_tree(),
+            OrchardAuthorized::from_parts(
+                Proof::new(vec![0u8; Proof::expected_proof_size(1)]),
+                ::orchard::primitives::redpallas::Signature::from([0u8; 64]),
+            ),
+            BundleVersion::orchard_v2(),
+        )
+        .expect("the bundle parts are valid");
+
+        TransactionData::<Authorized>::from_parts(
+            TxVersion::V5,
+            BranchId::Nu5,
+            0,
+            BlockHeight::from_u32(MINED_HEIGHT + 100),
+            #[cfg(all(zcash_unstable = "nu7", feature = "zip-233"))]
+            Zatoshis::ZERO,
+            None,
+            None,
+            None,
+            Some(bundle),
+        )
+        .freeze()
+        .expect("the transaction data is well-formed")
+    }
+
+    /// Recovers the wallet's view of a transaction, returning the transfer type and value of each
+    /// Orchard output that could be decrypted.
+    #[cfg(feature = "orchard")]
+    fn decrypt_orchard_with(
+        ufvk: UnifiedFullViewingKey,
+        tx: &Transaction,
+    ) -> Vec<(TransferType, Zatoshis)> {
+        let mut ufvks = HashMap::new();
+        ufvks.insert(0u32, ufvk);
+
+        decrypt_transaction(
+            &Network::TestNetwork,
+            Some(BlockHeight::from_u32(MINED_HEIGHT)),
+            None,
+            tx,
+            &ufvks,
+        )
+        .orchard_outputs()
+        .iter()
+        .map(|output| {
+            let (note, _) = output.note();
+            (
+                output.transfer_type(),
+                Zatoshis::from_u64(note.value().inner()).expect("note value is in range"),
+            )
+        })
+        .collect()
+    }
+
+    #[cfg(feature = "orchard")]
+    fn decrypt_orchard(tx: &Transaction) -> Vec<(TransferType, Zatoshis)> {
+        decrypt_orchard_with(wallet_ufvk(), tx)
+    }
+
+    /// An Orchard action is recovered under every OVK a ZIP 316-compliant sender might have chosen
+    /// for the transaction, including the Sapling and transparent-derived ones that a sender
+    /// spending from those pools uses. This is the cross-pool case: an OVK is pool-agnostic input
+    /// to the outgoing-ciphertext KDF, so the pool an output lands in says nothing about which key
+    /// encrypted it.
+    #[cfg(feature = "orchard")]
+    #[test]
+    fn orchard_action_recovered_with_every_zip316_ovk() {
+        let mut rng = ChaChaRng::seed_from_u64(2);
+        let recipient = counterparty_ufvk()
+            .orchard()
+            .expect("UFVK has an Orchard item")
+            .address_at(0u32, Scope::External);
+
+        for (label, ovk) in zip316_sender_ovks(&wallet_ufvk()) {
+            let tx = orchard_tx_paying(recipient, ovk, &mut rng);
+            assert_eq!(
+                decrypt_orchard(&tx),
+                vec![(TransferType::Outgoing, VALUE)],
+                "action encrypted under the {label} OVK was not recovered"
+            );
+        }
+    }
+
+    /// An outgoing ciphertext that no wallet key can open is not reported.
+    #[cfg(feature = "orchard")]
+    #[test]
+    fn orchard_action_not_recovered_with_foreign_ovk() {
+        let mut rng = ChaChaRng::seed_from_u64(3);
+        let recipient = counterparty_ufvk()
+            .orchard()
+            .expect("UFVK has an Orchard item")
+            .address_at(0u32, Scope::External);
+
+        let tx = orchard_tx_paying(recipient, foreign_ovk(), &mut rng);
+        assert_eq!(decrypt_orchard(&tx), vec![]);
+    }
+
+    /// An account whose UFVK has no Orchard item still recovers an Orchard action that it funded
+    /// from its Sapling notes. Having no Orchard item only means the account cannot be the
+    /// *recipient* of an Orchard action; it can still be the sender, in which case the outgoing
+    /// ciphertext is encrypted under its Sapling OVK.
+    #[cfg(feature = "orchard")]
+    #[test]
+    fn orchard_action_recovered_by_ufvk_without_orchard_item() {
+        let mut rng = ChaChaRng::seed_from_u64(4);
+        let recipient = counterparty_ufvk()
+            .orchard()
+            .expect("UFVK has an Orchard item")
+            .address_at(0u32, Scope::External);
+
+        let wallet = wallet_ufvk();
+        let dfvk = wallet.sapling().expect("UFVK has a Sapling item").clone();
+        let sapling_only = UnifiedFullViewingKey::new(
+            #[cfg(feature = "transparent-inputs")]
+            None,
+            Some(dfvk.clone()),
+            #[cfg(feature = "orchard")]
+            None,
+        )
+        .expect("a Sapling-only UFVK is valid");
+
+        let tx = orchard_tx_paying(recipient, dfvk.to_ovk(Scope::External).into(), &mut rng);
+        assert_eq!(
+            decrypt_orchard_with(sapling_only, &tx),
+            vec![(TransferType::Outgoing, VALUE)]
+        );
+    }
 }

--- a/zcash_client_backend/src/decrypt.rs
+++ b/zcash_client_backend/src/decrypt.rs
@@ -146,9 +146,9 @@ fn candidate_ovks(ufvk: &UnifiedFullViewingKey) -> Vec<OutgoingViewingKey> {
 
     #[cfg(feature = "transparent-inputs")]
     if let Some(pubkey) = ufvk.transparent() {
-        let (internal, external) = pubkey.ovks_for_shielding();
-        ovks.push(external.as_bytes().into());
-        ovks.push(internal.as_bytes().into());
+        let shielding_ovks = pubkey.ovks_for_shielding();
+        ovks.push(shielding_ovks.external().as_bytes().into());
+        ovks.push(shielding_ovks.internal().as_bytes().into());
     }
 
     ovks
@@ -441,15 +441,26 @@ mod tests {
         #[cfg(feature = "transparent-inputs")]
         {
             let tfvk = ufvk.transparent().expect("UFVK has a transparent item");
-            let (internal, external) = tfvk.ovks_for_shielding();
-            // `ovks_for_shielding` returns the pair in (internal, external) order, and both halves
-            // become raw bytes as soon as they are used, so only this destructure records which is
-            // which. Pin each half against the accessor that names it, so that a swap here cannot
-            // pass by relabelling both ends consistently.
-            assert_eq!(external.as_bytes(), tfvk.external_ovk().as_bytes());
-            assert_eq!(internal.as_bytes(), tfvk.internal_ovk().as_bytes());
-            ovks.push(("transparent external", external.as_bytes().into()));
-            ovks.push(("transparent internal", internal.as_bytes().into()));
+            let shielding_ovks = tfvk.ovks_for_shielding();
+            // Both halves of the pair become raw bytes as soon as they are used, so pin each half
+            // against the accessor that names its scope: a key bound to the wrong scope here
+            // cannot pass by relabelling both ends consistently.
+            assert_eq!(
+                shielding_ovks.external().as_bytes(),
+                tfvk.external_ovk().as_bytes()
+            );
+            assert_eq!(
+                shielding_ovks.internal().as_bytes(),
+                tfvk.internal_ovk().as_bytes()
+            );
+            ovks.push((
+                "transparent external",
+                shielding_ovks.external().as_bytes().into(),
+            ));
+            ovks.push((
+                "transparent internal",
+                shielding_ovks.internal().as_bytes().into(),
+            ));
         }
 
         ovks

--- a/zcash_transparent/CHANGELOG.md
+++ b/zcash_transparent/CHANGELOG.md
@@ -10,6 +10,15 @@ workspace.
 
 ## [Unreleased]
 
+### Added
+- `zcash_transparent::keys::ShieldingOvks`
+
+### Changed
+- `zcash_transparent::keys::AccountPubKey::ovks_for_shielding` now returns
+  `ShieldingOvks` instead of `(InternalOvk, ExternalOvk)`. Read each key from
+  `ShieldingOvks::internal` or `ShieldingOvks::external` instead of by tuple
+  position.
+
 ## [0.10.0] - 2026-07-23
 
 ### Changed

--- a/zcash_transparent/src/keys.rs
+++ b/zcash_transparent/src/keys.rs
@@ -436,24 +436,27 @@ impl AccountPubKey {
     /// Derives the internal ovk and external ovk corresponding to this
     /// transparent fvk. As specified in [ZIP 316][transparent-ovk].
     ///
+    /// A wallet uses these both to encrypt the outgoing ciphertexts of a transaction that spends
+    /// transparent funds, and to recover the outgoing ciphertexts of such a transaction.
+    ///
     /// [transparent-ovk]: https://zips.z.cash/zip-0316#deriving-internal-keys
-    pub fn ovks_for_shielding(&self) -> (InternalOvk, ExternalOvk) {
+    pub fn ovks_for_shielding(&self) -> ShieldingOvks {
         let i_ovk = PrfExpand::TRANSPARENT_ZIP316_OVK
             .with(&self.0.attrs().chain_code, &self.0.public_key().serialize());
         let ovk_external = ExternalOvk(i_ovk[..32].try_into().unwrap());
         let ovk_internal = InternalOvk(i_ovk[32..].try_into().unwrap());
 
-        (ovk_internal, ovk_external)
+        ShieldingOvks::new(ovk_internal, ovk_external)
     }
 
     /// Derives the internal ovk corresponding to this transparent fvk.
     pub fn internal_ovk(&self) -> InternalOvk {
-        self.ovks_for_shielding().0
+        self.ovks_for_shielding().internal
     }
 
     /// Derives the external ovk corresponding to this transparent fvk.
     pub fn external_ovk(&self) -> ExternalOvk {
-        self.ovks_for_shielding().1
+        self.ovks_for_shielding().external
     }
 
     pub fn serialize(&self) -> Vec<u8> {
@@ -688,6 +691,41 @@ impl ExternalOvk {
     }
 }
 
+/// The pair of outgoing viewing keys derived from a transparent full viewing key, as specified in
+/// [ZIP 316][transparent-ovk].
+///
+/// The two keys are distinct types, but a consumer reaches [`InternalOvk::as_bytes`] or
+/// [`ExternalOvk::as_bytes`] almost immediately, and past that point the scope of a key is carried
+/// only by the position it was read from. [`Self::internal`] and [`Self::external`] name the scope
+/// at that boundary, so that binding a key to the wrong scope is a visible mistake rather than a
+/// transposition.
+///
+/// [transparent-ovk]: https://zips.z.cash/zip-0316#deriving-internal-keys
+#[derive(Debug)]
+pub struct ShieldingOvks {
+    internal: InternalOvk,
+    external: ExternalOvk,
+}
+
+impl ShieldingOvks {
+    /// Constructs the pair from its two scopes.
+    pub fn new(internal: InternalOvk, external: ExternalOvk) -> Self {
+        Self { internal, external }
+    }
+
+    /// Returns the outgoing viewing key for the internal scope, which a wallet uses for the
+    /// outputs it sends to itself.
+    pub fn internal(&self) -> &InternalOvk {
+        &self.internal
+    }
+
+    /// Returns the outgoing viewing key for the external scope, which a wallet uses for the
+    /// outputs it sends to other recipients.
+    pub fn external(&self) -> &ExternalOvk {
+        &self.external
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use bip32::ChildNumber;
@@ -791,9 +829,9 @@ mod tests {
             key_bytes[32..].copy_from_slice(&tv.pk);
             assert_eq!(account_pubkey.serialize(), key_bytes);
 
-            let (internal_ovk, external_ovk) = account_pubkey.ovks_for_shielding();
-            assert_eq!(internal_ovk.as_bytes(), tv.internal_ovk);
-            assert_eq!(external_ovk.as_bytes(), tv.external_ovk);
+            let shielding_ovks = account_pubkey.ovks_for_shielding();
+            assert_eq!(shielding_ovks.internal().as_bytes(), tv.internal_ovk);
+            assert_eq!(shielding_ovks.external().as_bytes(), tv.external_ovk);
 
             // The test vectors are broken here: they should be deriving an address at the
             // address level, but instead use the account pubkey as an address.
@@ -816,10 +854,10 @@ mod tests {
             key_bytes[32..].copy_from_slice(&tv.pk);
             let account_key = AccountPubKey::deserialize(&key_bytes).unwrap();
 
-            let (internal, external) = account_key.ovks_for_shielding();
+            let shielding_ovks = account_key.ovks_for_shielding();
 
-            assert_eq!(tv.internal_ovk, internal.as_bytes());
-            assert_eq!(tv.external_ovk, external.as_bytes());
+            assert_eq!(tv.internal_ovk, shielding_ovks.internal().as_bytes());
+            assert_eq!(tv.external_ovk, shielding_ovks.external().as_bytes());
         }
     }
 
@@ -901,8 +939,10 @@ mod tests {
         let ephemeral_ivk = account_pubkey.derive_ephemeral_ivk().unwrap();
         assert_eq!(format!("{ephemeral_ivk:?}"), "EphemeralIvk(\"...\")");
 
-        let (internal_ovk, external_ovk) = account_pubkey.ovks_for_shielding();
-        assert_eq!(format!("{internal_ovk:?}"), "InternalOvk(\"...\")");
-        assert_eq!(format!("{external_ovk:?}"), "ExternalOvk(\"...\")");
+        let shielding_ovks = account_pubkey.ovks_for_shielding();
+        assert_eq!(
+            format!("{shielding_ovks:?}"),
+            "ShieldingOvks { internal: InternalOvk(\"...\"), external: ExternalOvk(\"...\") }"
+        );
     }
 }


### PR DESCRIPTION
Fixes #3021.

`decrypt_transaction` attempted outgoing-ciphertext recovery with exactly one OVK per output — the same-pool, external-scope one — and examined Orchard actions only for accounts whose UFVK carries an Orchard item. A ZIP 316-compliant sender chooses its OVK by the *source* of the funds and applies it to every output in the transaction (zcashd: `WalletTxBuilder::SelectOVKs` / `GetOVKsForUFVK`), so cross-pool payments (e.g. a Sapling-only account paying an Orchard receiver), wallet-authored shielding history, and internal-scope encryptions were unrecoverable despite the wallet holding the key.

The first commit builds, per account, the full candidate set the UFVK can produce — Orchard, Sapling, and ZIP 316 transparent-derived OVKs, external and internal scope each — and tries every candidate against both Sapling outputs and Orchard-family actions, after the existing IVK attempts, first success winning. An OVK-recovered output is unconditionally `TransferType::Outgoing`: the IVK attempts having already failed is what makes that sound. The previous behavior survives as a strict subset of the candidate list.

The second commit replaces `ovks_for_shielding`'s `(InternalOvk, ExternalOvk)` return with a `ShieldingOvks` struct (private fields, named accessors). The components are distinct newtypes, but every consumer eventually converts both to scope-erased bytes, and the workspace already carries both positional conventions (`ovks_for_shielding` returned internal-first; the `OvkPolicy` path destructures external-first over scope-erased `OutgoingViewingKey`s) — named accessors carry the discrimination to the conversion boundary. Which half is which is pinned by one independent oracle — the checked-in `zcash-test-vectors` ZIP 316 constants — with the struct eliminating the positional hazard at compile time.

**Cost.** Up to six symmetric trial decryptions per (account, output) instead of one, and only where the IVK attempts have already failed. `decrypt_transaction` is not on the scanning hot path — block scanning goes through `ScanningKeys` and the batch decryptor. Its callers are per-transaction: `decrypt_and_store_transaction`, `store_sent_tx`, and one `zcash_client_sqlite` data migration (`sapling_memo_consistency`), which re-decrypts stored transactions once, at upgrade, over a bounded set.

**Why the tests build transactions by hand.** The `data_api::testing` builders give a test no way to choose which OVK an output's outgoing ciphertext is encrypted under, and that choice is the entire subject of this change; the tests assemble `Transaction` values directly. The proofs and signatures in those bundles are dummies, which is sound because note decryption and outgoing-ciphertext recovery read only `cv`/`cv_net`, `cmu`/`cmx`, the ephemeral key, and the ciphertexts — never a proof or a signature.

**Note for third-party backends.** `decrypt_transaction` reports one output per (account, output) pair, so a `WalletWrite` implementation that maps a single UFVK under two different account ids would now see the same output attributed as `Outgoing` to both. `zcash_client_sqlite` cannot reach that state: `CREATE UNIQUE INDEX accounts_ufvk ON accounts (ufvk)` forbids two accounts sharing a UFVK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)