### PR TITLE
Add Tachyon bundles to V7 transactions and chain history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "addchain"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5665045de74fda906c0abfaec40cf2551f88c34dccea869f3fe950dde7209764"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -35,7 +46,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.12",
  "zeroize",
 ]
 
@@ -343,6 +354,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,8 +423,8 @@ dependencies = [
  "blake2s_simd",
  "byteorder",
  "crossbeam-channel",
- "ff",
- "group",
+ "ff 0.13.0",
+ "group 0.13.0",
  "lazy_static",
  "log",
  "num_cpus",
@@ -550,8 +570,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
 dependencies = [
- "ff",
- "group",
+ "ff 0.13.0",
+ "group 0.13.0",
  "pairing",
  "rand_core 0.6.4",
  "subtle",
@@ -663,7 +683,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.12",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -673,7 +704,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -782,6 +813,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-crc32-nostd"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808ac43170e95b11dd23d78aa9eaac5bea45776a602955552c4e833f3f0f823d"
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,9 +832,9 @@ checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "convert_case"
-version = "0.7.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -837,6 +874,15 @@ name = "cpufeatures"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -928,6 +974,12 @@ dependencies = [
  "cast",
  "itertools 0.13.0",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
@@ -1027,7 +1079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.12",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -1204,7 +1256,7 @@ dependencies = [
  "heck",
  "indexmap 2.12.0",
  "itertools 0.13.0",
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "sha3",
@@ -1222,13 +1274,24 @@ dependencies = [
  "heck",
  "indexmap 2.12.0",
  "itertools 0.14.0",
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "sha3",
  "strum 0.27.2",
  "syn 2.0.118",
  "void",
+]
+
+[[package]]
+name = "derive-getters"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1264,22 +1327,23 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
+ "rustc_version",
  "syn 2.0.118",
  "unicode-xid",
 ]
@@ -1499,9 +1563,9 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "digest 0.10.7",
- "ff",
+ "ff 0.13.0",
  "generic-array",
- "group",
+ "group 0.13.0",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -1668,6 +1732,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "bitvec",
+ "ff_derive",
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
+name = "ff_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241afe8c15ffa21933eaefe8a563af36fd9fc98a3e8a044e8f7db52eb1fae3d8"
+dependencies = [
+ "addchain",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1777,6 +1868,41 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "frost-core"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81ef2787af391c7e8bedc037a3b9ea03dde803fbd93e778e6bb369547800e5cd"
+dependencies = [
+ "byteorder",
+ "const-crc32-nostd",
+ "derive-getters",
+ "document-features",
+ "hex",
+ "itertools 0.14.0",
+ "postcard",
+ "rand_core 0.6.4",
+ "serde",
+ "serdect",
+ "thiserror 2.0.12",
+ "visibility",
+ "zeroize",
+ "zeroize_derive",
+]
+
+[[package]]
+name = "frost-rerandomized"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4c5cedd2426728adef2c0b1720f57676354c473836d1ccc50d0f0d1c91942b"
+dependencies = [
+ "derive-getters",
+ "document-features",
+ "frost-core",
+ "hex",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1976,9 +2102,20 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.0",
  "memuse",
  "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff 0.14.0",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -2038,8 +2175,8 @@ checksum = "fb2a697cad929f706b7987fe804ad57d43622cd37463ba7e4d662a926fdcfea3"
 dependencies = [
  "arrayvec",
  "bitvec",
- "ff",
- "group",
+ "ff 0.13.0",
+ "group 0.13.0",
  "halo2_poseidon",
  "halo2_proofs",
  "lazy_static",
@@ -2063,8 +2200,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa3da60b81f02f9b33ebc6252d766f843291fb4d2247a07ae73d20b791fc56f"
 dependencies = [
  "bitvec",
- "ff",
- "group",
+ "ff 0.13.0",
+ "group 0.13.0",
  "pasta_curves",
 ]
 
@@ -2075,14 +2212,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05713f117155643ce10975e0bee44a274bcda2f4bb5ef29a999ad67c1fa8d4d3"
 dependencies = [
  "blake2b_simd",
- "ff",
- "group",
+ "ff 0.13.0",
+ "group 0.13.0",
  "halo2_legacy_pdqsort",
  "indexmap 1.9.3",
- "maybe-rayon",
+ "maybe-rayon 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pasta_curves",
  "rand_core 0.6.4",
  "tracing",
+]
+
+[[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -2113,6 +2259,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin 0.9.9",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2497,8 +2657,8 @@ checksum = "8499f7a74008aafbecb2a2e608a3e13e4dd3e84df198b604451efe93f2de6e61"
 dependencies = [
  "bitvec",
  "bls12_381",
- "ff",
- "group",
+ "ff 0.13.0",
+ "group 0.13.0",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -2509,7 +2669,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.12",
 ]
 
 [[package]]
@@ -2643,6 +2803,15 @@ name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "git+https://github.com/tachyon-zcash/maybe-rayon.git?rev=5c37ee0dd448e8c1edc4529d0b8897ecaff5aad1#5c37ee0dd448e8c1edc4529d0b8897ecaff5aad1"
 dependencies = [
  "cfg-if",
  "rayon",
@@ -2844,9 +3013,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.5"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -2940,7 +3109,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -3017,10 +3186,10 @@ dependencies = [
  "bitvec",
  "blake2b_simd",
  "corez",
- "ff",
+ "ff 0.13.0",
  "fpe",
  "getset",
- "group",
+ "group 0.13.0",
  "halo2_gadgets",
  "halo2_poseidon",
  "halo2_proofs",
@@ -3106,7 +3275,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
- "group",
+ "group 0.13.0",
 ]
 
 [[package]]
@@ -3156,8 +3325,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
 dependencies = [
  "blake2b_simd",
- "ff",
- "group",
+ "ff 0.13.0",
+ "group 0.13.0",
  "lazy_static",
  "rand 0.8.5",
  "static_assertions",
@@ -3205,7 +3374,7 @@ dependencies = [
  "blake2b_simd",
  "bls12_381",
  "document-features",
- "ff",
+ "ff 0.13.0",
  "getset",
  "hex",
  "incrementalmerkletree",
@@ -3395,7 +3564,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.12",
  "opaque-debug",
  "universal-hash",
 ]
@@ -3424,6 +3593,7 @@ dependencies = [
  "cobs",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
+ "heapless",
  "serde",
 ]
 
@@ -3520,6 +3690,15 @@ checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
  "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+dependencies = [
+ "toml_edit 0.23.9",
 ]
 
 [[package]]
@@ -3674,6 +3853,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
+name = "ragu"
+version = "0.0.0"
+source = "git+https://github.com/tachyon-zcash/ragu?rev=f4f6315b10ed96944c40b2bbdbca0fe06af66ce0#f4f6315b10ed96944c40b2bbdbca0fe06af66ce0"
+dependencies = [
+ "blake2b_simd",
+ "ragu_arithmetic",
+ "ragu_circuits",
+ "ragu_core",
+ "ragu_pasta",
+ "ragu_pcd",
+ "ragu_primitives",
+]
+
+[[package]]
+name = "ragu_arithmetic"
+version = "0.0.0"
+source = "git+https://github.com/tachyon-zcash/ragu?rev=f4f6315b10ed96944c40b2bbdbca0fe06af66ce0#f4f6315b10ed96944c40b2bbdbca0fe06af66ce0"
+dependencies = [
+ "ff 0.14.0",
+ "group 0.14.0",
+ "maybe-rayon 0.1.1 (git+https://github.com/tachyon-zcash/maybe-rayon.git?rev=5c37ee0dd448e8c1edc4529d0b8897ecaff5aad1)",
+ "ragu_macros",
+ "rand 0.10.2",
+ "zakura-pasta-curves",
+]
+
+[[package]]
+name = "ragu_circuits"
+version = "0.0.0"
+source = "git+https://github.com/tachyon-zcash/ragu?rev=f4f6315b10ed96944c40b2bbdbca0fe06af66ce0#f4f6315b10ed96944c40b2bbdbca0fe06af66ce0"
+dependencies = [
+ "blake2b_simd",
+ "maybe-rayon 0.1.1 (git+https://github.com/tachyon-zcash/maybe-rayon.git?rev=5c37ee0dd448e8c1edc4529d0b8897ecaff5aad1)",
+ "ragu_arithmetic",
+ "ragu_core",
+ "ragu_primitives",
+]
+
+[[package]]
+name = "ragu_core"
+version = "0.0.0"
+source = "git+https://github.com/tachyon-zcash/ragu?rev=f4f6315b10ed96944c40b2bbdbca0fe06af66ce0#f4f6315b10ed96944c40b2bbdbca0fe06af66ce0"
+dependencies = [
+ "ragu_arithmetic",
+ "ragu_macros",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "ragu_macros"
+version = "0.0.0"
+source = "git+https://github.com/tachyon-zcash/ragu?rev=f4f6315b10ed96944c40b2bbdbca0fe06af66ce0#f4f6315b10ed96944c40b2bbdbca0fe06af66ce0"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "ragu_pasta"
+version = "0.0.0"
+source = "git+https://github.com/tachyon-zcash/ragu?rev=f4f6315b10ed96944c40b2bbdbca0fe06af66ce0#f4f6315b10ed96944c40b2bbdbca0fe06af66ce0"
+dependencies = [
+ "lazy_static",
+ "ragu_arithmetic",
+]
+
+[[package]]
+name = "ragu_pcd"
+version = "0.0.0"
+source = "git+https://github.com/tachyon-zcash/ragu?rev=f4f6315b10ed96944c40b2bbdbca0fe06af66ce0#f4f6315b10ed96944c40b2bbdbca0fe06af66ce0"
+dependencies = [
+ "maybe-rayon 0.1.1 (git+https://github.com/tachyon-zcash/maybe-rayon.git?rev=5c37ee0dd448e8c1edc4529d0b8897ecaff5aad1)",
+ "ragu_arithmetic",
+ "ragu_circuits",
+ "ragu_core",
+ "ragu_primitives",
+]
+
+[[package]]
+name = "ragu_primitives"
+version = "0.0.0"
+source = "git+https://github.com/tachyon-zcash/ragu?rev=f4f6315b10ed96944c40b2bbdbca0fe06af66ce0#f4f6315b10ed96944c40b2bbdbca0fe06af66ce0"
+dependencies = [
+ "ragu_arithmetic",
+ "ragu_core",
+ "ragu_macros",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3692,6 +3965,16 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20 0.10.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3731,6 +4014,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -3799,7 +4088,7 @@ checksum = "78a5191930e84973293aa5f532b513404460cd2216c1cfb76d08748c15b40b02"
 dependencies = [
  "blake2b_simd",
  "byteorder",
- "group",
+ "group 0.13.0",
  "hex",
  "jubjub",
  "pasta_curves",
@@ -4179,10 +4468,10 @@ dependencies = [
  "bls12_381",
  "corez",
  "document-features",
- "ff",
+ "ff 0.13.0",
  "fpe",
  "getset",
- "group",
+ "group 0.13.0",
  "hex",
  "incrementalmerkletree",
  "jubjub",
@@ -4444,13 +4733,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.12",
  "digest 0.10.7",
 ]
 
@@ -4461,7 +4760,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.12",
  "digest 0.10.7",
 ]
 
@@ -4472,7 +4771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "540c0893cce56cdbcfebcec191ec8e0f470dd1889b6e7a0b503e310a94a168f5"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.12",
  "digest 0.11.0-pre.9",
 ]
 
@@ -4552,7 +4851,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d268ae0ea06faafe1662e9967cd4f9022014f5eeb798e0c302c876df8b7af9c"
 dependencies = [
- "group",
+ "group 0.13.0",
  "pasta_curves",
  "subtle",
 ]
@@ -5132,6 +5431,18 @@ dependencies = [
  "serde_spanned 0.6.8",
  "toml_datetime 0.6.8",
  "winnow 0.6.20",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d7cbc3b4b49633d57a0509303158ca50de80ae32c265093b24c414705807832"
+dependencies = [
+ "indexmap 2.12.0",
+ "toml_datetime 0.7.3",
+ "toml_parser",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -7051,6 +7362,9 @@ name = "winnow"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winsafe"
@@ -7107,6 +7421,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
+name = "zakura-bls12-381"
+version = "1.0.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8fc912625871c00f3d703b1c3522ea34909418c2fd8fd4e65d4b4470439c59"
+dependencies = [
+ "ff 0.14.0",
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
+name = "zakura-jubjub"
+version = "1.0.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdd34bc3f0860439b77f8944a6cfcf8b54f2f1c2b235e75432480a4ec1a88fd"
+dependencies = [
+ "bitvec",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "rand_core 0.10.1",
+ "subtle",
+ "zakura-bls12-381",
+]
+
+[[package]]
+name = "zakura-pasta-curves"
+version = "1.0.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799be79d0316bc996b053448fadca787d23741380514301016977378c8e919a8"
+dependencies = [
+ "blake2b_simd",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "once_cell",
+ "rand 0.10.2",
+ "static_assertions",
+ "subtle",
+]
+
+[[package]]
+name = "zakura-reddsa"
+version = "1.0.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545c9c014fc397aa36a3d949d698500f5f6dc4ad727a5491a4b5c89927c504e3"
+dependencies = [
+ "blake2b_simd",
+ "frost-rerandomized",
+ "group 0.14.0",
+ "hex",
+ "rand_core 0.10.1",
+ "serde",
+ "thiserror 2.0.12",
+ "zakura-jubjub",
+ "zakura-pasta-curves",
+ "zeroize",
+]
+
+[[package]]
 name = "zcash"
 version = "0.1.0"
 dependencies = [
@@ -7148,7 +7520,7 @@ dependencies = [
  "fs-mistrust",
  "futures-util",
  "getset",
- "group",
+ "group 0.13.0",
  "gumdrop",
  "hex",
  "http-body-util",
@@ -7217,12 +7589,12 @@ dependencies = [
  "bs58",
  "byteorder",
  "document-features",
- "group",
+ "group 0.13.0",
  "hex",
  "incrementalmerkletree",
  "incrementalmerkletree-testing",
  "jubjub",
- "maybe-rayon",
+ "maybe-rayon 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nonempty",
  "orchard",
  "pasta_curves",
@@ -7312,7 +7684,7 @@ dependencies = [
  "byteorder",
  "corez",
  "document-features",
- "group",
+ "group 0.13.0",
  "hex",
  "jubjub",
  "memuse",
@@ -7343,7 +7715,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77efec759c3798b6e4d829fcc762070d9b229b0f13338c40bf993b7b609c2272"
 dependencies = [
- "chacha20",
+ "chacha20 0.9.1",
  "chacha20poly1305",
  "cipher",
  "rand_core 0.6.4",
@@ -7401,7 +7773,7 @@ dependencies = [
  "crypto-common 0.2.0-rc.1",
  "document-features",
  "equihash",
- "ff",
+ "ff 0.13.0",
  "hex",
  "incrementalmerkletree",
  "jubjub",
@@ -7410,6 +7782,7 @@ dependencies = [
  "orchard",
  "pprof",
  "proptest",
+ "rand 0.10.2",
  "rand_core 0.6.4",
  "rand_xorshift",
  "redjubjub",
@@ -7420,6 +7793,7 @@ dependencies = [
  "zcash_note_encryption",
  "zcash_protocol",
  "zcash_script",
+ "zcash_tachyon",
  "zcash_transparent",
  "zip32",
 ]
@@ -7433,7 +7807,7 @@ dependencies = [
  "bls12_381",
  "byteorder",
  "document-features",
- "group",
+ "group 0.13.0",
  "home",
  "jubjub",
  "known-folders",
@@ -7485,6 +7859,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded3f58b93486aa79b85acba1001f5298f27a46489859934954d262533ee2915"
 dependencies = [
  "blake2b_simd",
+]
+
+[[package]]
+name = "zcash_tachyon"
+version = "0.0.0"
+source = "git+https://github.com/tachyon-zcash/tachyon?rev=fd02241612a09284a0f37ee58970ef8dcb042e43#fd02241612a09284a0f37ee58970ef8dcb042e43"
+dependencies = [
+ "blake2b_simd",
+ "corez",
+ "derive_more",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "lazy_static",
+ "ragu",
+ "rand_core 0.10.1",
+ "zakura-pasta-curves",
+ "zakura-reddsa",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ zcash_protocol = { version = "0.10.5", path = "components/zcash_protocol", defau
 zip321 = { version = "0.9.0", path = "components/zip321" }
 
 zcash_note_encryption = "0.4.1"
+zcash_tachyon = { git = "https://github.com/tachyon-zcash/tachyon", rev = "fd02241612a09284a0f37ee58970ef8dcb042e43", default-features = false }
 zcash_primitives = { version = "0.30.1", path = "zcash_primitives", default-features = false }
 zcash_proofs = { version = "0.30.0", path = "zcash_proofs", default-features = false }
 

--- a/pczt/src/lib.rs
+++ b/pczt/src/lib.rs
@@ -630,6 +630,7 @@ impl Pczt {
                 sapling_bundle,
                 orchard_bundle,
                 ironwood_bundle,
+                None,
             ),
             _ => TransactionData::from_parts(
                 version,

--- a/zcash_history/CHANGELOG.md
+++ b/zcash_history/CHANGELOG.md
@@ -7,6 +7,11 @@ and this library adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Added
+- Experimental `zcash_history::{NodeDataV4, V4}` support behind
+  `zcash_unstable="nutachyon"`. V4 history nodes commit to the start and end
+  Tachyon anchors and the number of transactions containing Tachyon bundles.
+
 ## [0.6.0] - 2026-07-24
 
 ### Added

--- a/zcash_history/src/lib.rs
+++ b/zcash_history/src/lib.rs
@@ -18,8 +18,12 @@ mod version;
 mod test_vectors;
 
 pub use entry::{Entry, MAX_ENTRY_SIZE};
+#[cfg(zcash_unstable = "nutachyon")]
+pub use node_data::V4 as NodeDataV4;
 pub use node_data::{MAX_NODE_DATA_SIZE, NodeData, V2 as NodeDataV2, V3 as NodeDataV3};
 pub use tree::Tree;
+#[cfg(zcash_unstable = "nutachyon")]
+pub use version::V4;
 pub use version::{V1, V2, V3, Version};
 
 /// Crate-level error type

--- a/zcash_history/src/node_data.rs
+++ b/zcash_history/src/node_data.rs
@@ -22,8 +22,14 @@ pub const MAX_NODE_DATA_SIZE: usize = 32 + // subtree commitment
     9 + // Orchard tx count (compact uint)
     32 + // start Ironwood tree root
     32 + // end Ironwood tree root
-    9; // Ironwood tx count (compact uint)
-// = total of 317
+    9 + // Ironwood tx count (compact uint)
+    if cfg!(zcash_unstable = "nutachyon") {
+        32 + // start Tachyon anchor
+        32 + // end Tachyon anchor
+        9 // Tachyon tx count (compact uint)
+    } else {
+        0
+    };
 
 /// V1 node metadata.
 #[repr(C)]
@@ -287,6 +293,63 @@ impl V3 {
     }
 }
 
+/// V4 node metadata.
+///
+/// This extends the NU6.3 history node format with metadata for the Tachyon
+/// shielded pool. Tachyon has no note commitment tree; its pool state is a
+/// running anchor, so the anchor takes the place a tree root has for the other
+/// pools.
+#[cfg(zcash_unstable = "nutachyon")]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+pub struct V4 {
+    /// The V3 node data retained in V4.
+    pub v3: V3,
+    /// Tachyon anchor at the start of this node's interval.
+    pub start_tachyon_anchor: [u8; 32],
+    /// Tachyon anchor at the end of this node's interval.
+    pub end_tachyon_anchor: [u8; 32],
+    /// Number of transactions containing a Tachyon bundle.
+    pub tachyon_tx: u64,
+}
+
+#[cfg(zcash_unstable = "nutachyon")]
+impl V4 {
+    pub(crate) fn combine_inner(subtree_commitment: [u8; 32], left: &V4, right: &V4) -> V4 {
+        V4 {
+            v3: V3::combine_inner(subtree_commitment, &left.v3, &right.v3),
+            start_tachyon_anchor: left.start_tachyon_anchor,
+            end_tachyon_anchor: right.end_tachyon_anchor,
+            tachyon_tx: left.tachyon_tx + right.tachyon_tx,
+        }
+    }
+
+    /// Write to the byte representation.
+    pub fn write<W: corez::io::Write>(&self, w: &mut W) -> corez::io::Result<()> {
+        self.v3.write(w)?;
+        w.write_all(&self.start_tachyon_anchor)?;
+        w.write_all(&self.end_tachyon_anchor)?;
+        CompactSize::write_unbounded(&mut *w, self.tachyon_tx)?;
+        Ok(())
+    }
+
+    /// Read from the byte representation.
+    pub fn read<R: corez::io::Read>(
+        consensus_branch_id: u32,
+        r: &mut R,
+    ) -> corez::io::Result<Self> {
+        let mut data = V4 {
+            v3: V3::read(consensus_branch_id, r)?,
+            ..Default::default()
+        };
+        r.read_exact(&mut data.start_tachyon_anchor)?;
+        r.read_exact(&mut data.end_tachyon_anchor)?;
+        data.tachyon_tx = CompactSize::read_unbounded(&mut *r)?;
+
+        Ok(data)
+    }
+}
+
 #[cfg(any(test, feature = "test-dependencies"))]
 pub mod testing {
     use primitive_types::U256;
@@ -336,11 +399,15 @@ mod tests {
 
     use primitive_types::U256;
 
+    #[cfg(zcash_unstable = "nutachyon")]
+    use crate::V4 as HistoryV4;
     use crate::{
         Entry, EntryLink, MAX_ENTRY_SIZE, V1 as HistoryV1, V2 as HistoryV2, V3 as HistoryV3,
         Version,
     };
 
+    #[cfg(zcash_unstable = "nutachyon")]
+    use super::V4;
     use super::{MAX_NODE_DATA_SIZE, NodeData, V2, V3};
 
     fn node_data(start_height: u64, end_height: u64) -> NodeData {
@@ -375,6 +442,16 @@ mod tests {
             start_ironwood_root: [13; 32],
             end_ironwood_root: [14; 32],
             ironwood_tx: 15,
+        }
+    }
+
+    #[cfg(zcash_unstable = "nutachyon")]
+    fn node_data_v4(start_height: u64, end_height: u64) -> V4 {
+        V4 {
+            v3: node_data_v3(start_height, end_height),
+            start_tachyon_anchor: [16; 32],
+            end_tachyon_anchor: [17; 32],
+            tachyon_tx: 18,
         }
     }
 
@@ -413,6 +490,16 @@ mod tests {
         }
     }
 
+    #[cfg(zcash_unstable = "nutachyon")]
+    fn max_node_data_v4() -> V4 {
+        V4 {
+            v3: max_node_data_v3(),
+            start_tachyon_anchor: [8; 32],
+            end_tachyon_anchor: [9; 32],
+            tachyon_tx: u64::MAX,
+        }
+    }
+
     fn v1_fixture_bytes() -> Vec<u8> {
         let mut expected = vec![];
         expected.extend_from_slice(&[1; 32]);
@@ -443,6 +530,15 @@ mod tests {
         expected.extend_from_slice(&[13; 32]);
         expected.extend_from_slice(&[14; 32]);
         expected.push(15);
+        expected
+    }
+
+    #[cfg(zcash_unstable = "nutachyon")]
+    fn v4_fixture_bytes() -> Vec<u8> {
+        let mut expected = v3_fixture_bytes();
+        expected.extend_from_slice(&[16; 32]);
+        expected.extend_from_slice(&[17; 32]);
+        expected.push(18);
         expected
     }
 
@@ -545,6 +641,18 @@ mod tests {
         assert_eq!(HistoryV3::to_bytes(&node_data), v3_fixture_bytes());
     }
 
+    #[cfg(zcash_unstable = "nutachyon")]
+    #[test]
+    fn v4_serialization_round_trip() {
+        let node_data = node_data_v4(1, 2);
+
+        assert_eq!(
+            HistoryV4::from_bytes(1, v4_fixture_bytes()).unwrap(),
+            node_data
+        );
+        assert_eq!(HistoryV4::to_bytes(&node_data), v4_fixture_bytes());
+    }
+
     #[test]
     fn max_serialized_sizes_cover_all_versions() {
         // ZIP 221 specifies that history nodes are at most 171 bytes before NU5
@@ -553,21 +661,107 @@ mod tests {
         assert_eq!(HistoryV1::to_bytes(&max_node_data()).len(), 171);
         assert_eq!(HistoryV2::to_bytes(&max_node_data_v2()).len(), 244);
         let max_v3_bytes = HistoryV3::to_bytes(&max_node_data_v3());
-        assert_eq!(max_v3_bytes.len(), MAX_NODE_DATA_SIZE);
+        assert_eq!(max_v3_bytes.len(), 317);
         assert_eq!(
             HistoryV3::from_bytes(u32::MAX, &max_v3_bytes).unwrap(),
             max_node_data_v3()
         );
-        assert_eq!(MAX_NODE_DATA_SIZE, 317);
 
-        let entry = Entry::<HistoryV3>::new(
-            max_node_data_v3(),
-            EntryLink::Stored(u32::MAX),
-            EntryLink::Stored(u32::MAX),
-        );
+        #[cfg(not(zcash_unstable = "nutachyon"))]
+        let entry = {
+            assert_eq!(MAX_NODE_DATA_SIZE, 317);
+            Entry::<HistoryV3>::new(
+                max_node_data_v3(),
+                EntryLink::Stored(u32::MAX),
+                EntryLink::Stored(u32::MAX),
+            )
+        };
+
+        #[cfg(zcash_unstable = "nutachyon")]
+        let entry = {
+            let max_v4_bytes = HistoryV4::to_bytes(&max_node_data_v4());
+            assert_eq!(max_v4_bytes.len(), MAX_NODE_DATA_SIZE);
+            assert_eq!(
+                HistoryV4::from_bytes(u32::MAX, &max_v4_bytes).unwrap(),
+                max_node_data_v4()
+            );
+            assert_eq!(MAX_NODE_DATA_SIZE, 390);
+            Entry::<HistoryV4>::new(
+                max_node_data_v4(),
+                EntryLink::Stored(u32::MAX),
+                EntryLink::Stored(u32::MAX),
+            )
+        };
+
         let mut encoded = vec![];
         entry.write(&mut encoded).unwrap();
         assert_eq!(encoded.len(), MAX_ENTRY_SIZE);
+    }
+
+    #[cfg(zcash_unstable = "nutachyon")]
+    #[test]
+    fn v4_combine_tracks_tachyon_fields() {
+        let mut left = node_data_v4(1, 1);
+        left.start_tachyon_anchor = [22; 32];
+        left.end_tachyon_anchor = [23; 32];
+        left.tachyon_tx = 24;
+
+        let mut right = node_data_v4(2, 2);
+        right.start_tachyon_anchor = [25; 32];
+        right.end_tachyon_anchor = [26; 32];
+        right.tachyon_tx = 27;
+
+        let combined = HistoryV4::combine(&left, &right);
+
+        assert_eq!(combined.v3.v2.v1.start_height, 1);
+        assert_eq!(combined.v3.v2.v1.end_height, 2);
+        assert_eq!(combined.start_tachyon_anchor, [22; 32]);
+        assert_eq!(combined.end_tachyon_anchor, [26; 32]);
+        assert_eq!(combined.tachyon_tx, 51);
+    }
+
+    #[cfg(zcash_unstable = "nutachyon")]
+    #[test]
+    fn v4_combine_hash_commits_to_tachyon_fields() {
+        let left = node_data_v4(1, 1);
+        let right = node_data_v4(2, 2);
+        let base_hash = HistoryV4::combine(&left, &right)
+            .v3
+            .v2
+            .v1
+            .subtree_commitment;
+
+        let combined_hash =
+            |left, right| HistoryV4::combine(left, right).v3.v2.v1.subtree_commitment;
+
+        let mut changed_left_start_anchor = left.clone();
+        changed_left_start_anchor.start_tachyon_anchor[0] ^= 1;
+        assert_ne!(combined_hash(&changed_left_start_anchor, &right), base_hash);
+
+        let mut changed_left_end_anchor = left.clone();
+        changed_left_end_anchor.end_tachyon_anchor[0] ^= 1;
+        assert_ne!(combined_hash(&changed_left_end_anchor, &right), base_hash);
+
+        let mut changed_right_start_anchor = right.clone();
+        changed_right_start_anchor.start_tachyon_anchor[0] ^= 1;
+        assert_ne!(combined_hash(&left, &changed_right_start_anchor), base_hash);
+
+        let mut changed_right_end_anchor = right.clone();
+        changed_right_end_anchor.end_tachyon_anchor[0] ^= 1;
+        assert_ne!(combined_hash(&left, &changed_right_end_anchor), base_hash);
+
+        let mut changed_tx_count = left.clone();
+        changed_tx_count.tachyon_tx += 1;
+        assert_ne!(combined_hash(&changed_tx_count, &right), base_hash);
+
+        let mut redistributed_left_tx = left.clone();
+        let mut redistributed_right_tx = right.clone();
+        redistributed_left_tx.tachyon_tx += 1;
+        redistributed_right_tx.tachyon_tx -= 1;
+        assert_ne!(
+            combined_hash(&redistributed_left_tx, &redistributed_right_tx),
+            base_hash
+        );
     }
 
     #[test]

--- a/zcash_history/src/version.rs
+++ b/zcash_history/src/version.rs
@@ -4,6 +4,8 @@ use core::fmt;
 use blake2b_simd::Params as Blake2Params;
 use corez::io;
 
+#[cfg(zcash_unstable = "nutachyon")]
+use crate::NodeDataV4;
 use crate::{MAX_NODE_DATA_SIZE, NodeData, NodeDataV2, NodeDataV3};
 
 fn blake2b_personal(personalization: &[u8], input: &[u8]) -> [u8; 32] {
@@ -212,6 +214,47 @@ impl Version for V3 {
 
     fn read<R: io::Read>(consensus_branch_id: u32, r: &mut R) -> io::Result<Self::NodeData> {
         NodeDataV3::read(consensus_branch_id, r)
+    }
+
+    fn write<W: io::Write>(data: &Self::NodeData, w: &mut W) -> io::Result<()> {
+        data.write(w)
+    }
+}
+
+/// Version 4 of the Zcash chain history tree.
+///
+/// This version is used from the NuTachyon epoch for history nodes that include
+/// Tachyon shielded pool metadata. Earlier epochs continue to use the
+/// corresponding earlier history tree versions.
+#[cfg(zcash_unstable = "nutachyon")]
+pub enum V4 {}
+
+#[cfg(zcash_unstable = "nutachyon")]
+impl Version for V4 {
+    type NodeData = NodeDataV4;
+
+    fn consensus_branch_id(data: &Self::NodeData) -> u32 {
+        data.v3.v2.v1.consensus_branch_id
+    }
+
+    fn start_height(data: &Self::NodeData) -> u64 {
+        data.v3.v2.v1.start_height
+    }
+
+    fn end_height(data: &Self::NodeData) -> u64 {
+        data.v3.v2.v1.end_height
+    }
+
+    fn combine_inner(
+        subtree_commitment: [u8; 32],
+        left: &Self::NodeData,
+        right: &Self::NodeData,
+    ) -> Self::NodeData {
+        NodeDataV4::combine_inner(subtree_commitment, left, right)
+    }
+
+    fn read<R: io::Read>(consensus_branch_id: u32, r: &mut R) -> io::Result<Self::NodeData> {
+        NodeDataV4::read(consensus_branch_id, r)
     }
 
     fn write<W: io::Write>(data: &Self::NodeData, w: &mut W) -> io::Result<()> {

--- a/zcash_primitives/CHANGELOG.md
+++ b/zcash_primitives/CHANGELOG.md
@@ -12,8 +12,11 @@ workspace.
 
 ### Added
 - Experimental `TxVersion::V7` and `TransactionData::from_parts_v7` support
-  behind `zcash_unstable="nutachyon"`. V7 is enabled by NuTachyon and initially
-  uses the V6 transaction body and digest structure.
+  behind `zcash_unstable="nutachyon"`. V7 is enabled by NuTachyon and extends
+  the V6 transaction body and digest structure with the Tachyon bundle.
+- `TransactionData::tachyon_bundle`,
+  `TransactionDigest::{TachyonDigest, digest_tachyon}`, `v7_signature_hash`,
+  and the `transaction::components::tachyon` module.
 
 ## [0.30.1] - 2026-08-18
 

--- a/zcash_primitives/Cargo.toml
+++ b/zcash_primitives/Cargo.toml
@@ -76,6 +76,13 @@ corez.workspace = true
 workspace = true
 features = ["pre-zip-212"]
 
+# Keep the Tachyon proving stack out of builds that do not opt into NuTachyon.
+[target.'cfg(zcash_unstable = "nutachyon")'.dependencies]
+zcash_tachyon.workspace = true
+
+[target.'cfg(zcash_unstable = "nutachyon")'.dev-dependencies]
+rand_0_10 = { package = "rand", version = "0.10", default-features = false, features = ["std_rng"] }
+
 [dev-dependencies]
 bls12_381.workspace = true
 chacha20poly1305 = "0.10"
@@ -101,6 +108,7 @@ std = [
     "sapling/std",
     "orchard/std",
     "transparent/std",
+    "zcash_tachyon/std",
 ]
 zip-233 = []
 

--- a/zcash_primitives/src/transaction/builder.rs
+++ b/zcash_primitives/src/transaction/builder.rs
@@ -1581,6 +1581,8 @@ impl<P: consensus::Parameters, U: sapling::builder::ProverProgress> Builder<P, U
             sapling_bundle,
             orchard_bundle,
             ironwood_bundle,
+            #[cfg(zcash_unstable = "nutachyon")]
+            tachyon_bundle: None,
         };
 
         //
@@ -1690,6 +1692,8 @@ impl<P: consensus::Parameters, U: sapling::builder::ProverProgress> Builder<P, U
             sapling_bundle,
             orchard_bundle,
             ironwood_bundle,
+            #[cfg(zcash_unstable = "nutachyon")]
+            tachyon_bundle: None,
         };
 
         // The unwrap() here is safe because the txid hashing

--- a/zcash_primitives/src/transaction/components.rs
+++ b/zcash_primitives/src/transaction/components.rs
@@ -2,6 +2,8 @@
 pub mod orchard;
 pub mod sapling;
 pub mod sprout;
+#[cfg(zcash_unstable = "nutachyon")]
+pub mod tachyon;
 
 pub use self::sprout::JsDescription;
 

--- a/zcash_primitives/src/transaction/components/tachyon.rs
+++ b/zcash_primitives/src/transaction/components/tachyon.rs
@@ -1,0 +1,28 @@
+//! Functions for parsing & serialization of Tachyon transaction components.
+//!
+//! Delegates to `zcash_tachyon::TachyonBundle::{read,write}`. The wire-format
+//! `tachyonBundleState` byte (`0x00` absent, `0x01` proof-stamped, `0x02`
+//! pointer-stamped) is handled inside `TachyonBundle::{read,write}`, which own
+//! the `NoBundle` (`0x00`) state directly. Here we translate that state to and
+//! from `Option<TachyonBundle>` so the rest of the transaction code keeps its
+//! `Option`-based representation.
+
+use corez::io::{self, Read, Write};
+
+use zcash_tachyon::TachyonBundle;
+
+/// Reads a tachyon bundle from a v7 (tachyon) transaction.
+pub fn read_v7_bundle<R: Read>(reader: R) -> io::Result<Option<TachyonBundle>> {
+    Ok(match TachyonBundle::read(reader)? {
+        TachyonBundle::NoBundle => None,
+        bundle => Some(bundle),
+    })
+}
+
+/// Writes a tachyon bundle in a v7 (tachyon) transaction.
+pub fn write_v7_bundle<W: Write>(bundle: Option<&TachyonBundle>, mut writer: W) -> io::Result<()> {
+    match bundle {
+        None => TachyonBundle::NoBundle.write(&mut writer),
+        Some(bundle) => bundle.write(&mut writer),
+    }
+}

--- a/zcash_primitives/src/transaction/mod.rs
+++ b/zcash_primitives/src/transaction/mod.rs
@@ -37,6 +37,9 @@ use self::{
 };
 use ::transparent::util::sha256d::{HashReader, HashWriter};
 
+#[cfg(zcash_unstable = "nutachyon")]
+use self::components::tachyon as tachyon_serialization;
+
 #[cfg(feature = "circuits")]
 use ::sapling::builder as sapling_builder;
 
@@ -80,7 +83,7 @@ pub enum TxVersion {
     V6,
     /// Transaction version 7, introduced by the NuTachyon network upgrade.
     ///
-    /// V7 initially has the same fields and digest structure as V6.
+    /// V7 extends the V6 transaction body and digest structure with a Tachyon bundle.
     #[cfg(zcash_unstable = "nutachyon")]
     V7,
 }
@@ -202,13 +205,28 @@ impl TxVersion {
         }
     }
 
+    /// Returns `true` if this transaction version supports the tachyon protocol.
+    #[cfg(zcash_unstable = "nutachyon")]
+    pub fn has_tachyon(&self) -> bool {
+        match self {
+            TxVersion::Sprout(_)
+            | TxVersion::V3
+            | TxVersion::V4
+            | TxVersion::V5
+            | TxVersion::V6 => false,
+            TxVersion::V7 => true,
+        }
+    }
+
     #[cfg(all(zcash_unstable = "nu7", feature = "zip-233"))]
     pub fn has_zip233(&self) -> bool {
         match self {
             TxVersion::Sprout(_) | TxVersion::V3 | TxVersion::V4 | TxVersion::V5 => false,
             TxVersion::V6 => true,
+            // It is undecided whether ZIP-233 will be included in the v7 (tachyon) format, so
+            // for now v7 does not carry a burn amount.
             #[cfg(zcash_unstable = "nutachyon")]
-            TxVersion::V7 => true,
+            TxVersion::V7 => false,
         }
     }
 
@@ -353,6 +371,8 @@ pub struct TransactionData<A: Authorization> {
     sapling_bundle: Option<sapling::Bundle<A::SaplingAuth, ZatBalance>>,
     orchard_bundle: Option<orchard::bundle::Bundle<A::OrchardAuth, ZatBalance>>,
     ironwood_bundle: Option<orchard::bundle::Bundle<A::OrchardAuth, ZatBalance>>,
+    #[cfg(zcash_unstable = "nutachyon")]
+    tachyon_bundle: Option<zcash_tachyon::TachyonBundle>,
 }
 
 impl Clone for TransactionData<Authorized> {
@@ -369,6 +389,8 @@ impl Clone for TransactionData<Authorized> {
             sapling_bundle: self.sapling_bundle.clone(),
             orchard_bundle: self.orchard_bundle.clone(),
             ironwood_bundle: self.ironwood_bundle.clone(),
+            #[cfg(zcash_unstable = "nutachyon")]
+            tachyon_bundle: self.tachyon_bundle.clone(),
         }
     }
 }
@@ -411,6 +433,8 @@ impl<A: Authorization> TransactionData<A> {
             sapling_bundle,
             orchard_bundle,
             ironwood_bundle: None,
+            #[cfg(zcash_unstable = "nutachyon")]
+            tachyon_bundle: None,
         }
     }
 
@@ -451,7 +475,8 @@ impl<A: Authorization> TransactionData<A> {
         )
     }
 
-    /// Constructs a V7 [`TransactionData`] from the fields it currently shares with V6.
+    /// Constructs a V7 [`TransactionData`] from its constituent parts, including the Tachyon
+    /// bundle.
     #[cfg(zcash_unstable = "nutachyon")]
     #[allow(clippy::too_many_arguments)]
     pub fn from_parts_v7(
@@ -463,8 +488,9 @@ impl<A: Authorization> TransactionData<A> {
         sapling_bundle: Option<sapling::Bundle<A::SaplingAuth, ZatBalance>>,
         orchard_bundle: Option<orchard::Bundle<A::OrchardAuth, ZatBalance>>,
         ironwood_bundle: Option<orchard::Bundle<A::OrchardAuth, ZatBalance>>,
+        tachyon_bundle: Option<zcash_tachyon::TachyonBundle>,
     ) -> Self {
-        Self::from_parts_v6_or_v7(
+        let mut data = Self::from_parts_v6_or_v7(
             TxVersion::V7,
             consensus_branch_id,
             lock_time,
@@ -475,7 +501,9 @@ impl<A: Authorization> TransactionData<A> {
             sapling_bundle,
             orchard_bundle,
             ironwood_bundle,
-        )
+        );
+        data.tachyon_bundle = tachyon_bundle;
+        data
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -508,6 +536,8 @@ impl<A: Authorization> TransactionData<A> {
             sapling_bundle,
             orchard_bundle,
             ironwood_bundle,
+            #[cfg(zcash_unstable = "nutachyon")]
+            tachyon_bundle: None,
         }
     }
 
@@ -554,6 +584,11 @@ impl<A: Authorization> TransactionData<A> {
         self.zip233_amount
     }
 
+    #[cfg(zcash_unstable = "nutachyon")]
+    pub fn tachyon_bundle(&self) -> Option<&zcash_tachyon::TachyonBundle> {
+        self.tachyon_bundle.as_ref()
+    }
+
     /// Returns the total fees paid by the transaction, given a function that can be used to
     /// retrieve the value of previous transactions' transparent outputs that are being spent in
     /// this transaction.
@@ -584,6 +619,22 @@ impl<A: Authorization> TransactionData<A> {
                     self.ironwood_bundle
                         .as_ref()
                         .map_or_else(ZatBalance::zero, |b| *b.value_balance()),
+                    #[cfg(zcash_unstable = "nutachyon")]
+                    self.tachyon_bundle.as_ref().map_or_else(
+                        || Ok(ZatBalance::zero()),
+                        |b| {
+                            let value_balance = match b {
+                                zcash_tachyon::TachyonBundle::NoBundle => 0i64,
+                                zcash_tachyon::TachyonBundle::Proven(s) => {
+                                    i64::from(s.value_balance)
+                                }
+                                zcash_tachyon::TachyonBundle::Adjunct(s) => {
+                                    i64::from(s.value_balance)
+                                }
+                            };
+                            ZatBalance::try_from(value_balance).map_err(|_| BalanceError::Overflow)
+                        },
+                    )?,
                     #[cfg(all(zcash_unstable = "nu7", feature = "zip-233"))]
                     -ZatBalance::from(self.zip233_amount),
                 ];
@@ -618,6 +669,8 @@ impl<A: Authorization> TransactionData<A> {
             digester.digest_sapling(self.version, self.sapling_bundle.as_ref()),
             digester.digest_orchard(self.version, self.orchard_bundle.as_ref()),
             digester.digest_ironwood(self.ironwood_bundle.as_ref()),
+            #[cfg(zcash_unstable = "nutachyon")]
+            digester.digest_tachyon(self.tachyon_bundle.as_ref()),
         )
     }
 
@@ -669,6 +722,8 @@ impl<A: Authorization> TransactionData<A> {
             sapling_bundle: f_sapling(self.sapling_bundle),
             orchard_bundle: f_orchard(self.orchard_bundle),
             ironwood_bundle: f_orchard(self.ironwood_bundle),
+            #[cfg(zcash_unstable = "nutachyon")]
+            tachyon_bundle: self.tachyon_bundle,
         }
     }
 
@@ -708,6 +763,8 @@ impl<A: Authorization> TransactionData<A> {
             sapling_bundle: f_sapling(self.sapling_bundle)?,
             orchard_bundle: f_orchard(self.orchard_bundle)?,
             ironwood_bundle: f_orchard(self.ironwood_bundle)?,
+            #[cfg(zcash_unstable = "nutachyon")]
+            tachyon_bundle: self.tachyon_bundle,
         })
     }
 
@@ -751,6 +808,8 @@ impl<A: Authorization> TransactionData<A> {
                     |f, a| f.map_authorization(a),
                 )
             }),
+            #[cfg(zcash_unstable = "nutachyon")]
+            tachyon_bundle: self.tachyon_bundle,
         }
     }
 }
@@ -838,7 +897,7 @@ impl Transaction {
             TxVersion::V5 => Self::read_v5(reader.into_base_reader(), version),
             TxVersion::V6 => Self::read_v6(reader.into_base_reader(), version),
             #[cfg(zcash_unstable = "nutachyon")]
-            TxVersion::V7 => Self::read_v6(reader.into_base_reader(), version),
+            TxVersion::V7 => Self::read_v7(reader.into_base_reader(), version),
         }
     }
 
@@ -916,6 +975,8 @@ impl Transaction {
                 }),
                 orchard_bundle: None,
                 ironwood_bundle: None,
+                #[cfg(zcash_unstable = "nutachyon")]
+                tachyon_bundle: None,
             },
         })
     }
@@ -967,6 +1028,8 @@ impl Transaction {
             sapling_bundle,
             orchard_bundle,
             ironwood_bundle: None,
+            #[cfg(zcash_unstable = "nutachyon")]
+            tachyon_bundle: None,
         };
 
         Ok(Self::from_data_v5(data))
@@ -1000,6 +1063,51 @@ impl Transaction {
             sapling_bundle,
             orchard_bundle,
             ironwood_bundle,
+            #[cfg(zcash_unstable = "nutachyon")]
+            tachyon_bundle: None,
+        };
+
+        Ok(Self::from_data_v6(data))
+    }
+
+    /// Reads a v7 (tachyon) transaction: the v6 (Ironwood) body followed by a tachyon bundle.
+    ///
+    /// It is undecided whether ZIP-233 will be included in the v7 format, so for now the v7
+    /// header carries no burn amount and this reads the plain v5-shaped header regardless of the
+    /// `zip-233` feature.
+    #[cfg(zcash_unstable = "nutachyon")]
+    fn read_v7<R: Read>(mut reader: R, version: TxVersion) -> io::Result<Self> {
+        let (consensus_branch_id, lock_time, expiry_height) =
+            Self::read_header_fragment(&mut reader)?;
+
+        let transparent_bundle = Self::read_transparent(&mut reader)?;
+        let sapling_bundle = sapling_serialization::read_v5_bundle(&mut reader)?;
+        let orchard_bundle = orchard_serialization::read_v6_bundle(
+            &mut reader,
+            consensus_branch_id,
+            orchard::ValuePool::Orchard,
+        )?;
+        let ironwood_bundle = orchard_serialization::read_v6_bundle(
+            &mut reader,
+            consensus_branch_id,
+            orchard::ValuePool::Ironwood,
+        )?;
+
+        let tachyon_bundle = tachyon_serialization::read_v7_bundle(&mut reader)?;
+
+        let data = TransactionData {
+            version,
+            consensus_branch_id,
+            lock_time,
+            expiry_height,
+            #[cfg(all(zcash_unstable = "nu7", feature = "zip-233"))]
+            zip233_amount: Zatoshis::ZERO,
+            transparent_bundle,
+            sprout_bundle: None,
+            sapling_bundle,
+            orchard_bundle,
+            ironwood_bundle,
+            tachyon_bundle,
         };
 
         Ok(Self::from_data_v6(data))
@@ -1058,7 +1166,7 @@ impl Transaction {
             TxVersion::V5 => self.write_v5(writer),
             TxVersion::V6 => self.write_v6(writer),
             #[cfg(zcash_unstable = "nutachyon")]
-            TxVersion::V7 => self.write_v6(writer),
+            TxVersion::V7 => self.write_v7(writer),
         }
     }
 
@@ -1147,6 +1255,31 @@ impl Transaction {
         Ok(())
     }
 
+    /// Writes a v7 (tachyon) transaction: the v6 (Ironwood) body followed by a tachyon bundle.
+    ///
+    /// It is undecided whether ZIP-233 will be included in the v7 format, so for now the v7
+    /// header carries no burn amount and this writes the plain v5-shaped header regardless of the
+    /// `zip-233` feature.
+    #[cfg(zcash_unstable = "nutachyon")]
+    pub fn write_v7<W: Write>(&self, mut writer: W) -> io::Result<()> {
+        if self.sprout_bundle.is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Sprout components cannot be present when serializing to the V7 transaction format.",
+            ));
+        }
+        self.write_v5_header(&mut writer)?;
+
+        self.write_transparent(&mut writer)?;
+        self.write_v5_sapling(&mut writer)?;
+        orchard_serialization::write_v6_bundle(self.orchard_bundle.as_ref(), &mut writer)?;
+        orchard_serialization::write_v6_bundle(self.ironwood_bundle.as_ref(), &mut writer)?;
+
+        tachyon_serialization::write_v7_bundle(self.tachyon_bundle.as_ref(), &mut writer)?;
+
+        Ok(())
+    }
+
     pub fn write_v5_header<W: Write>(&self, mut writer: W) -> io::Result<()> {
         self.version.write(&mut writer)?;
         writer.write_u32_le(u32::from(self.consensus_branch_id))?;
@@ -1203,6 +1336,13 @@ pub struct TxDigests<A> {
     /// ID is derived from these digests, `None` is combined as the empty Ironwood bundle digest
     /// using the Ironwood bundle personalization.
     pub ironwood_digest: Option<A>,
+    /// The digest of the tachyon bundle used by version 7 transactions.
+    ///
+    /// This is `None` when the transaction has no tachyon bundle. When a version 7 transaction
+    /// ID is derived from these digests, `None` is combined as tachyon's "no bundle" commitment
+    /// digest.
+    #[cfg(zcash_unstable = "nutachyon")]
+    pub tachyon_digest: Option<[u8; 32]>,
 }
 
 pub trait TransactionDigest<A: Authorization> {
@@ -1212,6 +1352,9 @@ pub trait TransactionDigest<A: Authorization> {
     type OrchardDigest;
     /// The digest type produced for the Ironwood bundle in version 6 transactions.
     type IronwoodDigest;
+    /// The digest type produced for the tachyon bundle in version 7 transactions.
+    #[cfg(zcash_unstable = "nutachyon")]
+    type TachyonDigest;
 
     type Digest;
 
@@ -1254,6 +1397,19 @@ pub trait TransactionDigest<A: Authorization> {
         ironwood_bundle: Option<&orchard::Bundle<A::OrchardAuth, ZatBalance>>,
     ) -> Self::IronwoodDigest;
 
+    /// Computes the digest for the tachyon bundle in version 7 transactions.
+    ///
+    /// The effecting (txid/sighash) digest is
+    /// [`zcash_tachyon::TachyonBundle::commitment`]; the stamp is excluded because it is
+    /// authorizing data and is malleable during aggregation. Transaction commitment digesters
+    /// commit to the signatures and stamp instead
+    /// ([`zcash_tachyon::TachyonBundle::auth_digest`]).
+    #[cfg(zcash_unstable = "nutachyon")]
+    fn digest_tachyon(
+        &self,
+        tachyon_bundle: Option<&zcash_tachyon::TachyonBundle>,
+    ) -> Self::TachyonDigest;
+
     fn combine(
         &self,
         header_digest: Self::HeaderDigest,
@@ -1261,6 +1417,7 @@ pub trait TransactionDigest<A: Authorization> {
         sapling_digest: Self::SaplingDigest,
         orchard_digest: Self::OrchardDigest,
         ironwood_digest: Self::IronwoodDigest,
+        #[cfg(zcash_unstable = "nutachyon")] tachyon_digest: Self::TachyonDigest,
     ) -> Self::Digest;
 }
 
@@ -1332,6 +1489,8 @@ pub mod testing {
                 sapling_bundle,
                 orchard_bundle,
                 ironwood_bundle,
+                #[cfg(zcash_unstable = "nutachyon")]
+                tachyon_bundle: None,
             }
         }
     }
@@ -1361,6 +1520,8 @@ pub mod testing {
                 sapling_bundle,
                 orchard_bundle,
                 ironwood_bundle,
+                #[cfg(zcash_unstable = "nutachyon")]
+                tachyon_bundle: None,
             }
         }
     }
@@ -1388,6 +1549,8 @@ pub mod testing {
                 sapling_bundle,
                 orchard_bundle,
                 ironwood_bundle,
+                #[cfg(zcash_unstable = "nutachyon")]
+                tachyon_bundle: None,
             }
         }
     }

--- a/zcash_primitives/src/transaction/sighash.rs
+++ b/zcash_primitives/src/transaction/sighash.rs
@@ -51,8 +51,10 @@ pub fn signature_hash<
         TxVersion::V5 => v5_signature_hash(tx, signable_input, txid_parts),
 
         TxVersion::V6 => v6_signature_hash(tx, signable_input, txid_parts),
-        // V7 uses the V6 sighash for now, but this will change.
+
         #[cfg(zcash_unstable = "nutachyon")]
-        TxVersion::V7 => v6_signature_hash(tx, signable_input, txid_parts),
+        TxVersion::V7 => {
+            crate::transaction::sighash_v6::v7_signature_hash(tx, signable_input, txid_parts)
+        }
     })
 }

--- a/zcash_primitives/src/transaction/sighash_v6.rs
+++ b/zcash_primitives/src/transaction/sighash_v6.rs
@@ -7,6 +7,9 @@ use crate::transaction::{
     sighash_v5::transparent_sig_digest, txid::to_hash_v6,
 };
 
+#[cfg(zcash_unstable = "nutachyon")]
+use crate::transaction::txid::to_hash_v7;
+
 pub fn v6_signature_hash<
     TA: TransparentAuthorizingContext,
     A: Authorization<TransparentAuth = TA>,
@@ -34,5 +37,39 @@ pub fn v6_signature_hash<
         txid_parts.sapling_digest,
         txid_parts.orchard_digest,
         txid_parts.ironwood_digest,
+    )
+}
+
+/// Computes the v7 (tachyon) signature hash: the v6 sighash tree with the tachyon bundle's
+/// effecting commitment appended. The stamp is excluded as malleable authorizing data.
+#[cfg(zcash_unstable = "nutachyon")]
+pub fn v7_signature_hash<
+    TA: TransparentAuthorizingContext,
+    A: Authorization<TransparentAuth = TA>,
+>(
+    tx: &TransactionData<A>,
+    signable_input: &SignableInput<'_>,
+    txid_parts: &TxDigests<Blake2bHash>,
+) -> Blake2bHash {
+    // The caller must provide the transparent digests if and only if the
+    // transaction has a transparent component.
+    assert_eq!(
+        tx.transparent_bundle.is_some(),
+        txid_parts.transparent_digests.is_some()
+    );
+
+    to_hash_v7(
+        tx.consensus_branch_id,
+        txid_parts.header_digest,
+        transparent_sig_digest(
+            tx.transparent_bundle
+                .as_ref()
+                .zip(txid_parts.transparent_digests.as_ref()),
+            signable_input,
+        ),
+        txid_parts.sapling_digest,
+        txid_parts.orchard_digest,
+        txid_parts.ironwood_digest,
+        txid_parts.tachyon_digest,
     )
 }

--- a/zcash_primitives/src/transaction/tests.rs
+++ b/zcash_primitives/src/transaction/tests.rs
@@ -89,6 +89,7 @@ fn v7_is_enabled_by_nu_tachyon_and_roundtrips() {
         None,
         None,
         None,
+        None,
     )
     .freeze()
     .unwrap();
@@ -105,6 +106,100 @@ fn v7_is_enabled_by_nu_tachyon_and_roundtrips() {
     let decoded = Transaction::read(&encoded[..], BranchId::Sprout).unwrap();
     assert_eq!(decoded.version(), TxVersion::V7);
     assert_eq!(decoded.consensus_branch_id(), BranchId::NuTachyon);
+    let mut reencoded = Vec::new();
+    decoded.write(&mut reencoded).unwrap();
+    assert_eq!(reencoded, encoded);
+}
+
+#[test]
+#[cfg(zcash_unstable = "nutachyon")]
+fn v7_tachyon_bundle_roundtrips_and_changes_commitments() {
+    use crate::transaction::Authorized;
+    use rand_0_10::{SeedableRng, rngs::StdRng};
+    use zcash_tachyon::{
+        ActionPlan, Bundle, BundlePlan, Note, PointerStamp, TachyonBundle,
+        effect::Output,
+        entropy::ActionEntropy,
+        keys::private::SpendingKey,
+        note::CommitmentTrapdoor,
+        nullifier,
+        value::{Positive, Trapdoor},
+    };
+
+    let rng = &mut StdRng::seed_from_u64(0);
+    let spending_key = SpendingKey::from([1; 32]);
+    let note = Note {
+        pk: spending_key.derive_payment_key(),
+        value: Positive::try_from(1u64).unwrap(),
+        psi: nullifier::Trapdoor::random(rng),
+        rcm: CommitmentTrapdoor::random(rng),
+    };
+    let plan = BundlePlan::new(
+        Vec::new(),
+        alloc::vec![ActionPlan::<Output>::output(
+            note,
+            ActionEntropy::random(rng),
+            Trapdoor::random(rng),
+        )],
+    );
+    let unproven = plan
+        .sign(rng, &[0; 32], &spending_key.derive_auth_private())
+        .unwrap();
+    let tachyon_bundle = TachyonBundle::Adjunct(Bundle {
+        actions: unproven.actions,
+        value_balance: unproven.value_balance,
+        binding_sig: unproven.binding_sig,
+        memo: unproven.memo,
+        stamp: PointerStamp::try_from([0xee; 64]).unwrap(),
+    });
+
+    let transaction = TransactionData::<Authorized>::from_parts_v7(
+        BranchId::NuTachyon,
+        0,
+        0u32.into(),
+        #[cfg(all(zcash_unstable = "nu7", feature = "zip-233"))]
+        Zatoshis::ZERO,
+        None,
+        None,
+        None,
+        None,
+        Some(tachyon_bundle),
+    )
+    .freeze()
+    .unwrap();
+    let transaction_without_tachyon = TransactionData::<Authorized>::from_parts_v7(
+        BranchId::NuTachyon,
+        0,
+        0u32.into(),
+        #[cfg(all(zcash_unstable = "nu7", feature = "zip-233"))]
+        Zatoshis::ZERO,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .freeze()
+    .unwrap();
+
+    assert!(matches!(
+        transaction.tachyon_bundle(),
+        Some(TachyonBundle::Adjunct(_))
+    ));
+    assert_ne!(transaction.txid(), transaction_without_tachyon.txid());
+    assert_ne!(
+        transaction.auth_commitment(),
+        transaction_without_tachyon.auth_commitment()
+    );
+
+    let mut encoded = Vec::new();
+    transaction.write(&mut encoded).unwrap();
+    let decoded = Transaction::read(&encoded[..], BranchId::Sprout).unwrap();
+    assert!(matches!(
+        decoded.tachyon_bundle(),
+        Some(TachyonBundle::Adjunct(_))
+    ));
+
     let mut reencoded = Vec::new();
     decoded.write(&mut reencoded).unwrap();
     assert_eq!(reencoded, encoded);

--- a/zcash_primitives/src/transaction/txid.rs
+++ b/zcash_primitives/src/transaction/txid.rs
@@ -314,6 +314,8 @@ impl<A: Authorization> TransactionDigest<A> for TxIdDigester {
     type SaplingDigest = Option<Blake2bHash>;
     type OrchardDigest = Option<Blake2bHash>;
     type IronwoodDigest = Option<Blake2bHash>;
+    #[cfg(zcash_unstable = "nutachyon")]
+    type TachyonDigest = Option<[u8; 32]>;
 
     type Digest = TxDigests<Blake2bHash>;
 
@@ -375,6 +377,14 @@ impl<A: Authorization> TransactionDigest<A> for TxIdDigester {
         })
     }
 
+    #[cfg(zcash_unstable = "nutachyon")]
+    fn digest_tachyon(
+        &self,
+        tachyon_bundle: Option<&zcash_tachyon::TachyonBundle>,
+    ) -> Self::TachyonDigest {
+        tachyon_bundle.map(zcash_tachyon::TachyonBundle::commitment)
+    }
+
     fn combine(
         &self,
         header_digest: Self::HeaderDigest,
@@ -382,6 +392,7 @@ impl<A: Authorization> TransactionDigest<A> for TxIdDigester {
         sapling_digest: Self::SaplingDigest,
         orchard_digest: Self::OrchardDigest,
         ironwood_digest: Self::IronwoodDigest,
+        #[cfg(zcash_unstable = "nutachyon")] tachyon_digest: Self::TachyonDigest,
     ) -> Self::Digest {
         TxDigests {
             header_digest,
@@ -389,6 +400,8 @@ impl<A: Authorization> TransactionDigest<A> for TxIdDigester {
             sapling_digest,
             orchard_digest,
             ironwood_digest,
+            #[cfg(zcash_unstable = "nutachyon")]
+            tachyon_digest,
         }
     }
 }
@@ -477,16 +490,90 @@ pub(crate) fn to_hash_v6(
     h.finalize()
 }
 
+/// Combines transaction component digests for a version 7 (tachyon) transaction: the v6
+/// (Ironwood) digest tree with the tachyon bundle's effecting commitment appended.
+///
+/// The tachyon leaf is [`zcash_tachyon::TachyonBundle::commitment`]; the stamp is excluded
+/// because it is authorizing data and is malleable during aggregation. An absent bundle is
+/// combined as tachyon's "no bundle" commitment digest.
+#[cfg(zcash_unstable = "nutachyon")]
+pub(crate) fn to_hash_v7(
+    consensus_branch_id: BranchId,
+    header_digest: Blake2bHash,
+    transparent_digest: Blake2bHash,
+    sapling_digest: Option<Blake2bHash>,
+    orchard_digest: Option<Blake2bHash>,
+    ironwood_digest: Option<Blake2bHash>,
+    tachyon_digest: Option<[u8; 32]>,
+) -> Blake2bHash {
+    let mut personal = [0; 16];
+    personal[..12].copy_from_slice(ZCASH_TX_PERSONALIZATION_PREFIX);
+    (&mut personal[12..])
+        .write_u32_le(consensus_branch_id.into())
+        .unwrap();
+
+    let mut h = hasher(&personal);
+    h.write_all(header_digest.as_bytes()).unwrap();
+    h.write_all(transparent_digest.as_bytes()).unwrap();
+    h.write_all(
+        sapling_digest
+            .unwrap_or_else(hash_sapling_txid_empty)
+            .as_bytes(),
+    )
+    .unwrap();
+    h.write_all(
+        orchard_digest
+            .unwrap_or_else(|| {
+                let (value_pool, tx_version) = orchard_commitment_domain(TxVersion::V7);
+                orchard::commitments::hash_bundle_txid_empty(value_pool, tx_version)
+                    .expect("empty Orchard bundle txid commitment is valid for its tx format")
+            })
+            .as_bytes(),
+    )
+    .unwrap();
+    h.write_all(
+        ironwood_digest
+            .unwrap_or_else(|| {
+                let (value_pool, tx_version) = ironwood_v6_domain();
+                orchard::commitments::hash_bundle_txid_empty(value_pool, tx_version)
+                    .expect("empty Ironwood bundle txid commitment is valid")
+            })
+            .as_bytes(),
+    )
+    .unwrap();
+    h.write_all(
+        &tachyon_digest.unwrap_or_else(|| zcash_tachyon::TachyonBundle::NoBundle.commitment()),
+    )
+    .unwrap();
+
+    h.finalize()
+}
+
 /// Combines transaction component digests into a transaction ID.
 ///
-/// V6 and later transactions include the Ironwood bundle digest as a separate
-/// Orchard-shaped digest using Ironwood personalization. If any shielded bundle digest is
+/// Version 6 transactions include the Ironwood bundle digest as a separate
+/// Orchard-shaped digest using Ironwood personalization. Version 7 transactions additionally
+/// include the tachyon bundle's effecting commitment. If any shielded bundle digest is
 /// absent, this substitutes the protocol-defined empty bundle digest for that pool.
 pub fn to_txid(
     txversion: TxVersion,
     consensus_branch_id: BranchId,
     digests: &TxDigests<Blake2bHash>,
 ) -> TxId {
+    #[cfg(zcash_unstable = "nutachyon")]
+    if txversion.has_tachyon() {
+        let txid_digest = to_hash_v7(
+            consensus_branch_id,
+            digests.header_digest,
+            hash_transparent_txid_data(digests.transparent_digests.as_ref()),
+            digests.sapling_digest,
+            digests.orchard_digest,
+            digests.ironwood_digest,
+            digests.tachyon_digest,
+        );
+        return TxId::from_bytes(<[u8; 32]>::try_from(txid_digest.as_bytes()).unwrap());
+    }
+
     let txid_digest = if txversion.has_ironwood() {
         to_hash_v6(
             consensus_branch_id,
@@ -525,6 +612,8 @@ impl TransactionDigest<Authorized> for BlockTxCommitmentDigester {
     type SaplingDigest = Blake2bHash;
     type OrchardDigest = Blake2bHash;
     type IronwoodDigest = Blake2bHash;
+    #[cfg(zcash_unstable = "nutachyon")]
+    type TachyonDigest = [u8; 32];
 
     type Digest = Blake2bHash;
 
@@ -620,6 +709,21 @@ impl TransactionDigest<Authorized> for BlockTxCommitmentDigester {
         )
     }
 
+    /// Computes the authorizing digest for the tachyon bundle: the action signatures, the
+    /// binding signature, and the stamp digest
+    /// ([`zcash_tachyon::TachyonBundle::auth_digest`]). An absent bundle contributes tachyon's
+    /// "no bundle" authorizing digest.
+    #[cfg(zcash_unstable = "nutachyon")]
+    fn digest_tachyon(
+        &self,
+        tachyon_bundle: Option<&zcash_tachyon::TachyonBundle>,
+    ) -> Self::TachyonDigest {
+        tachyon_bundle.map_or_else(
+            || zcash_tachyon::TachyonBundle::NoBundle.auth_digest(),
+            zcash_tachyon::TachyonBundle::auth_digest,
+        )
+    }
+
     fn combine(
         &self,
         tx_context: Self::HeaderDigest,
@@ -627,6 +731,7 @@ impl TransactionDigest<Authorized> for BlockTxCommitmentDigester {
         sapling_digest: Self::SaplingDigest,
         orchard_digest: Self::OrchardDigest,
         ironwood_digest: Self::IronwoodDigest,
+        #[cfg(zcash_unstable = "nutachyon")] tachyon_digest: Self::TachyonDigest,
     ) -> Self::Digest {
         let (_txversion, consensus_branch_id) = tx_context;
         let mut personal = [0; 16];
@@ -642,6 +747,11 @@ impl TransactionDigest<Authorized> for BlockTxCommitmentDigester {
 
         if _txversion.has_ironwood() {
             h.write_all(ironwood_digest.as_bytes()).unwrap();
+        }
+
+        #[cfg(zcash_unstable = "nutachyon")]
+        if _txversion.has_tachyon() {
+            h.write_all(&tachyon_digest).unwrap();
         }
 
         h.finalize()


### PR DESCRIPTION
Follow-up to #3007 and #3012.

## Summary

- Add zcash_tachyon as a dependency only under cfg(zcash_unstable = "nutachyon").
- Extend V7 serialization and TransactionData with the Tachyon bundle.
- Commit Tachyon effecting data to the txid and signature hash, and authorizing data to the auth commitment.
- Include the Tachyon value balance in transaction balance calculation.
- Add cfg-gated V4 chain-history nodes that commit to Tachyon anchors and transaction counts.
- Keep PCZT extraction compatible by emitting V7 transactions without a Tachyon bundle, because PCZT does not represent Tachyon data.

## Scope

This contains the canonical transaction and chain-history representations needed to consume Tachyon V7 transactions in Zebra and Zakura without adding another librustzcash crate fork to zakura/libraries. It excludes unrelated client-scanning refactors, the large downstream fixture corpus, unused encoding helpers, CI/toolchain changes, and supply-chain policy changes.

## Testing

- Rust 1.88: cargo check -p zcash_primitives --all-features
- Rust 1.88: cargo test -p zcash_history --all-features
- NuTachyon: cargo test -p zcash_primitives --all-features
- NuTachyon: cargo test -p zcash_history --all-features
- NU7 + NuTachyon: cargo test -p zcash_primitives --all-features
- NU7 + NuTachyon: cargo test -p pczt --all-features
- NU7 + NuTachyon: cargo clippy -p zcash_primitives -p pczt --all-targets --all-features -- -D warnings
- NuTachyon: cargo clippy -p zcash_history --all-targets --all-features -- -D warnings
- NuTachyon: cargo check -p zcash_primitives --no-default-features
- NuTachyon: cargo check -p zcash_history --no-default-features
- cargo fmt --all -- --check

## Known follow-ups

The current pinned zcash_tachyon/Ragu dependency graph requires Rust 1.97 when the NuTachyon cfg is enabled; default builds continue to pass at the workspace Rust 1.88 MSRV. cargo vet --locked reports 27 new unaudited transitive dependencies. This draft intentionally does not add audit exemptions.