### PR TITLE
zcash_keys: use ASCII digit classes in zcashd HD-keypath parsing

### DIFF
--- a/zcash_keys/CHANGELOG.md
+++ b/zcash_keys/CHANGELOG.md
@@ -14,6 +14,12 @@ workspace.
   that require a smaller feature set should disable default features and enable
   only the features they need.
 
+### Fixed
+- `zcash_keys::keys::zcashd::ZcashdHdDerivation::parse_hd_path` no longer
+  panics when the `regex` crate is built without the `unicode-perl` feature,
+  which this crate does not require. This affected consumers whose dependency
+  graphs enabled no `regex` Unicode features.
+
 ## [0.16.1] - 2026-07-28
 
 ### Added

--- a/zcash_keys/src/keys/zcashd.rs
+++ b/zcash_keys/src/keys/zcashd.rs
@@ -127,7 +127,13 @@ impl ZcashdHdDerivation {
         network: &C,
         path: &str,
     ) -> Result<Self, PathParseError> {
-        let re = Regex::new(r"^m/32'/(\d+)'/(\d+)'(?:/(\d+)')?$").expect("checked to be valid");
+        // ASCII digit classes are used deliberately. An HD keypath's digits
+        // are ASCII by definition, and `\d` requires the regex crate's
+        // `unicode-perl` feature, which this crate does not declare. In a
+        // dependency graph that enables that feature nowhere else, a `\d`
+        // pattern fails to compile at runtime.
+        let re =
+            Regex::new(r"^m/32'/([0-9]+)'/([0-9]+)'(?:/([0-9]+)')?$").expect("checked to be valid");
         let parts = re.captures(path).ok_or(PathParseError::PathInvalid)?;
         assert!(parts.len() <= 4);
 


### PR DESCRIPTION
`ZcashdHdDerivation::parse_hd_path` used `\d` in its keypath pattern. `\d` requires the `regex` crate's `unicode-perl` feature, which `zcash_keys` does not declare: it builds `regex` with `default-features = false` and no Unicode features. In a dependency graph where no other crate enables `unicode-perl`, the pattern fails to compile at runtime and the function panics on its `expect`:

```
error: Unicode-aware Perl class not found (make sure the unicode-perl feature is enabled)
```

The bug is masked inside this workspace (other dependencies unify the feature on), but surfaced in a downstream consumer (zcash/zewif-zcashd#29) whose graph enables no `regex` Unicode features.

An HD keypath's digits are ASCII by definition, so `[0-9]` classes carry the intended semantics with no feature requirement — this also stops `\d` from admitting non-ASCII Unicode digits that `u32` parsing would then reject. No dependency or feature changes needed.

---
Filed with Claude Code assistance.
