### PR TITLE
Release zcash_protocol version 0.10.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7450,7 +7450,7 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "corez",
  "document-features",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ zcash_client_backend = { version = "0.24.0", path = "zcash_client_backend", defa
 zcash_encoding = { version = "0.4", default-features = false }
 zcash_keys = { version = "0.16.1", path = "zcash_keys", default-features = false  }
 zcash_pool_migration = { version = "0.1.0", path = "zcash_pool_migration" }
-zcash_protocol = { version = "0.10.5", path = "components/zcash_protocol", default-features = false }
+zcash_protocol = { version = "0.10.6", path = "components/zcash_protocol", default-features = false }
 zip321 = { version = "0.9.0", path = "components/zip321" }
 
 zcash_note_encryption = "0.4.1"

--- a/components/zcash_protocol/CHANGELOG.md
+++ b/components/zcash_protocol/CHANGELOG.md
@@ -10,10 +10,15 @@ workspace.
 
 ## [Unreleased]
 
+## [0.10.6] - 2026-09-04
+
 ### Added
-- Experimental NuTachyon support behind `zcash_unstable="nutachyon"`, including
-  its network upgrade, consensus branch ID, local-consensus activation parameter,
-  and V7 transaction format constants.
+- Experimental NuTachyon support. Every item listed here is available **only**
+  under the `--cfg zcash_unstable="nutachyon"` configuration flag, and is absent
+  from a default build:
+  - `zcash_protocol::constants::{V7_TX_VERSION, V7_VERSION_GROUP_ID}`
+  - `zcash_protocol::consensus::{NetworkUpgrade::NuTachyon, BranchId::NuTachyon}`
+  - `zcash_protocol::local_consensus::LocalNetwork::nu_tachyon`
 
 ## [0.10.5] - 2026-08-18
 

--- a/components/zcash_protocol/Cargo.toml
+++ b/components/zcash_protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zcash_protocol"
 description = "Zcash protocol network constants and value types."
-version = "0.10.5"
+version = "0.10.6"
 authors = [
     "Jack Grigg <jack@electriccoin.co>",
     "Kris Nuttycombe <kris@nutty.land>",

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,6 +1,10 @@
 
 # cargo-vet imports lock
 
+[[unpublished.zcash_protocol]]
+version = "0.10.6"
+audited_as = "0.10.5"
+
 [[publisher.bumpalo]]
 version = "3.16.0"
 when = "2024-04-08"


### PR DESCRIPTION
Publishes the NuTachyon network upgrade, its consensus branch ID, and the V7 transaction format constants, all gated behind `zcash_unstable="nutachyon"`. `pczt` and `zcash_primitives` depend upon these under that flag.